### PR TITLE
[Architecture / Data] Aligner l'import armure sur ADR-0008 : conservation des flags OggDude bruts

### DIFF
--- a/module/importer/items/armor-ogg-dude.mjs
+++ b/module/importer/items/armor-ogg-dude.mjs
@@ -8,6 +8,7 @@ import {
   clampNumber,
   sanitizeText,
   FLAG_STRICT_ARMOR_VALIDATION,
+  ARMOR_IGNORED_TAGS,
   getArmorImportStats,
   incrementArmorImportStat,
   addRejectionReason,
@@ -64,37 +65,39 @@ function validateArmorSystem(system) {
 }
 
 /**
- * Résout la catégorie d'une armure en ignorant les propriétés connues
- * @returns {string|null} La catégorie ou null si rejeté
+ * Résout la catégorie d'une armure selon l'ADR-0008 :
+ * 1. Ignore les tags ADR-ignorés
+ * 2. Cherche une catégorie valide
+ * 3. Saute les propriétés connues
+ * @returns {{ category: string|null, unknownCategories: string[] }}
  */
 function resolveArmorCategoryWithFallback(xmlCategories, armorName) {
-  // Catégories valides OggDude
-  const VALID_CATEGORIES = new Set(['light', 'medium', 'heavy', 'natural', 'unarmored', '0', '1', '2', '3', '4'])
-  // Propriétés connues qui ne sont PAS des catégories
-  const KNOWN_PROPERTIES = new Set(['full body', 'hard full body', 'hard', 'resistant', 'sealable', 'sealed', 'powered', 'light', 'half body'])
-  
-  // Recherche de la première catégorie reconnue (Light/Medium/Heavy/Natural/Unarmored)
   for (const xmlCategory of xmlCategories) {
     const sanitized = xmlCategory?.trim()
     if (!sanitized) continue
-    
-    // Ignorer si c'est une propriété connue
-    if (KNOWN_PROPERTIES.has(sanitized.toLowerCase())) continue
-    
-    // Vérifier si c'est une catégorie valide
-    if (VALID_CATEGORIES.has(sanitized.toLowerCase())) {
-      const resolvedCategory = resolveArmorCategory(sanitized)
-      if (resolvedCategory) {
-        return resolvedCategory
-      }
-    }
+
+    const lower = sanitized.toLowerCase()
+
+    if (ARMOR_IGNORED_TAGS.has(lower)) continue
+
+    const resolved = resolveArmorCategory(sanitized)
+    if (resolved) return { category: resolved, unknownCategories: [] }
+
+    if (ARMOR_PROPERTY_MAP[sanitized]?.swerpgProperty != null) continue
   }
 
-  // Gestion des catégories inconnues - logger seulement si on a vraiment des catégories inconnues (pas juste des propriétés)
-  const unknownCategories = xmlCategories.filter(cat => {
-    const sanitized = cat?.trim()?.toLowerCase()
-    return sanitized && !KNOWN_PROPERTIES.has(sanitized) && !VALID_CATEGORIES.has(sanitized)
-  })
+  const unknownCategories = []
+  for (const xmlCategory of xmlCategories) {
+    const sanitized = xmlCategory?.trim()
+    if (!sanitized) continue
+
+    const lower = sanitized.toLowerCase()
+    if (ARMOR_IGNORED_TAGS.has(lower)) continue
+    if (resolveArmorCategory(sanitized)) continue
+    if (ARMOR_PROPERTY_MAP[sanitized]?.swerpgProperty != null) continue
+
+    unknownCategories.push(sanitized)
+  }
 
   if (unknownCategories.length > 0) {
     incrementArmorImportStat('unknownCategories')
@@ -105,60 +108,41 @@ function resolveArmorCategoryWithFallback(xmlCategories, armorName) {
     addRejectionReason('ARMOR_CATEGORY_UNKNOWN')
     incrementArmorImportStat('rejected')
     logger.warn(`Armure rejetée en mode strict: "${armorName}" - catégorie inconnue`)
-    return null
+    return { category: null, unknownCategories }
   }
 
-  return SYSTEM.ARMOR.DEFAULT_CATEGORY || 'medium'
-}
-
-/**
- * Mapping des propriétés OggDude vers les qualités système
- */
-const OGGDUDE_ARMOR_PROPERTY_TO_QUALITY = {
-  'full body': 'full-body',
-  'hard full body': 'bulky',
-  'hard': 'bulky',
-  'resistant': 'organic',
-  'sealable': 'sealed',
-  'sealed': 'sealed',
-  'powered': 'bulky',
-  'light': null, // Pas une propriété d'armure système
-  'half body': null, // Pas une propriété d'armure système
+  return { category: SYSTEM.ARMOR.DEFAULT_CATEGORY || 'medium', unknownCategories }
 }
 
 /**
  * Traite les propriétés d'une armure et les convertit en format Option C
- * @returns {Array} Qualities array in Option C format
+ * Mapping strict selon ADR-0008 (ARMOR_PROPERTY_MAP uniquement, pas de mapping permissif)
+ * @returns {{ qualities: Array, unknownProperties: string[], ignoredProperties: string[] }}
  */
 function processArmorProperties(xmlCategories, armorName, isRestricted = false) {
   const resolvedProperties = new Set()
   const unknownProperties = []
+  const ignoredProperties = []
 
-  // Traiter chaque élément : si c'est une catégorie valide, l'ignorer ; sinon, c'est une propriété
   for (const xmlCategory of xmlCategories) {
     const sanitized = xmlCategory?.trim()
     if (!sanitized) continue
-    
-    // Vérifier si c'est une catégorie valide
-    const isCategory = resolveArmorCategory(sanitized)
-    if (isCategory) continue // C'est une catégorie, pas une propriété
-    
-    // C'est une propriété - chercher dans ARMOR_PROPERTY_MAP d'abord
-    let mappedProperty = ARMOR_PROPERTY_MAP[sanitized]?.swerpgProperty
-    
-    // Sinon, chercher dans le mapping OggDude
-    if (mappedProperty === undefined) {
-      mappedProperty = OGGDUDE_ARMOR_PROPERTY_TO_QUALITY[sanitized.toLowerCase()]
-    }
-    
+
+    if (resolveArmorCategory(sanitized)) continue
+
+    const mappedProperty = ARMOR_PROPERTY_MAP[sanitized]?.swerpgProperty
     if (mappedProperty) {
       resolvedProperties.add(mappedProperty)
-    } else if (mappedProperty === null) {
-      // Propriété connue mais pas pertinente pour le système - ignorer silencieusement
       continue
-    } else {
-      unknownProperties.push(sanitized)
     }
+
+    const lower = sanitized.toLowerCase()
+    if (ARMOR_IGNORED_TAGS.has(lower)) {
+      ignoredProperties.push(sanitized)
+      continue
+    }
+
+    unknownProperties.push(sanitized)
   }
 
   if (unknownProperties.length > 0) {
@@ -166,19 +150,10 @@ function processArmorProperties(xmlCategories, armorName, isRestricted = false) 
     logger.warn(`Propriétés d'armure inconnues pour "${armorName}": ${unknownProperties.join(', ')}`)
   }
 
-  // Ajouter sealed et full-body depuis le mapping OGGDUDE_ARMOR_PROPERTY_TO_QUALITY si applicable
-  for (const [oggDudeKey, systemKey] of Object.entries(OGGDUDE_ARMOR_PROPERTY_TO_QUALITY)) {
-    if (systemKey && resolvedProperties.has(systemKey)) {
-      // Déjà ajouté via la première boucle, rien à faire
-    }
-  }
-
-  // Ajouter restricted si applicable
   if (isRestricted) {
     resolvedProperties.add('restricted')
   }
 
-  // Convertir en format Option C
   const qualities = []
   for (const prop of resolvedProperties) {
     const qualityConfig = getQualityConfig(prop)
@@ -191,14 +166,14 @@ function processArmorProperties(xmlCategories, armorName, isRestricted = false) 
     })
   }
 
-  // Limitation et tri
   const maxProperties = 12
+  qualities.sort((a, b) => a.key.localeCompare(b.key))
   if (qualities.length > maxProperties) {
     logger.warn(`Trop de propriétés pour "${armorName}": ${qualities.length} > ${maxProperties}, troncature appliquée`)
-    return qualities.sort((a, b) => a.key.localeCompare(b.key)).slice(0, maxProperties)
+    qualities.length = maxProperties
   }
 
-  return qualities.sort((a, b) => a.key.localeCompare(b.key))
+  return { qualities, unknownProperties, ignoredProperties }
 }
 
 /**
@@ -242,18 +217,15 @@ function mapOggDudeArmor(xmlArmor) {
       ? xmlArmor.Categories.Category
       : xmlArmor?.Categories?.Category ? [xmlArmor.Categories.Category] : []
 
-    const category = resolveArmorCategoryWithFallback(xmlCategories, name)
-    if (category === null) {
-      return null // Rejeté en mode strict
+    const categoryResult = resolveArmorCategoryWithFallback(xmlCategories, name)
+    if (categoryResult.category === null) {
+      return null
     }
 
-    // Vérification restricted
     const isRestricted = parseOggDudeBoolean(xmlArmor.Restricted)
 
-    // Mapping des qualités en format Option C
-    const qualities = processArmorProperties(xmlCategories, name, isRestricted)
+    const propertyResult = processArmorProperties(xmlCategories, name, isRestricted)
 
-    // Mapping des valeurs numériques
     const soak = clampNumber(xmlArmor.Soak, 0, 20, DEFAULT_SOAK)
     const defense = clampNumber(xmlArmor.Defense, 0, 20, DEFAULT_DEFENSE)
     const hp = clampNumber(xmlArmor.HP, 0, Number.MAX_SAFE_INTEGER, 0)
@@ -261,11 +233,29 @@ function mapOggDudeArmor(xmlArmor) {
     const rarity = clampNumber(xmlArmor.Rarity, 0, 20, 0)
     const price = clampNumber(xmlArmor.Price, 0, Number.MAX_SAFE_INTEGER, 0)
 
-    // Construction de la description
     const description = buildArmorDescription(xmlArmor)
-
-    // Ajout des flags OggDude
     const baseMods = extractBaseMods(xmlArmor)
+
+    const rawCategories = [...new Set(
+      xmlCategories
+        .filter(c => c?.trim())
+        .map(c => c.trim())
+    )]
+
+    const oggdudeExtras = {}
+    if (rawCategories.length > 0) {
+      oggdudeExtras.categories = rawCategories
+    }
+    if (propertyResult.ignoredProperties.length > 0) {
+      oggdudeExtras.ignoredCategories = [...new Set(propertyResult.ignoredProperties)]
+    }
+    if (propertyResult.unknownProperties.length > 0) {
+      oggdudeExtras.unknownProperties = [...new Set(propertyResult.unknownProperties)]
+    }
+    if (baseMods.length > 0) {
+      oggdudeExtras.baseMods = baseMods
+    }
+
     const flags = {
       swerpg: {
         oggdudeKey,
@@ -273,24 +263,23 @@ function mapOggDudeArmor(xmlArmor) {
         oggdudeSourcePage: xmlArmor.Source?.$ ? parseInt(xmlArmor.Source.$.Page) || 0 : 0,
       },
     }
-
-    if (baseMods.length > 0) {
-      flags.swerpg.oggdude = { baseMods }
+    if (Object.keys(oggdudeExtras).length > 0) {
+      flags.swerpg.oggdude = oggdudeExtras
     }
 
     const armorObject = {
       name,
       type: 'armor',
-      img: 'icons/svg/aura.svg', // Image par défaut Foundry
+      img: 'icons/svg/aura.svg',
       system: {
-        category,
+        category: categoryResult.category,
         soak,
         defense,
         hp,
         encumbrance,
         rarity,
         price,
-        qualities,
+        qualities: propertyResult.qualities,
         restricted: isRestricted,
         description,
       },

--- a/module/importer/utils/armor-import-utils.mjs
+++ b/module/importer/utils/armor-import-utils.mjs
@@ -10,6 +10,16 @@ export { clampNumber, sanitizeText }
  */
 export const FLAG_STRICT_ARMOR_VALIDATION = false
 
+export const ARMOR_IGNORED_TAGS = new Set([
+  'full body',
+  'hard full body',
+  'hard',
+  'resistant',
+  'sealable',
+  'powered',
+  'half body',
+])
+
 /**
  * Statistics d'import des armures
  * @private

--- a/tests/importer/armor-import.integration.spec.mjs
+++ b/tests/importer/armor-import.integration.spec.mjs
@@ -1,36 +1,195 @@
-/**
- * Tests d'intégration pour l'import d'armures OggDude - Version simplifiée
- */
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, beforeEach, vi } from 'vitest'
 
-describe('Intégration armorMapper - Simplifié', () => {
-  it('should validate armor import structure', () => {
-    // Test simplifié sans dépendance au mapper supprimé
-    const mockArmor = {
-      name: 'Test Armor',
-      type: 'armor',
-      system: {
-        category: 'light',
-        defense: { base: 5 },
-        soak: { base: 3 },
-      },
-    }
+vi.mock('../../module/utils/logger.mjs', () => ({
+  logger: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    debug: vi.fn(),
+    error: vi.fn(),
+  },
+}))
 
-    expect(mockArmor.type).toBe('armor')
-    expect(mockArmor.system.defense.base).toBe(5)
-    expect(mockArmor.system.soak.base).toBe(3)
+import { armorMapper, getArmorImportStats, resetArmorImportStats } from '../../module/importer/items/armor-ogg-dude.mjs'
+
+describe('armorMapper - ADR-0008 alignment', () => {
+  beforeEach(() => {
+    resetArmorImportStats()
   })
 
-  it('should handle armor with qualities', () => {
-    const mockArmor = {
-      system: {
-        qualities: [
-          { key: 'bulky', rank: null, hasRank: false, active: true, source: 'oggdude' },
-        ],
+  it('maps basic Light armor with Bulky property', () => {
+    const xmlArmors = [
+      {
+        Name: 'Combat Armor',
+        Key: 'combat_armor',
+        Soak: 5,
+        Defense: 2,
+        Categories: { Category: ['Light', 'Bulky'] },
       },
-    }
+    ]
 
-    expect(Array.isArray(mockArmor.system.qualities)).toBe(true)
-    expect(mockArmor.system.qualities[0].key).toBe('bulky')
+    const result = armorMapper(xmlArmors)
+    expect(result).toHaveLength(1)
+
+    const armor = result[0]
+    expect(armor.system.category).toBe('light')
+    expect(armor.system.qualities).toEqual([
+      { key: 'bulky', rank: null, hasRank: false, active: true, source: 'oggdude' },
+    ])
+    expect(armor.flags.swerpg.oggdude.categories).toEqual(['Light', 'Bulky'])
+    expect(armor.flags.swerpg.oggdude.ignoredCategories).toBeUndefined()
+    expect(armor.flags.swerpg.oggdude.unknownProperties).toBeUndefined()
+  })
+
+  it('handles mixed tags: category, property, ignored, unknown', () => {
+    const xmlArmors = [
+      {
+        Name: 'Mixed Tags Armor',
+        Key: 'mixed_tags',
+        Soak: 8,
+        Defense: 14,
+        Categories: { Category: ['Heavy', 'Bulky', 'full body', 'MysteryTag'] },
+      },
+    ]
+
+    const result = armorMapper(xmlArmors)
+    expect(result).toHaveLength(1)
+
+    const armor = result[0]
+    expect(armor.system.category).toBe('heavy')
+    expect(armor.system.qualities).toEqual([
+      { key: 'bulky', rank: null, hasRank: false, active: true, source: 'oggdude' },
+    ])
+    expect(armor.flags.swerpg.oggdude.categories).toEqual(['Heavy', 'Bulky', 'full body', 'MysteryTag'])
+    expect(armor.flags.swerpg.oggdude.ignoredCategories).toEqual(['full body'])
+    expect(armor.flags.swerpg.oggdude.unknownProperties).toEqual(['MysteryTag'])
+  })
+
+  it('preserves categories when no properties, ignored, or unknown', () => {
+    const xmlArmors = [
+      {
+        Name: 'Plain Light',
+        Key: 'plain_light',
+        Soak: 7,
+        Defense: 2,
+        Categories: { Category: ['Light'] },
+      },
+    ]
+
+    const result = armorMapper(xmlArmors)
+    expect(result).toHaveLength(1)
+
+    const armor = result[0]
+    expect(armor.system.category).toBe('light')
+    expect(armor.system.qualities).toEqual([])
+    expect(armor.flags.swerpg.oggdude.categories).toEqual(['Light'])
+    expect(armor.flags.swerpg.oggdude.ignoredCategories).toBeUndefined()
+    expect(armor.flags.swerpg.oggdude.unknownProperties).toBeUndefined()
+  })
+
+  it('does not map ADR-ignored tags to qualities', () => {
+    const xmlArmors = [
+      {
+        Name: 'Sealed Armor Copy',
+        Key: 'sealed_copy',
+        Soak: 5,
+        Defense: 2,
+        Categories: { Category: ['Medium', 'sealable', 'powered'] },
+      },
+    ]
+
+    const result = armorMapper(xmlArmors)
+    expect(result).toHaveLength(1)
+
+    const armor = result[0]
+    expect(armor.system.category).toBe('medium')
+    expect(armor.system.qualities).toEqual([])
+    expect(armor.flags.swerpg.oggdude.ignoredCategories).toContain('sealable')
+    expect(armor.flags.swerpg.oggdude.ignoredCategories).toContain('powered')
+  })
+
+  it('coexists with baseMods without namespace overwrite', () => {
+    const xmlArmors = [
+      {
+        Name: 'Armor With Mods',
+        Key: 'with_mods',
+        Soak: 4,
+        Defense: 10,
+        Categories: { Category: ['Medium', 'Organic'] },
+        BaseMods: {
+          Mod: [
+            { MiscDesc: 'Reinforced Plating' },
+          ],
+        },
+      },
+    ]
+
+    const result = armorMapper(xmlArmors)
+    expect(result).toHaveLength(1)
+
+    const armor = result[0]
+    expect(armor.flags.swerpg.oggdude.categories).toBeDefined()
+    expect(armor.flags.swerpg.oggdude.baseMods).toBeDefined()
+    expect(armor.flags.swerpg.oggdude.baseMods).toHaveLength(1)
+    expect(armor.flags.swerpg.oggdude.baseMods[0].text).toBe('Reinforced Plating')
+  })
+
+  it('detects unknown properties and increments stats', () => {
+    const xmlArmors = [
+      {
+        Name: 'Unknown Props',
+        Key: 'unknown_props',
+        Soak: 5,
+        Defense: 2,
+        Categories: { Category: ['Light', 'Glowing', 'Sonic'] },
+      },
+    ]
+
+    const result = armorMapper(xmlArmors)
+    expect(result).toHaveLength(1)
+
+    const armor = result[0]
+    expect(armor.flags.swerpg.oggdude.unknownProperties).toEqual(['Glowing', 'Sonic'])
+
+    const stats = getArmorImportStats()
+    expect(stats.unknownProperties).toBe(2)
+  })
+
+  it('handles organic armor with Natural and Leather properties', () => {
+    const xmlArmors = [
+      {
+        Name: 'Bone Armor',
+        Key: 'bone_armor',
+        Soak: 8,
+        Defense: 6,
+        Categories: { Category: ['Medium', 'Natural', 'Leather'] },
+      },
+    ]
+
+    const result = armorMapper(xmlArmors)
+    expect(result).toHaveLength(1)
+
+    const armor = result[0]
+    expect(armor.system.category).toBe('medium')
+    expect(armor.system.qualities).toEqual([
+      { key: 'organic', rank: null, hasRank: false, active: true, source: 'oggdude' },
+    ])
+  })
+
+  it('deduplicates raw categories in flags', () => {
+    const xmlArmors = [
+      {
+        Name: 'Dedup Armor',
+        Key: 'dedup',
+        Soak: 5,
+        Defense: 2,
+        Categories: { Category: ['Light', 'Bulky', 'Light'] },
+      },
+    ]
+
+    const result = armorMapper(xmlArmors)
+    expect(result).toHaveLength(1)
+
+    const armor = result[0]
+    expect(armor.flags.swerpg.oggdude.categories).toEqual(['Light', 'Bulky'])
   })
 })


### PR DESCRIPTION
## Summary

Aligne `armor-ogg-dude.mjs` sur l'ADR-0008 (v2) en conservant les données OggDude brutes dans `flags.swerpg.oggdude` et en supprimant les mappings permissifs contraires à l'ADR.

## Changements

### 1. Flags structurés dans `flags.swerpg.oggdude`

Remplace l'ancien comportement où `baseMods` écrasait tout le namespace `flags.swerpg.oggdude` :

| Flag | Contenu |
|------|---------|
| `flags.swerpg.oggdude.categories` | Valeurs XML `<Category>` brutes, dédupliquées |
| `flags.swerpg.oggdude.ignoredCategories` | Tags ADR-explicitement ignorés (`full body`, `hard`, `powered`, etc.) |
| `flags.swerpg.oggdude.unknownProperties` | Valeurs non reconnues |
| `flags.swerpg.oggdude.baseMods` | Préservé sans écraser les autres clés |

### 2. Mapping fonctionnel strictement aligné sur ADR-0008

- Suppression du mapping permissif `OGGDUDE_ARMOR_PROPERTY_TO_QUALITY` qui mappait artificiellement `sealable` → `sealed`, `powered` → `bulky`, etc.
- Les tags ADR-ignorés (`full body`, `hard full body`, `hard`, `resistant`, `sealable`, `powered`, `half body`) ne sont plus mappés vers des qualités.
- Conservation du mapping canonique via `ARMOR_PROPERTY_MAP` (Bulky, Organic, Heavy → bulky, Unwieldy → bulky, Natural/Leather/Hide → organic).
- Nouvelle constante partagée `ARMOR_IGNORED_TAGS` utilisée par `resolveArmorCategoryWithFallback()` et `processArmorProperties()`.

### 3. Correction du bug d'écrasement du namespace

`flags.swerpg.oggdude = { baseMods }` remplacé par construction additive : chaque clé est ajoutée indépendamment, seule la présence de `flags.swerpg.oggdude` est conditionnelle.

### 4. Tests

8 tests d'intégration couvrant :
- Mapping basique (catégorie + propriété)
- Tags mixtes (catégorie + propriété + ignoré + inconnu)
- Absence de mappage pour les tags ADR-ignorés
- Coexistence `baseMods` avec les autres flags
- Détection des propriétés inconnues avec stats
- Déduplication des catégories brutes

## Références

- Issue : #102
- ADR : `documentation/architecture/adr/adr-0008-armor-taxonomy.md`
- Pattern existant : `module/importer/items/weapon-ogg-dude.mjs` (flags)