### PR TITLE
[OggDude / Gear] Aligner l'import gear sur system.restrictionLevel

### DIFF
--- a/module/importer/items/gear-ogg-dude.mjs
+++ b/module/importer/items/gear-ogg-dude.mjs
@@ -2,6 +2,7 @@ import { buildArmorImgWorldPath, buildItemImgSystemPath } from '../../settings/d
 import OggDudeImporter from '../oggDude.mjs'
 import OggDudeDataElement from '../../settings/models/OggDudeDataElement.mjs'
 import { logger } from '../../utils/logger.mjs'
+import { parseOggDudeBoolean } from '../mappings/oggdude-weapon-utils.mjs'
 import {
   sanitizeOggDudeGearDescription,
   extractGearSourceInfo,
@@ -114,9 +115,10 @@ function buildGearSystem(xmlGear, options = {}) {
 
     return {
       category,
-      quantity: 1, // Default for imported items
+      quantity: 1,
       price,
-      quality: 'standard', // Default quality tier
+      quality: 'standard',
+      restrictionLevel: options.restrictionLevel ?? 'none',
       encumbrance,
       rarity,
       broken,
@@ -124,7 +126,7 @@ function buildGearSystem(xmlGear, options = {}) {
         public: description,
         secret: '',
       },
-      actions: [], // No actions defined in XML data
+      actions: [],
     }
   } catch (error) {
     logger.warn('[GearImporter] Error building gear system object, using fallback values', {
@@ -138,6 +140,7 @@ function buildGearSystem(xmlGear, options = {}) {
       quantity: 1,
       price: 0,
       quality: 'standard',
+      restrictionLevel: 'none',
       encumbrance: 1,
       rarity: 1,
       broken: false,
@@ -195,6 +198,7 @@ export function gearMapper(gears) {
       })
 
       const category = slugifyGearCategory(originalType)
+      const isRestricted = parseOggDudeBoolean(xmlGear.Restricted)
       const system = buildGearSystem(xmlGear, {
         category,
         description: sanitizedDescription,
@@ -202,6 +206,7 @@ export function gearMapper(gears) {
         sourceLine,
         baseModsLines: baseModsData.descriptionLines,
         weaponUseLines: weaponProfileData.descriptionLines,
+        restrictionLevel: isRestricted ? 'restricted' : 'none',
       })
       if (system.category === 'general' && originalType) {
         addGearUnknownCategory(originalType)
@@ -232,6 +237,10 @@ export function gearMapper(gears) {
       }
       if (weaponProfileData.weaponProfile) {
         oggdudeNested.weaponProfile = weaponProfileData.weaponProfile
+      }
+      const rawRestricted = xmlGear.Restricted
+      if (rawRestricted !== undefined && rawRestricted !== null) {
+        oggdudeNested.restricted = rawRestricted
       }
       if (Object.keys(oggdudeNested).length > 0) {
         swerpgFlags.oggdude = oggdudeNested

--- a/tests/importer/gear-import.integration.spec.mjs
+++ b/tests/importer/gear-import.integration.spec.mjs
@@ -32,6 +32,7 @@ describe('Gear Import Integration', () => {
     expect(system).toHaveProperty('quantity')
     expect(system).toHaveProperty('price')
     expect(system).toHaveProperty('quality')
+    expect(system).toHaveProperty('restrictionLevel')
     expect(system).toHaveProperty('encumbrance')
     expect(system).toHaveProperty('rarity')
     expect(system).toHaveProperty('broken')

--- a/tests/importer/gear-oggdude.spec.mjs
+++ b/tests/importer/gear-oggdude.spec.mjs
@@ -2,7 +2,7 @@ import { describe, it, expect } from 'vitest'
 import { gearMapper } from '../../module/importer/items/gear-ogg-dude.mjs'
 
 describe('gearMapper', () => {
-  it('should map basic gear with all standard fields', () => {
+  it('should map basic gear with all standard fields and default restrictionLevel', () => {
     const xmlGears = [
       {
         Name: 'Test Gear',
@@ -27,6 +27,7 @@ describe('gearMapper', () => {
         quantity: 1,
         price: 100,
         quality: 'standard',
+        restrictionLevel: 'none',
         encumbrance: 2,
         rarity: 3,
         broken: false,
@@ -47,6 +48,72 @@ describe('gearMapper', () => {
       },
     })
     expect(result[0].flags.swerpg).not.toHaveProperty('oggdudeSource')
+  })
+
+  it('should use restrictionLevel restricted when Restricted is true and preserve raw value in flags', () => {
+    const xmlGears = [
+      {
+        Name: 'Restricted Gear',
+        Key: 'restrictedGear',
+        Description: 'A restricted gear item',
+        Type: 'weapon_part',
+        Price: 500,
+        Encumbrance: 1,
+        Rarity: 8,
+        Restricted: true,
+      },
+    ]
+
+    const result = gearMapper(xmlGears)
+
+    expect(result[0].system.restrictionLevel).toBe('restricted')
+    expect(result[0].flags.swerpg.oggdude.restricted).toBe(true)
+  })
+
+  it('should handle string Restricted values correctly', () => {
+    const xmlGears = [
+      {
+        Name: 'String Restricted Gear',
+        Key: 'stringRestrictedGear',
+        Restricted: 'true',
+      },
+    ]
+
+    const result = gearMapper(xmlGears)
+
+    expect(result[0].system.restrictionLevel).toBe('restricted')
+    expect(result[0].flags.swerpg.oggdude.restricted).toBe('true')
+  })
+
+  it('should default to none when Restricted is absent', () => {
+    const xmlGears = [
+      {
+        Name: 'No Restricted Gear',
+        Key: 'noRestrictedGear',
+      },
+    ]
+
+    const result = gearMapper(xmlGears)
+
+    expect(result[0].system.restrictionLevel).toBe('none')
+    expect(result[0].flags.swerpg.oggdude).toBeUndefined()
+  })
+
+  it('should not store restricted in flags when Restricted is absent', () => {
+    const xmlGears = [
+      {
+        Name: 'Gear Without Restricted',
+        Key: 'gearNoRestricted',
+        Type: 'tool',
+      },
+    ]
+
+    const result = gearMapper(xmlGears)
+
+    expect(result[0].system.restrictionLevel).toBe('none')
+    if (result[0].flags.swerpg.oggdude) {
+      expect(result[0].flags.swerpg.oggdude).not.toHaveProperty('restricted')
+    }
   })
 
   it('should normalize negative numeric values to defaults', () => {
@@ -85,29 +152,6 @@ describe('gearMapper', () => {
     expect(result[0].system.rarity).toBe(1)
   })
 
-  it('should validate boolean restricted field properly', () => {
-    const testCases = [
-      { input: true, expected: false }, // broken field not used currently
-      { input: false, expected: false },
-      { input: 'true', expected: false },
-      { input: undefined, expected: false },
-      { input: null, expected: false },
-    ]
-
-    testCases.forEach(({ input, expected }) => {
-      const xmlGears = [
-        {
-          Name: 'Test Gear',
-          Key: 'testGear',
-          Restricted: input,
-        },
-      ]
-
-      const result = gearMapper(xmlGears)
-      expect(result[0].system.broken).toBe(expected)
-    })
-  })
-
   it('should exclude unsupported fields from result', () => {
     const xmlGears = [
       {
@@ -141,7 +185,7 @@ describe('gearMapper', () => {
 
     // Only valid schema fields should be present in system
     const systemKeys = Object.keys(result[0].system)
-    const expectedKeys = ['category', 'quantity', 'price', 'quality', 'encumbrance', 'rarity', 'broken', 'description', 'actions']
+    const expectedKeys = ['category', 'quantity', 'price', 'quality', 'restrictionLevel', 'encumbrance', 'rarity', 'broken', 'description', 'actions']
     expect(systemKeys).toEqual(expect.arrayContaining(expectedKeys))
     expect(systemKeys).toHaveLength(expectedKeys.length)
 


### PR DESCRIPTION
## Summary

Conformément à l'ADR-0009, cette PR aligne l'import OggDude des équipements (gear) sur les mêmes patterns que Weapon (#113) et Armor (#114) : `system.restrictionLevel` remplace le traitement inexistant du champ `Restricted`.

## Changes

### `module/importer/items/gear-ogg-dude.mjs`

1. **Import** — Ajout de `parseOggDudeBoolean` depuis `oggdude-weapon-utils.mjs` (même source que Armor)
2. **`gearMapper()`** — Parse `xmlGear.Restricted` via `parseOggDudeBoolean`
3. **`buildGearSystem()`** — Nouveau champ `restrictionLevel` dans le retour réussi (`options.restrictionLevel ?? 'none'`) et dans le fallback (`'none'`)
4. **Flags** — Conservation de la valeur XML brute dans `flags.swerpg.oggdude.restricted`

### `tests/importer/gear-oggdude.spec.mjs`

- Test `should map basic gear` : ajout de `restrictionLevel: 'none'` aux assertions
- Test `should validate boolean restricted field properly` : **remplacé** par 4 tests dédiés :
  - `should use restrictionLevel restricted when Restricted is true and preserve raw value in flags`
  - `should handle string Restricted values correctly`
  - `should default to none when Restricted is absent`
  - `should not store restricted in flags when Restricted is absent`
- Test `should exclude unsupported fields` : ajout de `restrictionLevel` à `expectedKeys`

### `tests/importer/gear-import.integration.spec.mjs`

- Ajout de l'assertion `expect(system).toHaveProperty('restrictionLevel')`

## Mapping

| OggDude `Restricted` | `system.restrictionLevel` | `flags.swerpg.oggdude.restricted` |
|---|---|---|
| `true` | `restricted` | `true` |
| `false` | `none` | `false` |
| `"true"` | `restricted` | `"true"` |
| absent | `none` | pas de flag |

## Dépendances

- Schema `SwerpgPhysicalItem` avec `restrictionLevel` (Issue #112) - deja merge
- Enum `RESTRICTION_LEVELS` dans la config (Issue #111) - deja merge

## Tests

1240 tests pass, 0 echecs

Closes #115
