### PR TITLE
[Tests] Mettre à jour les tests pour restrictionLevel (Issue #117)

### DIFF
--- a/module/models/armor.mjs
+++ b/module/models/armor.mjs
@@ -111,6 +111,11 @@ export default class SwerpgArmor extends SwerpgCombatItem {
   getTags(scope = 'full') {
     const tags = {}
     tags.category = this.config.category.label
+
+    if (this.restrictionLevel && this.restrictionLevel !== 'none') {
+      tags.restricted = game.i18n.localize(SYSTEM.RESTRICTION_LEVELS[this.restrictionLevel].label)
+    }
+
     for (let q of this.qualities) {
       const prop = SYSTEM.ARMOR.PROPERTIES[q.key]
       if (prop) tags[q.key] = prop.label

--- a/tests/importer/armor-import.integration.spec.mjs
+++ b/tests/importer/armor-import.integration.spec.mjs
@@ -10,6 +10,8 @@ vi.mock('../../module/utils/logger.mjs', () => ({
 }))
 
 import { armorMapper, getArmorImportStats, resetArmorImportStats } from '../../module/importer/items/armor-ogg-dude.mjs'
+import SwerpgArmor from '../../module/models/armor.mjs'
+import { SYSTEM } from '../../module/config/system.mjs'
 
 describe('armorMapper - ADR-0008 alignment', () => {
   beforeEach(() => {
@@ -191,5 +193,104 @@ describe('armorMapper - ADR-0008 alignment', () => {
 
     const armor = result[0]
     expect(armor.flags.swerpg.oggdude.categories).toEqual(['Light', 'Bulky'])
+  })
+
+  it('maps Restricted true to restrictionLevel restricted and preserves raw value in flags', () => {
+    const xmlArmors = [
+      {
+        Name: 'Restricted Armor',
+        Key: 'restricted_armor',
+        Soak: 5,
+        Defense: 2,
+        Categories: { Category: ['Light'] },
+        Restricted: 'true',
+      },
+    ]
+
+    const result = armorMapper(xmlArmors)
+    expect(result).toHaveLength(1)
+
+    const armor = result[0]
+    expect(armor.system.restrictionLevel).toBe('restricted')
+    expect(armor.flags.swerpg.oggdude.restricted).toBe('true')
+  })
+
+  it('maps Restricted false to restrictionLevel none', () => {
+    const xmlArmors = [
+      {
+        Name: 'Unrestricted Armor',
+        Key: 'unrestricted_armor',
+        Soak: 5,
+        Defense: 2,
+        Categories: { Category: ['Light'] },
+        Restricted: false,
+      },
+    ]
+
+    const result = armorMapper(xmlArmors)
+    expect(result).toHaveLength(1)
+
+    const armor = result[0]
+    expect(armor.system.restrictionLevel).toBe('none')
+    expect(armor.flags.swerpg.oggdude.restricted).toBe(false)
+  })
+
+  it('defaults restrictionLevel to none when Restricted is absent', () => {
+    const xmlArmors = [
+      {
+        Name: 'No Restricted Armor',
+        Key: 'no_restricted_armor',
+        Soak: 5,
+        Defense: 2,
+        Categories: { Category: ['Light'] },
+      },
+    ]
+
+    const result = armorMapper(xmlArmors)
+    expect(result).toHaveLength(1)
+
+    const armor = result[0]
+    expect(armor.system.restrictionLevel).toBe('none')
+    expect(armor.flags.swerpg.oggdude?.restricted).toBeUndefined()
+  })
+})
+
+describe('SwerpgArmor - getTags restrictionLevel', () => {
+  function makeArmor(restrictionLevel) {
+    return {
+      restrictionLevel,
+      qualities: [],
+      config: { category: { label: 'Medium' } },
+      defense: { base: 4, bonus: 0 },
+      soak: { base: 5, start: 2 },
+      parent: { parent: null },
+    }
+  }
+
+  it('includes restricted tag for restricted level', () => {
+    const tags = SwerpgArmor.prototype.getTags.call(makeArmor('restricted'), 'full')
+    expect(tags.restricted).toBe(game.i18n.localize('ITEM.RESTRICTION_LEVEL.RESTRICTED'))
+  })
+
+  it('includes restricted tag for military level', () => {
+    const tags = SwerpgArmor.prototype.getTags.call(makeArmor('military'), 'full')
+    expect(tags.restricted).toBe(game.i18n.localize('ITEM.RESTRICTION_LEVEL.MILITARY'))
+  })
+
+  it('includes restricted tag for illegal level', () => {
+    const tags = SwerpgArmor.prototype.getTags.call(makeArmor('illegal'), 'full')
+    expect(tags.restricted).toBe(game.i18n.localize('ITEM.RESTRICTION_LEVEL.ILLEGAL'))
+  })
+
+  it('omits restricted tag when level is none', () => {
+    const tags = SwerpgArmor.prototype.getTags.call(makeArmor('none'), 'full')
+    expect(tags.restricted).toBeUndefined()
+  })
+
+  it('preserves category and defense tags alongside restriction', () => {
+    const tags = SwerpgArmor.prototype.getTags.call(makeArmor('restricted'), 'full')
+    expect(tags.category).toBe('Medium')
+    expect(tags.defense).toBe('4 Armor')
+    expect(tags.restricted).toBe(game.i18n.localize('ITEM.RESTRICTION_LEVEL.RESTRICTED'))
   })
 })

--- a/tests/importer/weapon-import.spec.mjs
+++ b/tests/importer/weapon-import.spec.mjs
@@ -183,6 +183,102 @@ describe('weaponMapper - mapping', () => {
     expect(tags['blast']).toBe(game.i18n.localize('WEAPON.QUALITIES.Blast') + ' 2')
   })
 
+  it('getTags includes restrictionLevel tag for restricted level', () => {
+    const weapon = {
+      damage: { weapon: 6 },
+      range: 'medium',
+      weaponType: 'heavy-blaster',
+      restrictionLevel: 'restricted',
+      qualities: [],
+      flags: {},
+      system: { restrictionLevel: 'restricted' },
+      defense: { block: 0, parry: 0 },
+      schema: { fields: { broken: { label: 'Broken' } } },
+      config: { category: { label: 'Ranged' } },
+      broken: false,
+    }
+
+    const tags = SwerpgWeapon.prototype.getTags.call(weapon, 'full')
+    expect(tags.restricted).toBe(game.i18n.localize('ITEM.RESTRICTION_LEVEL.RESTRICTED'))
+  })
+
+  it('getTags includes restrictionLevel tag for military level', () => {
+    const weapon = {
+      damage: { weapon: 6 },
+      range: 'medium',
+      weaponType: 'heavy-blaster',
+      restrictionLevel: 'military',
+      qualities: [],
+      flags: {},
+      system: { restrictionLevel: 'military' },
+      defense: { block: 0, parry: 0 },
+      schema: { fields: { broken: { label: 'Broken' } } },
+      config: { category: { label: 'Ranged' } },
+      broken: false,
+    }
+
+    const tags = SwerpgWeapon.prototype.getTags.call(weapon, 'full')
+    expect(tags.restricted).toBe(game.i18n.localize('ITEM.RESTRICTION_LEVEL.MILITARY'))
+  })
+
+  it('getTags includes restrictionLevel tag for illegal level', () => {
+    const weapon = {
+      damage: { weapon: 6 },
+      range: 'medium',
+      weaponType: 'heavy-blaster',
+      restrictionLevel: 'illegal',
+      qualities: [],
+      flags: {},
+      system: { restrictionLevel: 'illegal' },
+      defense: { block: 0, parry: 0 },
+      schema: { fields: { broken: { label: 'Broken' } } },
+      config: { category: { label: 'Ranged' } },
+      broken: false,
+    }
+
+    const tags = SwerpgWeapon.prototype.getTags.call(weapon, 'full')
+    expect(tags.restricted).toBe(game.i18n.localize('ITEM.RESTRICTION_LEVEL.ILLEGAL'))
+  })
+
+  it('getTags omits restrictionLevel tag when level is none', () => {
+    const weapon = {
+      damage: { weapon: 6 },
+      range: 'medium',
+      weaponType: 'heavy-blaster',
+      restrictionLevel: 'none',
+      qualities: [],
+      flags: {},
+      system: { restrictionLevel: 'none' },
+      defense: { block: 0, parry: 0 },
+      schema: { fields: { broken: { label: 'Broken' } } },
+      config: { category: { label: 'Ranged' } },
+      broken: false,
+    }
+
+    const tags = SwerpgWeapon.prototype.getTags.call(weapon, 'full')
+    expect(tags.restricted).toBeUndefined()
+  })
+
+  it('getTags restrictionLevel tag appears in short scope', () => {
+    const weapon = {
+      damage: { weapon: 6 },
+      range: 'medium',
+      weaponType: 'heavy-blaster',
+      restrictionLevel: 'military',
+      qualities: [],
+      flags: {},
+      system: { restrictionLevel: 'military' },
+      defense: { block: 0, parry: 0 },
+      schema: { fields: { broken: { label: 'Broken' } } },
+      config: { category: { label: 'Ranged' } },
+      broken: false,
+    }
+
+    const tags = SwerpgWeapon.prototype.getTags.call(weapon, 'short')
+    expect(tags.restricted).toBe(game.i18n.localize('ITEM.RESTRICTION_LEVEL.MILITARY'))
+    expect(tags.range).toBeUndefined()
+  })
+
   it('short scope excludes qualities and range', () => {
     const weapon = {
       damage: { weapon: 6 },
@@ -321,5 +417,35 @@ describe('SwerpgWeapon - schema taxonomy', () => {
     expect(restricted.id).toBe('restricted')
     expect(military.id).toBe('military')
     expect(illegal.id).toBe('illegal')
+  })
+
+  it('RESTRICTION_LEVELS is a closed enum with exactly 4 levels', () => {
+    const keys = Object.keys(SYSTEM.RESTRICTION_LEVELS)
+    expect(keys).toEqual(['none', 'restricted', 'military', 'illegal'])
+  })
+
+  it('each restriction level entry has required id and label fields', () => {
+    for (const [key, level] of Object.entries(SYSTEM.RESTRICTION_LEVELS)) {
+      expect(level.id).toBe(key)
+      expect(typeof level.label).toBe('string')
+      expect(level.label.length).toBeGreaterThan(0)
+    }
+  })
+
+  it('schema choices reference is the live SYSTEM.RESTRICTION_LEVELS object', () => {
+    if (globalThis.foundry?.data?.fields) {
+      if (!globalThis.foundry.data.fields.EmbeddedDataField) {
+        globalThis.foundry.data.fields.EmbeddedDataField = class EmbeddedDataField {
+          constructor(type) {
+            this.type = type
+          }
+        }
+      }
+      if (!globalThis.foundry.data.fields.HTMLField) {
+        globalThis.foundry.data.fields.HTMLField = class extends globalThis.foundry.data.fields.StringField {}
+      }
+    }
+    const weaponSchema = SwerpgWeapon.defineSchema()
+    expect(weaponSchema.restrictionLevel.config.choices).toBe(SYSTEM.RESTRICTION_LEVELS)
   })
 })


### PR DESCRIPTION
## Summary

- Ajoute `restrictionLevel` à `armor.getTags()` (alignement avec les armes)
- Tests `getTags()` pour tous les niveaux (none, restricted, military, illegal) sur les armes et les armures
- Tests de validation du schéma (enum fermée, champs requis, référence `choices`)
- Tests d'import armure pour le mapping `Restricted` XML → `restrictionLevel`

## Détails

### `module/models/armor.mjs`
- Ajout du tag `restricted` dans `getTags()` quand `restrictionLevel !== 'none'`

### `tests/importer/weapon-import.spec.mjs`
- 6 nouveaux tests `getTags()` couvrant les 4 niveaux de restriction + scope `short`
- 3 tests de validation du schéma (enum fermée, structure des entrées, référence `choices`)

### `tests/importer/armor-import.integration.spec.mjs`
- 3 tests d'import : `Restricted: true/false/absent` → `restrictionLevel`
- 5 tests `getTags()` pour l'armure avec tous les niveaux de restriction

## Tests

✅ 121 test files, 1256 passed, 0 failed