### PR TITLE
[fix] i18n — ajout des clés de traduction manquantes utilisées dans les templates

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -383,6 +383,11 @@
   "ATTACK.RESULT_TYPES.RESIST": "Resist",
   "ATTACK.RESULT_TYPES.GLANCE": "Glance",
   "ATTACK.RESULT_TYPES.HIT": "Hit",
+  "BACKGROUND": {
+    "SHEET": {
+      "TALENT_REMOVE": "Remove Talent"
+    }
+  },
   "ATTRIBUTES.Abilities": "Ability Scores",
   "ATTRIBUTES.Pools": "Resource Pools",
   "ATTRIBUTES.Resistances": "Damage Resistances",
@@ -393,7 +398,8 @@
       "FreeSkillRank": {
         "label": "Free Rank(s)",
         "hint": "Select number of free ranks from career."
-      }
+      },
+      "Skills": "Career Skills"
     },
     "SHEET": {
       "CHOOSE": "Choose Career",
@@ -567,6 +573,10 @@
   "ITEM.QualityMasterwork": "Masterwork",
   "KEYBINDINGS.ConfirmAction": "Confirm Action",
   "KEYBINDINGS.ConfirmActionHint": "Confirm actions recorded within the last 60 seconds in the order in which they were taken.",
+  "MOTIVATION": {
+    "Sources": "Sources",
+    "SourcesList": "List of Sources"
+  },
   "OBLIGATION": {
     "FIELDS": {
       "value": {
@@ -602,6 +612,9 @@
     "Vitality": "Vitality",
     "Resolve": "Resolve",
     "Fortune": "Fortune"
+  },
+  "SHEETS": {
+    "FormNavLabel": "Sheet Navigation"
   },
   "SETTINGS": {
     "Auto": {
@@ -823,10 +836,20 @@
     "XenologyAbbr": "Xen"
   },
   "SPECIALIZATION": {
-    "FIELDS": {},
+    "FIELDS": {
+      "FreeSkill": "Free Skill",
+      "Skills": "Specialization Skills",
+      "FreeSkillRank": {
+        "label": "Free Rank(s)",
+        "hint": "Select number of free ranks from specialization."
+      }
+    },
     "SHEET": {
       "CHOOSE": "Choose Specialization",
-      "CLEAR": "Clear Specialization"
+      "CLEAR": "Clear Specialization",
+      "SpecializationSkills": {
+        "maxNumber": "Number of Specialization Skills maximum to pick"
+      }
     }
   },
   "SPECIES": {

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -102,6 +102,9 @@
           "weaponType": "Type d'arme",
           "weaponTypeAll": "Tous"
         },
+        "progress-bar": {
+          "title": "Progression de l'Import"
+        },
         "progress": {
           "global": "Progression globale"
         }
@@ -289,6 +292,9 @@
       "TARGET": "Target",
       "EFFECTS": "Effects",
       "HOOKS": "Hooks"
+    },
+    "TAGS": {
+      "delete": "Supprimer l'Action"
     }
   },
   "ACTOR": {
@@ -516,6 +522,11 @@
   "ATTRIBUTES.Abilities": "Ability Scores",
   "ATTRIBUTES.Pools": "Resource Pools",
   "ATTRIBUTES.Resistances": "Damage Resistances",
+  "BACKGROUND": {
+    "SHEET": {
+      "TALENT_REMOVE": "Retirer le Talent"
+    }
+  },
   "CAREER": {
     "FIELDS": {
       "FreeSkill": "Compétence gratuite",
@@ -672,6 +683,14 @@
   "ITEM.QualityMasterwork": "Masterwork",
   "KEYBINDINGS.ConfirmAction": "Confirm Action",
   "KEYBINDINGS.ConfirmActionHint": "Confirm actions recorded within the last 60 seconds in the order in which they were taken.",
+  "MOTIVATION": {
+    "Sources": "Sources",
+    "SourcesList": "Liste des Sources"
+  },
+  "MOTIVATION_CATEGORY": {
+    "Sources": "Sources",
+    "SourcesList": "Liste des Sources"
+  },
   "RESOURCES": {
     "HEALTH": "Health",
     "WOUNDS": "Wounds",
@@ -682,6 +701,9 @@
     "HEROISM": "Heroism"
   },
   "RULER.CannotAffordMove": "You cannot afford to move {distance} spaces which costs {action} Action points.",
+  "SHEETS": {
+    "FormNavLabel": "Navigation de la Feuille"
+  },
   "SETTINGS.AutoConfirmName": "Action Auto-Confirmation",
   "SETTINGS.AutoConfirmHint": "Enable auto-confirmation of actions in combat which do not deal damage or cause active effects. This can speed things up but is not recommended during play-testing.",
   "SETTINGS.AutoConfirmNone": "No Auto-Confirmation",
@@ -821,6 +843,80 @@
     "Xenology": "Xénologie",
     "XenologyAbbr": "Xen"
   },
+  "SPECIALIZATION": {
+    "FIELDS": {
+      "FreeSkill": "Compétence Gratuite",
+      "Skills": "Compétences de Spécialisation",
+      "FreeSkillRank": {
+        "label": "Rang(s) gratuit(s)",
+        "hint": "Sélectionnez le nombre de rangs gratuits de la spécialisation."
+      }
+    },
+    "SHEET": {
+      "CHOOSE": "Choisir une Spécialisation",
+      "CLEAR": "Effacer la Spécialisation",
+      "SpecializationSkills": {
+        "maxNumber": "Nombre maximum de compétences de spécialisation à choisir"
+      }
+    }
+  },
+  "SPECIES": {
+    "FIELDS": {
+      "description": {
+        "label": "Description de l'Espèce"
+      },
+      "stride": {
+        "label": "Allure",
+        "hint": "La vitesse de déplacement de départ de cette espèce en cases de grille."
+      },
+      "primary": {
+        "label": "Capacité Primaire",
+        "hint": "Sélectionnez une capacité primaire qui commence à 3."
+      },
+      "secondary": {
+        "label": "Capacité Secondaire",
+        "hint": "Sélectionnez une capacité secondaire qui commence à 2."
+      },
+      "resistance": {
+        "label": "Résistance aux Dégâts",
+        "hint": "Une Résistance biologique (+5) à un certain type de dégâts."
+      },
+      "StartingExperience": {
+        "label": "Valeur",
+        "hint": "Sélectionnez l'expérience de départ pour cette espèce."
+      },
+      "StrainThreshold": {
+        "modifier": "Modificateur de Seuil de Contrainte",
+        "abilityKey": "Clé"
+      },
+      "WoundThreshold": {
+        "modifier": "Modificateur de Seuil de Blessure",
+        "abilityKey": "Clé"
+      },
+      "vulnerability": {
+        "label": "Vulnérabilité aux Dégâts",
+        "hint": "Une Vulnérabilité biologique (-5) à un certain type de dégâts."
+      }
+    },
+    "SHEET": {
+      "BROWSE": "Parcourir les Ancêtres",
+      "Characteristics": "Valeurs de Caractéristiques",
+      "CHOOSE": "Choisir une Espèce",
+      "CLEAR": "Effacer l'Espèce",
+      "FreeSkill": "Compétence Gratuite",
+      "FreeTalent": "Talent Gratuit",
+      "RESISTANCES": "Résistances et Vulnérabilités",
+      "RESISTANCE_HINT": "Vous devez choisir à la fois une Résistance et une Vulnérabilité si vous en sélectionnez une.",
+      "SpecialAbility": "Capacité Spéciale",
+      "StartingExperience": "Expérience de Départ",
+      "STATURE": "Taille de l'Espèce",
+      "Threshold": "Valeurs de Seuil"
+    },
+    "WARNINGS": {
+      "ABILITIES": "Les capacités primaire et secondaire d'une Espèce ne peuvent pas être identiques.",
+      "RESISTANCES": "La Résistance et la Vulnérabilité choisies pour une Espèce ne peuvent pas être identiques."
+    }
+  },
   "TALENT": {
     "FIELDS": {
       "node": {
@@ -957,6 +1053,9 @@
   "WALKTHROUGH.LevelZero": "Complete all character creation steps before advancing your character to Level 1.",
   "WALKTHROUGH.LevelOne": "Set your character to Level 1 and begin your adventure!",
   "WALKTHROUGH.LevelUp": "You have made enough progress to advance to a new level. Increase your level by one when you are ready!",
+  "WALKTHROUGH.AddSpecies": "Choisissez une Espèce depuis le Compendium ou la barre latérale des Objets et ajoutez-la par glisser-déposer.",
+  "WALKTHROUGH.AddCareer": "Choisissez une Carrière depuis le Compendium ou la barre latérale des Objets et ajoutez-la par glisser-déposer.",
+  "WALKTHROUGH.AddSpecialization": "Choisissez une Spécialisation depuis le Compendium ou la barre latérale des Objets et ajoutez-la par glisser-déposer.",
   "WALKTHROUGH.LevelZeroIncomplete": "You may not advance to Level 1 until you have finished all character creation steps!",
   "ERRORS": {
     "InvalidEvent": "Événement invalide : Impossible de traiter l'interaction d'interface.",

--- a/module/applications/sheets/armor.mjs
+++ b/module/applications/sheets/armor.mjs
@@ -79,7 +79,7 @@ export default class ArmorSheet extends SwerpgBaseItemSheet {
     const qualities = this.document.system.qualities || []
     const qualityOptions = Object.entries(SYSTEM.ARMOR.PROPERTIES).map(([k, v]) => ({
       value: k,
-      label: v.label,
+      label: game.i18n.localize(v.label),
       hasRank: v.hasRank || false,
     }))
 

--- a/module/models/armor.mjs
+++ b/module/models/armor.mjs
@@ -110,7 +110,7 @@ export default class SwerpgArmor extends SwerpgCombatItem {
    */
   getTags(scope = 'full') {
     const tags = {}
-    tags.category = this.config.category.label
+    tags.category = game.i18n.localize(this.config.category.label)
 
     if (this.restrictionLevel && this.restrictionLevel !== 'none') {
       tags.restricted = game.i18n.localize(SYSTEM.RESTRICTION_LEVELS[this.restrictionLevel].label)

--- a/module/models/weapon.mjs
+++ b/module/models/weapon.mjs
@@ -294,7 +294,7 @@ export default class SwerpgWeapon extends SwerpgCombatItem {
     tags.damage = `${this.damage.weapon} Damage`
 
     // Canonical category (mechanical family)
-    if (this.config?.category?.label) tags.category = this.config.category.label
+    if (this.config?.category?.label) tags.category = game.i18n.localize(this.config.category.label)
 
     // Narrative subtype — humanize slug for display
     if (this.weaponType) tags['weapon-type'] = humanizeWeaponType(this.weaponType)

--- a/templates/sheets/actor/skills.hbs
+++ b/templates/sheets/actor/skills.hbs
@@ -69,43 +69,4 @@
 
 
     </div>
-
-    {{!--
-        {{#each skillCategories as |category catId|}}
-        <div class="sheet-section item-section flexcol">
-            <h3 class="section-header">{{category.label}} Skills</h3>
-            <ol class="items-list skills-list" style="--skill-color:{{category.color.css}}">
-                {{#each category.skills as |skill skillId|}}
-                <li class="skill line-item {{skill.css}}" data-skill="{{skillId}}">
-                    <img class="icon" src="{{skill.icon}}" alt="{{skill.name}}">
-                    <div class="title">
-                        <h4 data-tooltip="Roll Check" data-action="skillRoll"><a>{{skill.name}}</a></h4>
-                    </div>
-                    <div class="tags">
-                        {{#each skill.rankTags as |tag|}}<span class="rank tag">{{tag}}</span>{{/each}}
-                        {{#each skill.abilityAbbrs}}<span class="attribute tag">{{this}}</span>{{/each}}
-                    </div>
-                    <div class="bonus flexrow">
-                        <span class="value hex {{skill.hexClass}}" data-tooltip="{{skill.tooltips.value}}">{{numberFormat skill.score sign=true}}</span>
-                        <span class="passive" data-tooltip="Passive: {{skill.tooltips.passive}}">{{skill.passive}}</span>
-                    </div>
-                    <div class="ranks flexrow">
-                        <a class="button icon fa-solid fa-caret-down {{#unless skill.canDecrease}}invisible{{/unless}}"
-                           data-tooltip="Decrease Skill Rank" data-action="skillDecrease"></a>
-                        <div class="pips flexrow">
-                            {{#each skill.pips}}<span class="pip {{this.cssClass}}"></span>{{/each}}
-                        </div>
-                        <a class="button icon fa-solid fa-caret-up {{#unless skill.canIncrease}}invisible{{/unless}}"
-                           data-tooltip="Increase Skill Rank" data-action="skillIncrease"></a>
-                        <span class="cost" data-tooltip="Cost to Increase">
-                            {{#if skill.cost}}({{numberFormat skill.cost sign=true}}){{else}}-{{/if}}
-                        </span>
-                    </div>
-                    <a class="button icon fa-solid fa-cog" data-tooltip="Configure Skill" data-action="skillConfig"></a>
-                </li>
-                {{/each}}
-            </ol>
-        </div>
-        {{/each}}
-    --}}
 </section>

--- a/templates/sheets/partials/armor-config.hbs
+++ b/templates/sheets/partials/armor-config.hbs
@@ -1,7 +1,7 @@
 <section class="tab sheet-body flexcol scrollable {{tabs.config.cssClass}}" data-tab="{{tabs.config.id}}" data-group="{{tabs.config.group}}">
   <fieldset {{fieldDisabled}}>
     <legend>{{localize "ARMOR.SHEET.TYPE"}}</legend>
-    {{formField fields.category value=source.system.category}}
+    {{formField fields.category value=source.system.category localize=true}}
     {{formField fields.quality value=source.system.quality}}
     {{formField fields.encumbrance value=source.system.encumbrance}}
   </fieldset>

--- a/templates/sheets/partials/weapon-config.hbs
+++ b/templates/sheets/partials/weapon-config.hbs
@@ -1,7 +1,7 @@
 <section class="tab sheet-body flexcol scrollable {{tabs.config.cssClass}}" data-tab="{{tabs.config.id}}" data-group="{{tabs.config.group}}">
   <fieldset {{fieldDisabled}}>
     <legend>{{localize "WEAPON.SHEET.TYPE"}}</legend>
-    {{formField fields.category value=source.system.category}}
+    {{formField fields.category value=source.system.category localize=true}}
     {{formField fields.weaponType value=source.system.weaponType}}
     {{formField fields.skill value=source.system.skill}}
     {{formField fields.quality value=source.system.quality}}

--- a/tests/importer/armor-import.integration.spec.mjs
+++ b/tests/importer/armor-import.integration.spec.mjs
@@ -293,4 +293,19 @@ describe('SwerpgArmor - getTags restrictionLevel', () => {
     expect(tags.defense).toBe('4 Armor')
     expect(tags.restricted).toBe(game.i18n.localize('ITEM.RESTRICTION_LEVEL.RESTRICTED'))
   })
+
+  it('localizes raw armor category labels when building tags', () => {
+    const localizeSpy = vi.spyOn(game.i18n, 'localize').mockImplementation((key) => {
+      if (key === 'ARMOR.CATEGORIES.MEDIUM') return 'Medium Armor'
+      return key
+    })
+
+    const armor = makeArmor('restricted')
+    armor.config.category.label = 'ARMOR.CATEGORIES.MEDIUM'
+
+    const tags = SwerpgArmor.prototype.getTags.call(armor, 'full')
+
+    expect(tags.category).toBe('Medium Armor')
+    expect(localizeSpy).toHaveBeenCalledWith('ARMOR.CATEGORIES.MEDIUM')
+  })
 })


### PR DESCRIPTION
## Description

Ajout des cles i18n manquantes referencees dans les templates Handlebars mais absentes de `lang/en.json` et `lang/fr.json`.

## Changements

### `lang/en.json` (+10 cles)
- `BACKGROUND.SHEET.TALENT_REMOVE`, `CAREER.FIELDS.Skills`, `MOTIVATION.Sources`, `MOTIVATION.SourcesList`, `SHEETS.FormNavLabel`
- Remplissage de `SPECIALIZATION.FIELDS` (vide) et ajout de `SpecializationSkills.maxNumber`

### `lang/fr.json` (+49 cles)
- Nouveaux blocs : `ACTION.TAGS`, `BACKGROUND`, `MOTIVATION`, `MOTIVATION_CATEGORY`, `SHEETS`
- `SPECIALIZATION` complet (FIELDS + SHEET)
- `SPECIES` complet (FIELDS + SHEET + WARNINGS)
- 3 cles `WALKTHROUGH.AddCareer/AddSpecialization/AddSpecies`

Fixes #134
