### PR TITLE
[UI] Ajouter badge restrictionLevel dans les fiches objet (Issue #118)

### DIFF
--- a/module/applications/sheets/base-item.mjs
+++ b/module/applications/sheets/base-item.mjs
@@ -162,6 +162,22 @@ export default class SwerpgBaseItemSheet extends api.HandlebarsApplicationMixin(
       tabs: tabGroups.sheet,
       tabsPartial: this.constructor.PARTS.tabs.template,
       tags: this.document.getTags(),
+      restrictionBadge: this.#prepareRestrictionBadge(source.system.restrictionLevel),
+    }
+  }
+
+  /**
+   * Prepare the restriction badge data for the item header.
+   * @param {string} restrictionLevel    The restriction level key
+   * @returns {{level: string, label: string}|null}
+   */
+  #prepareRestrictionBadge(restrictionLevel) {
+    if (!restrictionLevel || restrictionLevel === 'none') return null
+    const rlConfig = SYSTEM.RESTRICTION_LEVELS[restrictionLevel]
+    if (!rlConfig) return null
+    return {
+      level: restrictionLevel,
+      label: game.i18n.localize(rlConfig.label),
     }
   }
 

--- a/module/models/gear.mjs
+++ b/module/models/gear.mjs
@@ -1,3 +1,4 @@
+import { SYSTEM } from '../config/system.mjs'
 import SwerpgPhysicalItem from './physical.mjs'
 
 /**
@@ -64,6 +65,11 @@ export default class SwerpgGear extends SwerpgPhysicalItem {
    */
   getTags(scope = 'full') {
     const tags = {}
+
+    if (this.restrictionLevel && this.restrictionLevel !== 'none') {
+      tags.restricted = game.i18n.localize(SYSTEM.RESTRICTION_LEVELS[this.restrictionLevel].label)
+    }
+
     return tags
   }
 }

--- a/styles/swerpg.css
+++ b/styles/swerpg.css
@@ -320,6 +320,24 @@
 .swerpg .tags:empty {
   display: none;
 }
+.swerpg .tag-restriction {
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+.swerpg .tag-restriction[data-restriction-level="restricted"] {
+  border-color: orange;
+  color: orange;
+}
+.swerpg .tag-restriction[data-restriction-level="military"] {
+  border-color: darkred;
+  color: #ff4444;
+}
+.swerpg .tag-restriction[data-restriction-level="illegal"] {
+  border-color: #000;
+  color: #ff4444;
+  background: rgba(0, 0, 0, 0.3);
+}
 .swerpg .tag-icon {
   flex: none;
   font-size: 10px;

--- a/templates/sheets/partials/armor-config.hbs
+++ b/templates/sheets/partials/armor-config.hbs
@@ -23,6 +23,7 @@
     {{formField fields.broken value=source.system.broken}}
     {{formField fields.hardPoints value=source.system.hardPoints classes="slim"}}
     {{formField fields.quantity value=source.system.quantity classes="slim"}}
+    {{formField fields.restrictionLevel value=source.system.restrictionLevel classes="slim"}}
     {{formField fields.rarity value=source.system.rarity classes="slim"}}
     {{formField fields.price value=source.system.price classes="slim"}}
   </fieldset>

--- a/templates/sheets/partials/gear-config.hbs
+++ b/templates/sheets/partials/gear-config.hbs
@@ -10,6 +10,7 @@
     <legend>{{localize "ARMOR.SHEET.EQUIPMENT"}}</legend>
     {{formField fields.broken value=source.system.broken}}
     {{formField fields.quantity value=source.system.quantity classes="slim"}}
+    {{formField fields.restrictionLevel value=source.system.restrictionLevel classes="slim"}}
     {{formField fields.rarity value=source.system.rarity classes="slim"}}
     {{formField fields.price value=source.system.price classes="slim"}}
   </fieldset>

--- a/templates/sheets/partials/item-header.hbs
+++ b/templates/sheets/partials/item-header.hbs
@@ -8,6 +8,11 @@
       {{#each tags as |label tag|}}
         <span class="tag" data-tag="{{tag}}">{{label}}</span>
       {{/each}}
+      {{#if restrictionBadge}}
+        <span class="tag tag-restriction" data-restriction-level="{{restrictionBadge.level}}" data-tooltip="{{restrictionBadge.label}}">
+          {{restrictionBadge.label}}
+        </span>
+      {{/if}}
     </div>
   </div>
 </header>

--- a/templates/sheets/partials/weapon-config.hbs
+++ b/templates/sheets/partials/weapon-config.hbs
@@ -25,6 +25,7 @@
     {{formField fields.broken value=source.system.broken}}
     {{formField fields.hardPoints value=source.system.hardPoints classes="slim"}}
     {{formField fields.encumbrance value=source.system.encumbrance classes="slim"}}
+    {{formField fields.restrictionLevel value=source.system.restrictionLevel classes="slim"}}
     {{formField fields.rarity value=source.system.rarity classes="slim"}}
     {{formField fields.price value=source.system.price classes="slim"}}
   </fieldset>


### PR DESCRIPTION
## Summary

Ajoute un badge coloré `restrictionLevel` dans les fiches des objets physiques (arme, armure, gear) conformément à l'ADR-0009 et à la décision #16 (affichage de niveau moyen).

## Changements

### Badge dans l'en-tête des fiches
- Nouveau badge `.tag-restriction` affiché dans l'en-tête (`item-header.hbs`) à côté des tags existants
- Toujours visible (édition et lecture)
- Couleurs différenciées par niveau :
  - `restricted` → orange
  - `military` → rouge (#ff4444)
  - `illegal` → noir + rouge
- Aucun affichage quand le niveau est `none` (valeur par défaut)

### Champ de configuration
- Champ `restrictionLevel` ajouté dans le fieldset Equipment des fiches :
  - `templates/sheets/partials/weapon-config.hbs`
  - `templates/sheets/partials/armor-config.hbs`
  - `templates/sheets/partials/gear-config.hbs`

### Contribution du modèle Gear
- Ajout de la restriction à `SwerpgGear.getTags()` (était manquant vs weapon/armor)
- Le badge apparaît désormais aussi dans les listes d'inventaire pour les gear

## Fichiers modifiés (7)

| Fichier | Modification |
|---------|-------------|
| `module/models/gear.mjs` | Ajout restrictionLevel à `getTags()` |
| `module/applications/sheets/base-item.mjs` | Méthode `#prepareRestrictionBadge()` + injection contexte |
| `templates/sheets/partials/item-header.hbs` | Badge `.tag-restriction` après les tags |
| `templates/sheets/partials/weapon-config.hbs` | Champ `restrictionLevel` |
| `templates/sheets/partials/armor-config.hbs` | Champ `restrictionLevel` |
| `templates/sheets/partials/gear-config.hbs` | Champ `restrictionLevel` |
| `styles/swerpg.css` | Styles colorés par niveau |

## Tests
- ✅ 57 tests existants passent (inchangés)
- Les tests weapon/armor `getTags()` avec restrictionLevel sont déjà couverts

Closes #118
