### PR TITLE
🗑️ Clean up system configuration and unused localizations (Issue #56)

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -285,7 +285,6 @@
       "RESISTANCES": "The chosen Resistance and Vulnerability for an Ancestry may not be the same."
     }
   },
-  "ANCESTRY.ApplyError": "You may only apply an ancestry to a level 0 character with no spent skill or ability points.",
   "ACTION.Action": "Action",
   "ACTION.Condition": "Condition",
   "ACTION.Targets": "Targets",

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -404,7 +404,6 @@
       "RESISTANCES": "The chosen Resistance and Vulnerability for an Ancestry may not be the same."
     }
   },
-  "ANCESTRY.ApplyError": "You may only apply an ancestry to a level 0 character with no spent skill or ability points.",
   "ACTION.Action": "Action",
   "ACTION.Condition": "Condition",
   "ACTION.Targets": "Targets",

--- a/module/config/system.mjs
+++ b/module/config/system.mjs
@@ -32,15 +32,9 @@ export const ANCESTRIES = {
  * @enum {string}
  */
 export const COMPENDIUM_PACKS = {
-  ancestry: 'swerpg.ancestry',
-  archetype: 'swerpg.archetype',
   background: 'swerpg.background',
   origin: 'swerpg.origin',
-  spell: 'swerpg.spells',
-  spellExtensions: null,
   talent: 'swerpg.talent',
-  talentExtensions: null,
-  taxonomy: 'swerpg.taxonomy',
 }
 
 /* -------------------------------------------- */
@@ -104,10 +98,6 @@ export const ACTOR_HOOKS = Object.freeze({
     group: 'TALENT.HOOKS.GROUP_ACTION',
     argNames: ['action', 'origin', 'rollData'],
   },
-  defendSpellAttack: {
-    group: 'TALENT.HOOKS.GROUP_ACTION',
-    argNames: ['spell', 'origin', 'rollData'],
-  },
   defendWeaponAttack: {
     group: 'TALENT.HOOKS.GROUP_ACTION',
     argNames: ['action', 'origin', 'rollData'],
@@ -149,10 +139,6 @@ export const ACTOR_HOOKS = Object.freeze({
   prepareSkillAttack: {
     group: 'TALENT.HOOKS.GROUP_PREPARATION',
     argNames: ['action', 'target', 'rollData'],
-  },
-  prepareSpellAttack: {
-    group: 'TALENT.HOOKS.GROUP_PREPARATION',
-    argNames: ['spell', 'target', 'rollData'],
   },
   prepareTraining: {
     group: 'TALENT.HOOKS.GROUP_PREPARATION',

--- a/module/documents/actor-origin.mjs
+++ b/module/documents/actor-origin.mjs
@@ -991,8 +991,6 @@ export default class SwerpgActor extends Actor {
 
     // Call talent hooks
     this.callActorHooks('prepareStandardCheck', rollData)
-    this.callActorHooks('prepareSpellAttack', spell, target, rollData)
-    target.callActorHooks('defendSpellAttack', spell, this, rollData)
 
     // Create the Attack Roll instance
     const roll = new AttackRoll(rollData)

--- a/module/documents/actor.mjs
+++ b/module/documents/actor.mjs
@@ -1021,8 +1021,6 @@ export default class SwerpgActor extends Actor {
 
     // Call talent hooks
     this.callActorHooks('prepareStandardCheck', rollData)
-    this.callActorHooks('prepareSpellAttack', spell, target, rollData)
-    target.callActorHooks('defendSpellAttack', spell, this, rollData)
 
     // Create the Attack Roll instance
     const roll = new AttackRoll(rollData)

--- a/system.json
+++ b/system.json
@@ -137,12 +137,6 @@
       "adversary": {}
     },
     "Item": {
-      "ancestry": {
-        "htmlFields": ["description"]
-      },
-      "archetype": {
-        "htmlFields": ["description"]
-      },
       "armor": {
         "htmlFields": ["description.public", "description.secret"]
       },
@@ -167,13 +161,7 @@
       "species": {
         "htmlFields": ["description"]
       },
-      "spell": {
-        "htmlFields": ["description"]
-      },
       "talent": {
-        "htmlFields": ["description"]
-      },
-      "taxonomy": {
         "htmlFields": ["description"]
       },
       "weapon": {
@@ -183,9 +171,6 @@
         "htmlFields": ["description"]
       },
       "motivation": {
-        "htmlFields": ["description"]
-      },
-      "duty": {
         "htmlFields": ["description"]
       }
     },

--- a/tests/config/system.test.mjs
+++ b/tests/config/system.test.mjs
@@ -32,7 +32,7 @@ describe('System Configuration', () => {
 
   describe('COMPENDIUM_PACKS configuration', () => {
     test('should have all required compendium packs defined', () => {
-      const expectedPacks = ['ancestry', 'archetype', 'background', 'origin', 'spell', 'spellExtensions', 'talent', 'talentExtensions', 'taxonomy']
+      const expectedPacks = ['background', 'origin', 'talent']
 
       for (const packKey of expectedPacks) {
         expect(SystemConfig.COMPENDIUM_PACKS).toHaveProperty(packKey)
@@ -40,18 +40,9 @@ describe('System Configuration', () => {
     })
 
     test('should have correct pack identifiers for main packs', () => {
-      expect(SystemConfig.COMPENDIUM_PACKS.ancestry).toBe('swerpg.ancestry')
-      expect(SystemConfig.COMPENDIUM_PACKS.archetype).toBe('swerpg.archetype')
       expect(SystemConfig.COMPENDIUM_PACKS.background).toBe('swerpg.background')
       expect(SystemConfig.COMPENDIUM_PACKS.origin).toBe('swerpg.origin')
-      expect(SystemConfig.COMPENDIUM_PACKS.spell).toBe('swerpg.spells')
       expect(SystemConfig.COMPENDIUM_PACKS.talent).toBe('swerpg.talent')
-      expect(SystemConfig.COMPENDIUM_PACKS.taxonomy).toBe('swerpg.taxonomy')
-    })
-
-    test('should have null values for extension packs', () => {
-      expect(SystemConfig.COMPENDIUM_PACKS.spellExtensions).toBeNull()
-      expect(SystemConfig.COMPENDIUM_PACKS.talentExtensions).toBeNull()
     })
   })
 
@@ -139,7 +130,6 @@ describe('System Configuration', () => {
         'prepareWeaponAttack',
         'applyCriticalEffects',
         'defendSkillAttack',
-        'defendSpellAttack',
         'defendWeaponAttack',
         'applyActionOutcome',
       ]
@@ -162,6 +152,7 @@ describe('System Configuration', () => {
         'prepareResistances',
         'prepareSkillCheck',
         'prepareSkillAttack',
+        'prepareTraining',
       ]
 
       for (const hookName of preparationHooks) {


### PR DESCRIPTION
## Description
This PR implements issue #56 by cleaning up unused system configuration and localization keys.

## Changes Made

### System Configuration (`module/config/system.mjs`)
- ✅ Removed unused `COMPENDIUM_PACKS` entries:
  - `ancestry: 'swerpg.ancestry'`
  - `archetype: 'swerpg.archetype'`
  - `spell: 'swerpg.spells'`
  - `taxonomy: 'swerpg.taxonomy'`
  - `spellExtensions: null`
  - `talentExtensions: null`
- ✅ Removed unused `ACTOR_HOOKS` entries:
  - `defendSpellAttack`
  - `prepareSpellAttack`
- ✅ Removed calls to deleted hooks in `actor.mjs` and `actor-origin.mjs`

### System Configuration (`system.json`)
- ✅ Removed unused `documentTypes.Item` entries:
  - `ancestry`
  - `archetype`
  - `spell`
  - `taxonomy`
  - `duty` (per user decision)
- ✅ Kept `motivation` and `motivation-category` (per user request)

### Localization Files
- ✅ Removed `ANCESTRY.ApplyError` from `lang/en.json` and `lang/fr.json`
- ✅ No `SPELL.*`, `ARCHETYPE.*`, `TAXONOMY.*` keys found (already clean)
- ✅ Kept `MOTIVATION.*` (per user request)

### Test Updates
- ✅ Updated `tests/config/system.test.mjs` to reflect new `COMPENDIUM_PACKS` and `ACTOR_HOOKS`

## Notes
- `SPELL` import and config kept in `system.mjs` because spellcraft system (`spellcraft.mjs`) is still actively used (runes, gestures, inflections)
- The compendium pack folders (`packs/ancestry/`, `packs/archetype/`, `packs/taxonomy/`) exist but are empty - they can be removed separately if needed
- No `packs/spells/` folder exists

## Issue Closure
Closes #56

## Testing
- [x] `npx vitest run tests/config/system.test.mjs` - All 27 tests pass
- [x] No broken references to removed config entries
- [x] Spellcraft system still works (SPELL config preserved)