### PR TITLE
feat(weapon): use localized label from RESTRICTION_LEVELS in getTags() (Issue #116)

### DIFF
--- a/module/models/weapon.mjs
+++ b/module/models/weapon.mjs
@@ -303,7 +303,7 @@ export default class SwerpgWeapon extends SwerpgCombatItem {
     if (this.config?.category?.reload) tags.reload = 'Reload'
 
     if (this.restrictionLevel && this.restrictionLevel !== 'none') {
-      tags.restricted = 'Restricted'
+      tags.restricted = game.i18n.localize(SYSTEM.RESTRICTION_LEVELS[this.restrictionLevel].label)
     }
 
     if (scope === 'short') return tags

--- a/tests/importer/weapon-import.spec.mjs
+++ b/tests/importer/weapon-import.spec.mjs
@@ -179,7 +179,7 @@ describe('weaponMapper - mapping', () => {
     const tags = SwerpgWeapon.prototype.getTags.call(weapon, 'full')
     expect(tags.category).toBe('Ranged')
     expect(tags['weapon-type']).toBe('Heavy Blaster')
-    expect(tags.restricted).toBe('Restricted')
+    expect(tags.restricted).toBe(game.i18n.localize('ITEM.RESTRICTION_LEVEL.RESTRICTED'))
     expect(tags['blast']).toBe(game.i18n.localize('WEAPON.QUALITIES.Blast') + ' 2')
   })
 


### PR DESCRIPTION
## Summary

- Replace hardcoded `'Restricted'` string in `SwerpgWeapon.getTags()` with the localized label from `SYSTEM.RESTRICTION_LEVELS` via `game.i18n.localize()`
- Update test assertion to match the new localized value

## Changes

| File | Change |
|---|---|
| `module/models/weapon.mjs:306` | `tags.restricted = game.i18n.localize(SYSTEM.RESTRICTION_LEVELS[this.restrictionLevel].label)` |
| `tests/importer/weapon-import.spec.mjs:182` | `expect(tags.restricted).toBe(game.i18n.localize('ITEM.RESTRICTION_LEVEL.RESTRICTED'))` |

## Result

| `restrictionLevel` | Tag affiché |
|---|---|
| `none` | _(aucun tag)_ |
| `restricted` | Restricted |
| `military` | Military |
| `illegal` | Illegal |

Closes #116