### PR TITLE
feat(import): map OggDude weapon Type/Category to system.category and system.weaponType (Issue #101)

### DIFF
--- a/module/importer/items/weapon-ogg-dude.mjs
+++ b/module/importer/items/weapon-ogg-dude.mjs
@@ -11,13 +11,20 @@ import {
   WEAPON_QUALITY_MAP,
   WEAPON_RANGE_MAP,
   WEAPON_SKILL_MAP,
+  WEAPON_TYPE_MAP,
+  WEAPON_CATEGORY_MAP,
+  resolveWeaponType,
+  resolveWeaponCategory,
 } from '../mappings/index-weapon.mjs'
 import { getQualityConfig } from '../../config/qualities.mjs'
 import {
+  addWeaponUnknownCategory,
   addWeaponUnknownQuality,
   addWeaponUnknownSkill,
+  addWeaponUnknownType,
   FLAG_STRICT_WEAPON_VALIDATION,
   getWeaponImportStats,
+  incrementWeaponCategoryFallback,
   incrementWeaponImportStat,
   resetWeaponImportStats,
 } from '../utils/weapon-import-utils.mjs'
@@ -189,10 +196,32 @@ function mapOggDudeWeapon(xmlWeapon) {
     const hp = clampNumber(xmlWeapon.HP, 0, Number.MAX_SAFE_INTEGER, 0)
 
     const restricted = parseOggDudeBoolean(xmlWeapon.Restricted)
-    const typeTags = normalizeDelimitedValues(xmlWeapon.Type)
+    const rawType = xmlWeapon.Type || ''
     const categoryTags = normalizeCategoryValues(xmlWeapon?.Categories?.Category)
     const sizeHigh = normalizeSizeHigh(xmlWeapon.SizeHigh)
     const { name: sourceName, page: sourcePage } = extractSourceInfo(xmlWeapon.Source)
+
+    // Resolve system.category (ADR-0007 priority: Categories → SkillKey → Range → default)
+    const { category: resolvedCategory, source: categorySource } = resolveWeaponCategory(categoryTags, mappedSkill, mappedRange, 'ranged')
+    if (categorySource !== 'category') {
+      incrementWeaponCategoryFallback()
+    }
+
+    // Resolve system.weaponType
+    const { weaponType, isMapped } = resolveWeaponType(rawType)
+    if (!isMapped && rawType) {
+      logger.warn(`Unknown weapon type: "${rawType}" for "${name}", slugified to "${weaponType}"`, { category: 'WEAPON_IMPORT_INVALID' })
+      addWeaponUnknownType(rawType)
+    }
+
+    // Track unknown category values (not in map)
+    if (Array.isArray(categoryTags) && categoryTags.length > 0) {
+      for (const cat of categoryTags) {
+        if (cat && !WEAPON_CATEGORY_MAP[cat]) {
+          addWeaponUnknownCategory(cat)
+        }
+      }
+    }
 
     let description = sanitizeOggDudeWeaponDescription(xmlWeapon.Description)
     if (sourceName) {
@@ -200,39 +229,14 @@ function mapOggDudeWeapon(xmlWeapon) {
       description = description ? `${description}\n\n${sourceLine}` : sourceLine
     }
 
-    const oggdudeTags = []
-    const tagKeySet = new Set()
-    const buildTagKey = (type, value) => {
-      // Use consistent sanitization for both type and value
-      const sanitizedType = sanitizeText(type).toLowerCase()
-      const sanitizedValue = sanitizeText(value).toLowerCase()
-      return `${sanitizedType}-${sanitizedValue}`
-    }
-    const registerTag = (type, value, label) => {
-      if (!value) return
-      const key = buildTagKey(type, value)
-      if (tagKeySet.has(key)) return
-      tagKeySet.add(key)
-      oggdudeTags.push({ type, value, label })
-    }
-
-    typeTags.forEach((value) => registerTag('type', value, value))
-    categoryTags.forEach((value) => registerTag('category', value, value))
-    if (restricted) {
-      registerTag('status', 'restricted', 'Restricted')
-    }
-
-    const flags = {
-      swerpg: {
-        oggdudeKey,
-      },
-    }
-
-    if (oggdudeTags.length > 0) {
-      flags.swerpg.oggdudeTags = oggdudeTags
-    }
-
+    // Build structured flags (no more flat oggdudeTags)
     const oggdudeExtras = {}
+    if (rawType) {
+      oggdudeExtras.type = rawType
+    }
+    if (categoryTags.length > 0) {
+      oggdudeExtras.categories = [...categoryTags]
+    }
     if (sizeHigh !== null) {
       oggdudeExtras.sizeHigh = sizeHigh
     }
@@ -241,6 +245,12 @@ function mapOggDudeWeapon(xmlWeapon) {
         name: sourceName,
         page: sourcePage,
       }
+    }
+
+    const flags = {
+      swerpg: {
+        oggdudeKey,
+      },
     }
     if (Object.keys(oggdudeExtras).length > 0) {
       flags.swerpg.oggdude = oggdudeExtras
@@ -251,6 +261,8 @@ function mapOggDudeWeapon(xmlWeapon) {
       type: 'weapon',
       img: null,
       system: {
+        category: resolvedCategory,
+        weaponType,
         skill: mappedSkill,
         range: mappedRange,
         damage: totalDamage,

--- a/module/importer/mappings/index-weapon.mjs
+++ b/module/importer/mappings/index-weapon.mjs
@@ -9,3 +9,10 @@ export { WEAPON_RANGE_MAP } from './oggdude-weapon-range-map.mjs'
 export { WEAPON_QUALITY_MAP } from './oggdude-weapon-quality-map.mjs'
 export { WEAPON_HANDS_MAP } from './oggdude-weapon-hands-map.mjs'
 export { clampNumber, sanitizeText, parseOggDudeBoolean, sanitizeOggDudeWeaponDescription } from './oggdude-weapon-utils.mjs'
+export { WEAPON_TYPE_MAP, resolveWeaponType, slugifyWeaponType } from './oggdude-weapon-type-map.mjs'
+export {
+  WEAPON_CATEGORY_MAP,
+  SKILL_TO_CATEGORY_MAP,
+  RANGE_TO_CATEGORY_MAP,
+  resolveWeaponCategory,
+} from './oggdude-weapon-category-map.mjs'

--- a/module/importer/mappings/oggdude-weapon-category-map.mjs
+++ b/module/importer/mappings/oggdude-weapon-category-map.mjs
@@ -1,0 +1,110 @@
+/**
+ * Mapping and resolver for OggDude weapon Categories → system.category.
+ *
+ * Resolution priority (from ADR-0007):
+ * 1. First recognised <Categories> value → canonical system category
+ * 2. Fallback via mapped SkillKey → category
+ * 3. Fallback via mapped Range → category
+ * 4. Ultimate fallback → DEFAULT_CATEGORY ('ranged')
+ */
+
+/**
+ * Direct mapping from OggDude Category values to canonical system category IDs.
+ * @type {Record<string, string>}
+ */
+export const WEAPON_CATEGORY_MAP = {
+  // Direct matches
+  'Ranged': 'ranged',
+  'Melee': 'melee',
+  'Thrown': 'thrown',
+  'Vehicle': 'vehicle',
+  'Starship': 'vehicle',
+  'Explosive': 'explosive',
+  'Heavy': 'gunnery',
+  'Laser': 'ranged',
+
+  // Compound / subtype categories → resolved to canonical
+  'Cutting Edge Melee': 'melee',
+  'Powered Melee': 'melee',
+  'Bludgeoning Melee': 'melee',
+  'Template (Brawl and Melee)': 'melee',
+  'Brawling': 'natural',
+  'Bludgeoning Brawl': 'natural',
+  'Portable Gunnery': 'gunnery',
+  'Template (Ranged)': 'ranged',
+  'Grenade': 'explosive',
+  'Missile': 'vehicle',
+  'Lightsaber': 'melee',
+  'Shield': 'melee',
+  'Space Mine': 'explosive',
+  'Ion': 'ranged',
+  'Micro-Rocket': 'explosive',
+  'Rocket': 'explosive',
+  'Proton Torpedo': 'vehicle',
+  'Proton Bomb': 'explosive',
+  'Flak': 'explosive',
+  'Mine': 'explosive',
+  'Tractor': 'vehicle',
+}
+
+/**
+ * Mapping from mapped skill IDs to fallback system category.
+ * Used when no Category tag is recognised.
+ * @type {Record<string, string>}
+ */
+export const SKILL_TO_CATEGORY_MAP = {
+  'rangedLight': 'ranged',
+  'rangedHeavy': 'ranged',
+  'gunnery': 'gunnery',
+  'brawl': 'natural',
+  'melee': 'melee',
+  'lightSaber': 'melee',
+}
+
+/**
+ * Mapping from mapped range IDs to fallback system category.
+ * Used when neither Category nor SkillKey yields a category.
+ * @type {Record<string, string>}
+ */
+export const RANGE_TO_CATEGORY_MAP = {
+  'engaged': 'melee',
+  'short': 'ranged',
+  'medium': 'ranged',
+  'long': 'ranged',
+  'extreme': 'ranged',
+}
+
+/**
+ * Resolve a weapon's category from its OggDude data using the ADR-0007 priority chain.
+ * @param {string[]} rawCategories - Array of category strings from OggDude XML
+ * @param {string} mappedSkill - The already-mapped SWERPG skill ID
+ * @param {string} mappedRange - The already-mapped SWERPG range ID
+ * @param {string} defaultCategory - Fallback if nothing matches
+ * @returns {{ category: string, source: string }} The resolved category and how it was resolved
+ */
+export function resolveWeaponCategory(rawCategories, mappedSkill, mappedRange, defaultCategory = 'ranged') {
+  // Priority 1: direct match from Categories
+  if (Array.isArray(rawCategories) && rawCategories.length > 0) {
+    for (const raw of rawCategories) {
+      const trimmed = raw?.trim()
+      if (!trimmed) continue
+      const mapped = WEAPON_CATEGORY_MAP[trimmed]
+      if (mapped) {
+        return { category: mapped, source: 'category' }
+      }
+    }
+  }
+
+  // Priority 2: fallback from SkillKey
+  if (mappedSkill && SKILL_TO_CATEGORY_MAP[mappedSkill]) {
+    return { category: SKILL_TO_CATEGORY_MAP[mappedSkill], source: 'skill' }
+  }
+
+  // Priority 3: fallback from Range
+  if (mappedRange && RANGE_TO_CATEGORY_MAP[mappedRange]) {
+    return { category: RANGE_TO_CATEGORY_MAP[mappedRange], source: 'range' }
+  }
+
+  // Priority 4: default
+  return { category: defaultCategory, source: 'default' }
+}

--- a/module/importer/mappings/oggdude-weapon-type-map.mjs
+++ b/module/importer/mappings/oggdude-weapon-type-map.mjs
@@ -1,0 +1,58 @@
+/**
+ * Mapping table for OggDude weapon Type values to SWERPG system weaponType IDs.
+ * The raw Type is preserved in flags.swerpg.oggdude.type; this table normalizes
+ * it into a stable slug for system.weaponType.
+ *
+ * Unknown types are slugified (lowercased, spaces → hyphens) with a warning.
+ *
+ * @type {Record<string, string>}
+ */
+export const WEAPON_TYPE_MAP = {
+  'Blasters': 'blasters',
+  'Blasters/Heavy': 'heavy-blaster',
+  'Energy Weapon': 'energy-weapon',
+  'Melee': 'melee',
+  'Explosives/Other': 'explosive-other',
+  'Vehicle': 'vehicle',
+  'Slugthrower': 'slugthrower',
+  'Lightsaber': 'lightsaber',
+  'Lightwhip': 'lightwhip',
+  'Brawling': 'brawl',
+  'Thrown': 'thrown',
+  'Tool': 'tool',
+  'Flame Weapon': 'flame-weapon',
+  'Heavy': 'heavy',
+  'Grenade': 'grenade',
+  'Missile': 'missile',
+  'Ion Weapon': 'ion-weapon',
+}
+
+/**
+ * Slugify a weapon type string for use as weaponType value.
+ * Falls back gracefully for empty/null inputs.
+ * @param {string} raw - The raw weapon type string
+ * @returns {string} The slugified type
+ */
+export function slugifyWeaponType(raw) {
+  if (!raw) return ''
+  return String(raw)
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+}
+
+/**
+ * Resolve an OggDude weapon Type into a stable SWERPG weaponType.
+ * @param {string} rawType - The raw Type value from OggDude XML
+ * @returns {{ weaponType: string, isMapped: boolean }}
+ */
+export function resolveWeaponType(rawType) {
+  if (!rawType) {
+    return { weaponType: '', isMapped: false }
+  }
+  const mapped = WEAPON_TYPE_MAP[rawType]
+  if (mapped) {
+    return { weaponType: mapped, isMapped: true }
+  }
+  return { weaponType: slugifyWeaponType(rawType), isMapped: false }
+}

--- a/module/importer/utils/weapon-import-utils.mjs
+++ b/module/importer/utils/weapon-import-utils.mjs
@@ -10,6 +10,9 @@ export const FLAG_STRICT_WEAPON_VALIDATION = false
 const weaponStats = new ImportStats({
   unknownSkills: 0,
   unknownQualities: 0,
+  unknownTypes: 0,
+  unknownCategories: 0,
+  categoryFallbacks: 0,
 })
 
 /**
@@ -19,6 +22,9 @@ export function resetWeaponImportStats() {
   weaponStats.reset({
     unknownSkills: 0,
     unknownQualities: 0,
+    unknownTypes: 0,
+    unknownCategories: 0,
+    categoryFallbacks: 0,
   })
 }
 
@@ -48,8 +54,31 @@ export function addWeaponUnknownQuality(code) {
 }
 
 /**
+ * Enregistre un type d'arme inconnu.
+ * @param {string} typeValue
+ */
+export function addWeaponUnknownType(typeValue) {
+  weaponStats.addDetail('unknownTypes', typeValue, 'typeDetails')
+}
+
+/**
+ * Enregistre une catégorie d'arme inconnue.
+ * @param {string} categoryValue
+ */
+export function addWeaponUnknownCategory(categoryValue) {
+  weaponStats.addDetail('unknownCategories', categoryValue, 'categoryDetails')
+}
+
+/**
+ * Incrémente le compteur de fallback de catégorie.
+ */
+export function incrementWeaponCategoryFallback() {
+  weaponStats.increment('categoryFallbacks', 1)
+}
+
+/**
  * Récupère les statistiques actuelles dans un format sérialisable.
- * @returns {{total:number,rejected:number,imported:number,unknownSkills:number,unknownQualities:number,skillDetails:string[],qualityDetails:string[]}}
+ * @returns {{total:number,rejected:number,imported:number,unknownSkills:number,unknownQualities:number,unknownTypes:number,unknownCategories:number,categoryFallbacks:number,skillDetails:string[],qualityDetails:string[],typeDetails:string[],categoryDetails:string[]}}
  */
 export function getWeaponImportStats() {
   return weaponStats.getStats()

--- a/module/models/weapon.mjs
+++ b/module/models/weapon.mjs
@@ -301,42 +301,6 @@ export default class SwerpgWeapon extends SwerpgCombatItem {
 
     tags.reload = 'Reload'
 
-    const oggdudeTags = this.flags?.swerpg?.oggdudeTags
-    if (Array.isArray(oggdudeTags) && oggdudeTags.length > 0) {
-      const seenKeys = new Set()
-      const buildKey = (type, value) => {
-        const sanitizedType =
-          String(type || 'tag')
-            .toLowerCase()
-            .replace(/[^a-z0-9]+/g, '-')
-            .replace(/^-+|-+$/g, '') || 'tag'
-        const sanitizedValue =
-          String(value)
-            .toLowerCase()
-            .replace(/[^a-z0-9]+/g, '-')
-            .replace(/^-+|-+$/g, '') || 'value'
-        return `${sanitizedType}-${sanitizedValue}`
-      }
-
-      for (const entry of oggdudeTags) {
-        if (!entry || !entry.value) continue
-        const key = buildKey(entry.type, entry.value)
-        if (seenKeys.has(key)) continue
-        seenKeys.add(key)
-
-        let label = entry.label || String(entry.value)
-        if (!entry.label && entry.type === 'type') {
-          label = `Type: ${entry.value}`
-        } else if (!entry.label && entry.type === 'category') {
-          label = `Category: ${entry.value}`
-        } else if (!entry.label && entry.type === 'status' && entry.value === 'restricted') {
-          label = 'Restricted'
-        }
-
-        tags[key] = label
-      }
-    }
-
     if ((this.system?.restricted ?? this.restricted) && !tags.restricted) {
       tags.restricted = 'Restricted'
     }

--- a/tests/importer/weapon-import-stats.spec.mjs
+++ b/tests/importer/weapon-import-stats.spec.mjs
@@ -112,4 +112,100 @@ describe('weaponMapper - stats and fallbacks', () => {
     const blastQuality = result[0].system.qualities.find(q => q.key === 'blast')
     expect(blastQuality).toMatchObject({ key: 'blast', rank: 6, hasRank: true })
   })
+
+  it('records unknown weapon types and falls back to slugified weaponType', () => {
+    const xmlWeapons = [
+      {
+        Name: 'Mysterious Blaster',
+        Key: 'mysterious',
+        SkillKey: 'RangedLight',
+        Range: 'Short',
+        Damage: 3,
+        Crit: 2,
+        Type: 'Quantum/Plasma',
+        Qualities: {
+          Quality: { Key: 'Accurate', Count: 1 },
+        },
+      },
+    ]
+
+    const result = weaponMapper(xmlWeapons)
+    expect(result).toHaveLength(1)
+
+    // Unknown type → slugified
+    expect(result[0].system.weaponType).toBe('quantum-plasma')
+    // Raw type preserved in flags
+    expect(result[0].flags.swerpg.oggdude.type).toBe('Quantum/Plasma')
+
+    const stats = getWeaponImportStats()
+    expect(stats.unknownTypes).toBe(1)
+    expect(stats.typeDetails).toContain('Quantum/Plasma')
+  })
+
+  it('falls back category from SkillKey when no Categories match', () => {
+    const xmlWeapons = [
+      {
+        Name: 'Mystery Melee',
+        Key: 'mystery-melee',
+        SkillKey: 'Melee',
+        Range: 'Engaged',
+        Damage: 3,
+        Crit: 2,
+        Qualities: {
+          Quality: { Key: 'Breach', Count: 1 },
+        },
+      },
+    ]
+
+    const result = weaponMapper(xmlWeapons)
+    expect(result[0].system.category).toBe('melee')
+
+    const stats = getWeaponImportStats()
+    expect(stats.categoryFallbacks).toBeGreaterThan(0)
+  })
+
+  it('uses default category when both Categories and SkillKey are absent', () => {
+    const xmlWeapons = [
+      {
+        Name: 'No Hints',
+        Key: 'no-hints',
+        SkillKey: 'UNDEFINED_SKILL',
+        Range: 'UNDEFINED_RANGE',
+        Damage: 1,
+        Crit: 1,
+        Qualities: {
+          Quality: { Key: 'Accurate', Count: 1 },
+        },
+      },
+    ]
+
+    const result = weaponMapper(xmlWeapons)
+    expect(result[0].system.category).toBe('ranged')
+  })
+
+  it('records unknown category values', () => {
+    const xmlWeapons = [
+      {
+        Name: 'Weird Category',
+        Key: 'weird-cat',
+        SkillKey: 'RangedLight',
+        Range: 'Short',
+        Damage: 2,
+        Crit: 2,
+        Categories: {
+          Category: ['TotallyUnknownCategory'],
+        },
+        Qualities: {
+          Quality: { Key: 'Accurate', Count: 1 },
+        },
+      },
+    ]
+
+    const result = weaponMapper(xmlWeapons)
+    expect(result).toHaveLength(1)
+
+    const stats = getWeaponImportStats()
+    expect(stats.unknownCategories).toBe(1)
+    expect(stats.categoryDetails).toContain('TotallyUnknownCategory')
+  })
 })

--- a/tests/importer/weapon-import.integration.spec.mjs
+++ b/tests/importer/weapon-import.integration.spec.mjs
@@ -52,6 +52,17 @@ describe('Intégration OggDude -> weaponMapper', () => {
     expect(typeof first.system.hp).toBe('number')
     expect(typeof first.system.restricted).toBe('boolean')
 
+    // ADR-0007: every mapped weapon must have a resolved category and weaponType
+    for (const weapon of mapped) {
+      expect(weapon.system.category).toBeDefined()
+      expect(typeof weapon.system.category).toBe('string')
+      expect(weapon.system.category.length).toBeGreaterThan(0)
+      expect(weapon.system).toHaveProperty('weaponType')
+      expect(typeof weapon.system.weaponType).toBe('string')
+      // No flat oggdudeTags
+      expect(weapon.flags?.swerpg?.oggdudeTags).toBeUndefined()
+    }
+
     const stats = getWeaponImportStats()
     expect(stats.total).toBe(sample.length)
     expect(stats.imported).toBe(mapped.length)

--- a/tests/importer/weapon-import.spec.mjs
+++ b/tests/importer/weapon-import.spec.mjs
@@ -61,22 +61,17 @@ describe('weaponMapper - mapping', () => {
     const weapon = result[0]
     expect(weapon.system.range).toBe('short')
     expect(weapon.system.skill).toBe('rangedLight')
+    expect(weapon.system.category).toBe('ranged')
+    expect(weapon.system.weaponType).toBe('heavy-blaster')
     expect(weapon.system.qualities).toEqual([
       { key: 'blast', rank: 2, hasRank: true, active: true, source: 'oggdude' },
       { key: 'burn', rank: 3, hasRank: true, active: true, source: 'oggdude' },
     ])
 
-    const tags = weapon.flags.swerpg.oggdudeTags
-    expect(tags).toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({ type: 'type', value: 'Blasters' }),
-        expect.objectContaining({ type: 'type', value: 'Heavy' }),
-        expect.objectContaining({ type: 'category', value: 'Ranged' }),
-        expect.objectContaining({ type: 'category', value: 'Starship' }),
-        expect.objectContaining({ type: 'status', value: 'restricted' }),
-      ]),
-    )
-
+    // Structured flags (no more flat oggdudeTags)
+    expect(weapon.flags.swerpg.oggdudeTags).toBeUndefined()
+    expect(weapon.flags.swerpg.oggdude.type).toBe('Blasters/Heavy')
+    expect(weapon.flags.swerpg.oggdude.categories).toEqual(['Ranged', 'Starship'])
     expect(weapon.flags.swerpg.oggdude.sizeHigh).toBe(2.5)
     expect(weapon.flags.swerpg.oggdude.source).toEqual({ name: 'Core Rulebook', page: 123 })
     expect(weapon.system.description.public).toBe('DL-44\nFamous blaster.\n\nSource: Core Rulebook, p.123')
@@ -162,22 +157,16 @@ describe('weaponMapper - mapping', () => {
     })
   })
 
-  it('exposes oggdude tags through weapon getTags()', () => {
+  it('exposes category and weapon-type tags through getTags()', () => {
     const weapon = {
       damage: { weapon: 6 },
       range: 'medium',
+      weaponType: 'heavy-blaster',
+      restricted: true,
       qualities: [
         { key: 'blast', rank: 2, hasRank: true, active: true, source: 'base' },
       ],
-      flags: {
-        swerpg: {
-          oggdudeTags: [
-            { type: 'type', value: 'Explosive', label: 'Type: Explosive' },
-            { type: 'category', value: 'Ranged', label: 'Category: Ranged' },
-            { type: 'status', value: 'restricted', label: 'Restricted' },
-          ],
-        },
-      },
+      flags: {},
       system: { restricted: true },
       defense: { block: 0, parry: 0 },
       schema: { fields: { broken: { label: 'Broken' } } },
@@ -188,8 +177,8 @@ describe('weaponMapper - mapping', () => {
     }
 
     const tags = SwerpgWeapon.prototype.getTags.call(weapon, 'full')
-    expect(tags['type-explosive']).toBe('Type: Explosive')
-    expect(tags['category-ranged']).toBe('Category: Ranged')
+    expect(tags.category).toBe('Ranged')
+    expect(tags['weapon-type']).toBe('heavy-blaster')
     expect(tags.restricted).toBe('Restricted')
     expect(tags['blast']).toBe(game.i18n.localize('WEAPON.QUALITIES.Blast') + ' 2')
   })


### PR DESCRIPTION
## Summary

Implements ADR-0007 (D2/D3) for OggDude weapon import. Replaces the legacy flat `flags.swerpg.oggdudeTags` array with structured `system.category`, `system.weaponType`, and `flags.swerpg.oggdude.*` properties.

## Changes

**New files**
- `module/importer/mappings/oggdude-weapon-type-map.mjs` — mapping table `Type` → `weaponType` with slug fallback
- `module/importer/mappings/oggdude-weapon-category-map.mjs` — mapping table `Category` → `system.category` with fallback chain (Category → SkillKey → Range → default)

**Modified files**
- `module/importer/mappings/index-weapon.mjs` — exports new type/category maps
- `module/importer/utils/weapon-import-utils.mjs` — adds counters: `unknownTypes`, `unknownCategories`, `categoryFallbacks`
- `module/importer/items/weapon-ogg-dude.mjs` — `mapOggDudeWeapon()` now:
  - Resolves `system.category` from Categories (or falls back via SkillKey → Range → default)
  - Resolves `system.weaponType` from Type with slug fallback
  - Stores raw values in `flags.swerpg.oggdude.type` and `flags.swerpg.oggdude.categories`
  - **Removes** `flags.swerpg.oggdudeTags` generation entirely
- `module/models/weapon.mjs` — removes the `oggdudeTags` block from `getTags()` (category tag now sourced from `this.config.category.label`, weapon-type from `this.weaponType`)

**Tests**
- 3 test files adapted: remove `oggdudeTags` assertions, add `category`/`weaponType`/`flags.swerpg.oggdude.*` assertions
- 4 new test cases: unknown type slugification, SkillKey fallback, default fallback, unknown category tracking

## Breaking changes
- `flags.swerpg.oggdudeTags` no longer exists on imported weapons (UI code using it must migrate to `system.category`, `system.weaponType`, `flags.swerpg.oggdude.type`, `flags.swerpg.oggdude.categories`)

Closes #101