### PR TITLE
feat(schema): align weapon data model on canonical taxonomy (Issue #98)

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -956,6 +956,15 @@
     "ConvincingDemeanorAbbr": "Cdr"
   },
   "WEAPON": {
+    "CATEGORIES": {
+      "MELEE": "Melee",
+      "RANGED": "Ranged",
+      "GUNNERY": "Gunnery",
+      "EXPLOSIVE": "Explosive",
+      "THROWN": "Thrown",
+      "VEHICLE": "Vehicle",
+      "NATURAL": "Natural"
+    },
     "QUALITIES": {
       "Accurate": "Accurate",
       "AccurateTooltip": "This weapon is particularly accurate, granting +1 bonus to the attack roll.",
@@ -1059,6 +1068,10 @@
       "animation": {
         "label": "Weapon Animation Prefix",
         "hint": "If using Swerpg with JB2A animation integration, specify which animation prefix is used for this weapon."
+      },
+      "weaponType": {
+        "label": "Weapon Type",
+        "hint": "The narrative subtype or lineage of this weapon (e.g. blaster, lightsaber)."
       }
     },
     "TAGS": {

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -866,23 +866,13 @@
   },
   "WEAPON": {
     "CATEGORIES": {
-      "LIGHT1": "Light (1h)",
-      "SIMPLE1": "Simple (1h)",
-      "BALANCED1": "Balanced (1h)",
-      "HEAVY1": "Heavy (1h)",
-      "SIMPLE2": "Simple (2h)",
-      "BALANCED2": "Balanced (2h)",
-      "HEAVY2": "Heavy (2h)",
-      "PROJECTILE1": "Projectile (1h)",
-      "PROJECTILE2": "Projectile (2h)",
-      "MECHANICAL1": "Mechanical (1h)",
-      "MECHANICAL2": "Mechanical (2h)",
-      "NATURAL": "Natural",
-      "UNARMED": "Unarmed",
-      "SHIELD_LIGHT": "Light Shield",
-      "SHIELD_HEAVY": "Heavy Shield",
-      "TALISMAN1": "Talisman (1h)",
-      "TALISMAN2": "Talisman (2h)"
+      "MELEE": "Melee",
+      "RANGED": "Ranged",
+      "GUNNERY": "Gunnery",
+      "EXPLOSIVE": "Explosive",
+      "THROWN": "Thrown",
+      "VEHICLE": "Vehicle",
+      "NATURAL": "Natural"
     },
     "FIELDS": {
       "damageType": {
@@ -900,6 +890,10 @@
       "animation": {
         "label": "Weapon Animation Prefix",
         "hint": "If using Swerpg with JB2A animation integration, specify which animation prefix is used for this weapon."
+      },
+      "weaponType": {
+        "label": "Weapon Type",
+        "hint": "The narrative subtype or lineage of this weapon (e.g. blaster, lightsaber)."
       }
     },
     "TAGS": {

--- a/module/config/weapon.mjs
+++ b/module/config/weapon.mjs
@@ -13,6 +13,20 @@
  */
 
 /**
+ * @typedef {Object} WeaponCategory    A canonincal weapon mechanical family (system.category)
+ * @property {string} id               The category id
+ * @property {string} label            The localized label
+ * @property {boolean} ranged          Whether this is a ranged weapon family
+ * @property {boolean} reload          Whether weapons in this family require reloading
+ * @property {number} hands            Typical hand count (1 or 2)
+ * @property {boolean} main            Can be equipped in main-hand slot
+ * @property {boolean} off             Can be equipped in off-hand slot
+ * @property {string} training         Training key used for bonus lookups
+ * @property {string[]} scaling        Ability scaling keys (e.g. ['dexterity'])
+ * @property {RangeCategory} rangeCategory  The range category for attack roll mechanics
+ */
+
+/**
  * @typedef {Object} RangeType     A weapon range type
  * @property {string} id               The range category id
  * @property {string} abrev            The range category abbreviation
@@ -70,6 +84,98 @@ export const RANGE_CATEGORY = {
     id: 'distant',
     abrev: 'DIS',
     label: 'WEAPON.RANGE_CATEGORY.DISTANT',
+  },
+}
+
+/**
+ * Named weapon categories (canonical mechanical family taxonomy).
+ * Each entry defines metadata consumed by the runtime (equipment, actions, preparation).
+ * @enum {WeaponCategory}
+ */
+export const CATEGORIES = {
+  melee: {
+    id: 'melee',
+    label: 'WEAPON.CATEGORIES.MELEE',
+    ranged: false,
+    reload: false,
+    hands: 1,
+    main: true,
+    off: true,
+    training: 'melee',
+    scaling: ['strength'],
+    rangeCategory: RANGE_CATEGORY.melee,
+  },
+  ranged: {
+    id: 'ranged',
+    label: 'WEAPON.CATEGORIES.RANGED',
+    ranged: true,
+    reload: true,
+    hands: 1,
+    main: true,
+    off: false,
+    training: 'projectile',
+    scaling: ['dexterity'],
+    rangeCategory: RANGE_CATEGORY.distant,
+  },
+  gunnery: {
+    id: 'gunnery',
+    label: 'WEAPON.CATEGORIES.GUNNERY',
+    ranged: true,
+    reload: true,
+    hands: 2,
+    main: true,
+    off: false,
+    training: 'projectile',
+    scaling: ['dexterity'],
+    rangeCategory: RANGE_CATEGORY.distant,
+  },
+  explosive: {
+    id: 'explosive',
+    label: 'WEAPON.CATEGORIES.EXPLOSIVE',
+    ranged: true,
+    reload: false,
+    hands: 1,
+    main: true,
+    off: false,
+    training: 'projectile',
+    scaling: ['dexterity'],
+    rangeCategory: RANGE_CATEGORY.distant,
+  },
+  thrown: {
+    id: 'thrown',
+    label: 'WEAPON.CATEGORIES.THROWN',
+    ranged: true,
+    reload: false,
+    hands: 1,
+    main: true,
+    off: true,
+    training: 'projectile',
+    scaling: ['dexterity'],
+    rangeCategory: RANGE_CATEGORY.distant,
+  },
+  vehicle: {
+    id: 'vehicle',
+    label: 'WEAPON.CATEGORIES.VEHICLE',
+    ranged: true,
+    reload: true,
+    hands: 2,
+    main: true,
+    off: false,
+    training: 'mechanical',
+    scaling: ['dexterity'],
+    rangeCategory: RANGE_CATEGORY.distant,
+  },
+  natural: {
+    id: 'natural',
+    label: 'WEAPON.CATEGORIES.NATURAL',
+    ranged: false,
+    reload: false,
+    hands: 1,
+    main: true,
+    off: false,
+    training: 'melee',
+    scaling: ['strength'],
+    rangeCategory: RANGE_CATEGORY.melee,
   },
 }
 

--- a/module/models/weapon.mjs
+++ b/module/models/weapon.mjs
@@ -8,6 +8,12 @@ import SwerpgCombatItem from './combat.mjs'
  */
 export default class SwerpgWeapon extends SwerpgCombatItem {
   /** @override */
+  static ITEM_CATEGORIES = SYSTEM.WEAPON.CATEGORIES
+
+  /** @override */
+  static DEFAULT_CATEGORY = 'ranged'
+
+  /** @override */
   static ITEM_QUALITIES = SYSTEM.WEAPON.QUALITIES
 
   /** @override */
@@ -51,6 +57,10 @@ export default class SwerpgWeapon extends SwerpgCombatItem {
         required: false,
         choices: SYSTEM.WEAPON.ANIMATION_TYPES,
         initial: undefined,
+      }),
+      weaponType: new fields.StringField({
+        required: false,
+        initial: '',
       }),
     })
   }
@@ -101,9 +111,10 @@ export default class SwerpgWeapon extends SwerpgCombatItem {
    * Prepare derived data specific to the weapon type.
    */
   prepareBaseData() {
-    // Weapon Category
-    const skills = SYSTEM.WEAPON.SKILLS
-    const category = skills[this.category] || skills[this.constructor.QUALITY]
+    // Weapon Category — resolved from canonical taxonomy, with fallback to default
+    const categories = SYSTEM.WEAPON.CATEGORIES
+    const categoryId = this.category in categories ? this.category : this.constructor.DEFAULT_CATEGORY
+    const category = categories[categoryId]
 
     // Weapon Quality
     const qualities = SYSTEM.QUALITY_TIERS
@@ -281,6 +292,13 @@ export default class SwerpgWeapon extends SwerpgCombatItem {
 
     // Damage
     tags.damage = `${this.damage.weapon} Damage`
+
+    // Canonical category (mechanical family)
+    if (this.config?.category?.label) tags.category = this.config.category.label
+
+    // Narrative subtype
+    if (this.weaponType) tags['weapon-type'] = this.weaponType
+
     tags.reload = 'Reload'
 
     const oggdudeTags = this.flags?.swerpg?.oggdudeTags

--- a/templates/sheets/partials/weapon-config.hbs
+++ b/templates/sheets/partials/weapon-config.hbs
@@ -1,6 +1,8 @@
 <section class="tab sheet-body flexcol scrollable {{tabs.config.cssClass}}" data-tab="{{tabs.config.id}}" data-group="{{tabs.config.group}}">
   <fieldset {{fieldDisabled}}>
     <legend>{{localize "WEAPON.SHEET.TYPE"}}</legend>
+    {{formField fields.category value=source.system.category}}
+    {{formField fields.weaponType value=source.system.weaponType}}
     {{formField fields.skill value=source.system.skill}}
     {{formField fields.quality value=source.system.quality}}
     {{formField fields.range value=source.system.range localize=true}}

--- a/tests/importer/weapon-import.spec.mjs
+++ b/tests/importer/weapon-import.spec.mjs
@@ -11,6 +11,7 @@ vi.mock('../../module/utils/logger.mjs', () => ({
 
 import { weaponMapper, getWeaponImportStats, resetWeaponImportStats } from '../../module/importer/items/weapon-ogg-dude.mjs'
 import SwerpgWeapon from '../../module/models/weapon.mjs'
+import { SYSTEM } from '../../module/config/system.mjs'
 
 describe('weaponMapper - mapping', () => {
   beforeEach(() => {
@@ -191,5 +192,61 @@ describe('weaponMapper - mapping', () => {
     expect(tags['category-ranged']).toBe('Category: Ranged')
     expect(tags.restricted).toBe('Restricted')
     expect(tags['blast']).toBe(game.i18n.localize('WEAPON.QUALITIES.Blast') + ' 2')
+  })
+})
+
+describe('SwerpgWeapon - schema taxonomy', () => {
+  it('declares ITEM_CATEGORIES as the canonical weapon taxonomy', () => {
+    expect(SwerpgWeapon.ITEM_CATEGORIES).toBe(SYSTEM.WEAPON.CATEGORIES)
+    expect(SwerpgWeapon.ITEM_CATEGORIES).toHaveProperty('melee')
+    expect(SwerpgWeapon.ITEM_CATEGORIES).toHaveProperty('ranged')
+    expect(SwerpgWeapon.ITEM_CATEGORIES).toHaveProperty('gunnery')
+    expect(SwerpgWeapon.ITEM_CATEGORIES).toHaveProperty('explosive')
+    expect(SwerpgWeapon.ITEM_CATEGORIES).toHaveProperty('thrown')
+    expect(SwerpgWeapon.ITEM_CATEGORIES).toHaveProperty('vehicle')
+    expect(SwerpgWeapon.ITEM_CATEGORIES).toHaveProperty('natural')
+  })
+
+  it('uses ranged as DEFAULT_CATEGORY', () => {
+    expect(SwerpgWeapon.DEFAULT_CATEGORY).toBe('ranged')
+  })
+
+  it('defines system.weaponType in the schema', () => {
+    if (globalThis.foundry?.data?.fields) {
+      if (!globalThis.foundry.data.fields.EmbeddedDataField) {
+        globalThis.foundry.data.fields.EmbeddedDataField = class EmbeddedDataField {
+          constructor(type) { this.type = type }
+        }
+      }
+      if (!globalThis.foundry.data.fields.HTMLField) {
+        globalThis.foundry.data.fields.HTMLField = class extends globalThis.foundry.data.fields.StringField {}
+      }
+    }
+    const weaponSchema = SwerpgWeapon.defineSchema()
+    expect(weaponSchema.weaponType).toBeDefined()
+    expect(weaponSchema.weaponType.config.required).toBe(false)
+    expect(weaponSchema.weaponType.config.initial).toBe('')
+  })
+
+  it('category fallback uses DEFAULT_CATEGORY when value is invalid', () => {
+    const categories = SYSTEM.WEAPON.CATEGORIES
+    // Simulate the same lookup prepareBaseData does
+    const invalidCategory = 'nonexistent'
+    const resolved = invalidCategory in categories ? categories[invalidCategory] : categories[SwerpgWeapon.DEFAULT_CATEGORY]
+    expect(resolved).toBeDefined()
+    expect(resolved.id).toBe(SwerpgWeapon.DEFAULT_CATEGORY)
+  })
+
+  it('every category entry has required runtime metadata', () => {
+    const categories = SYSTEM.WEAPON.CATEGORIES
+    for (const [key, cat] of Object.entries(categories)) {
+      expect(cat.id).toBe(key)
+      expect(cat.label).toBeTruthy()
+      expect(typeof cat.ranged).toBe('boolean')
+      expect(typeof cat.reload).toBe('boolean')
+      expect(typeof cat.hands).toBe('number')
+      expect(Array.isArray(cat.scaling)).toBe(true)
+      expect(cat.rangeCategory).toBeDefined()
+    }
   })
 })


### PR DESCRIPTION
## Summary

- Adds canonical `SYSTEM.WEAPON.CATEGORIES` taxonomy (7 entries: melee, ranged, gunnery, explosive, thrown, vehicle, natural) with full runtime metadata
- Declares `ITEM_CATEGORIES` and `DEFAULT_CATEGORY = 'ranged'` on `SwerpgWeapon`
- Adds `system.weaponType` (StringField) to the weapon schema
- Fixes `prepareBaseData()` to resolve `system.category` against the new taxonomy instead of the old SKILLS-based lookup
- Updates `getTags()` to expose category label and weaponType
- Adds category and weaponType fields to the weapon config sheet template
- Updates i18n labels (replaces old 17-entry FR taxonomy with canonical 7)
- Adds 5 schema/taxonomy tests

## Related Issues

- Closes #98
- Depends on #97 (canonical enum definition) — now closed
- Prerequisite for #100 (UX/filters) and #101 (OggDude import mapping)
- Migration strategy for existing weapons tracked in #17

## Testing

- all 1218 tests pass, 0 regressions
- `npx vitest run tests/importer/weapon-import.spec.mjs` — 10/10 (5 new taxonomy tests)
- All existing weapon mapper, stats, and integration tests unaffected