### PR TITLE
[OggDude / Weapon] Remplacer system.restricted par system.restrictionLevel dans l'import arme

### DIFF
--- a/module/importer/items/weapon-ogg-dude.mjs
+++ b/module/importer/items/weapon-ogg-dude.mjs
@@ -195,7 +195,8 @@ function mapOggDudeWeapon(xmlWeapon) {
     const encumbrance = clampNumber(xmlWeapon.Encumbrance, 0, Number.MAX_SAFE_INTEGER, 0)
     const hp = clampNumber(xmlWeapon.HP, 0, Number.MAX_SAFE_INTEGER, 0)
 
-    const restricted = parseOggDudeBoolean(xmlWeapon.Restricted)
+    const isRestricted = parseOggDudeBoolean(xmlWeapon.Restricted)
+    const restrictionLevel = isRestricted ? 'restricted' : 'none'
     const rawType = xmlWeapon.Type || ''
     const categoryTags = normalizeCategoryValues(xmlWeapon?.Categories?.Category)
     const sizeHigh = normalizeSizeHigh(xmlWeapon.SizeHigh)
@@ -247,13 +248,19 @@ function mapOggDudeWeapon(xmlWeapon) {
       }
     }
 
+    const rawRestricted = xmlWeapon.Restricted
+    const oggdudeData = { ...oggdudeExtras }
+    if (rawRestricted !== undefined && rawRestricted !== null) {
+      oggdudeData.restricted = rawRestricted
+    }
+
     const flags = {
       swerpg: {
         oggdudeKey,
       },
     }
-    if (Object.keys(oggdudeExtras).length > 0) {
-      flags.swerpg.oggdude = oggdudeExtras
+    if (Object.keys(oggdudeData).length > 0) {
+      flags.swerpg.oggdude = oggdudeData
     }
 
     const weaponObject = {
@@ -273,7 +280,7 @@ function mapOggDudeWeapon(xmlWeapon) {
         price,
         rarity,
         hp,
-        restricted,
+        restrictionLevel,
         description: {
           public: description,
           secret: '',

--- a/module/models/weapon.mjs
+++ b/module/models/weapon.mjs
@@ -302,7 +302,7 @@ export default class SwerpgWeapon extends SwerpgCombatItem {
     // Reload — only if the weapon's category requires it
     if (this.config?.category?.reload) tags.reload = 'Reload'
 
-    if ((this.system?.restricted ?? this.restricted) && !tags.restricted) {
+    if (this.restrictionLevel && this.restrictionLevel !== 'none') {
       tags.restricted = 'Restricted'
     }
 

--- a/tests/importer/weapon-import.integration.spec.mjs
+++ b/tests/importer/weapon-import.integration.spec.mjs
@@ -50,7 +50,7 @@ describe('Intégration OggDude -> weaponMapper', () => {
     expect(typeof first.system.price).toBe('number')
     expect(typeof first.system.rarity).toBe('number')
     expect(typeof first.system.hp).toBe('number')
-    expect(typeof first.system.restricted).toBe('boolean')
+    expect(typeof first.system.restrictionLevel).toBe('string')
 
     // ADR-0007: every mapped weapon must have a resolved category and weaponType
     for (const weapon of mapped) {

--- a/tests/importer/weapon-import.spec.mjs
+++ b/tests/importer/weapon-import.spec.mjs
@@ -74,6 +74,8 @@ describe('weaponMapper - mapping', () => {
     expect(weapon.flags.swerpg.oggdude.categories).toEqual(['Ranged', 'Starship'])
     expect(weapon.flags.swerpg.oggdude.sizeHigh).toBe(2.5)
     expect(weapon.flags.swerpg.oggdude.source).toEqual({ name: 'Core Rulebook', page: 123 })
+    expect(weapon.system.restrictionLevel).toBe('restricted')
+    expect(weapon.flags.swerpg.oggdude.restricted).toBe('true')
     expect(weapon.system.description.public).toBe('DL-44\nFamous blaster.\n\nSource: Core Rulebook, p.123')
     expect(weapon.system.description.secret).toBe('')
     expect(weapon.system.actions).toEqual([])
@@ -162,10 +164,10 @@ describe('weaponMapper - mapping', () => {
       damage: { weapon: 6 },
       range: 'medium',
       weaponType: 'heavy-blaster',
-      restricted: true,
+      restrictionLevel: 'restricted',
       qualities: [{ key: 'blast', rank: 2, hasRank: true, active: true, source: 'base' }],
       flags: {},
-      system: { restricted: true },
+      system: { restrictionLevel: 'restricted' },
       defense: { block: 0, parry: 0 },
       schema: { fields: { broken: { label: 'Broken' } } },
       config: {
@@ -186,7 +188,7 @@ describe('weaponMapper - mapping', () => {
       damage: { weapon: 6 },
       range: 'medium',
       weaponType: 'lightsaber',
-      restricted: false,
+      restrictionLevel: 'none',
       qualities: [],
       flags: {},
       system: {},


### PR DESCRIPTION
## Résumé

Remplace le booléen `system.restricted` par l'enum `system.restrictionLevel` dans l'import arme OggDude, conformément à l'ADR-0009.

## Changements

### `module/importer/items/weapon-ogg-dude.mjs`
- `restricted` booléen → `restrictionLevel` enum
- Mapping : `Restricted=true` → `restrictionLevel: 'restricted'`, sinon `'none'`
- Valeur brute OggDude préservée dans `flags.swerpg.oggdude.restricted`

### `module/models/weapon.mjs`
- `getTags()` lit `this.restrictionLevel !== 'none'` au lieu de l'ancien booléen

### Tests
- `weapon-import.spec.mjs` : mocks mis à jour + assertions sur `restrictionLevel` et le flag brut
- `weapon-import.integration.spec.mjs` : assertion `restricted` → `restrictionLevel`

## Dépendances
- Issue #111 (RESTRICTION_LEVELS enum) — ✅ mergé
- Issue #112 (restrictionLevel schema) — ✅ mergé

## Vérifications
- `pnpm test` : 121 files, 1235 passed ✅