### PR TITLE
Fix: Restore missing getters and freeSkillRanks undefined error

### DIFF
--- a/module/documents/actor.mjs
+++ b/module/documents/actor.mjs
@@ -62,6 +62,147 @@ export default class SwerpgActor extends ResourcesMixin(CombatMixin(Actor)) {
    */
   actorHooks = {}
 
+  /* -------------------------------------------- */
+  /*  Getters                                     */
+  /* -------------------------------------------- */
+
+  /**
+   * Convenient access to the Actor's species.
+   * @type {object}  The species data
+   */
+  get species() {
+    return this.system.details.species
+  }
+
+  /**
+   * Convenient access to the Actor's experience points.
+   * @type {ExperiencePoints}  The experience points data
+   */
+  get experiencePoints() {
+    if (this.type !== SYSTEM.ACTOR_TYPE.character.type) return { gained: 0, spent: 0, startingExperience: 0 }
+    return this.system.progression.experience
+  }
+
+  /**
+   * Convenient access to the Actor's abilities.
+   * @type {object}  The abilities data
+   */
+  get abilities() {
+    return this.system.abilities
+  }
+
+  /**
+   * Convenient access to the Actor's defenses.
+   * @type {object}  The defenses data
+   */
+  get defenses() {
+    return this.system.defenses
+  }
+
+  /**
+   * Convenient access to the Actor's level.
+   * @type {number}  The actor level
+   */
+  get level() {
+    return this.system.details.level
+  }
+
+  /**
+   * Convenient access to the Actor's points (ability, skill, talent).
+   * @type {object}  The points data
+   */
+  get points() {
+    return this.system.points
+  }
+
+  /**
+   * Convenient access to the Actor's resistances.
+   * @type {object}  The resistances data
+   */
+  get resistances() {
+    return this.system.resistances
+  }
+
+  /**
+   * Convenient access to the Actor's skills.
+   * @type {object}  The skills data
+   */
+  get skills() {
+    return this.system.skills
+  }
+
+  /**
+   * Convenient access to the Actor's size.
+   * @type {number}  The actor size
+   */
+  get size() {
+    return this.system.details.size || 1
+  }
+
+  /**
+   * Convenient access to the Actor's status.
+   * @type {object}  The status data
+   */
+  get status() {
+    return this.system.status
+  }
+
+  /**
+   * Check if the actor is level 0.
+   * @type {boolean}
+   */
+  get isL0() {
+    return this.level === 0
+  }
+
+  /**
+   * Check if the actor is knocked out.
+   * @type {boolean}
+   */
+  get isKnockedOut() {
+    return this.system.status.conditions.knockedOut
+  }
+
+  /**
+   * Check if the actor is broken.
+   * @type {boolean}
+   */
+  get isBroken() {
+    return this.system.status.conditions.broken
+  }
+
+  /**
+   * Check if the actor is dead.
+   * @type {boolean}
+   */
+  get isDead() {
+    return this.system.status.conditions.dead
+  }
+
+  /**
+   * Check if the actor is insane.
+   * @type {boolean}
+   */
+  get isInsane() {
+    return this.system.status.conditions.insane
+  }
+
+  /**
+   * Check if the actor is incapacitated.
+   * @type {boolean}
+   */
+  get isIncapacitated() {
+    return this.isKnockedOut || this.isBroken || this.isDead || this.isInsane
+  }
+
+  /**
+   * Convenient access to the combatant.
+   * @type {object|null}  The combatant or null
+   */
+  get combatant() {
+    return this._combatant
+  }
+
   /*  Character Creation Methods                  */
 
   /* -------------------------------------------- */
@@ -813,11 +954,22 @@ export default class SwerpgActor extends ResourcesMixin(CombatMixin(Actor)) {
   /* -------------------------------------------- */
 
   /**
+   * Get the free skill ranks for the actor.
+   * @returns {FreeSkillRanks} The free skill ranks for the actor.
+   */
+  get freeSkillRanks() {
+    return this.system.progression.freeSkillRanks
+  }
+
+  /* -------------------------------------------- */
+
+  /**
    * Check if actor has any career free skill ranks available.
    * @returns {boolean}   True if actor has free skill ranks
    */
   hasCareerFreeSkillsAvailable() {
-    return this.freeSkillRanks.career.available !== 0
+    const career = this.freeSkillRanks.career
+    return (career.gained - career.spent) !== 0
   }
 
   /* -------------------------------------------- */
@@ -827,7 +979,8 @@ export default class SwerpgActor extends ResourcesMixin(CombatMixin(Actor)) {
    * @returns {boolean}   True if actor has free skill ranks
    */
   hasSpecializationFreeSkillsAvailable() {
-    return this.freeSkillRanks.specialization.available !== 0
+    const specialization = this.freeSkillRanks.specialization
+    return (specialization.gained - specialization.spent) !== 0
   }
 
   /* -------------------------------------------- */

--- a/module/documents/actor.mjs
+++ b/module/documents/actor.mjs
@@ -53,7 +53,14 @@ export default class SwerpgActor extends ResourcesMixin(CombatMixin(Actor)) {
   constructor(data, context) {
     super(data, context)
     this._cachedResources = {}
+    this.actorHooks = {}
   }
+
+  /**
+   * Talent hook functions which apply to this Actor based on their set of owned Talents.
+   * @type {Object<string, {talent: SwerpgItem, fn: Function}[]>}
+   */
+  actorHooks = {}
 
   /*  Character Creation Methods                  */
 
@@ -635,6 +642,41 @@ export default class SwerpgActor extends ResourcesMixin(CombatMixin(Actor)) {
   }
 
   /* -------------------------------------------- */
+  /*  Actor Preparation                            */
+
+  /* -------------------------------------------- */
+
+  /** @inheritDoc */
+  prepareEmbeddedDocuments() {
+    super.prepareEmbeddedDocuments()
+    const items = this.itemTypes
+    SwerpgActor.#prepareTalents.call(this, items.talent)
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Prepare Talent data for the Actor.
+   * @this {SwerpgActor}
+   * @param {SwerpgItem[]} talents
+   */
+  static #prepareTalents(talents) {
+    this.talentIds = new Set()
+    this.actorHooks = {}
+    this.permanentTalentIds = new Set()
+
+    // Iterate over talents
+    for (const t of talents) {
+      this.talentIds.add(t.id)
+
+      // Register hooks
+      for (const hook of t.system.actorHooks) SwerpgActor.#registerActorHook(this, t, hook)
+    }
+  }
+
+  /* -------------------------------------------- */
+
+  /* -------------------------------------------- */
   /*  Database Workflows                          */
 
   /* -------------------------------------------- */
@@ -854,6 +896,47 @@ export default class SwerpgActor extends ResourcesMixin(CombatMixin(Actor)) {
         if (token.width !== this.size) updates.push({ _id: token.id, width: this.size, height: this.size })
       }
       await canvas.scene.updateEmbeddedDocuments('Token', updates)
+    }
+  }
+
+  /* -------------------------------------------- */
+  /*  Talent Hooks                                */
+  /* -------------------------------------------- */
+
+  /**
+   * Register a hooked function declared by a Talent item.
+   * @param actor
+   * @param {SwerpgItem} talent   The Talent registering the hook
+   * @param {object} data           Registered hook data
+   * @param {string} data.hook        The hook name
+   * @param {string} data.fn          The hook function
+   * @private
+   */
+  static #registerActorHook(actor, talent, { hook, fn } = {}) {
+    const hookConfig = SYSTEM.ACTOR_HOOKS[hook]
+    if (!hookConfig) throw new Error(`Invalid Actor hook name "${hook}" defined by Talent "${talent.id}"`)
+    actor.actorHooks[hook] ||= []
+    actor.actorHooks[hook].push({ talent, fn: new Function('actor', ...hookConfig.argNames, fn) })
+  }
+
+  /**
+   * Call all actor hooks registered for a certain event name.
+   * Each registered function is called in sequence.
+   * @param {string} hook     The hook name to call.
+   * @param {...*} args       Arguments passed to the hooked function
+   */
+  callActorHooks(hook, ...args) {
+    const hookConfig = SYSTEM.ACTOR_HOOKS[hook]
+    if (!hookConfig) throw new Error(`Invalid Actor hook function "${hook}"`)
+    const hooks = (this.actorHooks[hook] ||= [])
+    for (const { talent, fn } of hooks) {
+      logger.debug(`Calling ${hook} hook for Talent ${talent.name}`)
+      try {
+        fn(this, ...args)
+      } catch (err) {
+        const msg = `The "${hook}" hook defined for Talent "${talent.name}" failed evaluation in Actor [${this.id}]`
+        logger.error(msg, err)
+      }
     }
   }
 

--- a/module/lib/skills/skill-factory.mjs
+++ b/module/lib/skills/skill-factory.mjs
@@ -78,13 +78,15 @@ export default class SkillFactory {
     }
 
     if (isCareer) {
-      if ((action === 'train' && SkillFactory.#hasCareerFreeSkill(actor)) || (action === 'forget' && actor.freeSkillRanks.career.spent > 0)) {
+      const careerSpent = actor.freeSkillRanks.career.spent
+      if ((action === 'train' && SkillFactory.#hasCareerFreeSkill(actor)) || (action === 'forget' && careerSpent > 0)) {
         return new CareerFreeSkill(actor, skill, { action, isCreation, isCareer, isSpecialization }, options)
       }
     }
 
     if (isSpecialization) {
-      if ((action === 'train' && SkillFactory.#hasSpecializationFreeSkill(actor)) || (action === 'forget' && actor.freeSkillRanks.specialization.spent > 0)) {
+      const specializationSpent = actor.freeSkillRanks.specialization.spent
+      if ((action === 'train' && SkillFactory.#hasSpecializationFreeSkill(actor)) || (action === 'forget' && specializationSpent > 0)) {
         return new SpecializationFreeSkill(
           actor,
           skill,
@@ -105,11 +107,13 @@ export default class SkillFactory {
   }
 
   static #hasCareerFreeSkill(actor) {
-    return actor.freeSkillRanks.career.available > 0
+    const career = actor.freeSkillRanks.career
+    return (career.gained - career.spent) > 0
   }
 
   static #hasSpecializationFreeSkill(actor) {
-    return actor.freeSkillRanks.specialization.available > 0
+    const specialization = actor.freeSkillRanks.specialization
+    return (specialization.gained - specialization.spent) > 0
   }
 
   /**

--- a/module/models/actor-type.mjs
+++ b/module/models/actor-type.mjs
@@ -235,19 +235,6 @@ export default class SwerpgActorType extends foundry.abstract.TypeDataModel {
     this._prepareDerivedAttributes()
     this._prepareFreeSkillRanks()
     this.parent.callActorHooks('prepareResources', this.resources)
-
-    // Defenses
-    // this.#prepareDefenses();
-    // this.parent.callActorHooks("prepareDefenses", this.defenses);
-    // this.#prepareTotalDefenses();
-
-    // Resistances
-    // this.parent.callActorHooks("prepareResistances", this.resistances);
-    // this.#prepareTotalResistances();
-
-    // Movement
-    // this._prepareMovement();
-    // this.parent.callActorHooks("prepareMovement", this.movement);
   }
 
   /**

--- a/swerpg.mjs
+++ b/swerpg.mjs
@@ -29,6 +29,7 @@ import * as chat from './module/chat.mjs'
 import Enum from './module/config/enum.mjs'
 import { registerSystemSettings } from './module/applications/settings/settings.js'
 import { logger } from './module/utils/logger.mjs'
+import { SwerpgTokenHUD } from './module/applications/_module.mjs'
 
 globalThis.SYSTEM = SYSTEM
 

--- a/tests/lib/skills/skill-factory.test.mjs
+++ b/tests/lib/skills/skill-factory.test.mjs
@@ -47,7 +47,7 @@ describe('SkillFactory build()', () => {
         test('click on a skill either career-free or specialization-free only and has a career-free skill point.', () => {
           const actor = createActor()
           actor.system.skills.brawl.rank.careerFree = 1
-          actor.freeSkillRanks = {
+          actor.system.progression.freeSkillRanks = {
             career: {
               spent: 1,
               gained: 4,
@@ -73,7 +73,7 @@ describe('SkillFactory build()', () => {
           actor.experiencePoints.spent = 10
           actor.experiencePoints.gained = 100
           actor.experiencePoints.available = 90
-          actor.freeSkillRanks = {
+          actor.system.progression.freeSkillRanks = {
             career: {
               spent: 4,
               gained: 4,
@@ -134,7 +134,7 @@ describe('SkillFactory build()', () => {
         })
         test('an actor that has spent career-free skill points and click on a skill that is both career-free and specialization-free.', () => {
           const actor = createActor()
-          actor.freeSkillRanks.career = {
+          actor.system.progression.freeSkillRanks.career = {
             spent: 4,
             gained: 4,
           }
@@ -155,7 +155,7 @@ describe('SkillFactory build()', () => {
         test('click on a skill either career-free or specialization-free only and has a specialization-free skill point.', () => {
           const actor = createActor()
           actor.system.skills.brawl.rank.specializationFree = 1
-          actor.freeSkillRanks = {
+          actor.system.progression.freeSkillRanks = {
             career: {
               spent: 0,
               gained: 4,
@@ -181,7 +181,7 @@ describe('SkillFactory build()', () => {
           actor.system.skills.brawl.rank.specializationFree = 1
           actor.system.skills.brawl.rank.careerFree = 1
           actor.experiencePoints.spent = 10
-          actor.freeSkillRanks = {
+          actor.system.progression.freeSkillRanks = {
             career: {
               spent: 1,
               gained: 4,
@@ -210,7 +210,7 @@ describe('SkillFactory build()', () => {
         const action = 'train'
         test('click on a skill neither career-free nor specialization-free and actor has no career-free points.', () => {
           const actor = createActor()
-          actor.freeSkillRanks = {
+          actor.system.progression.freeSkillRanks = {
             career: {
               spent: 4,
               gained: 4,
@@ -235,7 +235,7 @@ describe('SkillFactory build()', () => {
         })
         test('an actor that has spent career-free and specialization-free skill points and click on a skill that is both career-free and specialization-free.', () => {
           const actor = createActor()
-          actor.freeSkillRanks = {
+          actor.system.progression.freeSkillRanks = {
             career: {
               spent: 4,
               gained: 4,
@@ -264,7 +264,7 @@ describe('SkillFactory build()', () => {
           actor.experiencePoints.spent = 10
           actor.experiencePoints.gained = 100
           actor.experiencePoints.available = 90
-          actor.freeSkillRanks = {
+          actor.system.progression.freeSkillRanks = {
             career: {
               spent: 0,
               gained: 4,
@@ -292,7 +292,7 @@ describe('SkillFactory build()', () => {
           actor.experiencePoints.spent = 10
           actor.experiencePoints.gained = 100
           actor.experiencePoints.available = 90
-          actor.freeSkillRanks = {
+          actor.system.progression.freeSkillRanks = {
             career: {
               spent: 4,
               gained: 4,
@@ -327,7 +327,7 @@ describe('SkillFactory build()', () => {
           actor.system.skills.brawl.rank.specializationFree = 0
           actor.system.skills.brawl.rank.trained = 1
           actor.experiencePoints.spent = 10
-          actor.freeSkillRanks = {
+          actor.system.progression.freeSkillRanks = {
             career: {
               spent: 0,
               gained: 4,
@@ -356,7 +356,7 @@ describe('SkillFactory build()', () => {
           actor.system.skills.brawl.rank.specializationFree = 0
           actor.system.skills.brawl.rank.trained = 1
           actor.experiencePoints.spent = 10
-          actor.freeSkillRanks = {
+          actor.system.progression.freeSkillRanks = {
             career: {
               spent: 4,
               gained: 4,
@@ -385,7 +385,7 @@ describe('SkillFactory build()', () => {
           actor.system.skills.brawl.rank.specializationFree = 1
           actor.system.skills.brawl.rank.trained = 1
           actor.experiencePoints.spent = 10
-          actor.freeSkillRanks = {
+          actor.system.progression.freeSkillRanks = {
             career: {
               spent: 3,
               gained: 4,
@@ -414,7 +414,7 @@ describe('SkillFactory build()', () => {
           actor.system.skills.brawl.rank.specializationFree = 1
           actor.system.skills.brawl.rank.trained = 1
           actor.experiencePoints.spent = 10
-          actor.freeSkillRanks = {
+          actor.system.progression.freeSkillRanks = {
             career: {
               spent: 4,
               gained: 4,
@@ -443,7 +443,7 @@ describe('SkillFactory build()', () => {
           actor.system.skills.brawl.rank.specializationFree = 0
           actor.system.skills.brawl.rank.trained = 1
           actor.experiencePoints.spent = 10
-          actor.freeSkillRanks = {
+          actor.system.progression.freeSkillRanks = {
             career: {
               spent: 4,
               gained: 4,
@@ -508,7 +508,7 @@ describe('SkillFactory build()', () => {
           actor.system.skills.brawl.rank.careerFree = 0
           actor.system.skills.brawl.rank.specializationFree = 0
           actor.system.skills.brawl.rank.trained = 1
-          actor.freeSkillRanks = {
+          actor.system.progression.freeSkillRanks = {
             career: {
               spent: 4,
               gained: 4,


### PR DESCRIPTION
## Summary
- Restore getters (`species`, `experiencePoints`, `abilities`, etc.) that were removed during a refactor, causing `undefined` errors.
- Fix `freeSkillRanks` undefined error by adding the missing getter and computing `available` dynamically instead of relying on a non-existent property.
- Update `skill-factory.mjs` to avoid relying on the missing `.available` property.
- Update tests to use `system.progression.freeSkillRanks` instead of direct assignment to the getter.

## Related Issues
Fixes the error: `Uncaught (in promise) TypeError: can't access property "career", this.freeSkillRanks is undefined` when opening character sheets.

## Testing
- Unit tests updated to reflect the new getter behavior.
- Manual testing needed to confirm the character sheet opens without errors.