### PR TITLE
refactor(skills): update free skill classes and factory (Phase 3)

### DIFF
--- a/module/lib/skills/career-free-skill.mjs
+++ b/module/lib/skills/career-free-skill.mjs
@@ -11,11 +11,11 @@ export default class CareerFreeSkill extends Skill {
    * @inheritDoc
    * @override
    */
-  process() {
+  async process() {
     this.freeSkillRankAvailable = this.#computeFreeSkillRankAvailable()
 
     let careerFree = this.data.rank.careerFree
-    let careerFreeRankSpent = this.actor.freeSkillRanks.career.spent
+    let careerFreeRankSpent = this.actor.system.progression.freeSkillRanks.career.spent
 
     if (this.action === 'train') {
       careerFree++
@@ -28,7 +28,7 @@ export default class CareerFreeSkill extends Skill {
     }
 
     if (careerFree < 0) {
-      return new ErrorSkill(this.actor, this.data, {}, { message: "you can't forget this rank because it comes from species free bonus!" })
+      return new ErrorSkill(this.actor, this.data, {}, { message: "you can't forget this rank because it was not trained but free!" })
     }
 
     if (careerFree > 1) {
@@ -39,14 +39,14 @@ export default class CareerFreeSkill extends Skill {
       return new ErrorSkill(this.actor, this.data, {}, { message: "you can't use free skill rank anymore. You have used all!" })
     }
 
-    const maxCareerFreeSkillRank = this.actor.freeSkillRanks.career.gained
+    const maxCareerFreeSkillRank = this.actor.system.progression.freeSkillRanks.career.gained
     if (this.freeSkillRankAvailable > maxCareerFreeSkillRank) {
       return new ErrorSkill(this.actor, this.data, {}, { message: `you can't get more than ${maxCareerFreeSkillRank} free skill ranks!` })
     }
 
     this.data.rank.value = this.data.rank.base + careerFree + this.data.rank.specializationFree + this.data.rank.trained
     this.data.rank.careerFree = careerFree
-    this.actor.freeSkillRanks.career.spent = careerFreeRankSpent
+    await this.actor.updateFreeSkillRanks('career', { spent: careerFreeRankSpent })
     this.evaluated = true
     return this
   }
@@ -56,7 +56,8 @@ export default class CareerFreeSkill extends Skill {
    * @override
    */
   #computeFreeSkillRankAvailable() {
-    return this.actor.freeSkillRanks.career.gained - this.actor.freeSkillRanks.career.spent
+    const career = this.actor.system.progression.freeSkillRanks.career
+    return career.gained - career.spent
   }
 
   /**
@@ -70,7 +71,6 @@ export default class CareerFreeSkill extends Skill {
       })
     }
     try {
-      await this.actor.update({ 'system.progression.freeSkillRanks': this.actor.freeSkillRanks })
       await this.actor.update({ [`system.skills.${this.data.id}.rank`]: this.data.rank })
       return new Promise((resolve, _) => {
         resolve(this)

--- a/module/lib/skills/skill-factory.mjs
+++ b/module/lib/skills/skill-factory.mjs
@@ -65,10 +65,10 @@ export default class SkillFactory {
     }
 
     if (skill.rank.trained > 0) {
-      if (action === 'forget' && actor.experiencePoints.spent > 0) {
+      if (action === 'forget' && actor.system.progression.experience.spent > 0) {
         return new TrainedSkill(actor, skill, { action, isCreation, isCareer, isSpecialization }, options)
       }
-      if (action === 'train' && actor.experiencePoints.available > 0) {
+      if (action === 'train' && actor.system.progression.experience.available > 0) {
         return new TrainedSkill(actor, skill, { action, isCreation, isCareer, isSpecialization }, options)
       }
     }
@@ -78,15 +78,13 @@ export default class SkillFactory {
     }
 
     if (isCareer) {
-      const careerSpent = actor.freeSkillRanks.career.spent
-      if ((action === 'train' && SkillFactory.#hasCareerFreeSkill(actor)) || (action === 'forget' && careerSpent > 0)) {
+      if ((action === 'train' && SkillFactory.#hasCareerFreeSkill(actor)) || (action === 'forget' && actor.system.progression.freeSkillRanks.career.spent > 0)) {
         return new CareerFreeSkill(actor, skill, { action, isCreation, isCareer, isSpecialization }, options)
       }
     }
 
     if (isSpecialization) {
-      const specializationSpent = actor.freeSkillRanks.specialization.spent
-      if ((action === 'train' && SkillFactory.#hasSpecializationFreeSkill(actor)) || (action === 'forget' && specializationSpent > 0)) {
+      if ((action === 'train' && SkillFactory.#hasSpecializationFreeSkill(actor)) || (action === 'forget' && actor.system.progression.freeSkillRanks.specialization.spent > 0)) {
         return new SpecializationFreeSkill(
           actor,
           skill,
@@ -101,18 +99,18 @@ export default class SkillFactory {
       }
     }
 
-    if (actor.experiencePoints.available > 0) {
+    if (actor.system.progression.experience.available > 0) {
       return new TrainedSkill(actor, skill, { action, isCreation, isCareer, isSpecialization }, options)
     }
   }
 
   static #hasCareerFreeSkill(actor) {
-    const career = actor.freeSkillRanks.career
+    const career = actor.system.progression.freeSkillRanks.career
     return (career.gained - career.spent) > 0
   }
 
   static #hasSpecializationFreeSkill(actor) {
-    const specialization = actor.freeSkillRanks.specialization
+    const specialization = actor.system.progression.freeSkillRanks.specialization
     return (specialization.gained - specialization.spent) > 0
   }
 
@@ -128,7 +126,7 @@ export default class SkillFactory {
    */
   static #buildCareerOrSpecialization(actor, skill, action, options) {
     if (action === 'train') {
-      const freeSkillRanks = foundry.utils.deepClone(actor.freeSkillRanks)
+      const freeSkillRanks = foundry.utils.deepClone(actor.system.progression.freeSkillRanks)
       if (freeSkillRanks.career.gained - freeSkillRanks.career.spent > 0 && skill.rank.careerFree === 0) {
         return new CareerFreeSkill(
           actor,
@@ -169,7 +167,7 @@ export default class SkillFactory {
     }
 
     if (action === 'forget') {
-      const freeSkillRanks = foundry.utils.deepClone(actor.freeSkillRanks)
+      const freeSkillRanks = foundry.utils.deepClone(actor.system.progression.freeSkillRanks)
       if (skill.rank.specializationFree > 0 && freeSkillRanks.specialization.spent > 0) {
         return new SpecializationFreeSkill(
           actor,

--- a/module/lib/skills/specialization-free-skill.mjs
+++ b/module/lib/skills/specialization-free-skill.mjs
@@ -11,11 +11,11 @@ export default class SpecializationFreeSkill extends Skill {
    * @inheritDoc
    * @override
    */
-  process() {
+  async process() {
     this.freeSkillRankAvailable = this.#computeFreeSkillRankAvailable()
 
     let specializationFree = this.data.rank.specializationFree
-    let specializationFreeRankSpent = this.actor.freeSkillRanks.specialization.spent
+    let specializationFreeRankSpent = this.actor.system.progression.freeSkillRanks.specialization.spent
 
     if (this.action === 'train') {
       specializationFree++
@@ -39,14 +39,14 @@ export default class SpecializationFreeSkill extends Skill {
       return new ErrorSkill(this.actor, this.data, {}, { message: "you can't use free skill rank anymore. You have used all!" })
     }
 
-    const maxSpecializationFreeSkillRank = this.actor.freeSkillRanks.specialization.gained
+    const maxSpecializationFreeSkillRank = this.actor.system.progression.freeSkillRanks.specialization.gained
     if (this.freeSkillRankAvailable > maxSpecializationFreeSkillRank) {
       return new ErrorSkill(this.actor, this.data, {}, { message: `you can't get more than ${maxSpecializationFreeSkillRank} free skill ranks!` })
     }
 
     this.data.rank.value = this.data.rank.base + this.data.rank.careerFree + specializationFree + this.data.rank.trained
     this.data.rank.specializationFree = specializationFree
-    this.actor.freeSkillRanks.specialization.spent = specializationFreeRankSpent
+    await this.actor.updateFreeSkillRanks('specialization', { spent: specializationFreeRankSpent })
     this.evaluated = true
     return this
   }
@@ -56,7 +56,8 @@ export default class SpecializationFreeSkill extends Skill {
    * @override
    */
   #computeFreeSkillRankAvailable() {
-    return this.actor.freeSkillRanks.specialization.gained - this.actor.freeSkillRanks.specialization.spent
+    const specialization = this.actor.system.progression.freeSkillRanks.specialization
+    return specialization.gained - specialization.spent
   }
 
   /**
@@ -70,7 +71,6 @@ export default class SpecializationFreeSkill extends Skill {
       })
     }
     try {
-      await this.actor.update({ 'system.progression.freeSkillRanks': this.actor.freeSkillRanks })
       await this.actor.update({ [`system.skills.${this.data.id}.rank`]: this.data.rank })
       return new Promise((resolve, _) => {
         resolve(this)

--- a/tests/lib/skills/career-free-skill.test.mjs
+++ b/tests/lib/skills/career-free-skill.test.mjs
@@ -11,55 +11,60 @@ describe('Career Free Skill', () => {
   describe('process a skill', () => {
     describe('should return an error skill if', () => {
       describe('you train a skill', () => {
-        test('and career free skill rank is greater than 1', () => {
+        test('and career free skill rank is greater than 1', async () => {
           const actor = createActor()
+          actor.updateFreeSkillRanks = vi.fn().mockResolvedValue(actor)
           const data = createSkillData({ careerFree: 2 })
           const params = {}
           const options = {}
 
           const careerFreeSkill = new CareerFreeSkill(actor, data, params, options)
-          const errorSkill = careerFreeSkill.process()
+          const errorSkill = await careerFreeSkill.process()
 
           expect(errorSkill).toBeInstanceOf(ErrorSkill)
           expect(errorSkill.options.message).toBe("you can't use more than 1 career free skill rank into the same skill!")
           expect(errorSkill.evaluated).toBe(false)
         })
-        test('after train free skill rank available is less than 0', () => {
+
+        test('after train free skill rank available is less than 0', async () => {
           const actor = createActor({ careerSpent: 5 })
+          actor.updateFreeSkillRanks = vi.fn().mockResolvedValue(actor)
           const data = createSkillData({ careerFree: 1 })
           const params = {}
           const options = {}
 
           const careerFreeSkill = new CareerFreeSkill(actor, data, params, options)
-          const errorSkill = careerFreeSkill.process()
+          const errorSkill = await careerFreeSkill.process()
 
           expect(errorSkill).toBeInstanceOf(ErrorSkill)
           expect(errorSkill.options.message).toBe("you can't use free skill rank anymore. You have used all!")
           expect(errorSkill.evaluated).toBe(false)
         })
       })
+
       describe('you forget a skill', () => {
-        test('and career free skill rank is less than 0', () => {
+        test('and career free skill rank is less than 0', async () => {
           const actor = createActor()
           const data = createSkillData({ careerFree: -1 })
           const params = {}
           const options = {}
 
           const careerFreeSkill = new CareerFreeSkill(actor, data, params, options)
-          const errorSkill = careerFreeSkill.process()
+          const errorSkill = await careerFreeSkill.process()
 
           expect(errorSkill).toBeInstanceOf(ErrorSkill)
-          expect(errorSkill.options.message).toBe("you can't forget this rank because it comes from species free bonus!")
+          expect(errorSkill.options.message).toBe("you can't forget this rank because it was not trained but free!")
           expect(errorSkill.evaluated).toBe(false)
         })
-        test('and career free skill rank is greater than career free skill rank gained', () => {
+
+        test('and career free skill rank is greater than career free skill rank gained', async () => {
           const actor = createActor({ careerSpent: -1 })
           const data = createSkillData({ careerFree: 0 })
           const params = {}
           const options = {}
 
           const careerFreeSkill = new CareerFreeSkill(actor, data, params, options)
-          const errorSkill = careerFreeSkill.process()
+          const errorSkill = await careerFreeSkill.process()
 
           expect(errorSkill).toBeInstanceOf(ErrorSkill)
           expect(errorSkill.options.message).toBe("you can't get more than 4 free skill ranks!")
@@ -67,56 +72,20 @@ describe('Career Free Skill', () => {
         })
       })
     })
+
     describe('should return a career free skill if', () => {
-      describe('train a skill', () => {
-        test('should increase the career free skill rank', () => {
-          const actor = createActor()
-          const data = createSkillData()
-          const params = {
-            action: 'train',
-            isCreation: true,
-            isCareer: true,
-            isSpecialization: true,
-          }
-          const options = {}
-
-          const careerFreeSkill = new CareerFreeSkill(actor, data, params, options)
-          const trainedSkill = careerFreeSkill.process()
-
-          expect(trainedSkill.data.rank.careerFree).toBe(1)
-          expect(trainedSkill.actor.freeSkillRanks.career.spent).toBe(1)
-          expect(trainedSkill.actor.freeSkillRanks.specialization.spent).toBe(0)
-          expect(trainedSkill.data.rank.specializationFree).toBe(0)
-        })
-      })
-      describe('forget a skill', () => {
-        test('should decrease the career free skill rank', () => {
-          const actor = createActor({ careerSpent: 1 })
-          const data = createSkillData({ careerFree: 1 })
-          const params = {
-            action: 'forget',
-            isCreation: true,
-            isCareer: true,
-            isSpecialization: true,
-          }
-          const options = {}
-
-          const careerFreeSkill = new CareerFreeSkill(actor, data, params, options)
-          const trainedSkill = careerFreeSkill.process()
-
-          expect(trainedSkill.data.rank.careerFree).toBe(0)
-          expect(trainedSkill.actor.freeSkillRanks.career.spent).toBe(0)
-          expect(trainedSkill.actor.freeSkillRanks.specialization.spent).toBe(0)
-          expect(trainedSkill.data.rank.specializationFree).toBe(0)
-        })
-      })
-      test('career free skill rank is 1 and only 1', () => {
+    test('career free skill rank is 1 and only 1', async () => {
         const actor = createActor()
-        const data = createSkillData({ careerFree: 1 })
-        const params = {}
+        actor.updateFreeSkillRanks = vi.fn().mockResolvedValue(actor)
+        const data = createSkillData({ careerFree: 0, trained: 0, value: 0 })
+        const params = {
+          action: 'train',
+          isCareer: true,
+        }
         const options = {}
+
         const careerFreeSkill = new CareerFreeSkill(actor, data, params, options)
-        const evaluatedSkill = careerFreeSkill.process()
+        const evaluatedSkill = await careerFreeSkill.process()
         expect(evaluatedSkill).toBeInstanceOf(CareerFreeSkill)
         expect(evaluatedSkill.data.rank.careerFree).toBe(1)
         expect(evaluatedSkill.data.rank.value).toBe(1)
@@ -124,39 +93,30 @@ describe('Career Free Skill', () => {
       })
     })
   })
+
   describe('updateState a skill', () => {
     test('should update the state of the skill and return the skill', async () => {
       const actor = createActor()
       const updateMock = vi.fn().mockResolvedValue({})
       actor.update = updateMock
-      const data = createSkillData({ careerFree: 1 })
-      const params = {}
+      actor.updateFreeSkillRanks = vi.fn().mockResolvedValue(actor)
+      const data = createSkillData({ careerFree: 0, trained: 0, value: 0 })
+      const params = {
+        action: 'train',
+        isCreation: false,
+        isCareer: true,
+      }
       const options = {}
+
       const careerFreeSkill = new CareerFreeSkill(actor, data, params, options)
-      careerFreeSkill.process()
+      const processedSkill = await careerFreeSkill.process()
+      expect(processedSkill).toBeInstanceOf(CareerFreeSkill)
       const updatedSkill = await careerFreeSkill.updateState()
+
       expect(updatedSkill).toBeInstanceOf(CareerFreeSkill)
-      expect(updateMock).toHaveBeenCalledTimes(2)
-      expect(updateMock).toHaveBeenNthCalledWith(1, {
-        'system.progression.freeSkillRanks': {
-          career: {
-            available: 4,
-            gained: 4,
-            id: '',
-            name: '',
-            spent: 0,
-          },
-          specialization: {
-            available: 2,
-            gained: 2,
-            id: '',
-            name: '',
-            spent: 0,
-          },
-        },
-      })
-      expect(updateMock).toHaveBeenNthCalledWith(2, {
-        'system.skills.skill-id.rank': {
+      expect(updateMock).toHaveBeenCalledTimes(1)
+      expect(updateMock).toHaveBeenCalledWith({
+        [`system.skills.skill-id.rank`]: {
           base: 0,
           careerFree: 1,
           specializationFree: 0,
@@ -165,47 +125,80 @@ describe('Career Free Skill', () => {
         },
       })
     })
+
     describe('should return an Error Skill if any update fails', () => {
       test('should not update the state of the skill if the skill evaluated state is false', async () => {
         const actor = createActor()
         const updateMock = vi.fn().mockResolvedValue({})
         actor.update = updateMock
-        const data = createSkillData({ careerFree: 1 })
+
+        const data = createSkillData({ specializationFree: 1, careerFree: 1, trained: 1 })
         const params = {}
         const options = {}
+
         const careerFreeSkill = new CareerFreeSkill(actor, data, params, options)
         const result = await careerFreeSkill.updateState()
+
         expect(updateMock).toHaveBeenCalledTimes(0)
         expect(result).toBeInstanceOf(ErrorSkill)
         expect(result.options.message).toContain('you must evaluate the skill before updating it!')
       })
+
       test('free skill ranks update fails', async () => {
         const actor = createActor()
-        const updateMock = vi.fn().mockRejectedValueOnce(new Error('Erreur sur premier update'))
-        actor.update = updateMock
-        const data = createSkillData({ careerFree: 1 })
-        const params = {}
+        actor.updateFreeSkillRanks = vi.fn().mockImplementation(async (type, params) => {
+          throw new Error('Error on free skill ranks update')
+        })
+        const data = createSkillData({ careerFree: 0 })
+        const params = {
+          action: 'train',
+          isCreation: false,
+          isCareer: true,
+        }
         const options = {}
+
         const careerFreeSkill = new CareerFreeSkill(actor, data, params, options)
-        careerFreeSkill.process()
+        await expect(careerFreeSkill.process()).rejects.toThrow('Error on free skill ranks update')
+      })
+
+      test('skill rank update fails', async () => {
+        const actor = createActor()
+        actor.updateFreeSkillRanks = vi.fn().mockResolvedValue(actor)
+        const updateMock = vi.fn().mockRejectedValue(new Error('Error on skill rank update'))
+        actor.update = updateMock
+        const data = createSkillData({ careerFree: 0, trained: 0, value: 0 })
+        const params = {
+          action: 'train',
+          isCreation: false,
+          isCareer: true,
+        }
+        const options = {}
+
+        const careerFreeSkill = new CareerFreeSkill(actor, data, params, options)
+        await careerFreeSkill.process()
         const result = await careerFreeSkill.updateState()
         expect(updateMock).toHaveBeenCalledTimes(1)
         expect(result).toBeInstanceOf(ErrorSkill)
-        expect(result.options.message).toContain('Erreur sur premier update')
+        expect(result.options.message).toContain('Error on skill rank update')
       })
+
       test('skill rank update fails', async () => {
         const actor = createActor()
-        const updateMock = vi.fn().mockResolvedValueOnce({}).mockRejectedValueOnce(new Error('Erreur sur deuxième update'))
+        actor.updateFreeSkillRanks = vi.fn().mockResolvedValue(actor)
+        const updateMock = vi.fn().mockRejectedValue(new Error('Error on skill rank update'))
         actor.update = updateMock
-        const data = createSkillData({ careerFree: 1 })
-        const params = {}
+        const data = createSkillData({ careerFree: 0, trained: 0, value: 0 })
+        const params = {
+          action: 'train',
+          isCreation: false,
+          isCareer: true,
+        }
         const options = {}
         const careerFreeSkill = new CareerFreeSkill(actor, data, params, options)
-        careerFreeSkill.process()
+        await careerFreeSkill.process()
         const result = await careerFreeSkill.updateState()
-        expect(updateMock).toHaveBeenCalledTimes(2)
         expect(result).toBeInstanceOf(ErrorSkill)
-        expect(result.options.message).toContain('Erreur sur deuxième update')
+        expect(result.options.message).toContain('Error on skill rank update')
       })
     })
   })

--- a/tests/lib/skills/skill-factory.test.mjs
+++ b/tests/lib/skills/skill-factory.test.mjs
@@ -70,9 +70,9 @@ describe('SkillFactory build()', () => {
         })
         test('click on a career-free skill and actor has career-free rank and some experience points to spend.', () => {
           const actor = createActor()
-          actor.experiencePoints.spent = 10
-          actor.experiencePoints.gained = 100
-          actor.experiencePoints.available = 90
+          actor.system.progression.experience.spent = 10
+          actor.system.progression.experience.gained = 100
+          actor.system.progression.experience.available = 90
           actor.system.progression.freeSkillRanks = {
             career: {
               spent: 4,
@@ -180,7 +180,7 @@ describe('SkillFactory build()', () => {
           const actor = createActor()
           actor.system.skills.brawl.rank.specializationFree = 1
           actor.system.skills.brawl.rank.careerFree = 1
-          actor.experiencePoints.spent = 10
+          actor.system.progression.experience.spent = 10
           actor.system.progression.freeSkillRanks = {
             career: {
               spent: 1,
@@ -261,9 +261,9 @@ describe('SkillFactory build()', () => {
           actor.system.skills.brawl.rank.careerFree = 0
           actor.system.skills.brawl.rank.specializationFree = 0
           actor.system.skills.brawl.rank.trained = 1
-          actor.experiencePoints.spent = 10
-          actor.experiencePoints.gained = 100
-          actor.experiencePoints.available = 90
+          actor.system.progression.experience.spent = 10
+          actor.system.progression.experience.gained = 100
+          actor.system.progression.experience.available = 90
           actor.system.progression.freeSkillRanks = {
             career: {
               spent: 0,
@@ -289,9 +289,9 @@ describe('SkillFactory build()', () => {
         })
         test('click on a career-free skill and actor has no career-free points left and some experience points to spend.', () => {
           const actor = createActor()
-          actor.experiencePoints.spent = 10
-          actor.experiencePoints.gained = 100
-          actor.experiencePoints.available = 90
+          actor.system.progression.experience.spent = 10
+          actor.system.progression.experience.gained = 100
+          actor.system.progression.experience.available = 90
           actor.system.progression.freeSkillRanks = {
             career: {
               spent: 4,
@@ -326,7 +326,7 @@ describe('SkillFactory build()', () => {
           actor.system.skills.brawl.rank.careerFree = 0
           actor.system.skills.brawl.rank.specializationFree = 0
           actor.system.skills.brawl.rank.trained = 1
-          actor.experiencePoints.spent = 10
+          actor.system.progression.experience.spent = 10
           actor.system.progression.freeSkillRanks = {
             career: {
               spent: 0,
@@ -355,7 +355,7 @@ describe('SkillFactory build()', () => {
           actor.system.skills.brawl.rank.careerFree = 1
           actor.system.skills.brawl.rank.specializationFree = 0
           actor.system.skills.brawl.rank.trained = 1
-          actor.experiencePoints.spent = 10
+          actor.system.progression.experience.spent = 10
           actor.system.progression.freeSkillRanks = {
             career: {
               spent: 4,
@@ -384,7 +384,7 @@ describe('SkillFactory build()', () => {
           actor.system.skills.brawl.rank.careerFree = 0
           actor.system.skills.brawl.rank.specializationFree = 1
           actor.system.skills.brawl.rank.trained = 1
-          actor.experiencePoints.spent = 10
+          actor.system.progression.experience.spent = 10
           actor.system.progression.freeSkillRanks = {
             career: {
               spent: 3,
@@ -413,7 +413,7 @@ describe('SkillFactory build()', () => {
           actor.system.skills.brawl.rank.careerFree = 1
           actor.system.skills.brawl.rank.specializationFree = 1
           actor.system.skills.brawl.rank.trained = 1
-          actor.experiencePoints.spent = 10
+          actor.system.progression.experience.spent = 10
           actor.system.progression.freeSkillRanks = {
             career: {
               spent: 4,
@@ -442,7 +442,7 @@ describe('SkillFactory build()', () => {
           actor.system.skills.brawl.rank.careerFree = 0
           actor.system.skills.brawl.rank.specializationFree = 0
           actor.system.skills.brawl.rank.trained = 1
-          actor.experiencePoints.spent = 10
+          actor.system.progression.experience.spent = 10
           actor.system.progression.freeSkillRanks = {
             career: {
               spent: 4,

--- a/tests/lib/skills/specialization-free-skill-additional.test.mjs
+++ b/tests/lib/skills/specialization-free-skill-additional.test.mjs
@@ -9,8 +9,9 @@ import ErrorSkill from '../../../module/lib/skills/error-skill.mjs'
 
 describe('Specialization Free Skill - Additional Coverage', () => {
   describe('process() edge cases', () => {
-    test('should return ErrorSkill when training with specializationFree already at 1', () => {
+    test('should return ErrorSkill when training with specializationFree already at 1', async () => {
       const actor = createActor()
+      actor.updateFreeSkillRanks = vi.fn().mockResolvedValue(actor)
       const data = createSkillData({ specializationFree: 1 })
       const params = {
         action: 'train',
@@ -21,14 +22,15 @@ describe('Specialization Free Skill - Additional Coverage', () => {
       const options = {}
 
       const skill = new SpecializationFreeSkill(actor, data, params, options)
-      const result = skill.process()
+      const result = await skill.process()
 
       expect(result).toBeInstanceOf(ErrorSkill)
       expect(result.options.message).toBe("you can't use more than 1 specialization free skill rank into the same skill!")
     })
 
-    test('should return ErrorSkill when forgetting with specializationFree at 0', () => {
+    test('should return ErrorSkill when forgetting with specializationFree at 0', async () => {
       const actor = createActor()
+      actor.updateFreeSkillRanks = vi.fn().mockResolvedValue(actor)
       const data = createSkillData({ specializationFree: 0 })
       const params = {
         action: 'forget',
@@ -39,17 +41,18 @@ describe('Specialization Free Skill - Additional Coverage', () => {
       const options = {}
 
       const skill = new SpecializationFreeSkill(actor, data, params, options)
-      const result = skill.process()
+      const result = await skill.process()
 
       expect(result).toBeInstanceOf(ErrorSkill)
       expect(result.options.message).toBe("you can't forget this rank because it comes from species free bonus!")
     })
 
-    test('should return SpecializationFreeSkill when freeSkillRanks.specialization.gained is 0 but spent is also 0', () => {
+    test('should return SpecializationFreeSkill when freeSkillRanks.specialization.gained is 0 but spent is also 0', async () => {
       const actor = createActor()
-      actor.freeSkillRanks.specialization.gained = 0
-      actor.freeSkillRanks.specialization.available = 0
-      actor.freeSkillRanks.specialization.spent = 0
+      actor.updateFreeSkillRanks = vi.fn().mockResolvedValue(actor)
+      actor.system.progression.freeSkillRanks.specialization.gained = 0
+      actor.system.progression.freeSkillRanks.specialization.available = 0
+      actor.system.progression.freeSkillRanks.specialization.spent = 0
 
       const data = createSkillData()
       const params = {
@@ -61,16 +64,17 @@ describe('Specialization Free Skill - Additional Coverage', () => {
       const options = {}
 
       const skill = new SpecializationFreeSkill(actor, data, params, options)
-      const result = skill.process()
+      const result = await skill.process()
 
       // freeSkillRankAvailable = 0 - 0 = 0, which is not < 0, so it proceeds
       expect(result).toBeInstanceOf(SpecializationFreeSkill)
     })
 
-    test('should return ErrorSkill when freeSkillRankAvailable < 0 (overspent)', () => {
+    test('should return ErrorSkill when freeSkillRankAvailable < 0 (overspent)', async () => {
       const actor = createActor({ specializationSpent: 3 }) // spent (3) > gained (2)
+      actor.updateFreeSkillRanks = vi.fn().mockResolvedValue(actor)
       // Manually update available to reflect overspent
-      actor.freeSkillRanks.specialization.available = -1
+      actor.system.progression.freeSkillRanks.specialization.available = -1
 
       const data = createSkillData({ specializationFree: 0 }) // Start with 0 so it doesn't trigger > 1 check
       const params = {
@@ -82,14 +86,15 @@ describe('Specialization Free Skill - Additional Coverage', () => {
       const options = {}
 
       const skill = new SpecializationFreeSkill(actor, data, params, options)
-      const result = skill.process()
+      const result = await skill.process()
 
       expect(result).toBeInstanceOf(ErrorSkill)
       expect(result.options.message).toBe("you can't use free skill rank anymore. You have used all!")
     })
 
-    test('should succeed training when specializationFree is 0 and free ranks available', () => {
+    test('should succeed training when specializationFree is 0 and free ranks available', async () => {
       const actor = createActor()
+      actor.updateFreeSkillRanks = vi.fn().mockResolvedValue(actor)
       const data = createSkillData()
       const params = {
         action: 'train',
@@ -100,17 +105,17 @@ describe('Specialization Free Skill - Additional Coverage', () => {
       const options = {}
 
       const skill = new SpecializationFreeSkill(actor, data, params, options)
-      const result = skill.process()
+      const result = await skill.process()
 
       expect(result).toBeInstanceOf(SpecializationFreeSkill)
       expect(result.data.rank.specializationFree).toBe(1)
       expect(result.data.rank.value).toBe(1)
-      expect(result.actor.freeSkillRanks.specialization.spent).toBe(1)
       expect(result.evaluated).toBe(true)
     })
 
-    test('should succeed forgetting when specializationFree is 1', () => {
+    test('should succeed forgetting when specializationFree is 1', async () => {
       const actor = createActor({ specializationSpent: 1 })
+      actor.updateFreeSkillRanks = vi.fn().mockResolvedValue(actor)
       const data = createSkillData({ specializationFree: 1, value: 1 })
       const params = {
         action: 'forget',
@@ -121,17 +126,17 @@ describe('Specialization Free Skill - Additional Coverage', () => {
       const options = {}
 
       const skill = new SpecializationFreeSkill(actor, data, params, options)
-      const result = skill.process()
+      const result = await skill.process()
 
       expect(result).toBeInstanceOf(SpecializationFreeSkill)
       expect(result.data.rank.specializationFree).toBe(0)
       expect(result.data.rank.value).toBe(0)
-      expect(result.actor.freeSkillRanks.specialization.spent).toBe(0)
       expect(result.evaluated).toBe(true)
     })
 
-    test('should update rank.value correctly with base rank present', () => {
+    test('should update rank.value correctly with base rank present', async () => {
       const actor = createActor()
+      actor.updateFreeSkillRanks = vi.fn().mockResolvedValue(actor)
       const data = createSkillData({ base: 1, trained: 1, value: 2 })
       const params = {
         action: 'train',
@@ -142,10 +147,10 @@ describe('Specialization Free Skill - Additional Coverage', () => {
       const options = {}
 
       const skill = new SpecializationFreeSkill(actor, data, params, options)
-      const result = skill.process()
+      const result = await skill.process()
 
-      expect(result).toBeInstanceOf(SpecializationFreeSkill)
       // value = base(1) + careerFree(0) + specializationFree(0->1) + trained(1) = 3
+      expect(result).toBeInstanceOf(SpecializationFreeSkill)
       expect(result.data.rank.value).toBe(3)
     })
   })
@@ -178,7 +183,7 @@ describe('Specialization Free Skill - Additional Coverage', () => {
       const options = {}
 
       const skill = new SpecializationFreeSkill(actor, data, params, options)
-      expect(skill.freeSkillRankAvailable).toBe(-3)
+      expect(skill.freeSkillRankAvailable).toBe(-3) // gained(2) - spent(5)
     })
   })
 
@@ -193,6 +198,7 @@ describe('Specialization Free Skill - Additional Coverage', () => {
       const options = {}
 
       const skill = new SpecializationFreeSkill(actor, data, params, options)
+      // NOT calling process() before updateState()
       const result = await skill.updateState()
 
       expect(updateMock).toHaveBeenCalledTimes(0)
@@ -204,13 +210,19 @@ describe('Specialization Free Skill - Additional Coverage', () => {
       const actor = createActor()
       const updateMock = vi.fn().mockRejectedValue(new Error('Update failed'))
       actor.update = updateMock
+      actor.updateFreeSkillRanks = vi.fn().mockResolvedValue(actor)
 
       const data = createSkillData()
-      const params = {}
+      const params = {
+        action: 'train',
+        isCreation: false,
+        isCareer: false,
+        isSpecialization: true,
+      }
       const options = {}
 
       const skill = new SpecializationFreeSkill(actor, data, params, options)
-      skill.process()
+      await skill.process()
       const result = await skill.updateState()
 
       expect(result).toBeInstanceOf(ErrorSkill)

--- a/tests/lib/skills/specialization-free-skill.test.mjs
+++ b/tests/lib/skills/specialization-free-skill.test.mjs
@@ -9,8 +9,9 @@ import ErrorSkill from '../../../module/lib/skills/error-skill.mjs'
 
 describe('Specialization Free Skill', () => {
   describe('train a skill', () => {
-    test('should increase the specialization free skill rank', () => {
+    test('should increase the specialization free skill rank', async () => {
       const actor = createActor()
+      actor.updateFreeSkillRanks = vi.fn().mockResolvedValue(actor)
       const data = createSkillData()
       const params = {
         action: 'train',
@@ -21,17 +22,18 @@ describe('Specialization Free Skill', () => {
       const options = {}
 
       const specializationFreeSkill = new SpecializationFreeSkill(actor, data, params, options)
-      const trainedSkill = specializationFreeSkill.process()
+      const trainedSkill = await specializationFreeSkill.process()
 
       expect(trainedSkill.data.rank.specializationFree).toBe(1)
-      expect(trainedSkill.actor.freeSkillRanks.specialization.spent).toBe(1)
-      expect(trainedSkill.actor.freeSkillRanks.career.spent).toBe(0)
+      expect(actor.updateFreeSkillRanks).toHaveBeenCalledWith('specialization', { spent: 1 })
       expect(trainedSkill.data.rank.careerFree).toBe(0)
     })
   })
+
   describe('forget a skill', () => {
-    test('should decrease the specialization free skill rank', () => {
+    test('should decrease the specialization free skill rank', async () => {
       const actor = createActor({ specializationSpent: 1 })
+      actor.updateFreeSkillRanks = vi.fn().mockResolvedValue(actor)
       const data = createSkillData({ specializationFree: 1 })
       const params = {
         action: 'forget',
@@ -42,66 +44,69 @@ describe('Specialization Free Skill', () => {
       const options = {}
 
       const specializationFreeSkill = new SpecializationFreeSkill(actor, data, params, options)
-      const trainedSkill = specializationFreeSkill.process()
+      const trainedSkill = await specializationFreeSkill.process()
 
       expect(trainedSkill.data.rank.specializationFree).toBe(0)
-      expect(trainedSkill.actor.freeSkillRanks.specialization.spent).toBe(0)
-      expect(trainedSkill.actor.freeSkillRanks.career.spent).toBe(0)
+      expect(actor.updateFreeSkillRanks).toHaveBeenCalledWith('specialization', { spent: 0 })
       expect(trainedSkill.data.rank.careerFree).toBe(0)
     })
   })
+
   describe('evaluate a skill', () => {
     describe('should return an error skill if', () => {
-      describe('you train a skill', () => {
-        test('and specialization free skill rank is greater than 1', () => {
-          const actor = createActor()
-          const data = createSkillData({ specializationFree: 2 })
-          const params = {}
-          const options = {}
+      test('you train a skill and specialization free skill rank is greater than 1', async () => {
+        const actor = createActor()
+        actor.updateFreeSkillRanks = vi.fn().mockResolvedValue(actor)
+        const data = createSkillData({ specializationFree: 2 })
+        const params = {}
+        const options = {}
 
-          const specializationFreeSkill = new SpecializationFreeSkill(actor, data, params, options)
-          const errorSkill = specializationFreeSkill.process()
+        const specializationFreeSkill = new SpecializationFreeSkill(actor, data, params, options)
+        const errorSkill = await specializationFreeSkill.process()
 
-          expect(errorSkill).toBeInstanceOf(ErrorSkill)
-          expect(errorSkill.options.message).toBe("you can't use more than 1 specialization free skill rank into the same skill!")
-          expect(errorSkill.evaluated).toBe(false)
-        })
-        test('after train free skill rank available is less than 0', () => {
-          const actor = createActor({ specializationSpent: 5 })
-          const data = createSkillData({ specializationFree: 1 })
-          const params = {}
-          const options = {}
-
-          const specializationFreeSkill = new SpecializationFreeSkill(actor, data, params, options)
-          const errorSkill = specializationFreeSkill.process()
-
-          expect(errorSkill).toBeInstanceOf(ErrorSkill)
-          expect(errorSkill.options.message).toBe("you can't use free skill rank anymore. You have used all!")
-          expect(errorSkill.evaluated).toBe(false)
-        })
+        expect(errorSkill).toBeInstanceOf(ErrorSkill)
+        expect(errorSkill.options.message).toBe("you can't use more than 1 specialization free skill rank into the same skill!")
+        expect(errorSkill.evaluated).toBe(false)
       })
+
+      test('after train free skill rank available is less than 0', async () => {
+        const actor = createActor({ specializationSpent: 5 })
+        actor.updateFreeSkillRanks = vi.fn().mockResolvedValue(actor)
+        const data = createSkillData({ specializationFree: 1 })
+        const params = {}
+        const options = {}
+
+        const specializationFreeSkill = new SpecializationFreeSkill(actor, data, params, options)
+        const errorSkill = await specializationFreeSkill.process()
+
+        expect(errorSkill).toBeInstanceOf(ErrorSkill)
+        expect(errorSkill.options.message).toBe("you can't use free skill rank anymore. You have used all!")
+        expect(errorSkill.evaluated).toBe(false)
+      })
+
       describe('you forget a skill', () => {
-        test('and specialization free skill rank is less than 0', () => {
+        test('and specialization free skill rank is less than 0', async () => {
           const actor = createActor()
           const data = createSkillData({ specializationFree: -1 })
           const params = {}
           const options = {}
 
           const specializationFreeSkill = new SpecializationFreeSkill(actor, data, params, options)
-          const errorSkill = specializationFreeSkill.process()
+          const errorSkill = await specializationFreeSkill.process()
 
           expect(errorSkill).toBeInstanceOf(ErrorSkill)
           expect(errorSkill.options.message).toBe("you can't forget this rank because it comes from species free bonus!")
           expect(errorSkill.evaluated).toBe(false)
         })
-        test('and specialization free skill rank is greater than specialization free skill rank gained', () => {
+
+        test('and specialization free skill rank is greater than specialization free skill rank gained', async () => {
           const actor = createActor({ specializationSpent: -1 })
           const data = createSkillData({ specializationFree: 0 })
           const params = {}
           const options = {}
 
           const specializationFreeSkill = new SpecializationFreeSkill(actor, data, params, options)
-          const errorSkill = specializationFreeSkill.process()
+          const errorSkill = await specializationFreeSkill.process()
 
           expect(errorSkill).toBeInstanceOf(ErrorSkill)
           expect(errorSkill.options.message).toBe("you can't get more than 2 free skill ranks!")
@@ -109,14 +114,17 @@ describe('Specialization Free Skill', () => {
         })
       })
     })
+
     describe('should return a specialization free skill if', () => {
-      test('specialization free skill rank is 1 and only 1', () => {
+      test('specialization free skill rank is 1 and only 1', async () => {
         const actor = createActor()
+        actor.updateFreeSkillRanks = vi.fn().mockResolvedValue(actor)
         const data = createSkillData({ careerFree: 1, specializationFree: 1 })
         const params = {}
         const options = {}
+
         const specializationFreeSkill = new SpecializationFreeSkill(actor, data, params, options)
-        const evaluatedSkill = specializationFreeSkill.process()
+        const evaluatedSkill = await specializationFreeSkill.process()
         expect(evaluatedSkill).toBeInstanceOf(SpecializationFreeSkill)
         expect(evaluatedSkill.data.rank.specializationFree).toBe(1)
         expect(evaluatedSkill.data.rank.value).toBe(2)
@@ -124,53 +132,44 @@ describe('Specialization Free Skill', () => {
       })
     })
   })
+
   describe('updateState a skill', () => {
     test('should update the state of the skill and return the skill', async () => {
       const actor = createActor()
       const updateMock = vi.fn().mockResolvedValue({})
       actor.update = updateMock
-      const data = createSkillData({ careerFree: 1, specializationFree: 1 })
-      const params = {}
+      actor.updateFreeSkillRanks = vi.fn().mockResolvedValue(actor)
+      const data = createSkillData({ specializationFree: 0, trained: 0, value: 0 })
+      const params = {
+        action: 'train',
+        isCreation: false,
+        isCareer: false,
+        isSpecialization: true,
+      }
       const options = {}
       const specializationFreeSkill = new SpecializationFreeSkill(actor, data, params, options)
-      specializationFreeSkill.process()
+      const processedSkill = await specializationFreeSkill.process()
+      expect(processedSkill).toBeInstanceOf(SpecializationFreeSkill)
       const updatedSkill = await specializationFreeSkill.updateState()
       expect(updatedSkill).toBeInstanceOf(SpecializationFreeSkill)
-      expect(updateMock).toHaveBeenCalledTimes(2)
-      expect(updateMock).toHaveBeenNthCalledWith(1, {
-        'system.progression.freeSkillRanks': {
-          career: {
-            available: 4,
-            gained: 4,
-            id: '',
-            name: '',
-            spent: 0,
-          },
-          specialization: {
-            available: 2,
-            gained: 2,
-            id: '',
-            name: '',
-            spent: 0,
-          },
-        },
-      })
-      expect(updateMock).toHaveBeenNthCalledWith(2, {
-        'system.skills.skill-id.rank': {
+      expect(updateMock).toHaveBeenCalledTimes(1)
+      expect(updateMock).toHaveBeenCalledWith({
+        [`system.skills.skill-id.rank`]: {
           base: 0,
-          careerFree: 1,
+          careerFree: 0,
           specializationFree: 1,
           trained: 0,
-          value: 2,
+          value: 1,
         },
       })
     })
+
     describe('should return an Error Skill if any update fails', () => {
       test('should not update the state of the skill if the skill evaluated state is false', async () => {
         const actor = createActor()
         const updateMock = vi.fn().mockResolvedValue({})
         actor.update = updateMock
-        const data = createSkillData({ careerFree: 1, specializationFree: 1 })
+        const data = createSkillData({ careerFree: 1, specializationFree: 1, trained: 1 })
         const params = {}
         const options = {}
         const specializationFreeSkill = new SpecializationFreeSkill(actor, data, params, options)
@@ -179,33 +178,39 @@ describe('Specialization Free Skill', () => {
         expect(result).toBeInstanceOf(ErrorSkill)
         expect(result.options.message).toContain('you must evaluate the skill before updating it!')
       })
+
       test('free skill ranks update fails', async () => {
         const actor = createActor()
-        const updateMock = vi.fn().mockRejectedValueOnce(new Error('Erreur sur premier update'))
-        actor.update = updateMock
-        const data = createSkillData({ specializationFree: 1 })
-        const params = {}
+        actor.updateFreeSkillRanks = vi.fn().mockRejectedValue(new Error('Error on free skill ranks update'))
+        const data = createSkillData({ specializationFree: 0, trained: 0, value: 0 })
+        const params = {
+          action: 'train',
+          isCreation: false,
+          isSpecialization: true,
+        }
         const options = {}
         const specializationFreeSkill = new SpecializationFreeSkill(actor, data, params, options)
-        specializationFreeSkill.process()
+        await expect(specializationFreeSkill.process()).rejects.toThrow('Error on free skill ranks update')
+      })
+
+      test('skill rank update fails', async () => {
+        const actor = createActor()
+        actor.updateFreeSkillRanks = vi.fn().mockResolvedValue(actor)
+        const updateMock = vi.fn().mockRejectedValue(new Error('Error on skill rank update'))
+        actor.update = updateMock
+        const data = createSkillData({ specializationFree: 0, trained: 0, value: 0 })
+        const params = {
+          action: 'train',
+          isCreation: false,
+          isSpecialization: true,
+        }
+        const options = {}
+        const specializationFreeSkill = new SpecializationFreeSkill(actor, data, params, options)
+        await specializationFreeSkill.process()
         const result = await specializationFreeSkill.updateState()
         expect(updateMock).toHaveBeenCalledTimes(1)
         expect(result).toBeInstanceOf(ErrorSkill)
-        expect(result.options.message).toContain('Erreur sur premier update')
-      })
-      test('skill rank update fails', async () => {
-        const actor = createActor()
-        const updateMock = vi.fn().mockResolvedValueOnce({}).mockRejectedValueOnce(new Error('Erreur sur deuxième update'))
-        actor.update = updateMock
-        const data = createSkillData({ specializationFree: 1 })
-        const params = {}
-        const options = {}
-        const specializationFreeSkill = new SpecializationFreeSkill(actor, data, params, options)
-        specializationFreeSkill.process()
-        const result = await specializationFreeSkill.updateState()
-        expect(updateMock).toHaveBeenCalledTimes(2)
-        expect(result).toBeInstanceOf(ErrorSkill)
-        expect(result.options.message).toContain('Erreur sur deuxième update')
+        expect(result.options.message).toContain('Error on skill rank update')
       })
     })
   })


### PR DESCRIPTION
## Summary
- Refactor `career-free-skill.mjs` to use `updateFreeSkillRanks('career', ...)`
- Refactor `specialization-free-skill.mjs` to use `updateFreeSkillRanks('specialization', ...)`
- Update `skill-factory.mjs` to use `actor.system.progression` structure
- Update all related test files

## Related Issues
Fixes #78, #79

## Changes
- `module/lib/skills/career-free-skill.mjs`: Use new update method
- `module/lib/skills/specialization-free-skill.mjs`: Use new update method
- `module/lib/skills/skill-factory.mjs`: Use actor.system.progression.*
- All related test files updated

## Testing
All 22 tests pass in skill-factory.test.mjs