### PR TITLE
refactor(skills): update TrainedSkill to use updateExperiencePoints() (Phase 2)

### DIFF
--- a/module/lib/skills/trained-skill.mjs
+++ b/module/lib/skills/trained-skill.mjs
@@ -9,12 +9,12 @@ export default class TrainedSkill extends Skill {
     this.dataCostCalculator = new SkillCostCalculator(this)
   }
 
-  process() {
+  async process() {
     this.freeSkillRankAvailable = this.#computeFreeSkillRankAvailable()
 
     let trained = this.data.rank.trained
 
-    let experiencePointsSpent = this.actor.experiencePoints.spent
+    let experiencePointsSpent = this.actor.system.progression.experience.spent
     let value
 
     if (this.action === 'train') {
@@ -41,13 +41,13 @@ export default class TrainedSkill extends Skill {
       return new ErrorSkill(this.actor, this.data, {}, { message: "you can't have more than 5 rank!" })
     }
 
-    if (experiencePointsSpent > this.actor.experiencePoints.total) {
+    if (experiencePointsSpent > this.actor.system.progression.experience.total) {
       return new ErrorSkill(this.actor, this.data, {}, { message: "you can't spend more experience than your total!" })
     }
 
     this.data.rank.value = value
     this.data.rank.trained = trained
-    this.actor.experiencePoints.spent = experiencePointsSpent
+    await this.actor.updateExperiencePoints({ spent: experiencePointsSpent })
     this.evaluated = true
     return this
   }
@@ -71,7 +71,6 @@ export default class TrainedSkill extends Skill {
       })
     }
     try {
-      await this.actor.update({ 'system.progression.experience.spent': this.actor.experiencePoints.spent })
       await this.actor.update({ [`system.skills.${this.data.id}.rank`]: this.data.rank })
       return new Promise((resolve, _) => {
         resolve(this)

--- a/tests/lib/skills/trained-skill-additional.test.mjs
+++ b/tests/lib/skills/trained-skill-additional.test.mjs
@@ -9,12 +9,13 @@ import ErrorSkill from '../../../module/lib/skills/error-skill.mjs'
 
 describe('Trained Skill - Additional Coverage', () => {
   describe('process() edge cases', () => {
-    test('should return ErrorSkill when experiencePoints.spent equals total after training', () => {
+    test('should return ErrorSkill when experiencePoints.spent equals total after training', async () => {
       const actor = createActor()
-      actor.experiencePoints.spent = 95
-      actor.experiencePoints.gained = 100
-      actor.experiencePoints.total = 100
-      actor.experiencePoints.available = 5
+      actor.system.progression.experience.spent = 95
+      actor.system.progression.experience.gained = 100
+      actor.system.progression.experience.total = 100
+      actor.system.progression.experience.available = 5
+      actor.updateExperiencePoints = vi.fn().mockResolvedValue(actor)
 
       const data = createSkillData({ trained: 0 })
       const params = {
@@ -26,7 +27,7 @@ describe('Trained Skill - Additional Coverage', () => {
       const options = {}
 
       const trainedSkill = new TrainedSkill(actor, data, params, options)
-      const result = trainedSkill.process()
+      const result = await trainedSkill.process()
 
       // Rank 0 -> 1, cost = 1 * 5 + 5 = 10 (non-specialized)
       // 95 + 10 = 105 > 100 total, should fail
@@ -34,12 +35,13 @@ describe('Trained Skill - Additional Coverage', () => {
       expect(result.options.message).toBe("you can't spend more experience than your total!")
     })
 
-    test('should succeed when experiencePoints.spent + cost equals total exactly', () => {
+    test('should succeed when experiencePoints.spent + cost equals total exactly', async () => {
       const actor = createActor()
-      actor.experiencePoints.spent = 90
-      actor.experiencePoints.gained = 100
-      actor.experiencePoints.total = 100
-      actor.experiencePoints.available = 10
+      actor.system.progression.experience.spent = 90
+      actor.system.progression.experience.gained = 100
+      actor.system.progression.experience.total = 100
+      actor.system.progression.experience.available = 10
+      actor.updateExperiencePoints = vi.fn().mockResolvedValue(actor)
 
       const data = createSkillData({ trained: 0 })
       const params = {
@@ -51,15 +53,16 @@ describe('Trained Skill - Additional Coverage', () => {
       const options = {}
 
       const trainedSkill = new TrainedSkill(actor, data, params, options)
-      const result = trainedSkill.process()
+      const result = await trainedSkill.process()
 
       // 90 + 5 = 95 <= 100, should succeed
       expect(result).toBeInstanceOf(TrainedSkill)
       expect(result.data.rank.trained).toBe(1)
     })
 
-    test('should return ErrorSkill when forgetting with trained = 0 (bug: code checks wrong variable)', () => {
+    test('should return ErrorSkill when forgetting with trained = 0 (bug: code checks wrong variable)', async () => {
       const actor = createActor()
+      actor.updateExperiencePoints = vi.fn().mockResolvedValue(actor)
       const data = createSkillData({ trained: 0 })
       const params = {
         action: 'forget',
@@ -70,7 +73,7 @@ describe('Trained Skill - Additional Coverage', () => {
       const options = {}
 
       const trainedSkill = new TrainedSkill(actor, data, params, options)
-      const result = trainedSkill.process()
+      const result = await trainedSkill.process()
 
       // NOTE: There's a bug in the code - it checks this.data.rank.trained < 0 instead of the local 'trained' variable
       // When trained=0 and action=forget, local 'trained' becomes -1, but this.data.rank.trained is still 0
@@ -78,8 +81,9 @@ describe('Trained Skill - Additional Coverage', () => {
       expect(result).toBeInstanceOf(TrainedSkill) // Actual behavior due to bug
     })
 
-    test('should return ErrorSkill when forgetting with trained already negative', () => {
+    test('should return ErrorSkill when forgetting with trained already negative', async () => {
       const actor = createActor()
+      actor.updateExperiencePoints = vi.fn().mockResolvedValue(actor)
       const data = createSkillData({ trained: -1 }) // Already negative
       const params = {
         action: 'forget',
@@ -90,17 +94,18 @@ describe('Trained Skill - Additional Coverage', () => {
       const options = {}
 
       const trainedSkill = new TrainedSkill(actor, data, params, options)
-      const result = trainedSkill.process()
+      const result = await trainedSkill.process()
 
       expect(result).toBeInstanceOf(ErrorSkill)
       expect(result.options.message).toBe("you can't forget this rank because it was not trained but free!")
     })
 
-    test('should handle training at rank 5 during creation (isCreation=true)', () => {
+    test('should handle training at rank 5 during creation (isCreation=true)', async () => {
       const actor = createActor()
-      actor.experiencePoints.gained = 1000
-      actor.experiencePoints.total = 1000
-      actor.experiencePoints.available = 1000
+      actor.system.progression.experience.gained = 1000
+      actor.system.progression.experience.total = 1000
+      actor.system.progression.experience.available = 1000
+      actor.updateExperiencePoints = vi.fn().mockResolvedValue(actor)
 
       const data = createSkillData({ trained: 1, value: 1 })
       const params = {
@@ -112,15 +117,17 @@ describe('Trained Skill - Additional Coverage', () => {
       const options = {}
 
       const trainedSkill = new TrainedSkill(actor, data, params, options)
-      const result = trainedSkill.process()
+      const result = await trainedSkill.process()
 
       // Value becomes 2, which is allowed during creation
       expect(result).toBeInstanceOf(TrainedSkill)
       expect(result.data.rank.value).toBe(2)
     })
 
-    test('should return ErrorSkill when training beyond rank 2 during creation', () => {
+    test('should return ErrorSkill when training beyond rank 2 during creation', async () => {
       const actor = createActor()
+      actor.updateExperiencePoints = vi.fn().mockResolvedValue(actor)
+
       const data = createSkillData({ trained: 2, value: 2 })
       const params = {
         action: 'train',
@@ -131,17 +138,18 @@ describe('Trained Skill - Additional Coverage', () => {
       const options = {}
 
       const trainedSkill = new TrainedSkill(actor, data, params, options)
-      const result = trainedSkill.process()
+      const result = await trainedSkill.process()
 
       expect(result).toBeInstanceOf(ErrorSkill)
       expect(result.options.message).toBe("you can't have more than 2 rank at creation!")
     })
 
-    test('should correctly update experiencePoints.spent when forgetting', () => {
+    test('should correctly update experiencePoints.spent when forgetting', async () => {
       const actor = createActor()
-      actor.experiencePoints.spent = 15
-      actor.experiencePoints.gained = 100
-      actor.experiencePoints.available = 85
+      actor.system.progression.experience.spent = 15
+      actor.system.progression.experience.gained = 100
+      actor.system.progression.experience.available = 85
+      actor.updateExperiencePoints = vi.fn().mockResolvedValue(actor)
 
       const data = createSkillData({ careerFree: 1, trained: 1, value: 2 })
       const params = {
@@ -153,13 +161,13 @@ describe('Trained Skill - Additional Coverage', () => {
       const options = {}
 
       const trainedSkill = new TrainedSkill(actor, data, params, options)
-      const result = trainedSkill.process()
+      const result = await trainedSkill.process()
 
       expect(result).toBeInstanceOf(TrainedSkill)
       expect(result.data.rank.trained).toBe(0)
       // Forgetting rank 2 (value was 2, becomes 1): cost = calculateForgetCost(1) = calculateTrainCost(2) = 2 * 5 = 10 (specialized)
       // spent: 15 - 10 = 5
-      expect(result.actor.experiencePoints.spent).toBe(5)
+      expect(actor.updateExperiencePoints).toHaveBeenCalledWith({ spent: 5 })
     })
   })
 
@@ -168,6 +176,7 @@ describe('Trained Skill - Additional Coverage', () => {
       const actor = createActor()
       const updateMock = vi.fn().mockRejectedValue(new Error('Update failed'))
       actor.update = updateMock
+      actor.updateExperiencePoints = vi.fn().mockResolvedValue(actor)
 
       const data = createSkillData({ trained: 0 })
       const params = {
@@ -179,7 +188,7 @@ describe('Trained Skill - Additional Coverage', () => {
       const options = {}
 
       const trainedSkill = new TrainedSkill(actor, data, params, options)
-      trainedSkill.process()
+      await trainedSkill.process()
       const result = await trainedSkill.updateState()
 
       expect(result).toBeInstanceOf(ErrorSkill)

--- a/tests/lib/skills/trained-skill.test.mjs
+++ b/tests/lib/skills/trained-skill.test.mjs
@@ -9,8 +9,9 @@ import ErrorSkill from '../../../module/lib/skills/error-skill.mjs'
 
 describe('Trained Skill', () => {
   describe('train a skill', () => {
-    test('should increase the trained skill rank', () => {
+    test('should increase the trained skill rank', async () => {
       const actor = createActor()
+      actor.updateExperiencePoints = vi.fn().mockResolvedValue(actor)
       const data = createSkillData()
       const params = {
         action: 'train',
@@ -21,22 +22,22 @@ describe('Trained Skill', () => {
       const options = {}
 
       const trainedSkill = new TrainedSkill(actor, data, params, options)
-      const trainTrainedSkill = trainedSkill.process()
+      const trainTrainedSkill = await trainedSkill.process()
 
       expect(trainTrainedSkill.data.rank.trained).toBe(1)
       expect(trainTrainedSkill.data.rank.specializationFree).toBe(0)
-      expect(trainTrainedSkill.actor.freeSkillRanks.specialization.spent).toBe(0)
-      expect(trainTrainedSkill.actor.freeSkillRanks.career.spent).toBe(0)
+      expect(trainTrainedSkill.actor.system.progression.freeSkillRanks.specialization.spent).toBe(0)
+      expect(trainTrainedSkill.actor.system.progression.freeSkillRanks.career.spent).toBe(0)
       expect(trainTrainedSkill.data.rank.careerFree).toBe(0)
-      expect(trainedSkill.actor.experiencePoints.spent).toBe(5)
+      expect(actor.updateExperiencePoints).toHaveBeenCalledWith({ spent: 5 })
     })
   })
   describe('forget a skill', () => {
-    test('should decrease the trained skill rank', () => {
+    test('should decrease the trained skill rank', async () => {
       const actor = createActor()
-      actor.experiencePoints.spent = 20
-      actor.experiencePoints.gained = 100
-      actor.experiencePoints.available = 80
+      actor.system.progression.experience.spent = 20
+      actor.system.progression.experience.gained = 100
+      actor.updateExperiencePoints = vi.fn().mockResolvedValue(actor)
       const data = createSkillData({ trained: 1 })
       const params = {
         action: 'forget',
@@ -47,19 +48,19 @@ describe('Trained Skill', () => {
       const options = {}
 
       const trainedSkill = new TrainedSkill(actor, data, params, options)
-      const forgetTrainedSkill = trainedSkill.process()
+      const forgetTrainedSkill = await trainedSkill.process()
 
       expect(forgetTrainedSkill.data.rank.trained).toBe(0)
       expect(forgetTrainedSkill.data.rank.specializationFree).toBe(0)
-      expect(forgetTrainedSkill.actor.freeSkillRanks.specialization.spent).toBe(0)
-      expect(forgetTrainedSkill.actor.freeSkillRanks.career.spent).toBe(0)
+      expect(forgetTrainedSkill.actor.system.progression.freeSkillRanks.specialization.spent).toBe(0)
+      expect(forgetTrainedSkill.actor.system.progression.freeSkillRanks.career.spent).toBe(0)
       expect(forgetTrainedSkill.data.rank.careerFree).toBe(0)
-      expect(trainedSkill.actor.experiencePoints.spent).toBe(10)
+      expect(actor.updateExperiencePoints).toHaveBeenCalledWith({ spent: 10 })
     })
   })
   describe('evaluate a skill', () => {
     describe('should return an error skill if', () => {
-      test('trained skill rank is less than 0', () => {
+      test('trained skill rank is less than 0', async () => {
         const actor = createActor()
         const data = createSkillData({ trained: -1 })
         const params = {
@@ -71,17 +72,16 @@ describe('Trained Skill', () => {
         const options = {}
 
         const trainedSkill = new TrainedSkill(actor, data, params, options)
-        const errorSkill = trainedSkill.process()
+        const errorSkill = await trainedSkill.process()
 
         expect(errorSkill).toBeInstanceOf(ErrorSkill)
         expect(errorSkill.options.message).toBe("you can't forget this rank because it was not trained but free!")
         expect(errorSkill.evaluated).toBe(false)
       })
-      test('trained a skill costs more than experience points available', () => {
+      test('trained a skill costs more than experience points available', async () => {
         const actor = createActor()
-        actor.experiencePoints.spent = 90
-        actor.experiencePoints.gained = 100
-        actor.experiencePoints.available = 10
+        actor.system.progression.experience.spent = 90
+        actor.system.progression.experience.gained = 100
         const data = createSkillData({ careerFree: 1, trained: 1, value: 2 })
         const params = {
           action: 'train',
@@ -92,13 +92,13 @@ describe('Trained Skill', () => {
         const options = {}
 
         const trainedSkill = new TrainedSkill(actor, data, params, options)
-        const errorSkill = trainedSkill.process()
+        const errorSkill = await trainedSkill.process()
 
         expect(errorSkill).toBeInstanceOf(ErrorSkill)
         expect(errorSkill.options.message).toBe("you can't spend more experience than your total!")
         expect(errorSkill.evaluated).toBe(false)
       })
-      test('trained skill rank is greater than 2 and isCreation is true', () => {
+      test('trained skill rank is greater than 2 and isCreation is true', async () => {
         const actor = createActor()
         const data = createSkillData({ trained: 3 })
         const params = {
@@ -110,13 +110,13 @@ describe('Trained Skill', () => {
         const options = {}
 
         const trainedSkill = new TrainedSkill(actor, data, params, options)
-        const errorSkill = trainedSkill.process()
+        const errorSkill = await trainedSkill.process()
 
         expect(errorSkill).toBeInstanceOf(ErrorSkill)
         expect(errorSkill.options.message).toBe("you can't have more than 2 rank at creation!")
         expect(errorSkill.evaluated).toBe(false)
       })
-      test('trained skill rank is greater than 5 and isCreation is false', () => {
+      test('trained skill rank is greater than 5 and isCreation is false', async () => {
         const actor = createActor()
         const data = createSkillData({ trained: 6 })
         const params = {
@@ -128,7 +128,7 @@ describe('Trained Skill', () => {
         const options = {}
 
         const trainedSkill = new TrainedSkill(actor, data, params, options)
-        const errorSkill = trainedSkill.process()
+        const errorSkill = await trainedSkill.process()
 
         expect(errorSkill).toBeInstanceOf(ErrorSkill)
         expect(errorSkill.options.message).toBe("you can't have more than 5 rank!")
@@ -136,11 +136,10 @@ describe('Trained Skill', () => {
       })
     })
     describe('should return a trained skill if', () => {
-      test('trained skill rank is 1 and only 1', () => {
+      test('trained skill rank is 1 and only 1', async () => {
         const actor = createActor()
-        actor.experiencePoints.spent = 10
-        actor.experiencePoints.gained = 100
-        actor.experiencePoints.available = 90
+        actor.system.progression.experience.spent = 10
+        actor.updateExperiencePoints = vi.fn().mockResolvedValue(actor)
         const data = createSkillData({ careerFree: 1, specializationFree: 0, trained: 0, value: 1 })
         const params = {
           action: 'train',
@@ -150,7 +149,7 @@ describe('Trained Skill', () => {
         }
         const options = {}
         const trainedFreeSkill = new TrainedSkill(actor, data, params, options)
-        const evaluatedSkill = trainedFreeSkill.process()
+        const evaluatedSkill = await trainedFreeSkill.process()
         expect(evaluatedSkill).toBeInstanceOf(TrainedSkill)
         expect(evaluatedSkill.data.rank.trained).toBe(1)
         expect(evaluatedSkill.data.rank.value).toBe(2)
@@ -163,6 +162,7 @@ describe('Trained Skill', () => {
       const actor = createActor()
       const updateMock = vi.fn().mockResolvedValue({})
       actor.update = updateMock
+      actor.updateExperiencePoints = vi.fn().mockResolvedValue(actor)
       const data = createSkillData({ careerFree: 1, specializationFree: 1, trained: 0, value: 3 })
       const params = {
         action: 'train',
@@ -172,11 +172,11 @@ describe('Trained Skill', () => {
       }
       const options = {}
       const trainedFreeSkill = new TrainedSkill(actor, data, params, options)
-      const processedTrainedSkill = trainedFreeSkill.process()
+      const processedTrainedSkill = await trainedFreeSkill.process()
       const updatedSkill = await processedTrainedSkill.updateState()
       expect(updatedSkill).toBeInstanceOf(TrainedSkill)
-      expect(updateMock).toHaveBeenCalledTimes(2)
-      expect(updateMock).toHaveBeenNthCalledWith(2, {
+      expect(updateMock).toHaveBeenCalledTimes(1)
+      expect(updateMock).toHaveBeenCalledWith({
         'system.skills.skill-id.rank': {
           base: 0,
           careerFree: 1,
@@ -184,9 +184,6 @@ describe('Trained Skill', () => {
           trained: 1,
           value: 3,
         },
-      })
-      expect(updateMock).toHaveBeenNthCalledWith(1, {
-        'system.progression.experience.spent': 15,
       })
     })
     describe('should return an Error Skill if any update fails', () => {
@@ -203,33 +200,25 @@ describe('Trained Skill', () => {
         expect(result).toBeInstanceOf(ErrorSkill)
         expect(result.options.message).toContain('you must evaluate the skill before updating it!')
       })
-      test('free skill ranks update fails', async () => {
+      test('skill rank update fails', async () => {
         const actor = createActor()
-        const updateMock = vi.fn().mockRejectedValueOnce(new Error('Erreur sur premier update'))
+        actor.updateExperiencePoints = vi.fn().mockResolvedValue({})
+        const updateMock = vi.fn().mockRejectedValueOnce(new Error('Erreur sur update'))
         actor.update = updateMock
-        const data = createSkillData({ trainedFree: 1, specializationFree: 1, trained: 1 })
-        const params = {}
+        const data = createSkillData({ careerFree: 1, specializationFree: 1, trained: 1 })
+        const params = {
+          action: 'train',
+          isCreation: false,
+          isCareer: true,
+          isSpecialization: true,
+        }
         const options = {}
         const trainedFreeSkill = new TrainedSkill(actor, data, params, options)
-        trainedFreeSkill.process()
+        await trainedFreeSkill.process()
         const result = await trainedFreeSkill.updateState()
         expect(updateMock).toHaveBeenCalledTimes(1)
         expect(result).toBeInstanceOf(ErrorSkill)
-        expect(result.options.message).toContain('Erreur sur premier update')
-      })
-      test('skill rank update fails', async () => {
-        const actor = createActor()
-        const updateMock = vi.fn().mockResolvedValueOnce({}).mockRejectedValueOnce(new Error('Erreur sur deuxième update'))
-        actor.update = updateMock
-        const data = createSkillData({ trainedFree: 1, specializationFree: 1, trained: 1 })
-        const params = {}
-        const options = {}
-        const trainedFreeSkill = new TrainedSkill(actor, data, params, options)
-        trainedFreeSkill.process()
-        const result = await trainedFreeSkill.updateState()
-        expect(updateMock).toHaveBeenCalledTimes(2)
-        expect(result).toBeInstanceOf(ErrorSkill)
-        expect(result.options.message).toContain('Erreur sur deuxième update')
+        expect(result.options.message).toContain('Erreur sur update')
       })
     })
   })


### PR DESCRIPTION
## Summary
- Refactor `trained-skill.mjs` to use `actor.system.progression.experience`
- Use `await this.actor.updateExperiencePoints()` instead of direct state mutation
- Update `trained-skill.test.mjs` and `trained-skill-additional.test.mjs`
- Update `tests/utils/actors/actor.mjs` with `updateExperiencePoints` mock

## Related Issue
Fixes #77

## Changes
- `module/lib/skills/trained-skill.mjs`: Use new update method
- `tests/lib/skills/trained-skill.test.mjs`: Updated tests
- `tests/lib/skills/trained-skill-additional.test.mjs`: Updated tests
- `tests/utils/actors/actor.mjs`: Added mock

## Testing
All TrainedSkill tests pass with new async pattern.