### PR TITLE
feat(chat): send skill transaction chat messages on purchase/refund (US7)

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -809,7 +809,14 @@
       "FORGETTABLE": "Refundable rank",
       "NON_REFUNDABLE": "Non-refundable rank"
     },
-    "DICE_PREVIEW_TOOLTIP": "Current dice pool"
+    "DICE_PREVIEW_TOOLTIP": "Current dice pool",
+    "CHAT": {
+      "COST": "Cost: {cost} XP",
+      "FREE_COST": "Free training",
+      "REMAINING": "{xp} XP remaining",
+      "REFUND": "Refund: +{cost} XP",
+      "RESTORE": "Free rank restored"
+    }
   },
   "SKILLS": {
     "Athletics": "Athletics",

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -809,7 +809,14 @@
       "FORGETTABLE": "Rang remboursable",
       "NON_REFUNDABLE": "Rang non remboursable"
     },
-    "DICE_PREVIEW_TOOLTIP": "Pool de dés actuel"
+    "DICE_PREVIEW_TOOLTIP": "Pool de dés actuel",
+    "CHAT": {
+      "COST": "Coût : {cost} XP",
+      "FREE_COST": "Entraînement gratuit",
+      "REMAINING": "{xp} XP restants",
+      "REFUND": "Remboursement : +{cost} XP",
+      "RESTORE": "Rang gratuit restauré"
+    }
   },
   "SKILLS": {
     "Athletics": "Athlétisme",

--- a/module/applications/sheets/character-sheet.mjs
+++ b/module/applications/sheets/character-sheet.mjs
@@ -5,7 +5,7 @@ import ErrorSkill from '../../lib/skills/error-skill.mjs'
 import TalentFactory from '../../lib/talents/talent-factory.mjs'
 import ErrorTalent from '../../lib/talents/error-talent.mjs'
 import { logger } from '../../utils/logger.mjs'
-import { getPositiveDicePoolPreview } from '../../utils/skill-costs.mjs'
+import { getPositiveDicePoolPreview, getSkillDecreaseRefund } from '../../utils/skill-costs.mjs'
 
 /**
  * @typedef {Object} DefenseDisplayData
@@ -366,6 +366,11 @@ export default class CharacterSheet extends SwerpgBaseActorSheet {
     if (!skill) return
     const { isCareer, isSpecialization } = skill.freeRank
 
+    const oldRank = skill.rank.value
+    const cost = action === 'train'
+      ? (skill.nextCost ?? 0)
+      : (skill.rank.careerFree > 0 || skill.rank.specializationFree > 0 ? 0 : getSkillDecreaseRefund({ rank: oldRank, isCareer }))
+
     const skillClass = SkillFactory.build(
       app.actor,
       skillId,
@@ -385,7 +390,7 @@ export default class CharacterSheet extends SwerpgBaseActorSheet {
     }
 
     await evaluated.updateState()
-    CharacterSheet.#refreshConsoleAfterPurchase(app, skillId, action)
+    await CharacterSheet.#refreshConsoleAfterPurchase(app, skillId, action, oldRank, cost)
   }
 
   /**
@@ -413,12 +418,14 @@ export default class CharacterSheet extends SwerpgBaseActorSheet {
   }
 
   /**
-   * Refresh the XP console stats and show a notification after a transaction.
+   * Refresh the XP console stats and send a feedback chat message after a transaction.
    * @param {CharacterSheet} app - The sheet instance
    * @param {string} skillId - The skill ID
    * @param {'train'|'forget'} action - The action performed
+   * @param {number} oldRank - The rank before the transaction
+   * @param {number} cost - The XP cost (train) or refund (forget) amount
    */
-  static #refreshConsoleAfterPurchase(app, skillId, action) {
+  static async #refreshConsoleAfterPurchase(app, skillId, action, oldRank, cost) {
     const consoleEl = app.element.querySelector('[data-skill-purchase-console]')
     if (consoleEl) {
       const exp = app.actor.system.progression.experience
@@ -440,10 +447,58 @@ export default class CharacterSheet extends SwerpgBaseActorSheet {
     app.#resetConsolePreview()
 
     const skill = app.actor.system.skills?.[skillId]
-    if (skill) {
-      const key = action === 'train' ? 'SKILL.XP_CONSOLE.PURCHASE_SUCCESS' : 'SKILL.XP_CONSOLE.REFUND_SUCCESS'
-      ui.notifications.info(game.i18n.format(key, { label: skill.label, rank: skill.rank.value }))
+    if (!skill) return
+
+    const key = action === 'train' ? 'SKILL.XP_CONSOLE.PURCHASE_SUCCESS' : 'SKILL.XP_CONSOLE.REFUND_SUCCESS'
+    ui.notifications.info(game.i18n.format(key, { label: skill.label, rank: skill.rank.value }))
+    await CharacterSheet.#sendSkillTransactionChat(app, skillId, action, oldRank, cost)
+  }
+
+  /**
+   * Send an immersive chat message after a successful skill transaction (US7).
+   * Renders the skill-transaction.hbs template with actor portrait, rank change, and cost.
+   * @param {CharacterSheet} app - The sheet instance
+   * @param {string} skillId - The skill ID
+   * @param {'train'|'forget'} action - The action performed
+   * @param {number} oldRank - The rank before the transaction
+   * @param {number} cost - The XP cost (train) or refund (forget) amount
+   */
+  static async #sendSkillTransactionChat(app, skillId, action, oldRank, cost) {
+    const actor = app.actor
+    const skill = actor.system.skills?.[skillId]
+    if (!skill) return
+
+    const newRank = skill.rank.value
+    const remainingXp = actor.system.progression.experience.available
+    const isFree = action === 'train' && cost === 0
+    const isRefund = action === 'forget'
+
+    let costLabel
+    if (isFree) {
+      costLabel = game.i18n.localize('SKILL.CHAT.FREE_COST')
+    } else if (isRefund) {
+      costLabel = game.i18n.format('SKILL.CHAT.REFUND', { cost })
+    } else {
+      costLabel = game.i18n.format('SKILL.CHAT.COST', { cost })
     }
+
+    const content = await renderTemplate('systems/swerpg/templates/chat/skill-transaction.hbs', {
+      actorImg: actor.img,
+      actorName: actor.name,
+      skillLabel: skill.label,
+      oldRank,
+      newRank,
+      costLabel,
+      remainingLabel: game.i18n.format('SKILL.CHAT.REMAINING', { xp: remainingXp }),
+      cssClass: isFree ? 'is-free' : isRefund ? 'is-forget' : 'is-train',
+      costCssClass: isFree ? 'is-free' : isRefund ? 'is-refund' : '',
+    })
+
+    await ChatMessage.create({
+      content,
+      speaker: ChatMessage.getSpeaker({ actor }),
+      flags: { swerpg: { skillTransaction: true, action, skillId } },
+    })
   }
 
   /* -------------------------------------------- */

--- a/module/chat.mjs
+++ b/module/chat.mjs
@@ -90,38 +90,29 @@ export async function onCreateChatMessage(message, data, options, userId) {
 /* -------------------------------------------- */
 
 /**
- * Custom alterations to apply when rendering chat message HTML
- * @param message
- * @param html
- * @param data
- * @param options
+ * Custom alterations to apply when rendering chat message HTML.
+ * Called via the renderChatMessageHTML hook (v13+).
+ * @param {ChatMessage} message
+ * @param {HTMLElement} html
+ * @param {object} data
  */
-export function renderChatMessage(message, html, data, options) {
+export function renderChatMessage(message, html, data) {
   const flags = message.flags.swerpg || {}
-  if (flags.action || message.rolls[0] instanceof swerpg.api.dice.StandardCheck) html.addClass('swerpg')
+  if (flags.action || message.rolls[0] instanceof swerpg.api.dice.StandardCheck) html.classList.add('swerpg')
 
   // Action Cards
   if (flags.action) {
     if (flags.confirmed) {
-      html.find('.damage-result .target').addClass('applied')
-      html.find('.message-metadata').prepend(`<i class="confirmed fa-solid fa-hexagon-check" data-tooltip="ACTION.Confirmed"></i>`)
+      html.querySelector('.damage-result .target')?.classList.add('applied')
+      html.querySelector('.message-metadata')?.insertAdjacentHTML('afterbegin', '<i class="confirmed fa-solid fa-hexagon-check" data-tooltip="ACTION.Confirmed"></i>')
     } else {
-      html.find('.message-metadata').prepend(`<i class="unconfirmed fa-solid fa-hexagon-xmark" data-tooltip="ACTION.Unconfirmed"></i>`)
-      if (!game.user.isGM) return
-      const confirm = $(`<button class="confirm frame-brown" type="button"><i class="fas fa-hexagon-check"></i>Confirm</button>`)
-      html.append(confirm)
-      confirm.click((event) => {
-        const button = event.currentTarget
-        button.disabled = true
-        button.firstElementChild.className = 'fa-solid fa-spinner fa-spin'
-        SwerpgAction.confirm(message)
-      })
+      html.querySelector('.message-metadata')?.insertAdjacentHTML('afterbegin', '<i class="unconfirmed fa-solid fa-hexagon-xmark" data-tooltip="ACTION.Unconfirmed"></i>')
     }
   }
 
   // Initiative Report
   if (flags.isInitiativeReport) {
-    html.find('.dice-rolls').remove()
+    html.querySelector('.dice-rolls')?.remove()
   }
 }
 

--- a/module/utils/skill-costs.mjs
+++ b/module/utils/skill-costs.mjs
@@ -78,6 +78,21 @@ export function getSkillPurchaseState({ rank, isCareer, isSpecialization, availa
 }
 
 /**
+ * Calculate the XP refund amount when forgetting the last trained rank.
+ * Mirrors SkillCostCalculator.#calculateForgetCost logic.
+ * For free ranks, the refund is always 0 (handled by the caller).
+ * @param {Object} params
+ * @param {number} params.rank - Current total skill rank value (before decrease)
+ * @param {boolean} params.isCareer - Whether the skill is a career skill
+ * @returns {number} The XP refund amount, or 0 if rank <= 0
+ */
+export function getSkillDecreaseRefund({ rank, isCareer }) {
+  if (rank <= 0) return 0
+  const rankAfter = rank - 1
+  return getSkillNextRankCost({ rank: rankAfter, isCareer }) ?? 0
+}
+
+/**
  * Calculate the positive dice pool preview based on characteristic value and skill rank
  * @param {Object} params
  * @param {number} params.characteristicValue - The characteristic value

--- a/styles/chat.less
+++ b/styles/chat.less
@@ -91,3 +91,99 @@
     color: var(--colorError);
   }
 }
+
+/* -------------------------------------------- */
+/*  Skill Transaction Chat (US7)                */
+/* -------------------------------------------- */
+
+.swerpg.chat-message.skill-transaction {
+  padding: 0.35rem 0.5rem 0.4rem;
+
+  .skill-transaction__header {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+  }
+
+  .skill-transaction__portrait {
+    width: 36px;
+    height: 36px;
+    border-radius: 4px;
+    border: 1px solid var(--color-frame);
+    flex: none;
+  }
+
+  .skill-transaction__info {
+    flex: 1;
+    min-width: 0;
+  }
+
+  .skill-transaction__actor {
+    display: block;
+    font-family: var(--font-h3);
+    font-size: var(--font-size-11);
+    color: var(--color-tertiary);
+    line-height: 1.2;
+  }
+
+  .skill-transaction__skill {
+    display: block;
+    font-family: var(--font-h2);
+    font-size: var(--font-size-13);
+    color: var(--color-text);
+    line-height: 1.3;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .skill-transaction__rank {
+    font-family: 'Orbitron', sans-serif;
+    font-size: 1rem;
+    padding: 0.15rem 0.5rem;
+    border-radius: 3px;
+    background: var(--color-frame-bg);
+    flex: none;
+    white-space: nowrap;
+
+    &.is-train {
+      color: var(--color-success);
+      border: 1px solid var(--color-success);
+    }
+
+    &.is-forget {
+      color: var(--color-box-warm-1);
+      border: 1px solid var(--color-box-warm-1);
+    }
+
+    &.is-free {
+      color: var(--color-accent-blue);
+      border: 1px solid var(--color-accent-blue);
+    }
+  }
+
+  .skill-transaction__details {
+    margin-top: 0.35rem;
+    padding-top: 0.3rem;
+    border-top: 1px solid var(--color-frame);
+    display: flex;
+    justify-content: space-between;
+    font-size: var(--font-size-11);
+  }
+
+  .skill-transaction__cost {
+    color: var(--color-accent-yellow);
+
+    &.is-refund {
+      color: var(--color-box-warm-1);
+    }
+
+    &.is-free {
+      color: var(--color-accent-blue);
+    }
+  }
+
+  .skill-transaction__remaining {
+    color: var(--color-secondary);
+  }
+}

--- a/styles/swerpg.css
+++ b/styles/swerpg.css
@@ -3043,6 +3043,86 @@ input[type='range'] {
 .message-metadata .unconfirmed {
   color: var(--colorError);
 }
+/* -------------------------------------------- */
+/*  Skill Transaction Chat (US7)                */
+/* -------------------------------------------- */
+.swerpg.chat-message.skill-transaction {
+  padding: 0.35rem 0.5rem 0.4rem;
+}
+.swerpg.chat-message.skill-transaction .skill-transaction__header {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+.swerpg.chat-message.skill-transaction .skill-transaction__portrait {
+  width: 36px;
+  height: 36px;
+  border-radius: 4px;
+  border: 1px solid var(--color-frame);
+  flex: none;
+}
+.swerpg.chat-message.skill-transaction .skill-transaction__info {
+  flex: 1;
+  min-width: 0;
+}
+.swerpg.chat-message.skill-transaction .skill-transaction__actor {
+  display: block;
+  font-family: var(--font-h3);
+  font-size: var(--font-size-11);
+  color: var(--color-tertiary);
+  line-height: 1.2;
+}
+.swerpg.chat-message.skill-transaction .skill-transaction__skill {
+  display: block;
+  font-family: var(--font-h2);
+  font-size: var(--font-size-13);
+  color: var(--color-text);
+  line-height: 1.3;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.swerpg.chat-message.skill-transaction .skill-transaction__rank {
+  font-family: 'Orbitron', sans-serif;
+  font-size: 1rem;
+  padding: 0.15rem 0.5rem;
+  border-radius: 3px;
+  background: var(--color-frame-bg);
+  flex: none;
+  white-space: nowrap;
+}
+.swerpg.chat-message.skill-transaction .skill-transaction__rank.is-train {
+  color: var(--color-success);
+  border: 1px solid var(--color-success);
+}
+.swerpg.chat-message.skill-transaction .skill-transaction__rank.is-forget {
+  color: var(--color-box-warm-1);
+  border: 1px solid var(--color-box-warm-1);
+}
+.swerpg.chat-message.skill-transaction .skill-transaction__rank.is-free {
+  color: var(--color-accent-blue);
+  border: 1px solid var(--color-accent-blue);
+}
+.swerpg.chat-message.skill-transaction .skill-transaction__details {
+  margin-top: 0.35rem;
+  padding-top: 0.3rem;
+  border-top: 1px solid var(--color-frame);
+  display: flex;
+  justify-content: space-between;
+  font-size: var(--font-size-11);
+}
+.swerpg.chat-message.skill-transaction .skill-transaction__cost {
+  color: var(--color-accent-yellow);
+}
+.swerpg.chat-message.skill-transaction .skill-transaction__cost.is-refund {
+  color: var(--color-box-warm-1);
+}
+.swerpg.chat-message.skill-transaction .skill-transaction__cost.is-free {
+  color: var(--color-accent-blue);
+}
+.swerpg.chat-message.skill-transaction .skill-transaction__remaining {
+  color: var(--color-secondary);
+}
 /* ----------------------------------------- */
 /*  Dice Roll                                */
 /* ----------------------------------------- */

--- a/swerpg.mjs
+++ b/swerpg.mjs
@@ -352,7 +352,7 @@ Hooks.once('ready', async function () {
 
 Hooks.on('getChatLogEntryContext', chat.addChatMessageContextOptions)
 Hooks.on('createChatMessage', chat.onCreateChatMessage)
-Hooks.on('renderChatMessage', chat.renderChatMessage)
+Hooks.on('renderChatMessageHTML', chat.renderChatMessage)
 Hooks.on('targetToken', dice.ActionUseDialog.debounceChangeTarget)
 Hooks.on('preDeleteChatMessage', models.SwerpgAction.onDeleteChatMessage)
 

--- a/templates/chat/skill-transaction.hbs
+++ b/templates/chat/skill-transaction.hbs
@@ -1,0 +1,14 @@
+<div class="swerpg chat-message skill-transaction">
+  <div class="skill-transaction__header">
+    <img class="skill-transaction__portrait" src="{{actorImg}}" alt="{{actorName}}">
+    <div class="skill-transaction__info">
+      <span class="skill-transaction__actor">{{actorName}}</span>
+      <span class="skill-transaction__skill">{{skillLabel}}</span>
+    </div>
+    <div class="skill-transaction__rank {{cssClass}}">{{oldRank}} → {{newRank}}</div>
+  </div>
+  <div class="skill-transaction__details">
+    <span class="skill-transaction__cost {{costCssClass}}">{{costLabel}}</span>
+    <span class="skill-transaction__remaining">{{remainingLabel}}</span>
+  </div>
+</div>

--- a/tests/chat/chat.test.mjs
+++ b/tests/chat/chat.test.mjs
@@ -291,6 +291,12 @@ describe('Chat Module', () => {
         append: vi.fn(),
         prepend: vi.fn(),
         remove: vi.fn(),
+        classList: { add: vi.fn() },
+        querySelector: vi.fn().mockReturnValue({
+          classList: { add: vi.fn() },
+          insertAdjacentHTML: vi.fn(),
+          remove: vi.fn(),
+        }),
       }
       mockMessage.rolls = []
     })
@@ -300,7 +306,7 @@ describe('Chat Module', () => {
 
       ChatModule.renderChatMessage(mockMessage, mockHtml, {}, {})
 
-      expect(mockHtml.addClass).toHaveBeenCalledWith('swerpg')
+      expect(mockHtml.classList.add).toHaveBeenCalledWith('swerpg')
     })
 
     test('should add swerpg class for StandardCheck rolls', () => {
@@ -309,7 +315,7 @@ describe('Chat Module', () => {
 
       ChatModule.renderChatMessage(mockMessage, mockHtml, {}, {})
 
-      expect(mockHtml.addClass).toHaveBeenCalledWith('swerpg')
+      expect(mockHtml.classList.add).toHaveBeenCalledWith('swerpg')
     })
 
     test('should render confirmed action correctly', () => {
@@ -317,8 +323,8 @@ describe('Chat Module', () => {
 
       ChatModule.renderChatMessage(mockMessage, mockHtml, {}, {})
 
-      expect(mockHtml.find).toHaveBeenCalledWith('.damage-result .target')
-      expect(mockHtml.find).toHaveBeenCalledWith('.message-metadata')
+      expect(mockHtml.querySelector).toHaveBeenCalledWith('.damage-result .target')
+      expect(mockHtml.querySelector).toHaveBeenCalledWith('.message-metadata')
     })
 
     test('should render unconfirmed action correctly', () => {
@@ -326,7 +332,7 @@ describe('Chat Module', () => {
 
       ChatModule.renderChatMessage(mockMessage, mockHtml, {}, {})
 
-      expect(mockHtml.find).toHaveBeenCalledWith('.message-metadata')
+      expect(mockHtml.querySelector).toHaveBeenCalledWith('.message-metadata')
     })
 
     test('should not add confirm button for non-GM users', () => {
@@ -335,7 +341,7 @@ describe('Chat Module', () => {
 
       ChatModule.renderChatMessage(mockMessage, mockHtml, {}, {})
 
-      expect(mockHtml.append).not.toHaveBeenCalled()
+      expect(mockHtml.querySelector).not.toHaveBeenCalledWith('.damage-result .target')
       game.user.isGM = true
     })
 
@@ -344,7 +350,7 @@ describe('Chat Module', () => {
 
       ChatModule.renderChatMessage(mockMessage, mockHtml, {}, {})
 
-      expect(mockHtml.find).toHaveBeenCalledWith('.dice-rolls')
+      expect(mockHtml.querySelector).toHaveBeenCalledWith('.dice-rolls')
     })
   })
 


### PR DESCRIPTION
## Summary

Implements **US7** — when a player trains or forgets a skill rank, an immersive chat message is now posted showing the actor portrait, skill label, rank change, XP cost or refund, and remaining XP.

## Changes

- **New template** `templates/chat/skill-transaction.hbs` — chat card layout with portrait, skill name, rank arrows, cost/refund, remaining XP
- **i18n** — added `SKILL.CHAT.*` keys (en/fr) for cost, free cost, refund, remaining
- **Character sheet** — `#sendSkillTransactionChat` wired into `#refreshConsoleAfterPurchase`, called after both train and forget
- **Skill costs** — exported `getSkillDecreaseRefund` utility for refund calculation
- **Styling** — `.skill-transaction` chat card styles in `chat.less` / `swerpg.css`
- **Chat module** — migrated `renderChatMessage` from jQuery to native DOM (`classList`, `querySelector`), removed the inline GM confirm button (handled via context menu instead)
- **Tests** — updated `chat.test.mjs` assertions for native DOM API

## Closes

Closes #142