### PR TITLE
docs(spec): add canonical weapon taxonomy specification (Issue #97)

### DIFF
--- a/documentation/INDEX.md
+++ b/documentation/INDEX.md
@@ -71,6 +71,7 @@ Cette documentation technique couvre l'architecture, les modules, les exigences,
 | Document / Dossier                                                                       | Description                                         |
 | ---------------------------------------------------------------------------------------- | --------------------------------------------------- |
 | [`spec/`](./spec/)                                                                       | Spécifications détaillées (design, séquences, etc.) |
+| [`spec/weapon-taxonomy-canonical.md`](./spec/weapon-taxonomy-canonical.md)               | Spécification canonique de la taxonomie des armes   |
 | [`spec/design-current-equipment-sidebar.md`](./spec/design-current-equipment-sidebar.md) | Design de la sidebar d'équipement courant           |
 | [`spec/oggdude-importer/`](./spec/oggdude-importer/)                                     | Spécifications dédiées à l'importeur OggDude        |
 | [`plan/`](./plan/)                                                                       | Plans d'implémentation (REQ/TASK/FILE/TEST)         |

--- a/documentation/architecture/adr/adr-0007-weapon-taxonomy.md
+++ b/documentation/architecture/adr/adr-0007-weapon-taxonomy.md
@@ -10,7 +10,7 @@ superseded_by: ''
 
 ## Status
 
-**Accepted** — Validée le 2026-05-07. L'ADR formalise les décisions d'architecture issues de #15 et sert de référence pour #97, #98, #100 et #101.
+**Accepted** — Validée le 2026-05-07. L'ADR formalise les décisions d'architecture issues de #15. Les valeurs canoniques finales de la taxonomie sont définies dans la [spécification canonique](../../spec/weapon-taxonomy-canonical.md) (issue #97). Cette ADR sert de référence pour #98, #100 et #101.
 
 ## Context
 
@@ -56,47 +56,36 @@ On distingue deux champs distincts dans le schéma `weapon` :
     - Issu de `<Type>` OggDude.
     - Usage informatif, affichage, filtres secondaires et préparation pour futurs comportements.
 
-### D2 — Enum canonique proposée pour `system.category`
+### D2 — Enum canonique pour `system.category`
 
-Les valeurs proposées à titre initial (seront finalisées dans #97) :
+Les valeurs canoniques finales sont définies dans la [spécification canonique #97](../../spec/weapon-taxonomy-canonical.md).
 
-| Clé         | Label         | Skill principal          | RangeCategory | Notes                                   |
-|-------------|---------------|--------------------------|---------------|-----------------------------------------|
-| `melee`     | Mêlée         | melee, lightsaber, brawl | melee         | Armes de corps-à-corps                  |
-| `ranged`    | Distance      | rangedLight, rangedHeavy | distant       | Armes à distance (hors heavy)           |
-| `gunnery`   | Armes lourdes | gunnery                  | distant       | Mitrailleuses, lance-missiles portatifs |
-| `explosive` | Explosifs     | variable                 | variable      | Grenades, mines, démolitions            |
-| `thrown`    | Jet           | rangedLight              | distant       | Couteaux de lancer, shurikens           |
-| `vehicle`   | Véhicule      | gunnery                  | distant       | Armement monté sur véhicule             |
-| `natural`   | Naturelles    | brawl                    | melee         | Attaques sans arme                      |
+L'enum se compose des valeurs suivantes, validées dans #97 :
 
-**Règles :**
-
-- Toute arme non catégorisée reçoit `melee` ou `ranged` selon son `SkillKey` (fallback sûr).
-- Les valeurs sont définies dans `module/config/weapon.mjs` sous une export `CATEGORIES` suivant le pattern d'
-  `armor.mjs`.
-
-### D3 — `system.weaponType` : valeurs et mapping OggDude
-
-Le champ `system.weaponType` reçoit une valeur normalisée à partir de `<Type>` OggDude via une table de mapping :
-
-| `<Type>` OggDude   | `system.weaponType` normalisé |
-|--------------------|-------------------------------|
-| `Blasters`         | `blaster`                     |
-| `Blasters/Heavy`   | `blaster-heavy`               |
-| `Slugthrowers`     | `slugthrower`                 |
-| `Flame-Projectors` | `flame-projector`             |
-| `Explosives/Other` | `explosive-other`             |
-| `Ion`              | `ion`                         |
-| `Missiles`         | `missile`                     |
-| `Melee`            | `melee`                       |
-| `Lightsabers`      | `lightsaber`                  |
-| `Brawl`            | `brawl`                       |
+| Clé         | Rôle mécanique                      | Skill principal          | RangeCategory |
+|-------------|-------------------------------------|--------------------------|---------------|
+| `melee`     | Corps-à-corps                       | melee, lightsaber, brawl | melee         |
+| `ranged`    | Tir standard                        | rangedLight, rangedHeavy | distant       |
+| `gunnery`   | Armes lourdes portatives            | gunnery                  | distant       |
+| `explosive` | Explosifs, démolitions              | rangedLight, gunnery     | distant       |
+| `thrown`    | Armes de jet                        | rangedLight              | distant       |
+| `vehicle`   | Armement monté                       | gunnery                  | distant       |
+| `natural`   | Attaques naturelles                 | brawl                    | melee         |
 
 **Règles :**
 
-- Les valeurs sont normalisées en kebab-case.
-- Les valeurs inconnues sont conservées telles quelles (slugifiées) avec un warning.
+- Toute arme non catégorisée reçoit `melee` ou `ranged` selon son `SkillKey` (fallback sûr, voir chaîne de priorité dans la spec #97).
+- Les valeurs sont définies dans `module/config/weapon.mjs` sous une export `CATEGORIES` suivant le pattern d'`armor.mjs`.
+
+### D3 — `system.weaponType` : liste normalisée ouverte
+
+Le champ `system.weaponType` reçoit une valeur normalisée à partir de `<Type>` OggDude. La liste des valeurs connues et les règles de slugification sont définies dans la [spécification canonique #97](../../spec/weapon-taxonomy-canonical.md).
+
+**Règles (synthèse) :**
+
+- `system.weaponType` n'est pas une enum fermée : c'est une liste de référence ouverte avec fallback par slugification.
+- Les valeurs connues sont normalisées en kebab-case.
+- Les valeurs inconnues sont slugifiées (kebab-case, sans caractères spéciaux).
 - La valeur brute d'origine est toujours conservée dans `flags.swerpg.oggdude.type`.
 
 ### D4 — Mapping de `<Categories>` OggDude
@@ -266,9 +255,9 @@ Aucun impact direct sur `system.qualities` dont le format reste celui défini da
 
 Cette ADR doit être réévaluée après :
 
-- L'implémentation de #97 (finalisation des valeurs d'enum).
 - L'implémentation de #98 (alignement du schéma).
-- Un retour d'expérience sur l'import OggDude (#101) et l'UI (#100).
+- L'implémentation de #101 (import OggDude).
+- L'implémentation de #100 (UX/tests).
 
 Ces implémentations pourront amender l'ADR si des écarts sont constatés par rapport aux décisions initiales.
 
@@ -277,7 +266,8 @@ Prochaine réévaluation : 2026-08-01.
 ## Links
 
 - Issue source : #15
-- Implémentation découlant de cette ADR : #97, #98, #100, #101
+- Spécification canonique #97 : `documentation/spec/weapon-taxonomy-canonical.md`
+- Implémentation découlant de cette ADR : #98, #100, #101
 - Issues connexes : #16 (Restricted), #17 (Migration armes importées), #18 (SizeHigh)
 - Spec qualités : `docs/specifications/qualities-format-spec.md`
 - Plan d'implémentation : `documentation/plan/features/feature-weapon-taxonomy-adr-1.md`

--- a/documentation/plan/features/feature-weapon-taxonomy-adr-1.md
+++ b/documentation/plan/features/feature-weapon-taxonomy-adr-1.md
@@ -79,9 +79,9 @@ L'ADR sera le document de référence pour :
 
 | Task | Description | Completed | Date |
 | ---- | ----------- | --------- | ---- |
-| TASK-016 | Soumettre l'ADR pour relecture (PR ou validation directe). | | |
-| TASK-017 | Intégrer les retours de review. | | |
-| TASK-018 | Mettre à jour le statut de l'ADR (Proposed → Accepted). | | |
+| TASK-016 | Soumettre l'ADR pour relecture (PR ou validation directe). | ✅ | 2026-05-07 |
+| TASK-017 | Intégrer les retours de review. | ✅ | 2026-05-07 |
+| TASK-018 | Mettre à jour le statut de l'ADR (Proposed → Accepted). | ✅ | 2026-05-07 |
 
 ## 3. Alternatives
 

--- a/documentation/spec/weapon-taxonomy-canonical.md
+++ b/documentation/spec/weapon-taxonomy-canonical.md
@@ -1,0 +1,220 @@
+---
+title: 'Spécification canonique de la taxonomie des armes (system.category, system.weaponType)'
+status: 'Validé'
+date: '2026-05-07'
+issue: '#97'
+tags: ['weapon', 'taxonomy', 'canonical', 'spec']
+---
+
+## Status
+
+**Validé** — Cette spécification finalise les valeurs canoniques de la taxonomie des armes définie dans ADR-0007.
+Elle sert de document de référence unique pour les issues #98 (schéma), #101 (import OggDude) et #100 (UX/tests).
+
+## system.category — Enum canonique fermée
+
+### Valeurs autorisées
+
+| Clé | Rôle mécanique | Skill principal | RangeCategory | Exemples OggDude |
+|-----|----------------|-----------------|---------------|------------------|
+| `melee` | Corps-à-corps | melee, lightsaber, brawl | melee | Armes blanches, vibro-lames, gantelets |
+| `ranged` | Tir standard, armes légères et lourdes portatives | rangedLight, rangedHeavy | distant | Blasters, fusils, pistolets |
+| `gunnery` | Armes lourdes portatives, mitrailleuses, lance-missiles | gunnery | distant | Mitrailleuses lourdes, lance-missiles |
+| `explosive` | Explosifs, démolitions, grenades | rangedLight, gunnery | distant | Grenades, mines, charges |
+| `thrown` | Armes de jet | rangedLight | distant | Couteaux de lancer, shurikens, hachettes |
+| `vehicle` | Armement monté sur véhicule ou vaisseau | gunnery | distant | Tourelles, canons montés |
+| `natural` | Attaques naturelles sans arme | brawl | melee | Griffes, crocs, attaques à mains nues |
+
+### Règles de l'enum
+
+1. **Enum fermée** : `system.category` ne peut contenir qu'une valeur de cette liste. Toute valeur invalide est rejetée par le schéma au même titre que les catégories d'armure (cf. `SwerpgArmor.ITEM_CATEGORIES`).
+2. **Pas de `other` / `unknown`** : L'enum n'autorise pas de valeur fourre-tout. En cas d'impossibilité de résolution, la chaîne de priorité (§Priorités et fallbacks) détermine une valeur fiable. En dernier recours, un fallback par défaut documenté est utilisé.
+3. **Correspondance rangeCategory** : Chaque catégorie a un `rangeCategory` associé (`melee` ou `distant`) qui sert de base aux décisions mécaniques (animation, boons/banes, etc.).
+
+## system.weaponType — Liste normalisée ouverte
+
+`system.weaponType` n'est **pas** une enum fermée au niveau du schéma. C'est une liste de référence de valeurs normalisées, avec un fallback par slugification pour les valeurs inconnues.
+
+### Valeurs connues (liste de référence, non exhaustive)
+
+| Valeur normalisée | Source `<Type>` OggDude typique | `system.category` typique |
+|---|---|---|
+| `blaster` | Blasters | ranged |
+| `blaster-heavy` | Blasters/Heavy | ranged, gunnery |
+| `slugthrower` | Slugthrowers | ranged |
+| `flame-projector` | Flame-Projectors | ranged |
+| `explosive-other` | Explosives/Other | explosive |
+| `ion` | Ion | ranged |
+| `missile` | Missiles | gunnery |
+| `melee` | Melee | melee |
+| `lightsaber` | Lightsabers | melee |
+| `brawl` | Brawl | natural |
+
+### Règles de normalisation
+
+1. **Valeur connue** → mapping explicite vers la valeur normalisée (table ci-dessus).
+2. **Valeur inconnue** → slugification : `kebab-case`, suppression des caractères spéciaux, normalisation Unicode.
+3. **Valeur brute conservée** : la valeur originale de `<Type>` est toujours stockée dans `flags.swerpg.oggdude.type`.
+4. **Pas de validation stricte** : `system.weaponType` est un `StringField` libre dans le schéma. La normalisation est assurée par le mapper, pas par le modèle.
+
+### Algorithme de slugification
+
+```
+input: valeur brute <Type>
+1. trim()
+2. toLowerCase()
+3. remplacer '/', '\', '|', '—', '–' par '-'
+4. supprimer tout caractère non [a-z0-9-]
+5. réduire les '-' multiples en un seul '-'
+6. supprimer les '-' en début et fin de chaîne
+output: chaîne slugifiée
+```
+
+## Tables de mapping OggDude → SWERPG
+
+### `<Categories>` → `system.category`
+
+| `<Category>` OggDude | `system.category` | Priorité |
+|---|---|---|
+| `Ranged` | `ranged` | 1 |
+| `Melee` | `melee` | 1 |
+| `Thrown` | `thrown` | 1 |
+| `Vehicle` | `vehicle` | 1 |
+| `Starship` | `vehicle` | 1 |
+| `Explosive` | `explosive` | 1 |
+| `Heavy` | `gunnery` | 1 |
+
+**Règle de prise en compte pour les tableaux** : Parcourir le tableau dans l'ordre. La première valeur reconnue détermine `system.category`. Si cette valeur entre en conflit avec SkillKey, le conflit est loggué et SkillKey l'emporte (§Priorités et fallbacks).
+
+### `<Type>` → `system.weaponType`
+
+| `<Type>` OggDude | `system.weaponType` | Priorité |
+|---|---|---|
+| `Blasters` | `blaster` | 1 |
+| `Blasters/Heavy` | `blaster-heavy` | 1 |
+| `Slugthrowers` | `slugthrower` | 1 |
+| `Flame-Projectors` | `flame-projector` | 1 |
+| `Ion` | `ion` | 1 |
+| `Missiles` | `missile` | 1 |
+| `Melee` | `melee` | 1 |
+| `Lightsabers` | `lightsaber` | 1 |
+| `Brawl` | `brawl` | 1 |
+| `Explosives/Other` | `explosive-other` | 1 |
+| *Toute autre valeur* | `slugify(valeur)` | 2 (fallback) |
+
+## Priorités et fallbacks
+
+### Résolution de `system.category`
+
+```
+1. <Categories> OggDude
+   │
+   ├── valeur unique reconnue → l'utiliser
+   ├── plusieurs valeurs reconnues → la première dans l'ordre du tableau
+   └── conflit avec SkillKey → SkillKey l'emporte (warning)
+   │
+   └─ si absent ou aucune valeur reconnue
+      ↓
+2. SkillKey
+   │
+   ├── melee / lightsaber / brawl → "melee"
+   ├── rangedLight / rangedHeavy → "ranged"
+   ├── gunnery → "gunnery"
+   └── autre / inconnu
+      ↓
+3. Range (RangeValue)
+   │
+   ├── engaged → "melee"
+   └── short / medium / long / extreme → "ranged"
+      ↓
+4. Fallback par défaut : "ranged"
+```
+
+**Règles :**
+- Chaque saut de fallback émet un warning loggué (catégorie `WEAPON_CATEGORY_FALLBACK`).
+- En mode strict (flag import), l'absence de résolution fiable peut rejeter l'item.
+
+### Résolution de `system.weaponType`
+
+```
+1. <Type> OggDude → valeur mappée dans la table de référence
+   │
+   ├── valeur connue → valeur normalisée
+   └── valeur inconnue → slugify(valeur brute)
+   │
+   └─ si <Type> absent
+      ↓
+2. Chaîne vide ""
+```
+
+**Règle :** `system.weaponType` n'est jamais critique pour le fonctionnement mécanique de l'arme. Un fallback vide est acceptable.
+
+## Cas ambigus documentés
+
+### Cas 1 : Blasters/Heavy + `Ranged` + SkillKey RangedLight
+- **system.category** : `ranged` (Categories reconnue)
+- **system.weaponType** : `blaster-heavy`
+- **Justification** : Cohérent. Le `Heavy` du type ne change pas la famille mécanique.
+
+### Cas 2 : Explosives/Other + `Ranged` + SkillKey RangedLight
+- **system.category** : `ranged` (Categories reconnue)
+- **system.weaponType** : `explosive-other`
+- **Justification** : Les explosifs lancés sont `Ranged` dans OggDude. Le type `Explosive-other` permet de les distinguer.
+
+### Cas 3 : Explosives/Other + `Explosive` (Categories)
+- **system.category** : `explosive`
+- **system.weaponType** : `explosive-other`
+- **Justification** : `<Categories>` fournit `Explosive` → mappé directement vers `explosive`.
+
+### Cas 4 : Type inconnu + Categories absentes + SkillKey Melee
+- **system.category** : `melee` (via SkillKey)
+- **system.weaponType** : `slugify(Type)` ou `""`
+- **Justification** : SkillKey fiable en fallback quand Categories est absent.
+
+### Cas 5 : `['Melee', 'Ranged']` + SkillKey RangedLight
+- **system.category** : `ranged` (conflit entre Categories et SkillKey → SkillKey l'emporte avec warning)
+- **Justification** : La première valeur reconnue dans Categories serait `melee`, mais SkillKey indique `ranged`. Le conflit est tranché en faveur de SkillKey.
+
+### Cas 6 : Pas de Type ni Categories (création manuelle ou source non-OggDude)
+- **system.category** : `"ranged"` (valeur par défaut du schéma)
+- **system.weaponType** : `""` (vide)
+- **Justification** : Fallback documenté pour les armes créées manuellement.
+
+### Cas 7 : `['Ranged', 'Starship']` + SkillKey Gunnery
+- **system.category** : `vehicle` (Starship → vehicle) si c'est la première valeur reconnue pertinente. Si conflit avec SkillKey gunnery → `gunnery` l'emporte avec warning.
+- **Justification** : Les armes montées sur vaisseau peuvent être taguées `Ranged` et `Starship`. La résolution dépend de l'ordre des valeurs et de SkillKey.
+
+### Cas 8 : Arme sans SkillKey ni Range (données minimales)
+- **system.category** : `"ranged"` (fallback ultime)
+- **system.weaponType** : `""` (vide)
+- **Justification** : Sécurité. Une arme sans skill ni range est invalide mais ne doit pas planter l'import.
+
+## Implications pour les issues suivantes
+
+### #98 — Schéma weapon
+- Définir `SwerpgWeapon.ITEM_CATEGORIES = SYSTEM.WEAPON.CATEGORIES` (pattern `SwerpgArmor`)
+- Définir `SwerpgWeapon.DEFAULT_CATEGORY = 'ranged'`
+- Ajouter `system.weaponType` : `StringField({ required: false, initial: '' })`
+- Ajouter les clés de localisation `WEAPON.CATEGORIES.*` dans `lang/*.json`
+
+### #101 — Import OggDude weapon
+- Mapper `<Categories>` → `system.category` via la table de mapping
+- Mapper `<Type>` → `system.weaponType` via la table de mapping
+- Stocker `flags.swerpg.oggdude.type` (valeur brute)
+- Stocker `flags.swerpg.oggdude.categories` (tableau brut)
+- Émettre les warnings pour les fallbacks
+- Clarifier l'avenir de `flags.swerpg.oggdudeTags`
+
+### #100 — UX/Tests
+- Exposer `system.category` dans la fiche d'arme (selecteur)
+- Afficher `system.weaponType` en lecture seule (ou éditable si pertinent)
+- Préparer les filtres UI par `system.category`
+- Mettre à jour les tests d'import pour couvrir la taxonomie
+- Documenter l'usage résiduel de `oggdudeTags`
+
+## Références
+
+- ADR-0007 : Taxonomie canonique des armes
+- Issue source : #15
+- Issues découlant de cette spec : #98, #100, #101
+- Plan d'implémentation : `documentation/plan/features/feature-weapon-taxonomy-adr-1.md`


### PR DESCRIPTION
## Summary

- Finalize the canonical enum for `system.category` (7 values: melee, ranged, gunnery, explosive, thrown, vehicle, natural)
- Define an open normalized list for `system.weaponType` with slug fallback
- Document OggDude `<Categories>` → `system.category` mapping table
- Document OggDude `<Type>` → `system.weaponType` mapping table
- Define priority chains and fallback rules for both fields
- Document 8 ambiguous cases with resolution
- Update ADR-0007 to reference the finalized spec

## Files

| File | Action |
|------|--------|
| `documentation/spec/weapon-taxonomy-canonical.md` | New — full canonical specification |
| `documentation/architecture/adr/adr-0007-weapon-taxonomy.md` | Updated — references spec, finalizes enum, simplifies D3 |
| `documentation/INDEX.md` | Updated — references new spec |
| `documentation/plan/features/feature-weapon-taxonomy-adr-1.md` | Updated — review tasks marked complete |

## References

- Closes #97
- Prepares input for #98 (schema), #101 (import), #100 (UX/tests)