### PR TITLE
docs(changelog): document OggDude weapon import scope decision (Issue #17)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# [0.5.0](https://github.com/herveDarritchon/foundryvtt-swerpg/compare/v0.4.0...v0.5.0) (2026-05-08)
+
+### Bug Fixes
+
+- **import:** Correction du mapping des armes OggDude (Weapon.xml) — portée, qualités avec valeur, description, source, type/catégories, restriction. Les nouveaux imports produisent désormais des armes complètes et exploitables. ([#17](https://github.com/herveDarritchon/foundryvtt-swerpg/issues/17))
+
+  **Note :** Cette correction s'applique uniquement aux *futurs imports*. Les armes déjà importées via OggDude ne sont pas modifiées rétroactivement. Pour bénéficier des données corrigées, réimportez vos fichiers Weapons.xml.
+
 # [0.4.0](https://github.com/herveDarritchon/foundryvtt-swerpg/compare/v0.3.1...v0.4.0) (2026-05-04)
 
 ### Bug Fixes


### PR DESCRIPTION
## Summary

- Closes #17
- Documents the decision to apply the OggDude weapon import bugfix to **future imports only** (Option Minimaliste), without retroactive migration of existing weapons
- Updates CHANGELOG.md for v0.5.0

### Background

Issue #17 was a strategic decision about whether to:
- Fix only the import pipeline (future imports)
- Also provide a migration mechanism for already-imported weapons

The chosen approach (Option Minimaliste) was confirmed by the owner in the issue comments. Since the system has no production worlds yet, retroactive migration is unnecessary.

The actual import bugfix code was already delivered through previous PRs (#98, #101, #113, etc.) — this PR only documents the scope decision in the CHANGELOG.