### PR TITLE
[Config] Ajouter RESTRICTION_LEVELS dans SYSTEM (Issue #111)

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -551,6 +551,12 @@
       "SECRET": "Secret Description"
     }
   },
+  "ITEM.RESTRICTION_LEVEL": {
+    "NONE": "None",
+    "RESTRICTED": "Restricted",
+    "MILITARY": "Military",
+    "ILLEGAL": "Illegal"
+  },
   "ITEM.EnchantmentMundane": "Mundane",
   "ITEM.EnchantmentMinor": "Minor",
   "ITEM.EnchantmentMajor": "Major",

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -656,6 +656,12 @@
       "SECRET": "Secret Description"
     }
   },
+  "ITEM.RESTRICTION_LEVEL": {
+    "NONE": "Aucune restriction",
+    "RESTRICTED": "Restreint",
+    "MILITARY": "Militaire",
+    "ILLEGAL": "Illégal"
+  },
   "ITEM.EnchantmentMundane": "Mundane",
   "ITEM.EnchantmentMinor": "Minor",
   "ITEM.EnchantmentMajor": "Major",

--- a/module/config/system.mjs
+++ b/module/config/system.mjs
@@ -181,6 +181,31 @@ export const ACTION_HOOKS = Object.freeze({
 /* -------------------------------------------- */
 
 /**
+ * Named restriction levels which are allowed by the system.
+ * @enum {{id: string, label: string}}
+ */
+export const RESTRICTION_LEVELS = {
+  none: {
+    id: 'none',
+    label: 'ITEM.RESTRICTION_LEVEL.NONE',
+  },
+  restricted: {
+    id: 'restricted',
+    label: 'ITEM.RESTRICTION_LEVEL.RESTRICTED',
+  },
+  military: {
+    id: 'military',
+    label: 'ITEM.RESTRICTION_LEVEL.MILITARY',
+  },
+  illegal: {
+    id: 'illegal',
+    label: 'ITEM.RESTRICTION_LEVEL.ILLEGAL',
+  },
+}
+
+/* -------------------------------------------- */
+
+/**
  * Include all constant definitions within the SYSTEM global export
  * @type {Object}
  */
@@ -205,6 +230,7 @@ export const SYSTEM = {
   ENCHANTMENT_TIERS,
   PASSIVE_BASE: ATTRIBUTES.PASSIVE_BASE,
   QUALITY_TIERS,
+  RESTRICTION_LEVELS,
   RESOURCES: ATTRIBUTES.RESOURCES,
   SKILL,
   SKILLS: ATTRIBUTES.SKILLS,


### PR DESCRIPTION
## Summary

Ajoute l'enum canonique `RESTRICTION_LEVELS` dans la config système conformément à l'ADR-0009, avec 4 niveaux de restriction : `none`, `restricted`, `military`, `illegal`.

## Changements

### `module/config/system.mjs`
- Nouvelle enum `RESTRICTION_LEVELS` avec 4 niveaux
- Chaque entrée expose `id` et `label` (suivant le pattern de `THREAT_LEVELS`)
- Exportée via `SYSTEM.RESTRICTION_LEVELS`

### `lang/en.json`
- Clés de localisation sous `ITEM.RESTRICTION_LEVEL`

### `lang/fr.json`
- Traductions françaises pour les 4 niveaux

## Références
- Issue : #111
- ADR : `documentation/architecture/adr/adr-0009-restriction-level.md`
- Dépend de : #110 (ADR livré)
- Bloque : #112 (schéma), #113/#114/#115 (imports), #116/#118/#119 (UI)