### PR TITLE
[Cleanup] Supprimer restricted des ARMOR.PROPERTIES (Issue #121)

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -372,8 +372,7 @@
       "BULKY": "Bulky",
       "ORGANIC": "Organic",
       "SEALED": "Sealed",
-      "FULL_BODY": "Full Body",
-      "RESTRICTED": "Restricted"
+      "FULL_BODY": "Full Body"
     }
   },
   "ATTACK.RESULT_TYPES.MISS": "Miss",

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -502,8 +502,7 @@
       "BULKY": "Encombrante",
       "ORGANIC": "Organique",
       "SEALED": "Étanche",
-      "FULL_BODY": "Corps entier",
-      "RESTRICTED": "Restreint"
+      "FULL_BODY": "Corps entier"
     }
   },
   "ATTACK.RESULT_TYPES.MISS": "Miss",

--- a/module/config/armor.mjs
+++ b/module/config/armor.mjs
@@ -64,10 +64,6 @@ export const PROPERTIES = {
     label: 'ARMOR.PROPERTIES.FULL_BODY',
     hasRank: false,
   },
-  restricted: {
-    label: 'ARMOR.PROPERTIES.RESTRICTED',
-    hasRank: false,
-  },
 }
 
 /**


### PR DESCRIPTION
## Summary

Supprime l'entrée `restricted` de `ARMOR.PROPERTIES` dans la config armure, conformément à l'ADR-0009. Le concept de restriction légale est désormais géré exclusivement par le champ transverse `system.restrictionLevel`.

## Contexte

- `restricted` était listé comme une propriété d'armure dans `ARMOR.PROPERTIES` (vestige de l'ancien système)
- Depuis #114, l'import OggDude n'ajoute plus `restricted` aux qualités — il mappe sur `system.restrictionLevel`
- Aucun code ne référence `SYSTEM.ARMOR.PROPERTIES.restricted` — tous les accès sont dynamiques (`Object.keys`, `Object.entries`, accès par clé)

## Changements

- Suppression du bloc `restricted` dans `PROPERTIES` (`module/config/armor.mjs`)
- Suppression des entrées `ARMOR.PROPERTIES.RESTRICTED` dans les locales FR et EN
- Les entrées `ITEM.RESTRICTION_LEVEL.RESTRICTED` sont conservées (utilisées par le nouveau système)

## Fichiers modifiés (3)

| Fichier | Modification |
|---------|-------------|
| `module/config/armor.mjs` | Suppression bloc `restricted` dans `PROPERTIES` |
| `lang/fr.json` | Suppression `ARMOR.PROPERTIES.RESTRICTED` |
| `lang/en.json` | Suppression `ARMOR.PROPERTIES.RESTRICTED` |

## Tests
- ✅ 1256 tests passent (121 files)
- Les tests d'intégration vérifient déjà que `restricted` n'est pas dans les qualités

Closes #121
