### PR TITLE
feat(combat): Chantier 05 - Implémentation Effects Mixin

### DIFF
--- a/module/documents/actor-mixins/combat/effects.mixin.mjs
+++ b/module/documents/actor-mixins/combat/effects.mixin.mjs
@@ -1,16 +1,171 @@
 /**
  * Effects Manager Mixin - Handles combat action outcomes and effect management
- * Will be implemented in Chantier 05
+ * Extracted from actor.mjs lines ~1181-1417
  */
+
+import SYSTEM from '../../config/system.mjs'
 
 export const EffectsMixin = (Base) =>
   class extends Base {
-    // Methods to be implemented:
-    // - applyActionOutcome()
-    // - _applyOutcomeEffects()
-    // - _trackHeroismDamage()
-    // - onDealDamage()
-    // - applyDamageOverTime()
-    // - expireEffects()
-    // - _isEffectExpired()
+    /**
+     * Apply the outcome of an action (damage, resources, effects)
+     * @param {SwerpgAction} action - The action that was performed
+     * @param {object} outcome - The action outcome
+     * @param {object} options - Options including { reverse: boolean }
+     */
+    async applyActionOutcome(action, outcome, { reverse = false } = {}) {
+      const wasWeakened = this.isWeakened
+      const wasBroken = this.isBroken
+      const wasIncapacitated = this.isIncapacitated
+
+      // Prune effects if the attack was unsuccessful
+      if (!reverse && outcome.rolls.length && !outcome.rolls.some((r) => r.isSuccess)) {
+        outcome.effects.length = 0
+      }
+
+      // Call applyActionOutcome actor hooks
+      this.callActorHooks('applyActionOutcome', action, outcome, { reverse })
+
+      // Apply changes to the Actor
+      await this.alterResources(outcome.resources, outcome.actorUpdates, { reverse })
+      await this._applyOutcomeEffects(outcome, reverse)
+      await this._trackHeroismDamage(outcome.resources, reverse)
+
+      // Record target state changes
+      if (this.isWeakened && !wasWeakened) outcome.weakened = true
+      if (this.isBroken && !wasBroken) outcome.broken = true
+      if (this.isIncapacitated && !wasIncapacitated) outcome.incapacitated = true
+    }
+
+    /**
+     * Apply effects from an action outcome (create/update/delete ActiveEffects)
+     * @param {object} outcome - Action outcome containing effects
+     * @param {boolean} reverse - Whether to reverse the effects
+     */
+    async _applyOutcomeEffects(outcome, reverse = false) {
+      // Reverse effects - delete applied effects
+      if (reverse) {
+        const deleteEffectIds = outcome.effects.reduce((arr, e) => {
+          if (this.effects.has(e._id)) arr.push(e._id)
+          return arr
+        }, [])
+        await this.deleteEmbeddedDocuments('ActiveEffect', deleteEffectIds)
+        return
+      }
+
+      // Apply effects - create new or update existing
+      const toCreate = []
+      const toUpdate = []
+      const toDelete = []
+
+      for (const effectData of outcome.effects) {
+        const existing = this.effects.get(effectData._id)
+        if (existing && effectData._delete) {
+          toDelete.push(effectData._id)
+        } else if (existing) {
+          toUpdate.push(effectData)
+        } else {
+          toCreate.push(effectData)
+        }
+      }
+
+      await this.deleteEmbeddedDocuments('ActiveEffect', toDelete)
+      await this.updateEmbeddedDocuments('ActiveEffect', toUpdate)
+      await this.createEmbeddedDocuments('ActiveEffect', toCreate, { keepId: true })
+    }
+
+    /**
+     * Track heroism damage for combat metrics
+     * @param {object} resources - Resource changes
+     * @param {boolean} reverse - Whether to reverse the tracking
+     */
+    async _trackHeroismDamage(resources, reverse) {
+      if (!game.combat?.active) return
+
+      let delta = 0
+      for (const r of ['health', 'wounds', 'morale', 'madness']) {
+        delta += resources[r] || 0
+      }
+
+      if (delta === 0) return
+
+      if (reverse) delta *= -1
+
+      const heroism = Math.max((game.settings.get('swerpg', 'heroism') || 0) + delta, 0)
+      await game.settings.set('swerpg', 'heroism', heroism)
+    }
+
+    /**
+     * Called when this actor deals damage to others
+     * Applies critical effects if applicable
+     * @param {SwerpgAction} action - The action used
+     * @param {Map} outcomes - Map of outcomes by actor
+     */
+    onDealDamage(action, outcomes) {
+      const self = outcomes.get(this)
+      for (const outcome of outcomes.values()) {
+        if (outcome === self) continue
+        if (outcome.criticalSuccess) {
+          this.callActorHooks('applyCriticalEffects', action, outcome, self)
+        }
+      }
+    }
+
+    /**
+     * Apply damage over time effects (from ActiveEffects with dot flag)
+     */
+    async applyDamageOverTime() {
+      for (const effect of this.effects) {
+        const dot = effect.flags.swerpg?.dot
+        if (!dot) continue
+
+        // Categorize damage
+        const damage = {}
+        for (const r of Object.keys(SYSTEM.RESOURCES)) {
+          let v = dot[r]
+          if (!v) continue
+          if (v > 0) v = Math.clamp(v - this.resistances[dot.damageType].total, 0, 2 * v)
+          damage[r] ||= 0
+          damage[r] -= v
+        }
+        await this.alterResources(damage, {}, { statusText: effect.label })
+      }
+    }
+
+    /**
+     * Expire active effects whose durations have concluded
+     * @param {boolean} start - Is it the start of the turn (true) or the end of the turn (false)
+     */
+    async expireEffects(start = true) {
+      const toDelete = []
+      for (const effect of this.effects) {
+        if (this._isEffectExpired(effect, start)) toDelete.push(effect.id)
+      }
+      await this.deleteEmbeddedDocuments('ActiveEffect', toDelete)
+    }
+
+    /**
+     * Test whether an ActiveEffect is expired
+     * @param {ActiveEffect} effect - The effect being tested
+     * @param {boolean} start - Is it the start of the turn (true) or the end of the turn (false)
+     * @returns {boolean}
+     */
+    _isEffectExpired(effect, start = true) {
+      const { startRound, rounds, turns } = effect.duration
+      const elapsed = game.combat.round - startRound + 1
+
+      // Turn-based effects expire at the end of the turn
+      if (turns > 0) {
+        if (start) return false
+        return elapsed >= turns
+      }
+
+      // Round-based effects expire at the start of the turn
+      else if (rounds > 0) {
+        if (!start) return false
+        return elapsed > rounds
+      }
+
+      return false
+    }
   }


### PR DESCRIPTION
## Description
Implémentation du **Chantier 05** pour l'issue #48 : Implémentation d'`effects.mixin.mjs`.

## Changements
- ✅ Implémentation complète de `effects.mixin.mjs` (~130 lignes)
- ✅ Extraction de `applyActionOutcome()` (lignes 1181-1201)
- ✅ Extraction de `_applyOutcomeEffects()` (anciennement `#applyOutcomeEffects`, lignes 1211-1235)
- ✅ Extraction de `_trackHeroismDamage()` (anciennement `#trackHeroismDamage`, lignes 1244-1252)
- ✅ Extraction de `onDealDamage()` (lignes 1261-1269)
- ✅ Extraction de `applyDamageOverTime()` (lignes 1361-1377)
- ✅ Extraction de `expireEffects()` (lignes 1386-1392)
- ✅ Extraction de `_isEffectExpired()` (anciennement `#isEffectExpired`, lignes 1402-1417)
- ✅ Conversion des méthodes privées `#` en `_` (convention protected)
- ✅ Ajout de l'import `SYSTEM` pour `SYSTEM.RESOURCES`

## Méthodes implémentées

### Gestion des résultats d'action
- `applyActionOutcome(action, outcome, { reverse })` - Applique le résultat d'une action
- `onDealDamage(action, outcomes)` - Gère les dégâts critiques

### Gestion des effets
- `_applyOutcomeEffects(outcome, reverse)` - Crée/met à jour/supprime les ActiveEffects
- `expireEffects(start)` - Fait expirer les effets
- `_isEffectExpired(effect, start)` - Vérifie si un effet est expiré
- `applyDamageOverTime()` - Applique les dégâts dans le temps

### Tracking
- `_trackHeroismDamage(resources, reverse)` - Suit les dégâts pour l'héroïsme

## Notes techniques
⚠️ **Méthodes privées `#` → `_`**
- JavaScript ne permet pas d'utiliser `#` dans les mixins classiques
- Conversion vers `_` (convention "protected")
- Indique que ces méthodes ne sont pas destinées à être appelées de l'extérieur

⚠️ **Dépendances sur actor.mjs**
- `this.callActorHooks()` - Doit rester dans actor.mjs
- `this.alterResources()` - Doit rester dans actor.mjs
- Ces méthodes sont appelées par les mixins

## Prochaines étapes
- [ ] Chantier 06 : Intégrer les mixins dans `actor.mjs`
- [ ] Chantier 07 : Tests

## Issue liée
Part of #48

## Checklist
- [x] Syntaxe du fichier validée (`node --check`)
- [x] Code extrait des lignes correctes de actor.mjs
- [x] Méthodes privées converties en `_`
- [ ] Tests à ajouter au Chantier 07