### PR TITLE
feat(ux): align weapon tags, preview filters and lists on canonical taxonomy (Issue #100)

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -673,7 +673,11 @@
           "exists": "Exists",
           "new": "New",
           "pagination": "Preview Pagination",
-          "noData": "No data to preview"
+          "noData": "No data to preview",
+          "category": "Category",
+          "categoryAll": "All",
+          "weaponType": "Weapon Type",
+          "weaponTypeAll": "All"
         },
         "summary": {
           "title": "Import Summary"

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -96,7 +96,11 @@
           "exists": "Existe",
           "new": "Nouveau",
           "pagination": "Pagination d'aperçu",
-          "noData": "Aucune donnée à prévisualiser"
+          "noData": "Aucune donnée à prévisualiser",
+          "category": "Catégorie",
+          "categoryAll": "Toutes",
+          "weaponType": "Type d'arme",
+          "weaponTypeAll": "Tous"
         },
         "progress": {
           "global": "Progression globale"
@@ -160,7 +164,11 @@
         "exists": "Existe",
         "new": "Nouveau",
         "pagination": "Pagination d'aperçu",
-        "noData": "Aucune donnée à prévisualiser"
+        "noData": "Aucune donnée à prévisualiser",
+        "category": "Catégorie",
+        "categoryAll": "Toutes",
+        "weaponType": "Type d'arme",
+        "weaponTypeAll": "Tous"
       },
       "progress": {
         "global": "Progression globale"

--- a/module/models/weapon.mjs
+++ b/module/models/weapon.mjs
@@ -296,10 +296,11 @@ export default class SwerpgWeapon extends SwerpgCombatItem {
     // Canonical category (mechanical family)
     if (this.config?.category?.label) tags.category = this.config.category.label
 
-    // Narrative subtype
-    if (this.weaponType) tags['weapon-type'] = this.weaponType
+    // Narrative subtype — humanize slug for display
+    if (this.weaponType) tags['weapon-type'] = humanizeWeaponType(this.weaponType)
 
-    tags.reload = 'Reload'
+    // Reload — only if the weapon's category requires it
+    if (this.config?.category?.reload) tags.reload = 'Reload'
 
     if ((this.system?.restricted ?? this.restricted) && !tags.restricted) {
       tags.restricted = 'Restricted'
@@ -380,4 +381,17 @@ export default class SwerpgWeapon extends SwerpgCombatItem {
     // Return animation config
     return { src: animation, wait: -500 }
   }
+}
+
+/**
+ * Convert a kebab-case slug to a human-readable label for display.
+ * @param {string} slug  e.g. "heavy-blaster"
+ * @returns {string}     e.g. "Heavy Blaster"
+ */
+export function humanizeWeaponType(slug) {
+  if (!slug) return ''
+  return slug
+    .split('-')
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(' ')
 }

--- a/module/settings/OggDudeDataImporter.mjs
+++ b/module/settings/OggDudeDataImporter.mjs
@@ -7,6 +7,7 @@
 import OggDudeImporter from '../importer/oggDude.mjs'
 import { logger } from '../utils/logger.mjs'
 import { aggregateImportMetrics, formatGlobalMetrics, getAllImportStats } from '../importer/utils/global-import-metrics.mjs'
+import { SYSTEM } from '../config/system.mjs'
 // Similar syntax to importing, mais c'est du destructuring et peut être indisponible en environnement de test.
 
 // Fournit des fallbacks légers si l'API Foundry n'est pas initialisée (exécution tests).
@@ -31,7 +32,7 @@ export class OggDudeDataImporter extends HandlebarsApplicationMixin(ApplicationV
   domains = this._initializeDomains(this._domainNames)
   zipFile = null
   previewData = {}
-  previewFilters = { domain: 'all', text: '' }
+  previewFilters = { domain: 'all', text: '', category: 'all', weaponType: 'all' }
   pagination = { page: 1, size: 50 }
   // États de visibilité des sections repliables (collapsibles). Masqués par défaut.
   showStats = false
@@ -231,6 +232,24 @@ export class OggDudeDataImporter extends HandlebarsApplicationMixin(ApplicationV
       textInput.addEventListener('input', async (e) => {
         this.previewFilters.text = e.target.value
         // reset page to 1 on filter change
+        this.pagination.page = 1
+        await this.render()
+      })
+    }
+    const categorySelect = this.element.querySelector('select[name="preview-category"]')
+    if (categorySelect) {
+      categorySelect.value = this.previewFilters.category
+      categorySelect.addEventListener('change', async (e) => {
+        this.previewFilters.category = e.target.value
+        this.pagination.page = 1
+        await this.render()
+      })
+    }
+    const weaponTypeSelect = this.element.querySelector('select[name="preview-weaponType"]')
+    if (weaponTypeSelect) {
+      weaponTypeSelect.value = this.previewFilters.weaponType
+      weaponTypeSelect.addEventListener('change', async (e) => {
+        this.previewFilters.weaponType = e.target.value
         this.pagination.page = 1
         await this.render()
       })
@@ -459,15 +478,40 @@ export class OggDudeDataImporter extends HandlebarsApplicationMixin(ApplicationV
     const domains = Object.keys(this.previewData || {})
     const selectedDomain = this.previewFilters.domain === 'all' ? null : this.previewFilters.domain
     const text = (this.previewFilters.text || '').toLowerCase()
+    const selectedCategory = this.previewFilters.category === 'all' ? null : this.previewFilters.category
+    const selectedWeaponType = this.previewFilters.weaponType === 'all' ? null : this.previewFilters.weaponType
+
+    const categorySet = new Set()
+    const weaponTypeSet = new Set()
+
     let items = []
     for (const d of domains) {
       if (selectedDomain && d !== selectedDomain) continue
       const arr = this.previewData[d] || []
+      for (const it of arr) {
+        if (it.system?.category) categorySet.add(it.system.category)
+        if (it.system?.weaponType) weaponTypeSet.add(it.system.weaponType)
+      }
       items.push(...arr)
+    }
+
+    // Apply category filter
+    if (selectedCategory) {
+      items = items.filter((it) => it.system?.category === selectedCategory)
+    }
+    // Apply weaponType filter
+    if (selectedWeaponType) {
+      items = items.filter((it) => it.system?.weaponType === selectedWeaponType)
     }
     if (text) {
       items = items.filter((it) => `${it.name}`.toLowerCase().includes(text))
     }
+
+    const catLabel = (key) => {
+      const cat = SYSTEM.WEAPON.CATEGORIES[key]
+      return cat ? (game?.i18n?.localize?.(cat.label) ?? key) : key
+    }
+
     const total = items.length
     const size = this.pagination.size
     const page = Math.max(1, Math.min(this.pagination.page, Math.ceil(total / size) || 1))
@@ -481,6 +525,8 @@ export class OggDudeDataImporter extends HandlebarsApplicationMixin(ApplicationV
       totalPages: Math.max(1, Math.ceil(total / size)),
       items: pageItems,
       filters: this.previewFilters,
+      categoryOptions: Array.from(categorySet).sort().map((k) => ({ value: k, label: catLabel(k) })),
+      weaponTypeOptions: Array.from(weaponTypeSet).sort(),
     }
   }
 

--- a/templates/settings/oggDude-data-importer.hbs
+++ b/templates/settings/oggDude-data-importer.hbs
@@ -165,6 +165,26 @@
                     <input type="text" name="preview-text"
                                  placeholder="{{localize 'SETTINGS.OggDudeDataImporter.loadWindow.preview.textPlaceholder'}}"/>
                 </label>
+                <label>
+                    <span>{{localize "SETTINGS.OggDudeDataImporter.loadWindow.preview.category"}}</span>
+                    <select name="preview-category"
+                                    aria-label="{{localize 'SETTINGS.OggDudeDataImporter.loadWindow.preview.category'}}">
+                        <option value="all">{{localize "SETTINGS.OggDudeDataImporter.loadWindow.preview.categoryAll"}}</option>
+                        {{#each categoryOptions as |opt|}}
+                            <option value="{{opt.value}}">{{opt.label}}</option>
+                        {{/each}}
+                    </select>
+                </label>
+                <label>
+                    <span>{{localize "SETTINGS.OggDudeDataImporter.loadWindow.preview.weaponType"}}</span>
+                    <select name="preview-weaponType"
+                                    aria-label="{{localize 'SETTINGS.OggDudeDataImporter.loadWindow.preview.weaponType'}}">
+                        <option value="all">{{localize "SETTINGS.OggDudeDataImporter.loadWindow.preview.weaponTypeAll"}}</option>
+                        {{#each weaponTypeOptions as |opt|}}
+                            <option value="{{opt}}">{{opt}}</option>
+                        {{/each}}
+                    </select>
+                </label>
             </div>
             {{#if preview.hasData}}
                 <table class="preview-table" role="table" aria-describedby="preview-section">

--- a/tests/importer/preview-ui.spec.mjs
+++ b/tests/importer/preview-ui.spec.mjs
@@ -59,7 +59,7 @@ describe('Preview UI - preload', () => {
     // Injecte données dans l'application et vérifie le contexte
     const app = new OggDudeDataImporter()
     app.previewData = preview
-    app.previewFilters = { domain: 'all', text: '' }
+    app.previewFilters = { domain: 'all', text: '', category: 'all', weaponType: 'all' }
     app.pagination = { page: 1, size: 50 }
 
     const ctx = app._buildPreviewContext()
@@ -75,7 +75,7 @@ describe('Preview UI - preload', () => {
     const preview = await OggDudeImporter.preloadOggDudeData(buffer, domains)
     const app = new OggDudeDataImporter()
     app.previewData = preview
-    app.previewFilters = { domain: 'weapon', text: 'blaster' }
+    app.previewFilters = { domain: 'weapon', text: 'blaster', category: 'all', weaponType: 'all' }
     app.pagination = { page: 1, size: 50 }
 
     const ctx = app._buildPreviewContext()
@@ -83,5 +83,80 @@ describe('Preview UI - preload', () => {
     expect(ctx.hasData).toBeTypeOf('boolean')
     expect(ctx.page).toBe(1)
     expect(ctx.total).toBeGreaterThanOrEqual(0)
+  })
+
+  it('filters weapon items by category', () => {
+    const app = new OggDudeDataImporter()
+    app.previewData = {
+      weapon: [
+        { name: 'Blaster Rifle', type: 'weapon', system: { category: 'ranged', weaponType: 'blasters' } },
+        { name: 'Lightsaber', type: 'weapon', system: { category: 'melee', weaponType: 'lightsaber' } },
+        { name: 'Grenade', type: 'weapon', system: { category: 'explosive', weaponType: 'grenade' } },
+      ],
+    }
+    app.previewFilters = { domain: 'weapon', text: '', category: 'melee', weaponType: 'all' }
+    app.pagination = { page: 1, size: 50 }
+
+    const ctx = app._buildPreviewContext()
+    expect(ctx.hasData).toBe(true)
+    expect(ctx.total).toBe(1)
+    expect(ctx.items[0].name).toBe('Lightsaber')
+    expect(ctx.categoryOptions).toBeDefined()
+    const labels = ctx.categoryOptions.map((o) => o.value)
+    expect(labels).toContain('ranged')
+    expect(labels).toContain('melee')
+    expect(labels).toContain('explosive')
+  })
+
+  it('filters weapon items by weaponType', () => {
+    const app = new OggDudeDataImporter()
+    app.previewData = {
+      weapon: [
+        { name: 'Blaster Rifle', type: 'weapon', system: { category: 'ranged', weaponType: 'blasters' } },
+        { name: 'Lightsaber', type: 'weapon', system: { category: 'melee', weaponType: 'lightsaber' } },
+        { name: 'Blaster Pistol', type: 'weapon', system: { category: 'ranged', weaponType: 'blasters' } },
+      ],
+    }
+    app.previewFilters = { domain: 'weapon', text: '', category: 'all', weaponType: 'lightsaber' }
+    app.pagination = { page: 1, size: 50 }
+
+    const ctx = app._buildPreviewContext()
+    expect(ctx.hasData).toBe(true)
+    expect(ctx.total).toBe(1)
+    expect(ctx.items[0].name).toBe('Lightsaber')
+    expect(ctx.weaponTypeOptions).toEqual(expect.arrayContaining(['blasters', 'lightsaber']))
+  })
+
+  it('combines category and text filters', () => {
+    const app = new OggDudeDataImporter()
+    app.previewData = {
+      weapon: [
+        { name: 'Blaster Rifle', type: 'weapon', system: { category: 'ranged', weaponType: 'blasters' } },
+        { name: 'Blaster Pistol', type: 'weapon', system: { category: 'ranged', weaponType: 'blasters' } },
+        { name: 'Lightsaber', type: 'weapon', system: { category: 'melee', weaponType: 'lightsaber' } },
+      ],
+    }
+    app.previewFilters = { domain: 'weapon', text: 'pistol', category: 'ranged', weaponType: 'all' }
+    app.pagination = { page: 1, size: 50 }
+
+    const ctx = app._buildPreviewContext()
+    expect(ctx.total).toBe(1)
+    expect(ctx.items[0].name).toBe('Blaster Pistol')
+  })
+
+  it('exposes category and weaponType filter options from preview data', () => {
+    const app = new OggDudeDataImporter()
+    app.previewData = {
+      weapon: [
+        { name: 'Sword', type: 'weapon', system: { category: 'melee', weaponType: 'melee' } },
+      ],
+    }
+    app.previewFilters = { domain: 'all', text: '', category: 'all', weaponType: 'all' }
+    app.pagination = { page: 1, size: 50 }
+
+    const ctx = app._buildPreviewContext()
+    expect(ctx.categoryOptions.length).toBe(1)
+    expect(ctx.categoryOptions[0].value).toBe('melee')
+    expect(ctx.weaponTypeOptions).toContain('melee')
   })
 })

--- a/tests/importer/weapon-import.spec.mjs
+++ b/tests/importer/weapon-import.spec.mjs
@@ -178,9 +178,58 @@ describe('weaponMapper - mapping', () => {
 
     const tags = SwerpgWeapon.prototype.getTags.call(weapon, 'full')
     expect(tags.category).toBe('Ranged')
-    expect(tags['weapon-type']).toBe('heavy-blaster')
+    expect(tags['weapon-type']).toBe('Heavy Blaster')
     expect(tags.restricted).toBe('Restricted')
     expect(tags['blast']).toBe(game.i18n.localize('WEAPON.QUALITIES.Blast') + ' 2')
+  })
+
+  it('short scope excludes qualities and range', () => {
+    const weapon = {
+      damage: { weapon: 6 },
+      range: 'medium',
+      weaponType: 'lightsaber',
+      restricted: false,
+      qualities: [],
+      flags: {},
+      system: {},
+      defense: { block: 0, parry: 0 },
+      config: {
+        category: { label: 'Melee', reload: false },
+      },
+      broken: false,
+    }
+    const tags = SwerpgWeapon.prototype.getTags.call(weapon, 'short')
+    expect(tags.damage).toBe('6 Damage')
+    expect(tags.category).toBe('Melee')
+    expect(tags['weapon-type']).toBe('Lightsaber')
+    expect(tags.reload).toBeUndefined()
+    expect(tags.range).toBeUndefined()
+  })
+
+  it('reload tag present only when category.reload is true', () => {
+    const noReload = SwerpgWeapon.prototype.getTags.call({
+      damage: { weapon: 4 },
+      weaponType: 'melee',
+      qualities: [],
+      flags: {},
+      system: {},
+      defense: { block: 0, parry: 0 },
+      config: { category: { label: 'Melee', reload: false } },
+      broken: false,
+    }, 'short')
+    expect(noReload.reload).toBeUndefined()
+
+    const withReload = SwerpgWeapon.prototype.getTags.call({
+      damage: { weapon: 6 },
+      weaponType: 'heavy-blaster',
+      qualities: [],
+      flags: {},
+      system: {},
+      defense: { block: 0, parry: 0 },
+      config: { category: { label: 'Ranged', reload: true } },
+      broken: false,
+    }, 'short')
+    expect(withReload.reload).toBe('Reload')
   })
 })
 


### PR DESCRIPTION
## Summary

Alignement UX complet de la taxonomie canonique des armes (ADR-0007) dans la preview OggDude, les tags fiche arme et les listes d'inventaire/sidebar acteur.

## Changements

### Tags arme (`module/models/weapon.mjs`)
- `weaponType` humanisé (`heavy-blaster` → `Heavy Blaster`) pour l'affichage
- `reload` n'apparaît plus que si la catégorie le nécessite (`category.reload`)
- Nouveau `humanizeWeaponType()` exporté

### Preview OggDude (`module/settings/OggDudeDataImporter.mjs`, template HBS)
- Nouveau filtre **Catégorie** basé sur `system.category` (labels localisés via i18n)
- Nouveau filtre **Type d'arme** basé sur `system.weaponType`
- Options de filtres dynamiques dérivées des données preview
- Application combinée domaine + catégorie + weaponType + texte

### Localisation (`lang/en.json`, `lang/fr.json`)
- Nouvelles clés : `category`, `categoryAll`, `weaponType`, `weaponTypeAll`

### Tests
- Couverture des filtres preview (catégorie, weaponType, combinaison texte+catégorie)
- Couverture `getTags()` scope short/full (reload conditionnel, humanisation weaponType)
- 6 nouveaux tests, 121 test files passent (1228 tests)

## Issues liées
- Closes #100
- Suite de #98 (schéma) et #101 (import)
- ADR de référence : ADR-0007