### PR TITLE
refactor(characteristics/talents): update to use updateExperiencePoints() (Phase 4)

### DIFF
--- a/module/lib/characteristics/trained-characteristic.mjs
+++ b/module/lib/characteristics/trained-characteristic.mjs
@@ -8,8 +8,8 @@ export default class TrainedCharacteristic extends Characteristic {
     this.dataCostCalculator = new CharacteristicCostCalculator(this)
   }
 
-  process() {
-    let experiencePointsSpent = this.actor.experiencePoints.spent
+  async process() {
+    let experiencePointsSpent = this.actor.system.progression.experience.spent
     let trained = this.data.rank.trained
 
     let value
@@ -38,13 +38,13 @@ export default class TrainedCharacteristic extends Characteristic {
       return new ErrorCharacteristic(this.actor, this.data, {}, { message: "you can't have more than 6 rank!" })
     }
 
-    if (experiencePointsSpent > this.actor.experiencePoints.total) {
+    if (experiencePointsSpent > this.actor.system.progression.experience.total) {
       return new ErrorCharacteristic(this.actor, this.data, {}, { message: "you can't spend more experience than your total!" })
     }
 
     this.data.rank.value = value
     this.data.rank.trained = trained
-    this.actor.experiencePoints.spent = experiencePointsSpent
+    await this.actor.updateExperiencePoints({ spent: experiencePointsSpent })
     this.evaluated = true
     return this
   }
@@ -60,7 +60,6 @@ export default class TrainedCharacteristic extends Characteristic {
       })
     }
     try {
-      await this.actor.update({ 'system.progression.experience.spent': this.actor.experiencePoints.spent })
       await this.actor.update({ [`system.characteristics.${this.data.id}.rank`]: this.data.rank })
       return new Promise((resolve, _) => {
         resolve(this)

--- a/module/lib/talents/ranked-trained-talent.mjs
+++ b/module/lib/talents/ranked-trained-talent.mjs
@@ -9,8 +9,8 @@ export default class RankedTrainedTalent extends TrainedTalent {
     this.talentCostCalculator = new TalentCostCalculator(this)
   }
 
-  process() {
-    let experiencePointsSpent = this.actor.experiencePoints.spent
+  async process() {
+    let experiencePointsSpent = this.actor.system.progression.experience.spent
     const talent = this.data
     const row = talent.system.row
 
@@ -37,13 +37,13 @@ export default class RankedTrainedTalent extends TrainedTalent {
       idx = ranks.length - 1
     }
 
-    if (experiencePointsSpent > this.actor.experiencePoints.total) {
+    if (experiencePointsSpent > this.actor.system.progression.experience.total) {
       return new ErrorTalent(this.actor, talent, {}, { message: "you can't spend more experience than your total!" })
     }
 
     // As we are dealing with a ranked talent, we need to set the rank value to the number of ranks
     // Set to ranks.length because we are adding a new rank and we count from 0
-    this.actor.experiencePoints.spent = experiencePointsSpent
+    await this.actor.updateExperiencePoints({ spent: experiencePointsSpent })
 
     this.data.updateSource({
       system: {

--- a/module/lib/talents/trained-talent.mjs
+++ b/module/lib/talents/trained-talent.mjs
@@ -8,8 +8,8 @@ export default class TrainedTalent extends Talent {
     this.talentCostCalculator = new TalentCostCalculator(this)
   }
 
-  process() {
-    let experiencePointsSpent = this.actor.experiencePoints.spent
+  async process() {
+    let experiencePointsSpent = this.actor.system.progression.experience.spent
     const talent = this.data
     const row = talent.system.row
 
@@ -40,11 +40,11 @@ export default class TrainedTalent extends Talent {
       cost = 0
     }
 
-    if (experiencePointsSpent > this.actor.experiencePoints.total) {
+    if (experiencePointsSpent > this.actor.system.progression.experience.total) {
       return new ErrorTalent(this.actor, talent, {}, { message: "you can't spend more experience than your total!" })
     }
 
-    this.actor.experiencePoints.spent = experiencePointsSpent
+    await this.actor.updateExperiencePoints({ spent: experiencePointsSpent })
 
     talent.system.rank = {
       idx: 0,
@@ -65,7 +65,6 @@ export default class TrainedTalent extends Talent {
       })
     }
     try {
-      await this.actor.update({ 'system.progression.experience.spent': this.actor.experiencePoints.spent })
       if (this.action === 'train') {
         await this.actor.createEmbeddedDocuments('Item', [this.data.toObject()])
       } else {

--- a/tests/lib/characteristics/trained-characteristic.test.mjs
+++ b/tests/lib/characteristics/trained-characteristic.test.mjs
@@ -9,8 +9,9 @@ import ErrorCharacteristic from '../../../module/lib/characteristics/error-chara
 
 describe('Trained Characteristic', () => {
   describe('train a characteristic', () => {
-    test('should increase the trained characteristic rank to 1 and spend 20xp', () => {
+    test('should increase the trained characteristic rank to 1 and spend 20xp', async () => {
       const actor = createActor()
+      actor.updateExperiencePoints = vi.fn().mockResolvedValue(actor)
       const data = createCharacteristicData()
       const params = {
         action: 'train',
@@ -19,19 +20,20 @@ describe('Trained Characteristic', () => {
       const options = {}
 
       const trainedCharacteristic = new TrainedCharacteristic(actor, data, params, options)
-      const trainTrainedCharacteristic = trainedCharacteristic.process()
+      const trainTrainedCharacteristic = await trainedCharacteristic.process()
 
       expect(trainTrainedCharacteristic.data.rank.trained).toBe(1)
       expect(trainTrainedCharacteristic.data.rank.value).toBe(2)
-      expect(trainedCharacteristic.actor.experiencePoints.spent).toBe(20)
+      expect(actor.updateExperiencePoints).toHaveBeenCalledWith({ spent: 20 })
     })
   })
   describe('forget a characteristic', () => {
-    test('should decrease the trained characteristic rank to 1 and regain 20xp', () => {
+    test('should decrease the trained characteristic rank to 1 and regain 20xp', async () => {
       const actor = createActor()
-      actor.experiencePoints.spent = 30
-      actor.experiencePoints.gained = 100
-      actor.experiencePoints.available = 80
+      actor.updateExperiencePoints = vi.fn().mockResolvedValue(actor)
+      actor.system.progression.experience.spent = 30
+      actor.system.progression.experience.gained = 100
+      actor.system.progression.experience.total = 100
       const data = createCharacteristicData({ trained: 1, value: 2 })
       const params = {
         action: 'forget',
@@ -40,17 +42,18 @@ describe('Trained Characteristic', () => {
       const options = {}
 
       const trainedCharacteristic = new TrainedCharacteristic(actor, data, params, options)
-      const forgetTrainedCharacteristic = trainedCharacteristic.process()
+      const forgetTrainedCharacteristic = await trainedCharacteristic.process()
 
       expect(forgetTrainedCharacteristic.data.rank.trained).toBe(0)
       expect(forgetTrainedCharacteristic.data.rank.value).toBe(1)
-      expect(forgetTrainedCharacteristic.actor.experiencePoints.spent).toBe(10)
+      expect(actor.updateExperiencePoints).toHaveBeenCalledWith({ spent: 10 })
     })
   })
   describe('evaluate a characteristic', () => {
     describe('should return an error characteristic if', () => {
-      test('trained characteristic rank is less than 0', () => {
+      test('trained characteristic rank is less than 0', async () => {
         const actor = createActor()
+        actor.updateExperiencePoints = vi.fn().mockResolvedValue(actor)
         const data = createCharacteristicData({ trained: -1 })
         const params = {
           action: 'forget',
@@ -59,17 +62,18 @@ describe('Trained Characteristic', () => {
         const options = {}
 
         const trainedCharacteristic = new TrainedCharacteristic(actor, data, params, options)
-        const errorCharacteristic = trainedCharacteristic.process()
+        const errorCharacteristic = await trainedCharacteristic.process()
 
         expect(errorCharacteristic).toBeInstanceOf(ErrorCharacteristic)
         expect(errorCharacteristic.options.message).toBe("you can't forget this rank anymore because you are at & (minimal value)!")
         expect(errorCharacteristic.evaluated).toBe(false)
       })
-      test('trained a characteristic costs more than experience points available', () => {
+      test('trained a characteristic costs more than experience points available', async () => {
         const actor = createActor()
-        actor.experiencePoints.spent = 90
-        actor.experiencePoints.gained = 100
-        actor.experiencePoints.available = 10
+        actor.updateExperiencePoints = vi.fn().mockResolvedValue(actor)
+        actor.system.progression.experience.spent = 90
+        actor.system.progression.experience.gained = 100
+        actor.system.progression.experience.total = 100
         const data = createCharacteristicData({ careerFree: 1, trained: 1, value: 2 })
         const params = {
           action: 'train',
@@ -78,14 +82,15 @@ describe('Trained Characteristic', () => {
         const options = {}
 
         const trainedCharacteristic = new TrainedCharacteristic(actor, data, params, options)
-        const errorCharacteristic = trainedCharacteristic.process()
+        const errorCharacteristic = await trainedCharacteristic.process()
 
         expect(errorCharacteristic).toBeInstanceOf(ErrorCharacteristic)
         expect(errorCharacteristic.options.message).toBe("you can't spend more experience than your total!")
         expect(errorCharacteristic.evaluated).toBe(false)
       })
-      test('characteristic rank value is greater than 5 and isCreation is true', () => {
+      test('characteristic rank value is greater than 5 and isCreation is true', async () => {
         const actor = createActor()
+        actor.updateExperiencePoints = vi.fn().mockResolvedValue(actor)
         const data = createCharacteristicData({ trained: 5 })
         const params = {
           action: 'train',
@@ -94,14 +99,15 @@ describe('Trained Characteristic', () => {
         const options = {}
 
         const trainedCharacteristic = new TrainedCharacteristic(actor, data, params, options)
-        const errorCharacteristic = trainedCharacteristic.process()
+        const errorCharacteristic = await trainedCharacteristic.process()
 
         expect(errorCharacteristic).toBeInstanceOf(ErrorCharacteristic)
         expect(errorCharacteristic.options.message).toBe("you can't have more than 5 rank during creation!")
         expect(errorCharacteristic.evaluated).toBe(false)
       })
-      test('characteristic rank value is greater than 6 and isCreation is false', () => {
+      test('characteristic rank value is greater than 6 and isCreation is false', async () => {
         const actor = createActor()
+        actor.updateExperiencePoints = vi.fn().mockResolvedValue(actor)
         const data = createCharacteristicData({ trained: 6 })
         const params = {
           action: 'train',
@@ -110,7 +116,7 @@ describe('Trained Characteristic', () => {
         const options = {}
 
         const trainedCharacteristic = new TrainedCharacteristic(actor, data, params, options)
-        const errorCharacteristic = trainedCharacteristic.process()
+        const errorCharacteristic = await trainedCharacteristic.process()
 
         expect(errorCharacteristic).toBeInstanceOf(ErrorCharacteristic)
         expect(errorCharacteristic.options.message).toBe("you can't have more than 6 rank!")
@@ -118,19 +124,21 @@ describe('Trained Characteristic', () => {
       })
     })
     describe('should return a trained characteristic if', () => {
-      test('trained characteristic rank is 1 and only 1', () => {
+      test('trained characteristic rank is 1 and only 1', async () => {
         const actor = createActor()
-        actor.experiencePoints.spent = 10
-        actor.experiencePoints.gained = 100
-        actor.experiencePoints.available = 90
+        actor.updateExperiencePoints = vi.fn().mockResolvedValue(actor)
+        actor.system.progression.experience.spent = 10
+        actor.system.progression.experience.gained = 100
+        actor.system.progression.experience.total = 100
         const data = createCharacteristicData({ careerFree: 1, specializationFree: 0, trained: 0, value: 1 })
         const params = {
           action: 'train',
           isCreation: true,
         }
         const options = {}
+
         const trainedFreeCharacteristic = new TrainedCharacteristic(actor, data, params, options)
-        const evaluatedCharacteristic = trainedFreeCharacteristic.process()
+        const evaluatedCharacteristic = await trainedFreeCharacteristic.process()
         expect(evaluatedCharacteristic).toBeInstanceOf(TrainedCharacteristic)
         expect(evaluatedCharacteristic.data.rank.trained).toBe(1)
         expect(evaluatedCharacteristic.data.rank.value).toBe(2)
@@ -143,6 +151,7 @@ describe('Trained Characteristic', () => {
       const actor = createActor()
       const updateMock = vi.fn().mockResolvedValue({})
       actor.update = updateMock
+      actor.updateExperiencePoints = vi.fn().mockResolvedValue(actor)
       const data = createCharacteristicData({ trained: 1, value: 2 })
       const params = {
         action: 'train',
@@ -150,20 +159,18 @@ describe('Trained Characteristic', () => {
       }
       const options = {}
       const trainedFreeCharacteristic = new TrainedCharacteristic(actor, data, params, options)
-      const processedTrainedCharacteristic = trainedFreeCharacteristic.process()
+      const processedTrainedCharacteristic = await trainedFreeCharacteristic.process()
       const updatedCharacteristic = await processedTrainedCharacteristic.updateState()
       expect(updatedCharacteristic).toBeInstanceOf(TrainedCharacteristic)
-      expect(updateMock).toHaveBeenCalledTimes(2)
-      expect(updateMock).toHaveBeenNthCalledWith(2, {
+      expect(updateMock).toHaveBeenCalledTimes(1)
+      expect(updateMock).toHaveBeenCalledWith({
         'system.characteristics.characteristic-id.rank': {
           base: 1,
           trained: 2,
           value: 3,
         },
       })
-      expect(updateMock).toHaveBeenNthCalledWith(1, {
-        'system.progression.experience.spent': 30,
-      })
+      expect(actor.updateExperiencePoints).toHaveBeenCalledWith({ spent: 30 })
     })
     describe('should return an Error Characteristic if any update fails', () => {
       test('should not update the state of the characteristic if the characteristic evaluated state is false', async () => {
@@ -179,33 +186,23 @@ describe('Trained Characteristic', () => {
         expect(result).toBeInstanceOf(ErrorCharacteristic)
         expect(result.options.message).toContain('you must evaluate the characteristic before updating it!')
       })
-      test('free characteristic ranks update fails', async () => {
+      test('characteristic rank update fails', async () => {
         const actor = createActor()
-        const updateMock = vi.fn().mockRejectedValueOnce(new Error('Erreur sur premier update'))
+        const updateMock = vi.fn().mockRejectedValueOnce(new Error('Erreur sur update'))
         actor.update = updateMock
-        const data = createCharacteristicData({ trainedFree: 1, specializationFree: 1, trained: 1 })
-        const params = {}
+        actor.updateExperiencePoints = vi.fn().mockResolvedValue(actor)
+        const data = createCharacteristicData({ trained: 1, value: 2 })
+        const params = {
+          action: 'train',
+          isCreation: false,
+        }
         const options = {}
         const trainedFreeCharacteristic = new TrainedCharacteristic(actor, data, params, options)
-        trainedFreeCharacteristic.process()
+        await trainedFreeCharacteristic.process()
         const result = await trainedFreeCharacteristic.updateState()
         expect(updateMock).toHaveBeenCalledTimes(1)
         expect(result).toBeInstanceOf(ErrorCharacteristic)
-        expect(result.options.message).toContain('Erreur sur premier update')
-      })
-      test('characteristic rank update fails', async () => {
-        const actor = createActor()
-        const updateMock = vi.fn().mockResolvedValueOnce({}).mockRejectedValueOnce(new Error('Erreur sur deuxième update'))
-        actor.update = updateMock
-        const data = createCharacteristicData({ trainedFree: 1, specializationFree: 1, trained: 1 })
-        const params = {}
-        const options = {}
-        const trainedFreeCharacteristic = new TrainedCharacteristic(actor, data, params, options)
-        trainedFreeCharacteristic.process()
-        const result = await trainedFreeCharacteristic.updateState()
-        expect(updateMock).toHaveBeenCalledTimes(2)
-        expect(result).toBeInstanceOf(ErrorCharacteristic)
-        expect(result.options.message).toContain('Erreur sur deuxième update')
+        expect(result.options.message).toContain('Erreur sur update')
       })
     })
   })

--- a/tests/lib/talents/ranked-trained-talent.test.mjs
+++ b/tests/lib/talents/ranked-trained-talent.test.mjs
@@ -10,10 +10,11 @@ import TrainedTalent from '../../../module/lib/talents/trained-talent.mjs'
 
 describe('Ranked Trained Talent', () => {
   describe('train a ranked talent', () => {
-    test('should add a new ranked trained talent with idx 0, row 1 and spend 5xp', () => {
+    test('should add a new ranked trained talent with idx 0, row 1 and spend 5xp', async () => {
       const data = createTalentData('1', { isRanked: true })
       const existingTalents = [createTalentData('2', { name: 'talent-1' })]
       const actor = createActor({ items: existingTalents })
+      actor.updateExperiencePoints = vi.fn().mockResolvedValue(actor)
       const params = {
         action: 'train',
         isCreation: true,
@@ -21,17 +22,18 @@ describe('Ranked Trained Talent', () => {
       const options = {}
 
       const trainedTalent = new RankedTrainedTalent(actor, data, params, options)
-      const trainRankedTrainedTalent = trainedTalent.process()
+      const trainRankedTrainedTalent = await trainedTalent.process()
 
       expect(trainRankedTrainedTalent).toBeInstanceOf(RankedTrainedTalent)
       expect(trainRankedTrainedTalent.data._source.system.rank.idx).toBe(1)
       expect(trainRankedTrainedTalent.data._source.system.rank.cost).toBe(5)
-      expect(trainedTalent.actor.experiencePoints.spent).toBe(5)
+      expect(actor.updateExperiencePoints).toHaveBeenCalledWith({ spent: 5 })
     })
-    test('should add an existing ranked trained talent with idx 1, row 2 and spend 10xp', () => {
+    test('should add an existing ranked trained talent with idx 1, row 2 and spend 10xp', async () => {
       const data = createTalentData('2', { isRanked: true, row: 2 })
       const existingTalents = [createTalentData('1', { isRanked: true, row: 1 })]
       const actor = createActor({ items: existingTalents })
+      actor.updateExperiencePoints = vi.fn().mockResolvedValue(actor)
       const params = {
         action: 'train',
         isCreation: true,
@@ -39,22 +41,23 @@ describe('Ranked Trained Talent', () => {
       const options = {}
 
       const trainedTalent = new RankedTrainedTalent(actor, data, params, options)
-      const trainRankedTrainedTalent = trainedTalent.process()
+      const trainRankedTrainedTalent = await trainedTalent.process()
 
       expect(trainRankedTrainedTalent).toBeInstanceOf(RankedTrainedTalent)
       expect(trainRankedTrainedTalent.data._source.system.rank.idx).toBe(2)
       expect(trainRankedTrainedTalent.data._source.system.rank.cost).toBe(10)
-      expect(trainedTalent.actor.experiencePoints.spent).toBe(10)
+      expect(actor.updateExperiencePoints).toHaveBeenCalledWith({ spent: 10 })
     })
   })
   describe('forget a ranked talent', () => {
-    test('should remove a new trained talent, row 1 and regain 5xp', () => {
+    test('should remove a ranked trained talent, row 1 and regain 5xp', async () => {
       const data = createTalentData('2', { isRanked: true, row: 1 })
       const existingTalents = [data]
       const actor = createActor({ items: existingTalents })
-      actor.experiencePoints.spent = 30
-      actor.experiencePoints.gained = 100
-      actor.experiencePoints.available = 80
+      actor.updateExperiencePoints = vi.fn().mockResolvedValue(actor)
+      actor.system.progression.experience.spent = 30
+      actor.system.progression.experience.gained = 100
+      actor.system.progression.experience.total = 100
       const params = {
         action: 'forget',
         isCreation: true,
@@ -62,24 +65,24 @@ describe('Ranked Trained Talent', () => {
       const options = {}
 
       const trainedTalent = new RankedTrainedTalent(actor, data, params, options)
-      const forgetRankedTrainedTalent = trainedTalent.process()
+      const forgetRankedTrainedTalent = await trainedTalent.process()
 
       expect(forgetRankedTrainedTalent).toBeInstanceOf(RankedTrainedTalent)
       expect(forgetRankedTrainedTalent.data._source.system.rank.idx).toBe(0)
       expect(forgetRankedTrainedTalent.data._source.system.rank.cost).toBe(0)
-      expect(forgetRankedTrainedTalent.actor.experiencePoints.spent).toBe(25)
+      expect(actor.updateExperiencePoints).toHaveBeenCalledWith({ spent: 25 })
     })
   })
   describe('process a ranked talent', () => {
     describe('should return an error talent if', () => {
-      test('trained a talent costs more than experience points available', () => {
+      test('trained a talent costs more than experience points available', async () => {
         const data = createTalentData('2', { row: 3 })
         const existingTalents = [createTalentData('1', { name: 'talent-1' })]
         const actor = createActor({ items: existingTalents })
-
-        actor.experiencePoints.spent = 90
-        actor.experiencePoints.gained = 100
-        actor.experiencePoints.available = 10
+        actor.updateExperiencePoints = vi.fn().mockResolvedValue(actor)
+        actor.system.progression.experience.spent = 90
+        actor.system.progression.experience.gained = 100
+        actor.system.progression.experience.total = 100
         const params = {
           action: 'train',
           isCreation: false,
@@ -87,7 +90,7 @@ describe('Ranked Trained Talent', () => {
         const options = {}
 
         const trainedTalent = new RankedTrainedTalent(actor, data, params, options)
-        const errorTalent = trainedTalent.process()
+        const errorTalent = await trainedTalent.process()
 
         expect(errorTalent).toBeInstanceOf(ErrorTalent)
         expect(errorTalent.options.message).toBe("you can't spend more experience than your total!")
@@ -96,7 +99,7 @@ describe('Ranked Trained Talent', () => {
     })
   })
   describe('updateState a ranked talent', () => {
-    test('should return a TalentError is TrainedError is not evaluated', async () => {
+    test('should return a TalentError if RankedTrainedTalent is not evaluated', async () => {
       const data = createTalentData('1')
       const existingTalents = [createTalentData('2', { name: 'talent-1' })]
       const actor = createActor({ items: existingTalents })
@@ -113,8 +116,8 @@ describe('Ranked Trained Talent', () => {
       }
       const options = {}
 
-      const trainedFreeTalent = new RankedTrainedTalent(actor, data, params, options)
-      const updatedTalent = await trainedFreeTalent.updateState()
+      const trainedTalent = new RankedTrainedTalent(actor, data, params, options)
+      const updatedTalent = await trainedTalent.updateState()
 
       expect(updatedTalent).toBeInstanceOf(ErrorTalent)
       expect(updateMock).toHaveBeenCalledTimes(0)
@@ -127,6 +130,7 @@ describe('Ranked Trained Talent', () => {
 
       const updateMock = vi.fn().mockResolvedValue({})
       actor.update = updateMock
+      actor.updateExperiencePoints = vi.fn().mockResolvedValue(actor)
 
       const createEmbeddedDocumentsMock = vi.fn().mockResolvedValue([data.toObject()])
       actor.createEmbeddedDocuments = createEmbeddedDocumentsMock
@@ -137,14 +141,12 @@ describe('Ranked Trained Talent', () => {
       }
       const options = {}
 
-      const trainedFreeTalent = new RankedTrainedTalent(actor, data, params, options)
-      const processedRankedTrainedTalent = trainedFreeTalent.process()
+      const trainedTalent = new RankedTrainedTalent(actor, data, params, options)
+      const processedRankedTrainedTalent = await trainedTalent.process()
       await processedRankedTrainedTalent.updateState()
 
-      expect(updateMock).toHaveBeenCalledTimes(1)
-      expect(updateMock).toHaveBeenNthCalledWith(1, {
-        'system.progression.experience.spent': 5,
-      })
+      expect(updateMock).toHaveBeenCalledTimes(0)
+      expect(actor.updateExperiencePoints).toHaveBeenCalledWith({ spent: 5 })
       expect(createEmbeddedDocumentsMock).toHaveBeenCalledWith('Item', [data.toObject()])
     })
     test('should update the state of the forget talent and return the talent', async () => {
@@ -154,6 +156,10 @@ describe('Ranked Trained Talent', () => {
 
       const updateMock = vi.fn().mockResolvedValue({})
       actor.update = updateMock
+      actor.updateExperiencePoints = vi.fn().mockResolvedValue(actor)
+      actor.system.progression.experience.spent = 30
+      actor.system.progression.experience.gained = 100
+      actor.system.progression.experience.total = 100
 
       const deleteEmbeddedDocumentsMock = vi.fn().mockResolvedValue(['1'])
       actor.deleteEmbeddedDocuments = deleteEmbeddedDocumentsMock
@@ -164,26 +170,23 @@ describe('Ranked Trained Talent', () => {
       }
       const options = {}
 
-      const trainedFreeTalent = new RankedTrainedTalent(actor, data, params, options)
-      const processedTrainedTalent = trainedFreeTalent.process()
-      await processedTrainedTalent.updateState()
+      const trainedTalent = new RankedTrainedTalent(actor, data, params, options)
+      const processedRankedTrainedTalent = await trainedTalent.process()
+      await processedRankedTrainedTalent.updateState()
 
-      expect(updateMock).toHaveBeenCalledTimes(1)
-      expect(updateMock).toHaveBeenNthCalledWith(1, {
-        'system.progression.experience.spent': -5,
-      })
+      expect(updateMock).toHaveBeenCalledTimes(0)
+      expect(actor.updateExperiencePoints).toHaveBeenCalledWith({ spent: 25 })
       expect(deleteEmbeddedDocumentsMock).toHaveBeenCalledWith('Item', ['1'])
     })
     describe('should return an Error Talent if any update fails', () => {
-      test('create embedded fails', async () => {
+      test('talent creation fails', async () => {
         const data = createTalentData('1')
         const existingTalents = [createTalentData('2', { name: 'talent-1' })]
         const actor = createActor({ items: existingTalents })
 
-        const updateMock = vi.fn().mockResolvedValue({})
-        actor.update = updateMock
+        actor.updateExperiencePoints = vi.fn().mockResolvedValue(actor)
 
-        const createEmbeddedDocumentsMock = vi.fn().mockRejectedValueOnce(new Error('Erreur sur create embedded'))
+        const createEmbeddedDocumentsMock = vi.fn().mockRejectedValueOnce(new Error('Erreur création'))
         actor.createEmbeddedDocuments = createEmbeddedDocumentsMock
 
         const params = {
@@ -192,70 +195,13 @@ describe('Ranked Trained Talent', () => {
         }
         const options = {}
 
-        const trainedFreeTalent = new RankedTrainedTalent(actor, data, params, options)
-        const processedRankedTrainedTalent = trainedFreeTalent.process()
-        const result = await processedRankedTrainedTalent.updateState()
+        const trainedTalent = new RankedTrainedTalent(actor, data, params, options)
+        await trainedTalent.process()
+        const result = await trainedTalent.updateState()
 
         expect(createEmbeddedDocumentsMock).toHaveBeenCalledTimes(1)
-        expect(updateMock).toHaveBeenCalledTimes(1)
         expect(result).toBeInstanceOf(ErrorTalent)
-        expect(result.options.message).toContain('Erreur sur create embedded')
-      })
-
-      test('talent rank update fails', async () => {
-        const data = createTalentData('1')
-        const existingTalents = [createTalentData('2', { name: 'talent-1' })]
-        const actor = createActor({ items: existingTalents })
-
-        const updateMock = vi.fn().mockRejectedValueOnce(new Error('Erreur sur update'))
-        actor.update = updateMock
-
-        const createEmbeddedDocumentsMock = vi.fn().mockResolvedValue([data.toObject()])
-        actor.createEmbeddedDocuments = createEmbeddedDocumentsMock
-
-        const params = {
-          action: 'train',
-          isCreation: true,
-        }
-        const options = {}
-
-        const trainedFreeTalent = new RankedTrainedTalent(actor, data, params, options)
-        const processedRankedTrainedTalent = trainedFreeTalent.process()
-        const result = await processedRankedTrainedTalent.updateState()
-
-        expect(createEmbeddedDocumentsMock).toHaveBeenCalledTimes(0)
-        expect(updateMock).toHaveBeenCalledTimes(1)
-        expect(result).toBeInstanceOf(ErrorTalent)
-        expect(result.options.message).toContain('Erreur sur update')
-      })
-      test('forget talent rank update fails', async () => {
-        const data = createTalentData('1', { name: 'talent-1' })
-        const existingTalents = [data]
-        const actor = createActor({ items: existingTalents })
-
-        const updateMock = vi.fn().mockResolvedValue({})
-        actor.update = updateMock
-
-        const deleteEmbeddedDocumentsMock = vi.fn().mockRejectedValueOnce(new Error('Erreur sur deleteEmbeddedDocuments'))
-        actor.deleteEmbeddedDocuments = deleteEmbeddedDocumentsMock
-
-        const params = {
-          action: 'forget',
-          isCreation: true,
-        }
-        const options = {}
-
-        const trainedFreeTalent = new TrainedTalent(actor, data, params, options)
-        const processedTrainedTalent = trainedFreeTalent.process()
-        const result = await processedTrainedTalent.updateState()
-
-        expect(updateMock).toHaveBeenCalledTimes(1)
-        expect(updateMock).toHaveBeenNthCalledWith(1, {
-          'system.progression.experience.spent': -5,
-        })
-        expect(deleteEmbeddedDocumentsMock).toHaveBeenCalledWith('Item', ['1'])
-        expect(result).toBeInstanceOf(ErrorTalent)
-        expect(result.options.message).toContain('Erreur sur deleteEmbeddedDocuments')
+        expect(result.options.message).toContain('Erreur création')
       })
     })
   })

--- a/tests/lib/talents/trained-talent.test.mjs
+++ b/tests/lib/talents/trained-talent.test.mjs
@@ -9,10 +9,11 @@ import ErrorTalent from '../../../module/lib/talents/error-talent.mjs'
 
 describe('Trained Talent', () => {
   describe('train a talent', () => {
-    test('should add a trained talent with idx 0 and spend 5xp', () => {
+    test('should add a trained talent with idx 0 and spend 5xp', async () => {
       const data = createTalentData('1')
       const existingTalents = [createTalentData('2', { name: 'talent-1' })]
       const actor = createActor({ items: existingTalents })
+      actor.updateExperiencePoints = vi.fn().mockResolvedValue(actor)
       const params = {
         action: 'train',
         isCreation: true,
@@ -20,22 +21,23 @@ describe('Trained Talent', () => {
       const options = {}
 
       const trainedTalent = new TrainedTalent(actor, data, params, options)
-      const trainTrainedTalent = trainedTalent.process()
+      const trainTrainedTalent = await trainedTalent.process()
 
       expect(trainTrainedTalent).toBeInstanceOf(TrainedTalent)
       expect(trainTrainedTalent.data.system.rank.idx).toBe(0)
       expect(trainTrainedTalent.data.system.rank.cost).toBe(5)
-      expect(trainedTalent.actor.experiencePoints.spent).toBe(5)
+      expect(actor.updateExperiencePoints).toHaveBeenCalledWith({ spent: 5 })
     })
   })
   describe('forget a talent', () => {
-    test('should remove a trained talent and regain 5xp', () => {
+    test('should remove a trained talent and regain 5xp', async () => {
       const data = createTalentData('1')
       const existingTalents = [data]
       const actor = createActor({ items: existingTalents })
-      actor.experiencePoints.spent = 30
-      actor.experiencePoints.gained = 100
-      actor.experiencePoints.available = 80
+      actor.updateExperiencePoints = vi.fn().mockResolvedValue(actor)
+      actor.system.progression.experience.spent = 30
+      actor.system.progression.experience.gained = 100
+      actor.system.progression.experience.total = 100
       const params = {
         action: 'forget',
         isCreation: true,
@@ -43,20 +45,21 @@ describe('Trained Talent', () => {
       const options = {}
 
       const trainedTalent = new TrainedTalent(actor, data, params, options)
-      const forgetTrainedTalent = trainedTalent.process()
+      const forgetTrainedTalent = await trainedTalent.process()
 
       expect(forgetTrainedTalent).toBeInstanceOf(TrainedTalent)
       expect(forgetTrainedTalent.data.system.rank.idx).toBe(0)
       expect(forgetTrainedTalent.data.system.rank.cost).toBe(0)
-      expect(forgetTrainedTalent.actor.experiencePoints.spent).toBe(25)
+      expect(actor.updateExperiencePoints).toHaveBeenCalledWith({ spent: 25 })
     })
   })
   describe('evaluate a talent', () => {
     describe('should return an error talent if', () => {
-      test('remove a trained talent not known', () => {
+      test('remove a trained talent not known', async () => {
         const data = createTalentData('1')
         const existingTalents = [createTalentData('2', { name: 'talent-1' })]
         const actor = createActor({ items: existingTalents })
+        actor.updateExperiencePoints = vi.fn().mockResolvedValue(actor)
         const params = {
           action: 'forget',
           isCreation: true,
@@ -64,17 +67,18 @@ describe('Trained Talent', () => {
         const options = {}
 
         const trainedTalent = new TrainedTalent(actor, data, params, options)
-        const errorTalent = trainedTalent.process()
+        const errorTalent = await trainedTalent.process()
 
         expect(errorTalent).toBeInstanceOf(ErrorTalent)
         expect(errorTalent.options.message).toBe("you can't forget a talent ('talent-name') you don't own!")
         expect(errorTalent.evaluated).toBe(false)
       })
 
-      test('drop a trained talent already known by id', () => {
+      test('drop a trained talent already known by id', async () => {
         const data = createTalentData('1')
         const existingTalents = [data]
         const actor = createActor({ items: existingTalents })
+        actor.updateExperiencePoints = vi.fn().mockResolvedValue(actor)
         const params = {
           action: 'train',
           isCreation: true,
@@ -82,17 +86,18 @@ describe('Trained Talent', () => {
         const options = {}
 
         const trainedTalent = new TrainedTalent(actor, data, params, options)
-        const errorTalent = trainedTalent.process()
+        const errorTalent = await trainedTalent.process()
 
         expect(errorTalent).toBeInstanceOf(ErrorTalent)
         expect(errorTalent.options.message).toBe("Talent 'talent-name' (ID: '1)' is already owned by the actor.")
         expect(errorTalent.evaluated).toBe(false)
       })
 
-      test('drop a trained talent already known by name', () => {
+      test('drop a trained talent already known by name', async () => {
         const data = createTalentData('1')
         const existingTalents = [createTalentData('2')]
         const actor = createActor({ items: existingTalents })
+        actor.updateExperiencePoints = vi.fn().mockResolvedValue(actor)
         const params = {
           action: 'train',
           isCreation: true,
@@ -100,21 +105,21 @@ describe('Trained Talent', () => {
         const options = {}
 
         const trainedTalent = new TrainedTalent(actor, data, params, options)
-        const errorTalent = trainedTalent.process()
+        const errorTalent = await trainedTalent.process()
 
         expect(errorTalent).toBeInstanceOf(ErrorTalent)
         expect(errorTalent.options.message).toBe("you already own this talent ('talent-name') and it is not a Ranked Talent!")
         expect(errorTalent.evaluated).toBe(false)
       })
 
-      test('trained a talent costs more than experience points available', () => {
+      test('trained a talent costs more than experience points available', async () => {
         const data = createTalentData('1', { row: 3 })
         const existingTalents = [createTalentData('2', { name: 'talent-1' })]
         const actor = createActor({ items: existingTalents })
-
-        actor.experiencePoints.spent = 90
-        actor.experiencePoints.gained = 100
-        actor.experiencePoints.available = 10
+        actor.updateExperiencePoints = vi.fn().mockResolvedValue(actor)
+        actor.system.progression.experience.spent = 90
+        actor.system.progression.experience.gained = 100
+        actor.system.progression.experience.total = 100
         const params = {
           action: 'train',
           isCreation: false,
@@ -122,7 +127,7 @@ describe('Trained Talent', () => {
         const options = {}
 
         const trainedTalent = new TrainedTalent(actor, data, params, options)
-        const errorTalent = trainedTalent.process()
+        const errorTalent = await trainedTalent.process()
 
         expect(errorTalent).toBeInstanceOf(ErrorTalent)
         expect(errorTalent.options.message).toBe("you can't spend more experience than your total!")
@@ -131,7 +136,7 @@ describe('Trained Talent', () => {
     })
   })
   describe('updateState a talent', () => {
-    test('should return a TalentError is TrainedError is not evaluated', async () => {
+    test('should return a TalentError if TrainedTalent is not evaluated', async () => {
       const data = createTalentData('1')
       const existingTalents = [createTalentData('2', { name: 'talent-1' })]
       const actor = createActor({ items: existingTalents })
@@ -148,8 +153,8 @@ describe('Trained Talent', () => {
       }
       const options = {}
 
-      const trainedFreeTalent = new TrainedTalent(actor, data, params, options)
-      const updatedTalent = await trainedFreeTalent.updateState()
+      const trainedTalent = new TrainedTalent(actor, data, params, options)
+      const updatedTalent = await trainedTalent.updateState()
 
       expect(updatedTalent).toBeInstanceOf(ErrorTalent)
       expect(updateMock).toHaveBeenCalledTimes(0)
@@ -162,6 +167,7 @@ describe('Trained Talent', () => {
 
       const updateMock = vi.fn().mockResolvedValue({})
       actor.update = updateMock
+      actor.updateExperiencePoints = vi.fn().mockResolvedValue(actor)
 
       const createEmbeddedDocumentsMock = vi.fn().mockResolvedValue([data.toObject()])
       actor.createEmbeddedDocuments = createEmbeddedDocumentsMock
@@ -172,23 +178,25 @@ describe('Trained Talent', () => {
       }
       const options = {}
 
-      const trainedFreeTalent = new TrainedTalent(actor, data, params, options)
-      const processedTrainedTalent = trainedFreeTalent.process()
+      const trainedTalent = new TrainedTalent(actor, data, params, options)
+      const processedTrainedTalent = await trainedTalent.process()
       await processedTrainedTalent.updateState()
 
-      expect(updateMock).toHaveBeenCalledTimes(1)
-      expect(updateMock).toHaveBeenNthCalledWith(1, {
-        'system.progression.experience.spent': 5,
-      })
+      expect(updateMock).toHaveBeenCalledTimes(0)
+      expect(actor.updateExperiencePoints).toHaveBeenCalledWith({ spent: 5 })
       expect(createEmbeddedDocumentsMock).toHaveBeenCalledWith('Item', [data.toObject()])
     })
     test('should update the state of the forget talent and return the talent', async () => {
       const data = createTalentData('1', { name: 'talent-1' })
       const existingTalents = [data]
       const actor = createActor({ items: existingTalents })
+      actor.system.progression.experience.spent = 30
+      actor.system.progression.experience.gained = 100
+      actor.system.progression.experience.total = 100
 
       const updateMock = vi.fn().mockResolvedValue({})
       actor.update = updateMock
+      actor.updateExperiencePoints = vi.fn().mockResolvedValue(actor)
 
       const deleteEmbeddedDocumentsMock = vi.fn().mockResolvedValue(['1'])
       actor.deleteEmbeddedDocuments = deleteEmbeddedDocumentsMock
@@ -199,26 +207,23 @@ describe('Trained Talent', () => {
       }
       const options = {}
 
-      const trainedFreeTalent = new TrainedTalent(actor, data, params, options)
-      const processedTrainedTalent = trainedFreeTalent.process()
+      const trainedTalent = new TrainedTalent(actor, data, params, options)
+      const processedTrainedTalent = await trainedTalent.process()
       await processedTrainedTalent.updateState()
 
-      expect(updateMock).toHaveBeenCalledTimes(1)
-      expect(updateMock).toHaveBeenNthCalledWith(1, {
-        'system.progression.experience.spent': -5,
-      })
+      expect(updateMock).toHaveBeenCalledTimes(0)
+      expect(actor.updateExperiencePoints).toHaveBeenCalledWith({ spent: 25 })
       expect(deleteEmbeddedDocumentsMock).toHaveBeenCalledWith('Item', ['1'])
     })
     describe('should return an Error Talent if any update fails', () => {
-      test('create embedded fails', async () => {
+      test('talent creation fails', async () => {
         const data = createTalentData('1')
         const existingTalents = [createTalentData('2', { name: 'talent-1' })]
         const actor = createActor({ items: existingTalents })
 
-        const updateMock = vi.fn().mockResolvedValue({})
-        actor.update = updateMock
+        actor.updateExperiencePoints = vi.fn().mockResolvedValue(actor)
 
-        const createEmbeddedDocumentsMock = vi.fn().mockRejectedValueOnce(new Error('Erreur sur create embedded'))
+        const createEmbeddedDocumentsMock = vi.fn().mockRejectedValueOnce(new Error('Erreur création'))
         actor.createEmbeddedDocuments = createEmbeddedDocumentsMock
 
         const params = {
@@ -227,70 +232,13 @@ describe('Trained Talent', () => {
         }
         const options = {}
 
-        const trainedFreeTalent = new TrainedTalent(actor, data, params, options)
-        const processedTrainedTalent = trainedFreeTalent.process()
-        const result = await processedTrainedTalent.updateState()
+        const trainedTalent = new TrainedTalent(actor, data, params, options)
+        await trainedTalent.process()
+        const result = await trainedTalent.updateState()
 
         expect(createEmbeddedDocumentsMock).toHaveBeenCalledTimes(1)
-        expect(updateMock).toHaveBeenCalledTimes(1)
         expect(result).toBeInstanceOf(ErrorTalent)
-        expect(result.options.message).toContain('Erreur sur create embedded')
-      })
-
-      test('train talent rank update fails', async () => {
-        const data = createTalentData('1')
-        const existingTalents = [createTalentData('2', { name: 'talent-1' })]
-        const actor = createActor({ items: existingTalents })
-
-        const updateMock = vi.fn().mockRejectedValueOnce(new Error('Erreur sur update'))
-        actor.update = updateMock
-
-        const createEmbeddedDocumentsMock = vi.fn().mockResolvedValue([data.toObject()])
-        actor.createEmbeddedDocuments = createEmbeddedDocumentsMock
-
-        const params = {
-          action: 'train',
-          isCreation: true,
-        }
-        const options = {}
-
-        const trainedFreeTalent = new TrainedTalent(actor, data, params, options)
-        const processedTrainedTalent = trainedFreeTalent.process()
-        const result = await processedTrainedTalent.updateState()
-
-        expect(createEmbeddedDocumentsMock).toHaveBeenCalledTimes(0)
-        expect(updateMock).toHaveBeenCalledTimes(1)
-        expect(result).toBeInstanceOf(ErrorTalent)
-        expect(result.options.message).toContain('Erreur sur update')
-      })
-      test('forget talent rank update fails', async () => {
-        const data = createTalentData('1', { name: 'talent-1' })
-        const existingTalents = [data]
-        const actor = createActor({ items: existingTalents })
-
-        const updateMock = vi.fn().mockResolvedValue({})
-        actor.update = updateMock
-
-        const deleteEmbeddedDocumentsMock = vi.fn().mockRejectedValueOnce(new Error('Erreur sur deleteEmbeddedDocuments'))
-        actor.deleteEmbeddedDocuments = deleteEmbeddedDocumentsMock
-
-        const params = {
-          action: 'forget',
-          isCreation: true,
-        }
-        const options = {}
-
-        const trainedFreeTalent = new TrainedTalent(actor, data, params, options)
-        const processedTrainedTalent = trainedFreeTalent.process()
-        const result = await processedTrainedTalent.updateState()
-
-        expect(updateMock).toHaveBeenCalledTimes(1)
-        expect(updateMock).toHaveBeenNthCalledWith(1, {
-          'system.progression.experience.spent': -5,
-        })
-        expect(deleteEmbeddedDocumentsMock).toHaveBeenCalledWith('Item', ['1'])
-        expect(result).toBeInstanceOf(ErrorTalent)
-        expect(result.options.message).toContain('Erreur sur deleteEmbeddedDocuments')
+        expect(result.options.message).toContain('Erreur création')
       })
     })
   })

--- a/tests/utils/actors/actor.mjs
+++ b/tests/utils/actors/actor.mjs
@@ -24,7 +24,7 @@ export function createActor({ careerSpent = 0, specializationSpent = 0, items = 
             gained: 2,
           },
         },
-        experiencePoints: {
+        experience: {
           spent: 0,
           gained: 0,
           startingExperience: 100,


### PR DESCRIPTION
## Summary
- Refactor `trained-characteristic.mjs` to use `updateExperiencePoints()`
- Refactor `trained-talent.mjs` to use `updateExperiencePoints()`
- Refactor `ranked-trained-talent.mjs` to use `updateExperiencePoints()`
- Update all related test files to use async pattern
- Fix `tests/utils/actors/actor.mjs` to use `system.progression.experience`

## Related Issue
Fixes #80

## Changes
- `module/lib/characteristics/trained-characteristic.mjs`: Use new update method
- `module/lib/talents/trained-talent.mjs`: Use new update method
- `module/lib/talents/ranked-trained-talent.mjs`: Use new update method
- `tests/lib/characteristics/trained-characteristic.test.mjs`: Updated tests (10/10 pass)
- `tests/lib/talents/trained-talent.test.mjs`: Updated tests (10/10 pass)
- `tests/lib/talents/ranked-trained-talent.test.mjs`: Updated tests (8/8 pass)
- `tests/utils/actors/actor.mjs`: Fixed experience structure

## Testing
All characteristics and talents tests pass with new async pattern.