### PR TITLE
[UI] Ajouter badge restrictionLevel dans les listes (Issue #119)

### DIFF
--- a/module/applications/sheets/base-actor-sheet.mjs
+++ b/module/applications/sheets/base-actor-sheet.mjs
@@ -357,6 +357,19 @@ export default class SwerpgBaseActorSheet extends HBMixin(BaseActorSheetV2) {
     // On limite aux armes équipées (filtrage métier dans computeFeaturedEquipment)
     const weapons = this.actor.items.filter((i) => i.type === 'weapon' && i.system?.equipped)
     const featured = computeFeaturedEquipment({ armor, weapons })
+    // Enrich featured equipment with restriction badge data
+    for (const item of featured) {
+      const src = this.actor.items.get(item.id)
+      const rl = src?.system?.restrictionLevel
+      if (rl && rl !== 'none') {
+        const label = game.i18n.localize(SYSTEM.RESTRICTION_LEVELS[rl].label)
+        item.restrictionLevel = rl
+        item.restrictionBadge = { level: rl, label }
+        // Remove duplicate restriction tag from generic tags array
+        const idx = item.tags.indexOf(label)
+        if (idx !== -1) item.tags.splice(idx, 1)
+      }
+    }
     logger.debug('[base-actor-sheet] featuredEquipment', featured)
     return featured
   }
@@ -382,6 +395,15 @@ export default class SwerpgBaseActorSheet extends HBMixin(BaseActorSheetV2) {
     // Iterate over items and organize them
     for (let i of this.document.items) {
       const d = { id: i.id, name: i.name, img: i.img, tags: i.getTags() }
+      // restriction badge for inventory lists
+      const rl = i.system?.restrictionLevel
+      if (rl && rl !== 'none') {
+        d.restrictionLevel = rl
+        d.restrictionBadge = {
+          level: rl,
+          label: game.i18n.localize(SYSTEM.RESTRICTION_LEVELS[rl].label),
+        }
+      }
       let section
       switch (i.type) {
         case 'armor':

--- a/module/applications/sheets/base-item.mjs
+++ b/module/applications/sheets/base-item.mjs
@@ -162,7 +162,7 @@ export default class SwerpgBaseItemSheet extends api.HandlebarsApplicationMixin(
       tabs: tabGroups.sheet,
       tabsPartial: this.constructor.PARTS.tabs.template,
       tags: this.document.getTags(),
-      restrictionBadge: this.#prepareRestrictionBadge(source.system.restrictionLevel),
+      restrictionBadge: this.#prepareRestrictionBadge(this.document.system.restrictionLevel),
     }
   }
 

--- a/styles/swerpg.css
+++ b/styles/swerpg.css
@@ -338,6 +338,16 @@
   color: #ff4444;
   background: rgba(0, 0, 0, 0.3);
 }
+
+/* Restriction badge in list contexts (inventory, sidebar) */
+.swerpg .line-item .tags .tag-restriction .fa-lock {
+  margin-right: 2px;
+  font-size: 9px;
+}
+.swerpg .line-item--compact .tags .tag-restriction {
+  padding: 0 3px;
+  font-size: 9px;
+}
 .swerpg .tag-icon {
   flex: none;
   font-size: 10px;

--- a/templates/sheets/actor/inventory.hbs
+++ b/templates/sheets/actor/inventory.hbs
@@ -16,8 +16,16 @@
                 {{~item.name~}}
               </h4>
               <div class="tags">
-                {{#each item.tags}}
-                  {{#if this}}<span class="tag">{{this}}</span>{{/if}}
+                {{#each item.tags as |label tag|}}
+                  {{#if label}}
+                    {{#if (eq tag "restricted")}}
+                      <span class="tag tag-restriction" data-restriction-level="{{item.restrictionBadge.level}}" data-tooltip="{{label}}">
+                        <i class="fa-solid fa-lock"></i> {{label}}
+                      </span>
+                    {{else}}
+                      <span class="tag">{{label}}</span>
+                    {{/if}}
+                  {{/if}}
                 {{/each}}
               </div>
             </div>

--- a/templates/sheets/actor/sidebar.hbs
+++ b/templates/sheets/actor/sidebar.hbs
@@ -10,6 +10,11 @@
         <div class="title">
           <h4 data-action="itemEdit" title="{{e.name}}"><a>{{e.name}}</a></h4>
           <div class="tags">
+            {{#if e.restrictionBadge}}
+              <span class="tag tag-restriction" data-restriction-level="{{e.restrictionLevel}}" data-tooltip="{{e.restrictionBadge.label}}">
+                <i class="fa-solid fa-lock"></i>
+              </span>
+            {{/if}}
             {{#each e.tags}}
               <span class="tag" title="{{this}}">{{this}}</span>
             {{/each}}


### PR DESCRIPTION
## Summary

Ajoute un badge coloré `restrictionLevel` dans les listes d'items (inventaire et sidebar équipement), conformément à l'ADR-0009 (affichage de niveau moyen).

## Changements

### Inventaire (onglet Equipment / Backpack)
- Le tag `restricted` est désormais rendu avec la classe `.tag-restriction` et les couleurs par niveau (orange/rouge/noir) définies dans #118
- Icône 🔒 (`fa-lock`) ajoutée avant le texte du niveau
- Attribut `data-restriction-level` pour hook de filtre futur
- Changement de l'itération des tags de value-only vers key-value pour identifier le tag `restricted`

### Sidebar (équipement featured)
- Icône lock colorée uniquement (pas de texte, gain de place)
- Badge dédié avant les tags génériques
- Dédoublonnage : le tag `restricted` est retiré des tags génériques côté JS pour éviter l'affichage en double

### Hook filtre futur
- `data-restriction-level="restricted|military|illegal"` sur chaque badge
- Prêt pour un filtre CSS/JS "Afficher/masquer les objets restreints"

## Fichiers modifiés (4)

| Fichier | Modification |
|---------|-------------|
| `module/applications/sheets/base-actor-sheet.mjs` | Ajout `restrictionBadge` dans `#prepareItems()` et `#prepareFeaturedEquipment()` |
| `templates/sheets/actor/inventory.hbs` | Key-value loop + `.tag-restriction` + icône lock |
| `templates/sheets/actor/sidebar.hbs` | Badge icône lock avant les tags |
| `styles/swerpg.css` | Ajustements liste + mode compact |

## Tests
- ✅ 57 tests existants passent (inchangés)

Closes #119
