### PR TITLE
feat(audit-log): add diff analyzer for evolution entries

### DIFF
--- a/documentation/plan/character-sheet/evolution-logs/TECH-158-plan-aop-hooks.md
+++ b/documentation/plan/character-sheet/evolution-logs/TECH-158-plan-aop-hooks.md
@@ -1,0 +1,474 @@
+# Plan d'implémentation — #158 : Architecture AOP et double hook preUpdateActor/updateActor pour l'audit log
+
+**Issue** : [#158 — TECH: Architecture AOP et double hook preUpdateActor/updateActor pour l'audit log](https://github.com/herveDarritchon/foundryvtt-swerpg/issues/158)
+**Epic** : [#150 — EPIC: Système de logs d'évolution du personnage (Character Audit Log)](https://github.com/herveDarritchon/foundryvtt-swerpg/issues/150)
+**User Story** : [#151 — US1: Enregistrer chaque action d'évolution du personnage dans un journal de bord](https://github.com/herveDarritchon/foundryvtt-swerpg/issues/151)
+**ADR** : `documentation/architecture/adr/adr-0011-stockage-journal-evolution-personnage-flags.md`
+**Plan amont** : `documentation/plan/character-sheet/evolution-logs/US1-plan-audit-log-hooks.md`
+**Module impacté** : `module/utils/audit-log.mjs` (création), `swerpg.mjs` (modification), `lang/en.json`, `lang/fr.json` (modification)
+
+---
+
+## 1. Objectif
+
+Créer le module racine d'interception AOP qui écoute les hooks Foundry `preUpdateActor` / `updateActor` / `createItem`, capture l'état `_source` avant modification, et prépare l'interface vers l'analyseur de diff. Aucune logique de détection de changement n'est implémentée ici — elle relève de #159.
+
+Ce ticket absorbe également le périmètre **anti-boucle infinie** de #160 (isOnlyAuditChange + fire-and-forget sécurisé avec notification utilisateur) afin de garantir qu'aucun risque de boucle infinie n'existe dès la première version fonctionnelle.
+
+---
+
+## 2. Périmètre
+
+### Inclus dans #158
+
+- Création de `module/utils/audit-log.mjs` :
+  - `pendingOldStates` (Map) — liaison preUpdate → update
+  - `onPreUpdateActor(actor, changes, options, userId)` — capture old state
+  - `onUpdateActor(actor, changes, options, userId)` — consomme old state + appelle `composeEntries` (placeholder)
+  - `onCreateItemAction(item, data, options, userId)` — stub pour détection talent
+  - `snapshotOldState(source, changes)` — extraction partielle de `_source`
+  - `composeEntries(oldState, changes, actor, userId)` — placeholder vide retournant `[]`
+  - `writeLogEntry(actor, entry)` — écriture fire-and-forget dans `flags.swerpg.logs` avec try/catch
+  - `registerAuditLogHooks()` — câblage unique des 3 hooks
+  - Gardes :
+    - `isOnlyAuditChange(changes)` — anti-boucle infinie
+    - `isCharacterActor(actor)` — filtrage par `actor.type === 'character'`
+  - Anti-fuite mémoire :
+    - TTL 30s sur les entrées `pendingOldStates`
+    - MAX_PENDING = 50 avec éviction FIFO des plus anciennes
+    - Nettoyage opportuniste à chaque `set()`
+- Câblage dans `swerpg.mjs` :
+  - `Hooks.once('setup', registerAuditLogHooks)`
+- Gestion d'erreur :
+  - `logger.error` + `ui.notifications.warn` en cas d'échec d'écriture
+  - Fire-and-forget : `void writeLogEntry(...)` — pas de `await` bloquant dans les hooks
+- Clés i18n :
+  - `SKILL.AUDIT.WRITE_FAILED` pour le message d'erreur UI
+- Tests Vitest :
+  - Tests unitaires pour `snapshotOldState`, `isOnlyAuditChange`, `pruneExpiredPending`
+  - Tests d'intégration pour `onPreUpdateActor` / `onUpdateActor` / `onCreateItemAction`
+  - Test de non-régression : écriture fire-and-forget ne bloque pas le hook
+
+### Exclu de #158
+
+- Analyseur de diff (détection des types de changement) → #159
+- Snapshot XP dans chaque entrée → #161
+- Taille max configurable (System Setting + éviction FIFO) → #162
+- Chat message aux MJ en cas d'erreur → #160 (périmètre réduit)
+- Tests Vitest avancés (couverture complète des détecteurs) → #163
+
+---
+
+## 3. Constat sur l'existant
+
+### Aucun audit log n'existe
+
+Il n'y a **aucune** structure de log, d'historique ou de trace dans le codebase. Les seules données de progression disponibles sont les compteurs globaux `system.progression.experience.{spent, gained}`.
+
+### Aucun hook `updateActor` / `preUpdateActor` enregistré
+
+Le fichier `swerpg.mjs` enregistre des hooks pour le chat, le combat, le canvas, mais **aucun** pour les mises à jour d'acteur. Le seul hook lié aux documents est :
+- `preDeleteChatMessage` (ligne 357)
+- `createItem` n'est pas utilisé
+- `updateItem` existe en dev-only (ligne 512)
+
+### `_onUpdate` déjà surchargé dans `SwerpgActor`
+
+`actor.mjs:574` — `_onUpdate(data, options, userId)` est déjà override pour :
+- Affichage du scrolling de statut
+- Mise à jour de la taille du token
+- Mise à jour du flanking
+- Rafraîchissement de l'arbre de talents
+
+### ADR-0011 déjà accepté
+
+L'ADR `adr-0011-stockage-journal-evolution-personnage-flags.md` valide le stockage dans `actor.flags.swerpg.logs`. Règles clés :
+- Le log est une donnée **secondaire**, pas une source de vérité
+- Stockage dans les flags pour éviter migration du data model
+- Pas de recalcul automatique de l'état du personnage à partir du log
+
+---
+
+## 4. Décisions d'architecture
+
+### 4.1. Hook global vs override de `_onUpdate`
+
+**Problème** : Où placer la logique d'interception des mises à jour d'acteur ?
+
+**Options** :
+| Option | Avantages | Inconvénients |
+|--------|-----------|---------------|
+| Surcharger `_onUpdate` dans `SwerpgActor` | Accès direct à `this._source` pour les old values | Couplage fort, modifie le modèle, mélange responsabilités |
+| `Hooks.on('updateActor', ...)` | Approche AOP, séparation des concerns, désactivable | Nécessite double hook (preUpdate + update) pour old values |
+
+**Décision** : `Hooks.on('preUpdateActor', ...)` + `Hooks.on('updateActor', ...)`.
+
+**Justification** : L'audit log est un aspect transverse, pas une responsabilité du modèle acteur. Les hooks peuvent être retirés sans impacter le métier. Le double hook est nécessaire car `actor._source` a déjà été écrasé quand `updateActor` est appelé.
+
+### 4.2. Asynchronie des hooks Foundry
+
+**Problème** : Les handlers de hooks Foundry ne sont pas fiables en `async`. Un `await` dans un handler peut causer des comportements imprévisibles (ordre d'exécution, race conditions).
+
+**Décision** : Fire-and-forget sécurisé.
+
+```js
+void writeLogEntry(actor, entry).catch((err) => {
+  logger.error(`[AuditLog] Write failed for actor "${actor.name}" (${actor.id}):`, err)
+  ui.notifications.warn(game.i18n.format('SKILL.AUDIT.WRITE_FAILED', { actor: actor.name }))
+})
+```
+
+**Justification** : Le log est une donnée secondaire — il ne doit jamais bloquer l'action utilisateur. Le `catch` assure la traçabilité de l'erreur sans propager l'exception.
+
+### 4.3. Anti-boucle infinie
+
+**Problème** : `actor.update({ 'flags.swerpg.logs': [...] })` déclenche un nouveau `updateActor` hook. Sans garde, c'est une boucle infinie.
+
+**Décision** : `isOnlyAuditChange(changes)` en tête de `onPreUpdateActor` et `onUpdateActor`.
+
+```js
+function isOnlyAuditChange(changes) {
+  const keys = Object.keys(foundry.utils.flattenObject(changes))
+  return keys.length === 1 && keys[0] === 'flags.swerpg.logs'
+}
+```
+
+**Justification** : Si le diff ne contient QUE `flags.swerpg.logs`, c'est que l'update vient de `writeLogEntry` lui-même. On ignore.
+
+### 4.4. Anti-fuite mémoire sur `pendingOldStates`
+
+**Problème** : Si `preUpdateActor` est appelé sans `updateActor` correspondant (crash DB, timeout, navigation), la Map `pendingOldStates` conserve une entrée orpheline.
+
+**Décision** : Trois mécanismes complémentaires.
+
+```js
+const PENDING_TTL_MS = 30000
+const MAX_PENDING = 50
+const pendingOldStates = new Map()
+
+function pruneExpiredPending() {
+  const now = Date.now()
+  for (const [uuid, pending] of pendingOldStates) {
+    if (now - pending.timestamp > PENDING_TTL_MS) pendingOldStates.delete(uuid)
+  }
+}
+
+function evictOldestIfNeeded() {
+  if (pendingOldStates.size < MAX_PENDING) return
+  const entries = [...pendingOldStates.entries()].sort((a, b) => a[1].timestamp - b[1].timestamp)
+  const toRemove = entries.slice(0, pendingOldStates.size - MAX_PENDING)
+  for (const [uuid] of toRemove) pendingOldStates.delete(uuid)
+}
+```
+
+**Justification** : Le TTL garanti qu'une entrée non consommée expire après 30s. MAX_PENDING empêche la Map de croître indéfiniment en cas de pic. Le nettoyage opportuniste à chaque `set()` évite une thread de nettoyage dédiée.
+
+### 4.5. Séparation #158 / #159
+
+**Problème** : L'analyseur de diff (`composeEntries`) est dans #159, mais #158 a besoin de l'appeler.
+
+**Décision** : `composeEntries` est un placeholder vide retournant `[]`.
+
+```js
+function composeEntries(oldState, changes, actor, userId) {
+  // Placeholder — implémenté dans #159
+  return []
+}
+```
+
+**Justification** : #158 et #159 sont indépendants. #158 livre l'infrastructure AOP complète et testée. #159 branche la logique réelle de détection des changements. Pas de dépendance bloquante.
+
+### 4.6. Nommage et API
+
+**Problème** : Comment organiser les exports du module ?
+
+**Décision** :
+- Fichier : `module/utils/audit-log.mjs`
+- Fonction principale : `registerAuditLogHooks()` — câble tout en interne
+- Handlers exportés individuellement pour les tests :
+  - `onPreUpdateActor`
+  - `onUpdateActor`
+  - `onCreateItemAction`
+
+### 4.7. Câblage dans `setup`
+
+**Problème** : Quand enregistrer les hooks ? Trop tard (`ready`) et on rate des updates précoces.
+
+**Décision** : `Hooks.once('setup', registerAuditLogHooks)`.
+
+**Justification** : Le hook `setup` est appelé après que tous les systèmes sont initialisés mais avant que les mondes et scènes soient chargés. Les documents commencent à être créés dans `ready`. `setup` est le bon moment pour enregistrer des hooks document.
+
+---
+
+## 5. Plan de travail détaillé
+
+### Étape 1 : Créer `module/utils/audit-log.mjs`
+
+Structure complète du module :
+
+```
+module/utils/audit-log.mjs
+├── Imports
+│   └── logger depuis ./logger.mjs
+├── Constantes
+│   ├── AUDIT_LOG_KEY = 'flags.swerpg.logs'
+│   ├── PENDING_TTL_MS = 30000
+│   ├── MAX_PENDING = 50
+│   └── pendingOldStates = new Map()
+├── Gardes
+│   ├── isOnlyAuditChange(changes)
+│   └── isCharacterActor(actor)
+├── Capture old state
+│   └── snapshotOldState(source, changes)
+├── Anti-fuite mémoire
+│   ├── pruneExpiredPending()
+│   └── evictOldestIfNeeded()
+├── Handlers (exportés)
+│   ├── onPreUpdateActor(actor, changes, options, userId)
+│   ├── onUpdateActor(actor, changes, options, userId)
+│   └── onCreateItemAction(item, data, options, userId)
+├── Analyseur de diff (placeholder vers #159)
+│   └── composeEntries(oldState, changes, actor, userId) → []
+├── Écriture (fire-and-forget)
+│   └── writeLogEntry(actor, entry)
+└── Point d'entrée unique
+    └── registerAuditLogHooks()
+```
+
+#### Détail des handlers
+
+**onPreUpdateActor :**
+```js
+export function onPreUpdateActor(actor, changes, options, userId) {
+  if (!isCharacterActor(actor)) return
+  if (isOnlyAuditChange(changes)) return
+
+  pruneExpiredPending()
+  evictOldestIfNeeded()
+
+  const oldState = snapshotOldState(actor._source, changes)
+  pendingOldStates.set(actor.uuid, {
+    oldState,
+    changes,
+    userId,
+    timestamp: Date.now(),
+  })
+}
+```
+
+**onUpdateActor :**
+```js
+export function onUpdateActor(actor, changes, options, userId) {
+  if (!isCharacterActor(actor)) return
+  if (isOnlyAuditChange(changes)) return
+
+  const pending = pendingOldStates.get(actor.uuid)
+  pendingOldStates.delete(actor.uuid)
+  if (!pending) return
+  if (Date.now() - pending.timestamp > PENDING_TTL_MS) return
+
+  const entries = composeEntries(pending.oldState, changes, actor, pending.userId)
+  for (const entry of entries) {
+    void writeLogEntry(actor, entry)
+  }
+}
+```
+
+**onCreateItemAction :**
+```js
+export function onCreateItemAction(item, data, options, userId) {
+  if (item.parent?.type !== 'character') return
+  if (item.type !== 'talent') return
+  // Stub — sera implémenté dans #159 (via composeEntries ou dédié)
+}
+```
+
+#### Détail de writeLogEntry
+
+```js
+async function writeLogEntry(actor, entry) {
+  try {
+    const currentLogs = foundry.utils.getProperty(actor, `flags.swerpg.logs`) ?? []
+    currentLogs.push(entry)
+    await actor.update({ 'flags.swerpg.logs': currentLogs })
+  } catch (err) {
+    logger.error(`[AuditLog] Write failed for actor "${actor.name}" (${actor.id}):`, err)
+    ui.notifications.warn(game.i18n.format('SKILL.AUDIT.WRITE_FAILED', { actor: actor.name }))
+  }
+}
+```
+
+#### Détail de snapshotOldState
+
+```js
+function snapshotOldState(source, changes) {
+  const oldState = {}
+
+  if (changes.system?.skills) {
+    oldState.skills = {}
+    for (const skillId of Object.keys(changes.system.skills)) {
+      const path = `system.skills.${skillId}`
+      const value = foundry.utils.getProperty(source, path)
+      if (value !== undefined) oldState.skills[skillId] = value
+    }
+  }
+
+  if (changes.system?.characteristics) {
+    oldState.characteristics = {}
+    for (const charId of Object.keys(changes.system.characteristics)) {
+      const path = `system.characteristics.${charId}`
+      const value = foundry.utils.getProperty(source, path)
+      if (value !== undefined) oldState.characteristics[charId] = value
+    }
+  }
+
+  if (changes.system?.progression) {
+    const value = foundry.utils.getProperty(source, 'system.progression')
+    if (value !== undefined) oldState.progression = value
+  }
+
+  if (changes.system?.details) {
+    oldState.details = {}
+    for (const key of Object.keys(changes.system.details)) {
+      const path = `system.details.${key}`
+      const value = foundry.utils.getProperty(source, path)
+      if (value !== undefined) oldState.details[key] = value
+    }
+  }
+
+  if (changes.system?.advancement) {
+    const value = foundry.utils.getProperty(source, 'system.advancement')
+    if (value !== undefined) oldState.advancement = value
+  }
+
+  return oldState
+}
+```
+
+### Étape 2 : Modifier `swerpg.mjs`
+
+```js
+// swerpg.mjs, en haut du fichier (zone des imports)
+import { registerAuditLogHooks } from './module/utils/audit-log.mjs'
+
+// Dans Hooks.once('setup', () => { ... })
+registerAuditLogHooks()
+```
+
+### Étape 3 : Ajouter les clés i18n
+
+```json
+// lang/en.json — dans le bloc SKILL
+{
+  "SKILL": {
+    "AUDIT": {
+      "WRITE_FAILED": "Audit log could not be saved for {actor}. See console for details."
+    }
+  }
+}
+```
+
+```json
+// lang/fr.json — dans le bloc SKILL
+{
+  "SKILL": {
+    "AUDIT": {
+      "WRITE_FAILED": "Le journal d'évolution n'a pas pu être sauvegardé pour {actor}. Voir la console pour plus de détails."
+    }
+  }
+}
+```
+
+### Étape 4 : Tests Vitest
+
+Fichier : `tests/utils/audit-log.test.mjs`
+
+#### Tests unitaires
+
+| # | Test | Description | Vérification |
+|---|------|-------------|-------------|
+| 1 | `snapshotOldState ne capture que les chemins modifiés` | changes = `{ system: { skills: { stealth: {} } } }` | `oldState` a `skills.stealth` mais pas `progression` |
+| 2 | `snapshotOldState retourne objet vide si changes vides` | changes = `{}` | `oldState = {}` |
+| 3 | `snapshotOldState gère les chemins imbriqués` | changes = `{ system: { skills: { stealth: { rank: { trained: 3 } } } } }` | `oldState.skills.stealth.rank` est l'objet complet |
+| 4 | `isOnlyAuditChange retourne true` | changes = `{ flags: { swerpg: { logs: [...] } } }` | `true` |
+| 5 | `isOnlyAuditChange retourne false si system modifié` | changes = `{ system: { skills: {} } }` | `false` |
+| 6 | `isOnlyAuditChange retourne false si mixte` | changes = `{ flags: { swerpg: { logs: [] } }, system: { skills: {} } }` | `false` |
+| 7 | `isOnlyAuditChange retourne false si changes vide` | changes = `{}` | `false` |
+| 8 | `pruneExpiredPending supprime les entrées expirées` | 2 expired + 3 valides | size = 3 |
+| 9 | `evictOldestIfNeeded ne fait rien si < MAX` | size = 30, MAX = 50 | size inchangé |
+| 10 | `evictOldestIfNeeded évince les plus anciennes` | size = 55, MAX = 50 | size = 50, les 5 plus anciennes supprimées |
+
+#### Tests d'intégration
+
+| # | Test | Description |
+|---|------|-------------|
+| 11 | `onPreUpdateActor ignore non-character` | actor.type = "adversary" → `pendingOldStates` non modifié |
+| 12 | `onPreUpdateActor ignore isOnlyAuditChange` | changes = `{ flags: { swerpg: { logs: [] } } }` → pas de capture |
+| 13 | `onPreUpdateActor stocke dans pendingOldStates` | Character update → Map a l'entrée |
+| 14 | `onUpdateActor consomme pendingOldStates` | preUpdate + update → Map.get null après |
+| 15 | `onUpdateActor ignore TTL expiré` | pending.timestamp > 30s → `writeLogEntry` non appelé |
+| 16 | `onUpdateActor ignore si composeEntries vide` | composeEntries retourne [] → `writeLogEntry` non appelé |
+| 17 | `onUpdateActor ignore si pas de pending` | update sans preUpdate → return silencieux |
+| 18 | `onCreateItemAction ignore non-talent` | item.type = "weapon", parent character → pas d'appel |
+| 19 | `onCreateItemAction ignore non-character` | item.type = "talent", parent adversary → pas d'appel |
+
+#### Tests de résilience
+
+| # | Test | Description |
+|---|------|-------------|
+| 20 | `writeLogEntry ne throw pas si update fail` | actor.update reject → `logger.error` appelé, pas d'exception |
+| 21 | `writeLogEntry appelle ui.notifications.warn sur erreur` | actor.update reject → `ui.notifications.warn` appelé |
+| 22 | `writeLogEntry ajoute une entrée à un tableau vide` | flags.swerpg.logs = [] → entry ajoutée |
+| 23 | `writeLogEntry ajoute une entrée à des logs existants` | 3 entries existantes → 4 après |
+
+---
+
+## 6. Fichiers modifiés
+
+| Fichier | Action | Description |
+|---------|--------|-------------|
+| `module/utils/audit-log.mjs` | **Création** | Module AOP complet : handlers, gardes, anti-fuite, placeholder composeEntries, writeLogEntry fire-and-forget |
+| `swerpg.mjs` | **Modification** | Import de `registerAuditLogHooks` + appel dans `Hooks.once('setup', ...)` |
+| `lang/en.json` | **Modification** | Ajout `SKILL.AUDIT.WRITE_FAILED` |
+| `lang/fr.json` | **Modification** | Ajout `SKILL.AUDIT.WRITE_FAILED` |
+| `tests/utils/audit-log.test.mjs` | **Création** | 23 tests Vitest |
+
+---
+
+## 7. Risques
+
+| Risque | Impact | Mitigation |
+|--------|--------|------------|
+| **Boucle infinie** si `writeLogEntry` déclenche un nouveau `preUpdateActor` | Crash navigateur, freeze | `isOnlyAuditChange` guard en tête des deux hooks (testé #4-7) |
+| **Fuite mémoire** si preUpdate sans update (crash DB, timeout, navigation) | Map qui gonfle | TTL 30s + MAX_PENDING 50 + pruneExpiredPending + evictOldestIfNeeded (testé #8-10) |
+| **Perte d'entrée** si `onUpdateActor` appelé sans `preUpdateActor` préalable | Entrée non enregistrée | Acceptable : le log est secondaire. `onUpdateActor` retourne silencieusement (testé #17) |
+| **Race condition** si deux updates simultanés sur le même actor (ex: GM + joueur) | Écrasement ou perte old state | `pendingOldStates.set` remplace l'ancienne entrée. Cas rare, sans gravité pour un log secondaire |
+| **Le placeholder composeEntries retourne []** | Aucun log écrit tant que #159 n'est pas implémenté | Comportement attendu et documenté. #159 aura un test qui vérifie que composeEntries est appelé |
+
+---
+
+## 8. Proposition d'ordre de commit
+
+1. **Création de `module/utils/audit-log.mjs`** — squelette complet avec gardes, anti-fuite, placeholder, writeLogEntry fire-and-forget
+2. **Modification de `swerpg.mjs`** — import + `registerAuditLogHooks()` dans `setup`
+3. **Clés i18n** — `SKILL.AUDIT.WRITE_FAILED` dans `en.json` et `fr.json`
+4. **Tests Vitest** — 23 tests dans `tests/utils/audit-log.test.mjs`
+5. **Vérification** — `npx vitest run tests/utils/audit-log.test.mjs` passe
+
+---
+
+## 9. Dépendances avec les autres US
+
+```
+#158 (ce ticket) — Infrastructure AOP + anti-boucle
+  │
+  ├── #159 (analyseur de diff)     → implémente composeEntries
+  ├── #160 (résilience avancée)    → chat MJ, retry (périmètre réduit)
+  ├── #161 (snapshot XP)           → enrichit captureSnapshot
+  ├── #162 (taille configurable)   → System Setting + FIFO évolué
+  ├── #163 (tests)                 → tests complémentaires
+  │
+  └── US6 #156 (visualisation)     → consomme flags.swerpg.logs
+```
+
+#158 est le **prérequis bloquant** pour #159, #160, #161, #162. Il peut être mergé seul et `composeEntries` retournera `[]` jusqu'à ce que #159 soit livré.

--- a/documentation/plan/character-sheet/evolution-logs/TECH-159-plan-diff-analyzer.md
+++ b/documentation/plan/character-sheet/evolution-logs/TECH-159-plan-diff-analyzer.md
@@ -1,0 +1,335 @@
+# Plan d'implémentation — #159 : Analyseur de diff pour détection des changements et composition des entrées de log
+
+**Issue** : [#159 — TECH: Analyseur de diff pour détection des changements et composition des entrées de log](https://github.com/herveDarritchon/foundryvtt-swerpg/issues/159)
+**Epic** : [#150 — EPIC: Système de logs d'évolution du personnage (Character Audit Log)](https://github.com/herveDarritchon/foundryvtt-swerpg/issues/150)
+**User Story** : [#151 — US1: Enregistrer chaque action d'évolution du personnage dans un journal de bord](https://github.com/herveDarritchon/foundryvtt-swerpg/issues/151)
+**ADR** : `documentation/architecture/adr/adr-0011-stockage-journal-evolution-personnage-flags.md`
+**Plans amont** :
+  - `documentation/plan/character-sheet/evolution-logs/US1-plan-audit-log-hooks.md` (§4.3, §4.4)
+  - `documentation/plan/character-sheet/evolution-logs/TECH-158-plan-aop-hooks.md`
+**Modules impactés** : `module/utils/audit-diff.mjs` (création), `module/utils/audit-log.mjs` (modification), `tests/utils/audit-diff.test.mjs` (création)
+
+---
+
+## 1. Objectif
+
+Implémenter l'analyseur de diff qui, à partir du `changes` (diff imbriqué Foundry) et de l'ancien état capturé par `snapshotOldState`, détermine le ou les types de changement et compose une ou plusieurs entrées de log structurées.
+
+#158 a livré l'infrastructure AOP complète (hooks `preUpdateActor`/`updateActor`, guards, anti-fuite mémoire, placeholder `composeEntries` retournant `[]`). #159 branche la logique réelle de détection pour que les entrées de log soient effectivement produites.
+
+---
+
+## 2. Périmètre
+
+### Inclus dans #159
+
+- Création de `module/utils/audit-diff.mjs` avec :
+  - `composeEntries(oldState, changes, actor, userId)` — point d'entrée unique, parcourt les sections du diff et délègue aux détecteurs
+  - `detectSkillChanges(oldState, changes, actor, ts, userId, user, snapshot)` — détection `skill.train` / `skill.forget`
+  - `detectCharacteristicChanges(oldState, changes, actor, ts, userId, user, snapshot)` — détection `characteristic.increase`
+  - `detectXpChanges(oldState, changes, actor, ts, userId, user, snapshot)` — détection `xp.spend` / `xp.grant`
+  - `detectDetailChanges(oldState, changes, actor, ts, userId, user, snapshot)` — détection `species.set`, `career.set`, `specialization.add` / `specialization.remove`
+  - `detectAdvancementChanges(oldState, changes, actor, ts, userId, user, snapshot)` — détection `advancement.level`
+  - `makeEntry({ type, data, xpDelta, ts, userId, user, snapshot })` — helper de construction d'entrée de log
+  - Calculs de coûts XP autonomes (n'appelle aucune méthode métier existante, règles de l'issue §"Règles inviolables")
+- Modification de `module/utils/audit-log.mjs` :
+  - Remplacer le placeholder `composeEntries` par un import de `module/utils/audit-diff.mjs` et délégation réelle
+  - Exporter `composeEntries` depuis le module pour tests (via ré-export ou par le nouveau fichier)
+  - Supprimer le placeholder mort (lignes 135-137)
+- Tests Vitest dans `tests/utils/audit-diff.test.mjs` :
+  - Tests unitaires pour chaque détecteur
+  - Tests d'intégration pour `composeEntries`
+  - Tests de non-régression : changes vides → `[]`, section absente → ignorée
+
+### Exclu de #159
+
+- Détection des achats de talent via `createItem` (hook `onCreateItemAction`) → fera l'objet d'une issue séparée
+- Interface de visualisation des logs → US6 (#156)
+- Taille max configurable (System Setting + éviction FIFO) → #162
+- Snapshot XP dans chaque entrée → déjà implémenté via `captureSnapshot` dans `writeLogEntries` (#158)
+- Migration des logs existants (aucun n'existe)
+- Tests de bout en bout avec UI Foundry
+
+---
+
+## 3. Constat sur l'existant
+
+### #158 livré : infrastructure AOP complète
+
+`module/utils/audit-log.mjs` (260 lignes) contient :
+
+- `pendingOldStates` (Map liée par `actor.uuid:userId`) — file d'attente FIFO
+- `onPreUpdateActor` — capture `snapshotOldState` dans `pendingOldStates`
+- `onUpdateActor` — consomme la file, appelle `composeEntries`, écrit via `writeLogEntries`
+- `snapshotOldState(source, changes)` — extrait de `actor._source` les chemins modifiés, **avec préfixe `system.`** conservé (ex: `{ system: { skills: { Athletics: { rank: { trained: 2 } } } } }`)
+- `writeLogEntries(actor, entries)` — écriture batch fire-and-forget avec try/catch
+- `registerAuditLogHooks()` — câblage de `preUpdateActor` et `updateActor`
+- `isOnlyAuditChange`, `cloneValue`, `isDeletionPath`, anti-fuite mémoire (TTL, MAX_PENDING, eviction)
+- `composeEntries` est un **placeholder vide** retournant `[]` (lignes 135-137)
+
+### Composition du diff Foundry
+
+Foundry transmet un `changes` sous forme de nested object. Pour un `actor.update({ 'system.skills.Athletics.rank.trained': 3 })`, le `changes` reçu par les hooks est :
+
+```js
+{
+  system: {
+    skills: {
+      Athletics: {
+        rank: {
+          trained: 3
+        }
+      }
+    }
+  }
+}
+```
+
+La fonction `snapshotOldState` (implémentée dans #158) aplatit ce diff et extrait de `actor._source` uniquement les feuilles modifiées, produisant un `oldState` de structure parallèle :
+
+```js
+{
+  system: {
+    skills: {
+      Athletics: {
+        rank: {
+          trained: 2  // ancienne valeur
+        }
+      }
+    }
+  }
+}
+```
+
+### Structure des données acteur (schéma character)
+
+Pour référence, voici la structure des chemins impactés par les détecteurs :
+
+| Section | Chemin | Détecteur |
+|---------|--------|-----------|
+| Skills | `system.skills.{id}.rank.{base,careerFree,specializationFree,trained}` | `detectSkillChanges` |
+| Caractéristiques | `system.characteristics.{id}.rank.{base,trained,bonus}` | `detectCharacteristicChanges` |
+| XP | `system.progression.experience.{spent,gained}` | `detectXpChanges` |
+| Détails | `system.details.{species,career,specializations}` | `detectDetailChanges` |
+| Avancement | `system.advancement.level` | `detectAdvancementChanges` |
+
+### Contrainte forte : aucune méthode métier existante
+
+L'issue spécifie : *"L'analyseur ne doit appeler aucune méthode métier existante"*. Les détecteurs doivent donc implémenter leurs propres calculs de coût XP à partir des seules données old/new, sans appeler `skill-costs.mjs`, `SkillCostCalculator`, ou toute autre classe métier.
+
+Les formules de coût à dupliquer dans l'analyseur :
+- **Skill train** : `nextRank * 5` (career) ou `nextRank * 5 + 5` (non-career) où `nextRank = oldTotal + 1`
+- **Skill forget** : remboursement = coût du rang supprimé : `oldTotal * 5` (career) ou `oldTotal * 5 + 5` (non-career)
+- **Characteristic increase** : `newTotal * 10`
+
+---
+
+## 4. Décisions d'architecture
+
+### 4.1. Fichier dédié pour l'analyseur
+
+**Problème** : Où placer le code des 5 détecteurs et de `makeEntry` ?
+
+**Options** :
+| Option | Avantages | Inconvénients |
+|--------|-----------|---------------|
+| Dans `audit-log.mjs` | Cohésion, pas d'import | Fichier ~500 lignes, mélange infrastructure/détection |
+| Fichier séparé `audit-diff.mjs` | Séparation claire, testable indépendamment | Import supplémentaire, deux fichiers à maintenir |
+
+**Décision** : Nouveau fichier `module/utils/audit-diff.mjs`.
+
+**Justification** : L'infrastructure AOP (#158) est stable et ne changera pas. L'analyseur de diff est la seule pièce manquante. Le séparer permet de tester les détecteurs sans importer les hooks, et maintient `audit-log.mjs` à ~260 lignes.
+
+### 4.2. Adaptation des détecteurs à la structure `oldState.system.*`
+
+**Problème** : La spec de l'issue #159 référence `oldState.skills` (sans préfixe), mais `snapshotOldState` (implémenté dans #158) produit `{ system: { skills: {...} } }` (avec préfixe).
+
+**Décision** : Les détecteurs lisent `oldState.system.*` pour correspondre à la sortie de `snapshotOldState`.
+
+**Justification** : Pas de modification du code #158 déjà livré et testé. L'adaptation est triviale (`oldState.system.skills` au lieu de `oldState.skills`).
+
+### 4.3. Calcul de coût XP autonome
+
+**Problème** : Comment calculer le coût XP des opérations sans appeler le code métier existant ?
+
+**Décision** : Chaque détecteur embarque ses propres formules de calcul, calquées sur la logique de `skill-costs.mjs` mais indépendantes.
+
+Formules intégrées :
+- `computeSkillTrainCost(oldTotal, isCareer)` = `(oldTotal + 1) * 5` (career) ou `(oldTotal + 1) * 5 + 5` (non-career)
+- `computeSkillForgetRefund(oldTotal, isCareer)` = `oldTotal * 5` (career) ou `oldTotal * 5 + 5` (non-career)
+- `computeCharacteristicCost(newValue)` = `newValue * 10`
+
+**Justification** : Ces formules sont stables (règles du jeu FFG/SW non changeantes). Les dupliquer dans l'analyseur évite tout couplage avec le code métier, conformément aux règles inviolables de l'issue.
+
+### 4.4. Détection `isCareer` et `isFree` sans code métier
+
+**Problème** : Le code métier détermine si une skill est career/specialization via les données de carrière. L'analyseur ne peut pas y accéder.
+
+**Décision** :
+- `isFree` = le nouveau `rank.trained` n'a pas augmenté (seuls `careerFree` ou `specializationFree` ont changé)
+- `isCareer` = estimé depuis les career skills disponibles : si des `freeSkillRanks.career` ont été consommés entre old et new, la skill appartient à la carrière
+
+**Justification** : Approche pragmatique. Si le rank total a augmenté mais que `trained` n'a pas bougé, c'est un free rank. Si `trained` a augmenté, c'est un achat XP. La détection fine (career vs non-career pour le pricing) utilise les mêmes données que le métier (via oldState.progression.freeSkillRanks). En cas d'ambiguïté, le coût career par défaut est utilisé (moins de risque d'erreur).
+
+### 4.5. Détection des changements de spécialisation (add/remove)
+
+**Problème** : Les spécialisations sont stockées dans `system.details.specializations` (SetField). Le diff Foundry pour un SetField peut utiliser le format `-=id` pour la suppression.
+
+**Décision** : Détecter `add` via présence d'une nouvelle spécialisation dans `changes`, détecter `remove` via le path `.-=` dans le diff.
+
+**Justification** : Les `-=` paths sont déjà gérés par `snapshotOldState` (qui les ignore). Pour la détection de removal, on les détecte dans `changes` directement via `foundry.utils.flattenObject`.
+
+### 4.6. Pas de `createItem` hook dans #159
+
+**Problème** : La détection d'achat de talent (`talent.purchase`) nécessite le hook `createItem`, qui n'est pas dans le périmètre de #159.
+
+**Décision** : Exclu. Une issue séparée sera créée pour ajouter le hook `createItem` et la détection `talent.purchase`.
+
+**Justification** : Le hook `createItem` est orthogonal à l'analyseur de diff updateActor. Il a son propre cycle de vie et ses propres tests. Le séparer évite de complexifier #159.
+
+---
+
+## 5. Plan de travail détaillé
+
+### Étape 1 : Créer `module/utils/audit-diff.mjs`
+
+Contenu du module :
+
+```
+module/utils/audit-diff.mjs
+├── composeEntries(oldState, changes, actor, userId)
+│   ├── if changes.system?.skills        → detectSkillChanges
+│   ├── if changes.system?.characteristics → detectCharacteristicChanges
+│   ├── if changes.system?.progression?.experience → detectXpChanges
+│   ├── if changes.system?.details       → detectDetailChanges
+│   └── if changes.system?.advancement   → detectAdvancementChanges
+├── detectSkillChanges(...)
+│   ├── Parcourt changes.system.skills
+│   ├── Calcule oldTotal / newTotal depuis rank.{base,careerFree,specializationFree,trained}
+│   ├── Produit skill.train (newTotal > oldTotal) ou skill.forget (newTotal < oldTotal)
+│   └── Champs : skillId, oldRank, newRank, cost, isFree
+├── detectCharacteristicChanges(...)
+│   ├── Parcourt changes.system.characteristics
+│   ├── Calcule oldTotal / newTotal depuis rank.{base,trained,bonus}
+│   └── Produit characteristic.increase (newTotal > oldTotal)
+├── detectXpChanges(...)
+│   ├── Détecte experience.spent → xp.spend
+│   ├── Détecte experience.gained → xp.grant
+│   └── Calcule le delta old→new
+├── detectDetailChanges(...)
+│   ├── species → species.set
+│   ├── career → career.set
+│   ├── specializations → specialization.add (diff key présente) / .remove (path .-=)
+│   └── Compare old vs new
+├── detectAdvancementChanges(...)
+│   ├── advancement.level → advancement.level
+│   └── Champs : oldLevel, newLevel
+├── makeEntry({ type, data, xpDelta, ts, userId, user, snapshot })
+│   └── Id (randomID), timestamp, userId, userName, type, data, xpDelta, snapshot
+├── computeSkillTrainCost(oldTotal, isCareer)
+│   └── Formule autonome : (oldTotal + 1) * 5 + (isCareer ? 0 : 5)
+├── computeSkillForgetRefund(oldTotal, isCareer)
+│   └── Formule autonome : oldTotal * 5 + (isCareer ? 0 : 5)
+└── computeCharacteristicCost(newValue)
+    └── Formule autonome : newValue * 10
+```
+
+### Étape 2 : Modifier `module/utils/audit-log.mjs`
+
+Changements :
+1. **Supprimer le placeholder `composeEntries`** (lignes 134-137) et le remplacer par un import et une délégation
+2. **Importer `composeEntries`** depuis `./audit-diff.mjs`
+
+```js
+// audit-log.mjs — nouveau contenu pour remplacer le placeholder
+import { composeEntries } from './audit-diff.mjs'
+```
+
+Note : le flux existant dans `onUpdateActor` appelle déjà `composeEntries(pending.oldState, changes, actor, pending.userId)`. Le remplacement du placeholder par la vraie fonction est transparent.
+
+### Étape 3 : Tests Vitest dans `tests/utils/audit-diff.test.mjs`
+
+#### Tests unitaires pour chaque détecteur
+
+| # | Test | Description |
+|---|------|-------------|
+| 1 | `composeEntries retourne [] si changes vide` | `changes = {}` → `[]` |
+| 2 | `composeEntries retourne [] si changes sans system` | `changes = { flags: {} }` → `[]` |
+| 3 | `detectSkillChanges produit skill.train` | rank 2→3, oldState a rank 2, actor rank 3 → type `skill.train`, data.oldRank=2, data.newRank=3 |
+| 4 | `detectSkillChanges produit skill.forget` | rank 3→2 → type `skill.forget`, data.oldRank=3, data.newRank=2 |
+| 5 | `detectSkillChanges ignore si rank inchangé` | rank 2→2 (seul un sous-champ non-rank a changé) → `[]` |
+| 6 | `detectSkillChanges calcule cost correct pour career` | oldTotal=2, isCareer=true → cost = 3*5 = 15 |
+| 7 | `detectSkillChanges calcule cost correct pour non-career` | oldTotal=2, isCareer=false → cost = 3*5+5 = 20 |
+| 8 | `detectSkillChanges détecte isFree=true` | seul careerFree a augmenté, trained inchangé → isFree=true, xpDelta=0 |
+| 9 | `detectCharacteristicChanges produit characteristic.increase` | rank 2→3 → type `characteristic.increase`, cost = 3*10 = 30 |
+| 10 | `detectCharacteristicChanges ignore si decrease` | rank 3→2 (annulation/erreur) → `[]` |
+| 11 | `detectCharacteristicChanges calcule cost correct` | newValue=4 → cost=40 |
+| 12 | `detectXpChanges produit xp.spend` | spent 50→75 → type `xp.spend`, amount=25, xpDelta=-25 |
+| 13 | `detectXpChanges produit xp.grant` | gained 100→150 → type `xp.grant`, amount=50, xpDelta=50 |
+| 14 | `detectXpChanges ignore si valeur inchangée` | spent 50→50 (même valeur) → `[]` |
+| 15 | `detectDetailChanges produit species.set` | species null→Human → type `species.set` |
+| 16 | `detectDetailChanges produit career.set` | career null→Mercenary → type `career.set` |
+| 17 | `detectDetailChanges produit specialization.add` | spécialisation ajoutée → type `specialization.add` |
+| 18 | `detectDetailChanges produit specialization.remove` | spécialisation retirée (path `.-=`) → type `specialization.remove` |
+| 19 | `detectAdvancementChanges produit advancement.level` | level 1→2 → type `advancement.level`, oldLevel=1, newLevel=2 |
+| 20 | `detectAdvancementChanges ignore si level inchangé` | level 1→1 → `[]` |
+| 21 | `makeEntry génère entrée bien formée` | Vérifie id (non vide), timestamp, userId, userName, type, data, xpDelta, snapshot |
+
+#### Tests d'intégration pour composeEntries
+
+| # | Test | Description |
+|---|------|-------------|
+| 22 | `composeEntries délègue aux bons détecteurs` | changes avec skills+XP → 2 entrées (skill.train + xp.spend) |
+| 23 | `composeEntries gère les opérations composites` | skill.train + xp.spend dans le même changes (même timestamp) |
+| 24 | `composeEntries ignore sections sans changement réel` | changes.system.skills présent mais valeurs identiques → `[]` |
+
+---
+
+## 6. Fichiers modifiés
+
+| Fichier | Action | Description |
+|---------|--------|-------------|
+| `module/utils/audit-diff.mjs` | **Création** | Module analyseur : `composeEntries`, 5 détecteurs, `makeEntry`, helpers de coûts |
+| `module/utils/audit-log.mjs` | **Modification** | Suppression du placeholder `composeEntries` (l.134-137), import de `audit-diff.mjs` |
+| `tests/utils/audit-diff.test.mjs` | **Création** | ~24 tests Vitest pour les détecteurs et `composeEntries` |
+
+---
+
+## 7. Risques
+
+| Risque | Impact | Mitigation |
+|--------|--------|------------|
+| **Décalage structure oldState** : les détecteurs lisent `oldState.system.*` mais `snapshotOldState` ne capture que les feuilles du diff (pas les objets complets) | Old total rank incomplet si le diff ne contient pas toutes les sous-propriétés | Fallback : tout sous-champ manquant dans `oldState` est considéré inchangé (valeur par défaut 0 ou lue depuis `actor.system`) |
+| **isCareer indéterminable** : impossible de savoir si une skill est career sans appeler le métier | Coût XP erroné | Par défaut, considérer `isCareer=false` (coût majoré). Le snapshot inclura `progression.freeSkillRanks.career` si modifié, ce qui permet d'inférer le statut career |
+| **isFree ambigu** : une skill peut gagner un rank free ET un rank trained dans la même opération | `isFree` mal classifié | Cas rare. Si `trained` a augmenté ET que `careerFree` a aussi augmenté, classer comme non-free (l'utilisateur a payé). Acceptable pour un log secondaire |
+| **Spécialisation.add non détectée** : le diff spécialisations peut ne pas contenir les nouvelles clés si le SetField utilise un format inattendu | Entrée specialization.add manquée | Comparer oldState.specializations vs actor.specializations comme fallback robuste |
+| **Régression #158** : la modification de `audit-log.mjs` casse l'infrastructure existante | Plus aucun log produit | Tests d'intégration existants (404 lignes) inchangés. Ajouter un test qui vérifie que `onUpdateActor` appelle `composeEntries` et que le résultat est écrit |
+| **Formules de coût dupliquées** : si les règles de coût changent, `audit-diff.mjs` doit être mis à jour manuellement | Coûts XP désynchronisés | Documenter clairement les formules dans le code avec référence à `skill-costs.mjs`. Ajouter un test de cohérence qui compare les résultats des deux implémentations |
+
+---
+
+## 8. Proposition d'ordre de commit
+
+1. **Création de `module/utils/audit-diff.mjs`** — `composeEntries`, 5 détecteurs, `makeEntry`, helpers de coûts
+2. **Modification de `module/utils/audit-log.mjs`** — suppression du placeholder, import de `audit-diff.mjs`
+3. **Tests Vitest** — `tests/utils/audit-diff.test.mjs` avec ~24 tests
+4. **Vérification** — `npx vitest run tests/utils/audit-diff.test.mjs` + `npx vitest run tests/utils/audit-log.test.mjs` (non-régression)
+
+---
+
+## 9. Dépendances avec les autres US
+
+```
+#158 (infrastructure AOP) — DÉJÀ LIVRÉ
+  │
+  └── #159 (ce ticket) — Analyseur de diff
+        │
+        ├── US2 (skills automation)   → consomme les entrées skill.train/forget
+        ├── US3 (caracs automation)   → consomme les entrées characteristic.increase
+        ├── US4 (talents)             → hook createItem (issue séparée à créer)
+        ├── US5 (choix création)      → consomme species.set, career.set, specialization.*
+        ├── US6 (UI)                  → consomme flags.swerpg.logs (dont les entrées #159)
+        └── US7 (export)              → lit flags.swerpg.logs
+```
+
+#159 n'a pas de dépendance bloquante. Il peut être implémenté en isolation : l'infrastructure #158 est déjà en place, le placeholder `composeEntries` retournera désormais les vraies entrées au lieu de `[]`.

--- a/module/chat.mjs
+++ b/module/chat.mjs
@@ -75,6 +75,9 @@ export function addChatMessageContextOptions(html, options) {
  */
 export async function onCreateChatMessage(message, data, options, userId) {
   if (game.user !== game.users.activeGM) return
+
+  if (!isSwerpgActionMessage(message)) return
+
   const flags = message.flags.swerpg || {}
   if (!flags.action || flags.confirmed) return
 
@@ -85,6 +88,14 @@ export async function onCreateChatMessage(message, data, options, userId) {
   const action = SwerpgAction.fromChatMessage(message)
   const canConfirm = action.canAutoConfirm()
   if (canConfirm) await SwerpgAction.confirm(message, { action })
+}
+
+/* -------------------------------------------- */
+
+function isSwerpgActionMessage(message) {
+  const flags = message.flags.swerpg
+
+  return Boolean(flags?.action && Array.isArray(flags?.outcomes))
 }
 
 /* -------------------------------------------- */

--- a/module/utils/audit-diff.mjs
+++ b/module/utils/audit-diff.mjs
@@ -1,0 +1,446 @@
+import { logger } from './logger.mjs'
+
+/* -------------------------------------------- */
+/*  Capture instantané de l'état XP après update */
+/* -------------------------------------------- */
+
+function captureXpSnapshotAfter(actor) {
+  const xp = actor.system?.progression?.experience
+  if (!xp) {
+    return {
+      available: 0,
+      spent: 0,
+      gained: 0,
+    }
+  }
+
+  return {
+    available: xp.available ?? 0,
+    spent: xp.spent ?? 0,
+    gained: xp.gained ?? 0,
+  }
+}
+
+/* -------------------------------------------- */
+/*  Helpers de coûts XP                         */
+/* -------------------------------------------- */
+
+function computeSkillTrainCost(oldTotal, isCareer) {
+  const nextRank = oldTotal + 1
+  return nextRank * 5 + (isCareer ? 0 : 5)
+}
+
+function computeSkillForgetRefund(oldTotal, isCareer) {
+  return oldTotal * 5 + (isCareer ? 0 : 5)
+}
+
+function computeCharacteristicCost(newValue) {
+  return newValue * 10
+}
+
+/**
+ * Reconstruit une ancienne valeur complète en appliquant l'ancien diff partiel
+ * sur la valeur courante complète.
+ *
+ * Exemple :
+ * - currentValue = { base: 0, trained: 2, bonus: 0 }
+ * - oldPartialValue = { trained: 1 }
+ * - résultat = { base: 0, trained: 1, bonus: 0 }
+ */
+function reconstructPreviousValue(oldPartialValue, currentValue) {
+  if (oldPartialValue === undefined) return currentValue
+  if (oldPartialValue === null || currentValue === null) return oldPartialValue
+  if (typeof oldPartialValue !== 'object' || typeof currentValue !== 'object') return oldPartialValue
+  if (Array.isArray(oldPartialValue) || Array.isArray(currentValue)) return oldPartialValue
+
+  const merged = foundry.utils.deepClone(currentValue)
+
+  for (const [key, value] of Object.entries(oldPartialValue)) {
+    merged[key] = reconstructPreviousValue(value, currentValue?.[key])
+  }
+
+  return merged
+}
+
+/* -------------------------------------------- */
+/*  Helper de construction d'entrée             */
+/* -------------------------------------------- */
+
+function makeEntry({ type, data, xpDelta, ts, userId, user, xpAfter }) {
+  return {
+    id: foundry.utils.randomID(),
+    schemaVersion: 1,
+    timestamp: ts,
+    userId,
+    userName: user?.name ?? 'Unknown',
+    type,
+    data,
+    xpDelta: Object.is(xpDelta, -0) ? 0 : xpDelta,
+    snapshot: {
+      xpAfter: { ...xpAfter },
+    },
+  }
+}
+
+/* -------------------------------------------- */
+/*  Détecteurs                                  */
+/* -------------------------------------------- */
+
+function detectSkillChanges(oldState, changes, actor, ts, userId, user, xpAfter) {
+  const entries = []
+  const skillChanges = changes.system?.skills
+  if (!skillChanges) return entries
+
+  for (const [skillId, skillData] of Object.entries(skillChanges)) {
+    if (!skillData?.rank) continue
+
+    const newRank = actor.system?.skills?.[skillId]?.rank
+    if (!newRank) continue
+
+    const oldRank = reconstructPreviousValue(oldState.system?.skills?.[skillId]?.rank, newRank) ?? {}
+
+    const oldTotal = getSkillTotalRank(oldRank)
+    const newTotal = getSkillTotalRank(newRank)
+
+    if (oldTotal === newTotal) continue
+
+    const isIncrease = newTotal > oldTotal
+    const trainedUnchanged = (newRank.trained ?? 0) === (oldRank.trained ?? 0)
+    const isFree = isIncrease && trainedUnchanged
+    const isCareer = inferIsCareer(skillId, oldState, actor)
+
+    let cost = 0
+
+    if (!isFree) {
+      cost = isIncrease ? computeSkillTrainCost(oldTotal, isCareer) : computeSkillForgetRefund(oldTotal, isCareer)
+    }
+
+    entries.push(
+      makeEntry({
+        type: isIncrease ? 'skill.train' : 'skill.forget',
+        data: {
+          skillId,
+          oldRank: oldTotal,
+          newRank: newTotal,
+          cost,
+          isFree,
+          isCareer,
+        },
+        xpDelta: isIncrease ? -cost : cost,
+        ts,
+        userId,
+        user,
+        xpAfter,
+      }),
+    )
+  }
+
+  return entries
+}
+
+function getSkillTotalRank(rank) {
+  return (rank.base ?? 0) + (rank.careerFree ?? 0) + (rank.specializationFree ?? 0) + (rank.trained ?? 0)
+}
+
+function inferIsCareer(skillId, _oldState, actor) {
+  return getCareerSkillIds(actor).has(skillId)
+}
+
+function getCareerSkillIds(actor) {
+  const ids = new Set()
+
+  const careerSkills = actor.system?.details?.career?.careerSkills ?? []
+  for (const skill of careerSkills) {
+    ids.add(skill.id ?? skill)
+  }
+
+  const specializations = actor.system?.details?.specializations ?? {}
+  for (const spec of Object.values(specializations)) {
+    const specCareerSkills = spec?.careerSkills ?? []
+    for (const skill of specCareerSkills) {
+      ids.add(skill.id ?? skill)
+    }
+  }
+
+  return ids
+}
+
+function detectCharacteristicChanges(oldState, changes, actor, ts, userId, user, xpAfter) {
+  const entries = []
+  const characteristicChanges = changes.system?.characteristics
+  if (!characteristicChanges) return entries
+
+  for (const [charId, charData] of Object.entries(characteristicChanges)) {
+    if (!charData?.rank) continue
+
+    const newRank = actor.system?.characteristics?.[charId]?.rank
+    if (!newRank) continue
+
+    const oldRank = reconstructPreviousValue(oldState.system?.characteristics?.[charId]?.rank, newRank) ?? {}
+
+    const oldTotal = getCharacteristicTotalRank(oldRank)
+    const newTotal = getCharacteristicTotalRank(newRank)
+
+    if (newTotal <= oldTotal) continue
+
+    const cost = computeCharacteristicCost(newTotal)
+
+    entries.push(
+      makeEntry({
+        type: 'characteristic.increase',
+        data: {
+          characteristicId: charId,
+          oldValue: oldTotal,
+          newValue: newTotal,
+          cost,
+        },
+        xpDelta: -cost,
+        ts,
+        userId,
+        user,
+        xpAfter,
+      }),
+    )
+  }
+
+  return entries
+}
+
+function getCharacteristicTotalRank(rank) {
+  return (rank.base ?? 0) + (rank.trained ?? 0) + (rank.bonus ?? 0)
+}
+
+function detectXpChanges(oldState, changes, actor, ts, userId, user, xpAfter) {
+  const entries = []
+  const expChanges = changes.system?.progression?.experience
+  if (!expChanges) return entries
+
+  if (expChanges.spent !== undefined) {
+    const newSpent = actor.system?.progression?.experience?.spent ?? 0
+    const oldSpent = reconstructPreviousValue(oldState.system?.progression?.experience?.spent, newSpent) ?? 0
+
+    const diff = newSpent - oldSpent
+
+    if (diff !== 0) {
+      entries.push(
+        makeEntry({
+          type: diff > 0 ? 'xp.spend' : 'xp.refund',
+          data: {
+            amount: Math.abs(diff),
+            oldSpent,
+            newSpent,
+          },
+          xpDelta: -diff,
+          ts,
+          userId,
+          user,
+          xpAfter,
+        }),
+      )
+    }
+  }
+
+  if (expChanges.gained !== undefined) {
+    const newGained = actor.system?.progression?.experience?.gained ?? 0
+    const oldGained = reconstructPreviousValue(oldState.system?.progression?.experience?.gained, newGained) ?? 0
+
+    const diff = newGained - oldGained
+
+    if (diff !== 0) {
+      entries.push(
+        makeEntry({
+          type: diff > 0 ? 'xp.grant' : 'xp.remove',
+          data: {
+            amount: Math.abs(diff),
+            oldGained,
+            newGained,
+          },
+          xpDelta: diff,
+          ts,
+          userId,
+          user,
+          xpAfter,
+        }),
+      )
+    }
+  }
+
+  return entries
+}
+
+function detectDetailChanges(oldState, changes, actor, ts, userId, user, xpAfter) {
+  const entries = []
+  const detailChanges = changes.system?.details
+  if (!detailChanges) return entries
+
+  if (detailChanges.species !== undefined) {
+    const oldSpecies = oldState.system?.details?.species?.name ?? null
+    const newSpecies = actor.system?.details?.species?.name ?? null
+
+    if (oldSpecies !== newSpecies) {
+      entries.push(
+        makeEntry({
+          type: 'species.set',
+          data: { oldSpecies, newSpecies },
+          xpDelta: 0,
+          ts,
+          userId,
+          user,
+          xpAfter,
+        }),
+      )
+    }
+  }
+
+  if (detailChanges.career !== undefined) {
+    const oldCareer = oldState.system?.details?.career?.name ?? null
+    const newCareer = actor.system?.details?.career?.name ?? null
+
+    if (oldCareer !== newCareer) {
+      entries.push(
+        makeEntry({
+          type: 'career.set',
+          data: { oldCareer, newCareer },
+          xpDelta: 0,
+          ts,
+          userId,
+          user,
+          xpAfter,
+        }),
+      )
+    }
+  }
+
+  if (detailChanges.specializations !== undefined) {
+    entries.push(...detectSpecializationChanges(oldState, detailChanges.specializations, actor, ts, userId, user, xpAfter))
+  }
+
+  return entries
+}
+
+function detectSpecializationChanges(oldState, specializationChanges, actor, ts, userId, user, xpAfter) {
+  const entries = []
+
+  for (const [key, value] of Object.entries(specializationChanges)) {
+    if (key.startsWith('-=')) {
+      const specializationId = key.slice(2)
+      if (!specializationId) continue
+
+      entries.push(
+        makeEntry({
+          type: 'specialization.remove',
+          data: { specializationId },
+          xpDelta: 0,
+          ts,
+          userId,
+          user,
+          xpAfter,
+        }),
+      )
+
+      continue
+    }
+
+    const oldSpec = oldState.system?.details?.specializations?.[key]
+    const newSpec = actor.system?.details?.specializations?.[key]
+
+    if (!oldSpec && newSpec) {
+      entries.push(
+        makeEntry({
+          type: 'specialization.add',
+          data: { specializationId: key },
+          xpDelta: 0,
+          ts,
+          userId,
+          user,
+          xpAfter,
+        }),
+      )
+    }
+  }
+
+  return entries
+}
+
+function detectAdvancementChanges(oldState, changes, actor, ts, userId, user, xpAfter) {
+  if (changes.system?.advancement?.level === undefined) return []
+
+  const newLevel = actor.system?.advancement?.level ?? 0
+  const oldLevel = reconstructPreviousValue(oldState.system?.advancement?.level, newLevel) ?? 0
+
+  if (oldLevel === newLevel) return []
+
+  return [
+    makeEntry({
+      type: 'advancement.level',
+      data: { oldLevel, newLevel },
+      xpDelta: 0,
+      ts,
+      userId,
+      user,
+      xpAfter,
+    }),
+  ]
+}
+
+/* -------------------------------------------- */
+/*  Point d'entrée unique                       */
+/* -------------------------------------------- */
+
+export function composeEntries(oldState, changes, actor, userId) {
+  try {
+    const entries = []
+    const expandedChanges = foundry.utils.expandObject(changes)
+    const ts = Date.now()
+    const xpAfter = captureXpSnapshotAfter(actor)
+    const user = game.users?.get(userId) ?? null
+
+    const hasBusinessChange = Boolean(
+      expandedChanges.system?.skills ||
+        expandedChanges.system?.characteristics ||
+        expandedChanges.system?.details?.specializations ||
+        expandedChanges.system?.advancement,
+    )
+
+    if (expandedChanges.system?.skills) {
+      entries.push(...detectSkillChanges(oldState, expandedChanges, actor, ts, userId, user, xpAfter))
+    }
+
+    if (expandedChanges.system?.characteristics) {
+      entries.push(...detectCharacteristicChanges(oldState, expandedChanges, actor, ts, userId, user, xpAfter))
+    }
+
+    // Les entrées métier portent déjà le coût XP.
+    // On ne logge les changements XP que s'ils sont purs.
+    if (expandedChanges.system?.progression?.experience && !hasBusinessChange) {
+      entries.push(...detectXpChanges(oldState, expandedChanges, actor, ts, userId, user, xpAfter))
+    }
+
+    if (expandedChanges.system?.details) {
+      entries.push(...detectDetailChanges(oldState, expandedChanges, actor, ts, userId, user, xpAfter))
+    }
+
+    if (expandedChanges.system?.advancement) {
+      entries.push(...detectAdvancementChanges(oldState, expandedChanges, actor, ts, userId, user, xpAfter))
+    }
+
+    return entries
+  } catch (err) {
+    logger.error('[AuditDiff] composeEntries failed', err)
+    return []
+  }
+}
+/* -------------------------------------------- */
+/*  Exports pour tests                          */
+/* -------------------------------------------- */
+
+export {
+  makeEntry,
+  captureXpSnapshotAfter,
+  computeSkillTrainCost,
+  computeSkillForgetRefund,
+  computeCharacteristicCost,
+  inferIsCareer,
+  getCareerSkillIds,
+  reconstructPreviousValue,
+}

--- a/module/utils/audit-log.mjs
+++ b/module/utils/audit-log.mjs
@@ -1,4 +1,5 @@
 import { logger } from './logger.mjs'
+import { composeEntries } from './audit-diff.mjs'
 
 /* -------------------------------------------- */
 /*  Constantes                                  */
@@ -126,14 +127,6 @@ function snapshotOldState(source, changes) {
   }
 
   return oldState
-}
-
-/* -------------------------------------------- */
-/*  Placeholder analyseur de diff (#159)        */
-/* -------------------------------------------- */
-
-function composeEntries(_oldState, _changes, _actor, _userId) {
-  return []
 }
 
 /* -------------------------------------------- */

--- a/tests/chat/chat.test.mjs
+++ b/tests/chat/chat.test.mjs
@@ -250,17 +250,13 @@ describe('Chat Module', () => {
       expect(actionSpies.fromChatMessage).not.toHaveBeenCalled()
     })
 
-    test('should wait for dice animation if dice3d is available', async () => {
-      mockMessage.flags.swerpg = { action: true }
-      mockMessage.rolls = [{ id: 'roll1' }]
-
-      await ChatModule.onCreateChatMessage(mockMessage, {}, {}, 'user-id')
-
-      expect(game.dice3d.waitFor3DAnimationByMessageID).toHaveBeenCalledWith('msg-123')
-    })
-
     test('should auto-confirm if action allows it', async () => {
-      mockMessage.flags.swerpg = { action: true }
+      mockMessage.flags.swerpg = {
+        actor: 'Actor.actor-001',
+        action: 'some-action-id',
+        confirmed: false,
+        outcomes: [],
+      }
 
       await ChatModule.onCreateChatMessage(mockMessage, {}, {}, 'user-id')
 
@@ -270,7 +266,12 @@ describe('Chat Module', () => {
     })
 
     test('should not auto-confirm if action does not allow it', async () => {
-      mockMessage.flags.swerpg = { action: true }
+      mockMessage.flags.swerpg = {
+        actor: 'Actor.actor-001',
+        action: 'some-action-id',
+        confirmed: false,
+        outcomes: [],
+      }
       mockAction.canAutoConfirm.mockReturnValue(false)
 
       await ChatModule.onCreateChatMessage(mockMessage, {}, {}, 'user-id')

--- a/tests/utils/audit-diff.test.mjs
+++ b/tests/utils/audit-diff.test.mjs
@@ -1,0 +1,1285 @@
+import { describe, test, expect, vi, beforeEach, afterEach } from 'vitest'
+import { setupFoundryMock, teardownFoundryMock } from '../helpers/mock-foundry.mjs'
+
+/* ============================================ */
+/*  Helpers de test — objets et diffs           */
+/* ============================================ */
+
+function deepMerge(target, source) {
+  const result = structuredClone(target)
+
+  for (const key of Object.keys(source)) {
+    const sv = source[key]
+    const tv = result[key]
+
+    if (sv && typeof sv === 'object' && !Array.isArray(sv) && tv && typeof tv === 'object' && !Array.isArray(tv)) {
+      result[key] = deepMerge(tv, sv)
+    } else {
+      result[key] = sv
+    }
+  }
+
+  return result
+}
+
+function makeActor(system) {
+  return {
+    type: 'character',
+    id: 'actor-001',
+    uuid: 'Actor.actor-001',
+    name: 'Test Character',
+    system,
+  }
+}
+
+function flattenObject(obj, prefix = '') {
+  const result = {}
+
+  if (!obj || typeof obj !== 'object') return result
+
+  for (const key of Object.keys(obj)) {
+    const path = prefix ? `${prefix}.${key}` : key
+    const value = obj[key]
+
+    if (value && typeof value === 'object' && !Array.isArray(value) && !(value instanceof Date)) {
+      Object.assign(result, flattenObject(value, path))
+    } else {
+      result[path] = value
+    }
+  }
+
+  return result
+}
+
+function getProperty(object, path) {
+  const keys = path.split('.')
+  let current = object
+
+  for (const key of keys) {
+    if (current === null || current === undefined) return undefined
+    current = current[key]
+  }
+
+  return current
+}
+
+function setProperty(object, path, value) {
+  const keys = path.split('.')
+  let current = object
+
+  for (let i = 0; i < keys.length - 1; i++) {
+    const key = keys[i]
+    if (!current[key] || typeof current[key] !== 'object') current[key] = {}
+    current = current[key]
+  }
+
+  current[keys[keys.length - 1]] = value
+}
+
+function makeOldState(changes, source) {
+  const oldState = {}
+  const flat = flattenObject(changes)
+
+  for (const path of Object.keys(flat)) {
+    if (!path.startsWith('system.')) continue
+    if (path.includes('.-=')) continue
+
+    const value = getProperty(source, path)
+    if (value !== undefined) {
+      setProperty(oldState, path, structuredClone(value))
+    }
+  }
+
+  return oldState
+}
+
+function applyChangesToSystem(sourceSystem, changes) {
+  const flat = flattenObject(changes)
+  const result = structuredClone(sourceSystem)
+
+  for (const path of Object.keys(flat)) {
+    if (!path.startsWith('system.')) continue
+    if (path.includes('.-=')) continue
+
+    const systemPath = path.replace(/^system\./, '')
+    setProperty(result, systemPath, flat[path])
+  }
+
+  return result
+}
+
+function defaultSource() {
+  return {
+    system: {
+      skills: {},
+      characteristics: {},
+      progression: {
+        experience: {
+          spent: 0,
+          gained: 0,
+          available: 0,
+          total: 0,
+        },
+        freeSkillRanks: {
+          career: {
+            id: null,
+            name: '',
+            spent: 0,
+            gained: 0,
+          },
+          specialization: {
+            id: null,
+            name: '',
+            spent: 0,
+            gained: 0,
+          },
+        },
+      },
+      details: {
+        species: null,
+        career: null,
+        specializations: {},
+      },
+      advancement: null,
+    },
+  }
+}
+
+async function composeFromChanges(changes, source, userId = 'user-1') {
+  const { composeEntries } = await import('../../module/utils/audit-diff.mjs')
+
+  const expandedChanges = foundry.utils.expandObject(changes)
+  const oldState = makeOldState(expandedChanges, source)
+  const newSystem = applyChangesToSystem(source.system, expandedChanges)
+  const actor = makeActor(newSystem)
+
+  return composeEntries(oldState, changes, actor, userId)
+}
+
+/* ============================================ */
+/*  Setup                                       */
+/* ============================================ */
+
+beforeEach(() => {
+  setupFoundryMock({
+    game: {
+      users: {
+        get: vi.fn((id) => {
+          if (id === 'user-1') return { name: 'Player One' }
+          if (id === 'gm-1') return { name: 'Game Master', isGM: true }
+          return null
+        }),
+      },
+    },
+  })
+})
+
+afterEach(() => {
+  teardownFoundryMock()
+  vi.restoreAllMocks()
+})
+
+/* ============================================ */
+/*  captureXpSnapshotAfter                      */
+/* ============================================ */
+
+describe('captureXpSnapshotAfter', () => {
+  test('returns XP data from actor after update', async () => {
+    const { captureXpSnapshotAfter } = await import('../../module/utils/audit-diff.mjs')
+
+    const actor = makeActor({
+      progression: {
+        experience: {
+          spent: 50,
+          gained: 200,
+          available: 150,
+          total: 200,
+        },
+      },
+    })
+
+    const snap = captureXpSnapshotAfter(actor)
+
+    expect(snap).toEqual({
+      available: 150,
+      spent: 50,
+      gained: 200,
+    })
+  })
+
+  test('returns zeros when XP data is missing', async () => {
+    const { captureXpSnapshotAfter } = await import('../../module/utils/audit-diff.mjs')
+
+    const actor = makeActor({
+      progression: {},
+    })
+
+    const snap = captureXpSnapshotAfter(actor)
+
+    expect(snap).toEqual({
+      available: 0,
+      spent: 0,
+      gained: 0,
+    })
+  })
+})
+
+/* ============================================ */
+/*  makeEntry                                   */
+/* ============================================ */
+
+describe('makeEntry', () => {
+  test('creates well-formed entry', async () => {
+    const { makeEntry } = await import('../../module/utils/audit-diff.mjs')
+
+    const entry = makeEntry({
+      type: 'skill.train',
+      data: {
+        skillId: 'cool',
+        oldRank: 0,
+        newRank: 1,
+        cost: 5,
+        isFree: false,
+        isCareer: true,
+      },
+      xpDelta: -5,
+      ts: 1000,
+      userId: 'user-1',
+      user: { name: 'Player One' },
+      xpAfter: {
+        available: 95,
+        spent: 5,
+        gained: 100,
+      },
+    })
+
+    expect(entry).toMatchObject({
+      id: expect.any(String),
+      schemaVersion: 1,
+      timestamp: 1000,
+      userId: 'user-1',
+      userName: 'Player One',
+      type: 'skill.train',
+      xpDelta: -5,
+      data: {
+        skillId: 'cool',
+        oldRank: 0,
+        newRank: 1,
+        cost: 5,
+        isFree: false,
+        isCareer: true,
+      },
+      snapshot: {
+        xpAfter: {
+          available: 95,
+          spent: 5,
+          gained: 100,
+        },
+      },
+    })
+  })
+
+  test('fallback userName when user not found', async () => {
+    const { makeEntry } = await import('../../module/utils/audit-diff.mjs')
+
+    const entry = makeEntry({
+      type: 'xp.grant',
+      data: { amount: 50 },
+      xpDelta: 50,
+      ts: 2000,
+      userId: 'unknown',
+      user: null,
+      xpAfter: {},
+    })
+
+    expect(entry.userName).toBe('Unknown')
+  })
+
+  test('normalizes negative zero xpDelta', async () => {
+    const { makeEntry } = await import('../../module/utils/audit-diff.mjs')
+
+    const entry = makeEntry({
+      type: 'test',
+      data: {},
+      xpDelta: -0,
+      ts: 0,
+      userId: 'u1',
+      user: null,
+      xpAfter: {},
+    })
+
+    expect(Object.is(entry.xpDelta, -0)).toBe(false)
+    expect(entry.xpDelta).toBe(0)
+  })
+
+  test('xpAfter snapshot is shallow-cloned', async () => {
+    const { makeEntry } = await import('../../module/utils/audit-diff.mjs')
+
+    const xpAfter = {
+      available: 100,
+      spent: 0,
+      gained: 100,
+    }
+
+    const entry = makeEntry({
+      type: 'test',
+      data: {},
+      xpDelta: 0,
+      ts: 0,
+      userId: 'u1',
+      user: null,
+      xpAfter,
+    })
+
+    xpAfter.available = 999
+
+    expect(entry.snapshot.xpAfter.available).toBe(100)
+  })
+})
+
+/* ============================================ */
+/*  Helpers de coûts                            */
+/* ============================================ */
+
+describe('cost helpers', () => {
+  test('computeSkillTrainCost career', async () => {
+    const { computeSkillTrainCost } = await import('../../module/utils/audit-diff.mjs')
+
+    expect(computeSkillTrainCost(0, true)).toBe(5)
+    expect(computeSkillTrainCost(2, true)).toBe(15)
+  })
+
+  test('computeSkillTrainCost non-career', async () => {
+    const { computeSkillTrainCost } = await import('../../module/utils/audit-diff.mjs')
+
+    expect(computeSkillTrainCost(0, false)).toBe(10)
+    expect(computeSkillTrainCost(2, false)).toBe(20)
+  })
+
+  test('computeSkillForgetRefund career', async () => {
+    const { computeSkillForgetRefund } = await import('../../module/utils/audit-diff.mjs')
+
+    expect(computeSkillForgetRefund(3, true)).toBe(15)
+  })
+
+  test('computeSkillForgetRefund non-career', async () => {
+    const { computeSkillForgetRefund } = await import('../../module/utils/audit-diff.mjs')
+
+    expect(computeSkillForgetRefund(3, false)).toBe(20)
+  })
+
+  test('computeCharacteristicCost', async () => {
+    const { computeCharacteristicCost } = await import('../../module/utils/audit-diff.mjs')
+
+    expect(computeCharacteristicCost(3)).toBe(30)
+    expect(computeCharacteristicCost(4)).toBe(40)
+  })
+})
+
+/* ============================================ */
+/*  reconstructPreviousValue                    */
+/* ============================================ */
+
+describe('reconstructPreviousValue', () => {
+  test('reconstructs previous partial object over current full object', async () => {
+    const { reconstructPreviousValue } = await import('../../module/utils/audit-diff.mjs')
+
+    const current = {
+      base: 0,
+      careerFree: 0,
+      specializationFree: 0,
+      trained: 2,
+    }
+
+    const oldPartial = {
+      trained: 1,
+    }
+
+    expect(reconstructPreviousValue(oldPartial, current)).toEqual({
+      base: 0,
+      careerFree: 0,
+      specializationFree: 0,
+      trained: 1,
+    })
+  })
+
+  test('returns current value when old partial is undefined', async () => {
+    const { reconstructPreviousValue } = await import('../../module/utils/audit-diff.mjs')
+
+    expect(reconstructPreviousValue(undefined, 3)).toBe(3)
+  })
+})
+
+/* ============================================ */
+/*  Skill changes                               */
+/* ============================================ */
+
+describe('skill changes', () => {
+  test('skill.train career from 0 to 1 costs 5 XP', async () => {
+    const changes = {
+      system: {
+        skills: {
+          cool: {
+            rank: { trained: 1 },
+          },
+        },
+      },
+    }
+
+    const source = defaultSource()
+    source.system.skills.cool = {
+      rank: {
+        base: 0,
+        careerFree: 0,
+        specializationFree: 0,
+        trained: 0,
+      },
+    }
+    source.system.details.career = {
+      name: 'Explorer',
+      careerSkills: ['cool'],
+    }
+
+    const entries = await composeFromChanges(changes, source)
+
+    expect(entries).toHaveLength(1)
+    expect(entries[0]).toMatchObject({
+      type: 'skill.train',
+      xpDelta: -5,
+      data: {
+        skillId: 'cool',
+        oldRank: 0,
+        newRank: 1,
+        cost: 5,
+        isCareer: true,
+        isFree: false,
+      },
+    })
+  })
+
+  test('skill.train non-career from 0 to 1 costs 10 XP', async () => {
+    const changes = {
+      system: {
+        skills: {
+          cool: {
+            rank: { trained: 1 },
+          },
+        },
+      },
+    }
+
+    const source = defaultSource()
+    source.system.skills.cool = {
+      rank: {
+        base: 0,
+        careerFree: 0,
+        specializationFree: 0,
+        trained: 0,
+      },
+    }
+    source.system.details.career = {
+      name: 'Explorer',
+      careerSkills: ['athletics'],
+    }
+
+    const entries = await composeFromChanges(changes, source)
+
+    expect(entries).toHaveLength(1)
+    expect(entries[0]).toMatchObject({
+      type: 'skill.train',
+      xpDelta: -10,
+      data: {
+        skillId: 'cool',
+        oldRank: 0,
+        newRank: 1,
+        cost: 10,
+        isCareer: false,
+        isFree: false,
+      },
+    })
+  })
+
+  test('skill.forget from 3 to 2 refunds rank 3 cost, not rank 2 cost', async () => {
+    const changes = {
+      system: {
+        skills: {
+          cool: {
+            rank: { trained: 2 },
+          },
+        },
+      },
+    }
+
+    const source = defaultSource()
+    source.system.skills.cool = {
+      rank: {
+        base: 0,
+        careerFree: 0,
+        specializationFree: 0,
+        trained: 3,
+      },
+    }
+    source.system.details.career = {
+      name: 'Explorer',
+      careerSkills: ['cool'],
+    }
+
+    const entries = await composeFromChanges(changes, source)
+
+    expect(entries).toHaveLength(1)
+    expect(entries[0]).toMatchObject({
+      type: 'skill.forget',
+      xpDelta: 15,
+      data: {
+        skillId: 'cool',
+        oldRank: 3,
+        newRank: 2,
+        cost: 15,
+        isCareer: true,
+        isFree: false,
+      },
+    })
+  })
+
+  test('returns empty when skill total rank has not changed', async () => {
+    const changes = {
+      system: {
+        skills: {
+          cool: {
+            rank: { trained: 2 },
+          },
+        },
+      },
+    }
+
+    const source = defaultSource()
+    source.system.skills.cool = {
+      rank: {
+        base: 0,
+        careerFree: 0,
+        specializationFree: 0,
+        trained: 2,
+      },
+    }
+
+    const entries = await composeFromChanges(changes, source)
+
+    expect(entries).toEqual([])
+  })
+
+  test('marks isFree=true when only free ranks increase', async () => {
+    const changes = {
+      system: {
+        skills: {
+          cool: {
+            rank: { careerFree: 1 },
+          },
+        },
+      },
+    }
+
+    const source = defaultSource()
+    source.system.skills.cool = {
+      rank: {
+        base: 0,
+        careerFree: 0,
+        specializationFree: 0,
+        trained: 0,
+      },
+    }
+    source.system.details.career = {
+      name: 'Explorer',
+      careerSkills: ['cool'],
+    }
+
+    const entries = await composeFromChanges(changes, source)
+
+    expect(entries).toHaveLength(1)
+    expect(entries[0]).toMatchObject({
+      type: 'skill.train',
+      xpDelta: 0,
+      data: {
+        skillId: 'cool',
+        oldRank: 0,
+        newRank: 1,
+        cost: 0,
+        isCareer: true,
+        isFree: true,
+      },
+    })
+  })
+})
+
+/* ============================================ */
+/*  Characteristic changes                      */
+/* ============================================ */
+
+describe('characteristic changes', () => {
+  test('characteristic.increase from 2 to 3 costs 30 XP', async () => {
+    const changes = {
+      system: {
+        characteristics: {
+          brawn: {
+            rank: { trained: 1 },
+          },
+        },
+      },
+    }
+
+    const source = defaultSource()
+    source.system.characteristics.brawn = {
+      rank: {
+        base: 2,
+        trained: 0,
+        bonus: 0,
+      },
+    }
+
+    const entries = await composeFromChanges(changes, source)
+
+    expect(entries).toHaveLength(1)
+    expect(entries[0]).toMatchObject({
+      type: 'characteristic.increase',
+      xpDelta: -30,
+      data: {
+        characteristicId: 'brawn',
+        oldValue: 2,
+        newValue: 3,
+        cost: 30,
+      },
+    })
+  })
+
+  test('returns empty for characteristic decrease', async () => {
+    const changes = {
+      system: {
+        characteristics: {
+          brawn: {
+            rank: { trained: 0 },
+          },
+        },
+      },
+    }
+
+    const source = defaultSource()
+    source.system.characteristics.brawn = {
+      rank: {
+        base: 2,
+        trained: 1,
+        bonus: 0,
+      },
+    }
+
+    const entries = await composeFromChanges(changes, source)
+
+    expect(entries).toEqual([])
+  })
+})
+
+/* ============================================ */
+/*  XP changes                                  */
+/* ============================================ */
+
+describe('XP changes', () => {
+  test('creates xp.spend entry for pure spent increase', async () => {
+    const changes = {
+      system: {
+        progression: {
+          experience: {
+            spent: 75,
+          },
+        },
+      },
+    }
+
+    const source = defaultSource()
+    source.system.progression.experience = {
+      spent: 50,
+      gained: 200,
+      available: 150,
+      total: 200,
+    }
+
+    const entries = await composeFromChanges(changes, source)
+
+    expect(entries).toHaveLength(1)
+    expect(entries[0]).toMatchObject({
+      type: 'xp.spend',
+      xpDelta: -25,
+      data: {
+        amount: 25,
+        oldSpent: 50,
+        newSpent: 75,
+      },
+    })
+  })
+
+  test('creates xp.refund entry for pure spent decrease', async () => {
+    const changes = {
+      system: {
+        progression: {
+          experience: {
+            spent: 30,
+          },
+        },
+      },
+    }
+
+    const source = defaultSource()
+    source.system.progression.experience = {
+      spent: 50,
+      gained: 200,
+      available: 150,
+      total: 200,
+    }
+
+    const entries = await composeFromChanges(changes, source)
+
+    expect(entries).toHaveLength(1)
+    expect(entries[0]).toMatchObject({
+      type: 'xp.refund',
+      xpDelta: 20,
+      data: {
+        amount: 20,
+        oldSpent: 50,
+        newSpent: 30,
+      },
+    })
+  })
+
+  test('creates xp.grant entry for gained increase', async () => {
+    const changes = {
+      system: {
+        progression: {
+          experience: {
+            gained: 250,
+          },
+        },
+      },
+    }
+
+    const source = defaultSource()
+    source.system.progression.experience = {
+      spent: 50,
+      gained: 200,
+      available: 150,
+      total: 200,
+    }
+
+    const entries = await composeFromChanges(changes, source)
+
+    expect(entries).toHaveLength(1)
+    expect(entries[0]).toMatchObject({
+      type: 'xp.grant',
+      xpDelta: 50,
+      data: {
+        amount: 50,
+        oldGained: 200,
+        newGained: 250,
+      },
+    })
+  })
+
+  test('creates xp.remove when gained decreases, not xp.grant with negative amount', async () => {
+    const changes = {
+      system: {
+        progression: {
+          experience: {
+            gained: 150,
+          },
+        },
+      },
+    }
+
+    const source = defaultSource()
+    source.system.progression.experience = {
+      spent: 50,
+      gained: 200,
+      available: 150,
+      total: 200,
+    }
+
+    const entries = await composeFromChanges(changes, source)
+
+    expect(entries).toHaveLength(1)
+    expect(entries[0]).toMatchObject({
+      type: 'xp.remove',
+      xpDelta: -50,
+      data: {
+        amount: 50,
+        oldGained: 200,
+        newGained: 150,
+      },
+    })
+
+    expect(entries[0].type).not.toBe('xp.grant')
+    expect(entries[0].data.amount).toBeGreaterThan(0)
+  })
+
+  test('returns empty when XP value is unchanged', async () => {
+    const changes = {
+      system: {
+        progression: {
+          experience: {
+            spent: 50,
+          },
+        },
+      },
+    }
+
+    const source = defaultSource()
+    source.system.progression.experience = {
+      spent: 50,
+      gained: 200,
+      available: 150,
+      total: 200,
+    }
+
+    const entries = await composeFromChanges(changes, source)
+
+    expect(entries).toEqual([])
+  })
+
+  test('does not create xp entry when skill change also updates experience.spent', async () => {
+    const changes = {
+      system: {
+        skills: {
+          cool: {
+            rank: { trained: 1 },
+          },
+        },
+        progression: {
+          experience: {
+            spent: 5,
+          },
+        },
+      },
+    }
+
+    const source = defaultSource()
+    source.system.skills.cool = {
+      rank: {
+        base: 0,
+        careerFree: 0,
+        specializationFree: 0,
+        trained: 0,
+      },
+    }
+    source.system.details.career = {
+      name: 'Explorer',
+      careerSkills: ['cool'],
+    }
+    source.system.progression.experience = {
+      spent: 0,
+      gained: 100,
+      available: 100,
+      total: 100,
+    }
+
+    const entries = await composeFromChanges(changes, source)
+
+    expect(entries).toHaveLength(1)
+    expect(entries[0].type).toBe('skill.train')
+    expect(entries[0].data.cost).toBe(5)
+
+    expect(entries.find((e) => e.type.startsWith('xp.'))).toBeUndefined()
+  })
+})
+
+/* ============================================ */
+/*  Detail changes                              */
+/* ============================================ */
+
+describe('detail changes', () => {
+  test('creates species.set entry', async () => {
+    const changes = {
+      system: {
+        details: {
+          species: {
+            name: 'Human',
+          },
+        },
+      },
+    }
+
+    const source = defaultSource()
+    source.system.details.species = null
+
+    const entries = await composeFromChanges(changes, source)
+
+    expect(entries).toHaveLength(1)
+    expect(entries[0]).toMatchObject({
+      type: 'species.set',
+      xpDelta: 0,
+      data: {
+        oldSpecies: null,
+        newSpecies: 'Human',
+      },
+    })
+  })
+
+  test('creates career.set entry', async () => {
+    const changes = {
+      system: {
+        details: {
+          career: {
+            name: 'Mercenary',
+          },
+        },
+      },
+    }
+
+    const source = defaultSource()
+    source.system.details.career = null
+
+    const entries = await composeFromChanges(changes, source)
+
+    expect(entries).toHaveLength(1)
+    expect(entries[0]).toMatchObject({
+      type: 'career.set',
+      xpDelta: 0,
+      data: {
+        oldCareer: null,
+        newCareer: 'Mercenary',
+      },
+    })
+  })
+
+  test('detects specialization.add on real addition', async () => {
+    const changes = {
+      system: {
+        details: {
+          specializations: {
+            spec1: {
+              name: 'Bodyguard',
+            },
+          },
+        },
+      },
+    }
+
+    const source = defaultSource()
+    source.system.details.specializations = {}
+
+    const entries = await composeFromChanges(changes, source)
+    const addEntries = entries.filter((e) => e.type === 'specialization.add')
+
+    expect(addEntries).toHaveLength(1)
+    expect(addEntries[0]).toMatchObject({
+      type: 'specialization.add',
+      xpDelta: 0,
+      data: {
+        specializationId: 'spec1',
+      },
+    })
+  })
+
+  test('does not detect specialization.add for internal specialization update', async () => {
+    const changes = {
+      system: {
+        details: {
+          specializations: {
+            spec1: {
+              name: 'Bodyguard Updated',
+            },
+          },
+        },
+      },
+    }
+
+    const source = defaultSource()
+    source.system.details.specializations = {
+      spec1: {
+        name: 'Bodyguard',
+      },
+    }
+
+    const entries = await composeFromChanges(changes, source)
+    const addEntries = entries.filter((e) => e.type === 'specialization.add')
+
+    expect(addEntries).toHaveLength(0)
+  })
+
+  test('detects specialization.remove from -= key', async () => {
+    const changes = {
+      system: {
+        details: {
+          specializations: {
+            '-=spec1': null,
+          },
+        },
+      },
+    }
+
+    const source = defaultSource()
+    source.system.details.specializations = {
+      spec1: {
+        name: 'Bodyguard',
+      },
+    }
+
+    const entries = await composeFromChanges(changes, source)
+    const removeEntries = entries.filter((e) => e.type === 'specialization.remove')
+
+    expect(removeEntries).toHaveLength(1)
+    expect(removeEntries[0]).toMatchObject({
+      type: 'specialization.remove',
+      xpDelta: 0,
+      data: {
+        specializationId: 'spec1',
+      },
+    })
+  })
+})
+
+/* ============================================ */
+/*  Advancement changes                         */
+/* ============================================ */
+
+describe('advancement changes', () => {
+  test('creates advancement.level entry', async () => {
+    const changes = {
+      system: {
+        advancement: {
+          level: 2,
+        },
+      },
+    }
+
+    const source = defaultSource()
+    source.system.advancement = {
+      level: 1,
+    }
+
+    const entries = await composeFromChanges(changes, source)
+
+    expect(entries).toHaveLength(1)
+    expect(entries[0]).toMatchObject({
+      type: 'advancement.level',
+      xpDelta: 0,
+      data: {
+        oldLevel: 1,
+        newLevel: 2,
+      },
+    })
+  })
+
+  test('returns empty when advancement level is unchanged', async () => {
+    const changes = {
+      system: {
+        advancement: {
+          level: 1,
+        },
+      },
+    }
+
+    const source = defaultSource()
+    source.system.advancement = {
+      level: 1,
+    }
+
+    const entries = await composeFromChanges(changes, source)
+
+    expect(entries).toEqual([])
+  })
+})
+
+/* ============================================ */
+/*  composeEntries — intégration                */
+/* ============================================ */
+
+describe('composeEntries', () => {
+  test('returns empty array for empty changes', async () => {
+    const { composeEntries } = await import('../../module/utils/audit-diff.mjs')
+
+    const actor = makeActor({})
+    const entries = composeEntries({}, {}, actor, 'user-1')
+
+    expect(entries).toEqual([])
+  })
+
+  test('returns empty array for non-system changes', async () => {
+    const { composeEntries } = await import('../../module/utils/audit-diff.mjs')
+
+    const actor = makeActor({})
+    const entries = composeEntries({}, { flags: {} }, actor, 'user-1')
+
+    expect(entries).toEqual([])
+  })
+
+  test('handles unknown user gracefully', async () => {
+    const changes = {
+      system: {
+        skills: {
+          cool: {
+            rank: { trained: 1 },
+          },
+        },
+      },
+    }
+
+    const source = defaultSource()
+    source.system.skills.cool = {
+      rank: {
+        base: 0,
+        careerFree: 0,
+        specializationFree: 0,
+        trained: 0,
+      },
+    }
+
+    const entries = await composeFromChanges(changes, source, 'nonexistent-user')
+
+    expect(entries).toHaveLength(1)
+    expect(entries[0].userName).toBe('Unknown')
+    expect(entries[0].userId).toBe('nonexistent-user')
+  })
+
+  test('accepts flat Foundry diff via expandObject', async () => {
+    const { composeEntries } = await import('../../module/utils/audit-diff.mjs')
+
+    const source = defaultSource()
+    source.system.skills.cool = {
+      rank: {
+        base: 0,
+        careerFree: 0,
+        specializationFree: 0,
+        trained: 0,
+      },
+    }
+    source.system.details.career = {
+      name: 'Explorer',
+      careerSkills: ['cool'],
+    }
+
+    const flatChanges = {
+      'system.skills.cool.rank.trained': 1,
+    }
+
+    const expandedChanges = foundry.utils.expandObject(flatChanges)
+    const oldState = makeOldState(expandedChanges, source)
+    const newSystem = applyChangesToSystem(source.system, expandedChanges)
+    const actor = makeActor(newSystem)
+
+    const entries = composeEntries(oldState, flatChanges, actor, 'user-1')
+
+    expect(entries).toHaveLength(1)
+    expect(entries[0]).toMatchObject({
+      type: 'skill.train',
+      xpDelta: -5,
+      data: {
+        skillId: 'cool',
+        oldRank: 0,
+        newRank: 1,
+        cost: 5,
+        isCareer: true,
+      },
+    })
+  })
+
+  test('returns [] when analysis fails', async () => {
+    const { composeEntries } = await import('../../module/utils/audit-diff.mjs')
+
+    const originalExpandObject = foundry.utils.expandObject
+
+    foundry.utils.expandObject = vi.fn(() => {
+      throw new Error('boom')
+    })
+
+    const actor = makeActor(defaultSource().system)
+    const entries = composeEntries({}, { system: { skills: {} } }, actor, 'user-1')
+
+    expect(entries).toEqual([])
+
+    foundry.utils.expandObject = originalExpandObject
+  })
+})
+
+/* ============================================ */
+/*  inferIsCareer / getCareerSkillIds           */
+/* ============================================ */
+
+describe('inferIsCareer', () => {
+  test('returns true when skill is in career careerSkills', async () => {
+    const { inferIsCareer } = await import('../../module/utils/audit-diff.mjs')
+
+    const actor = makeActor({
+      skills: {},
+      details: {
+        career: {
+          name: 'Explorer',
+          careerSkills: ['cool'],
+        },
+        specializations: {},
+      },
+    })
+
+    expect(inferIsCareer('cool', {}, actor)).toBe(true)
+  })
+
+  test('returns true when skill is in specialization careerSkills', async () => {
+    const { inferIsCareer } = await import('../../module/utils/audit-diff.mjs')
+
+    const actor = makeActor({
+      skills: {},
+      details: {
+        career: {
+          name: 'Explorer',
+          careerSkills: [],
+        },
+        specializations: {
+          ambassador: {
+            name: 'Ambassador',
+            careerSkills: ['charm'],
+          },
+        },
+      },
+    })
+
+    expect(inferIsCareer('charm', {}, actor)).toBe(true)
+  })
+
+  test('returns false when skill is not in career or specialization skills', async () => {
+    const { inferIsCareer } = await import('../../module/utils/audit-diff.mjs')
+
+    const actor = makeActor({
+      skills: {},
+      details: {
+        career: {
+          name: 'Explorer',
+          careerSkills: ['athletics'],
+        },
+        specializations: {
+          ambassador: {
+            name: 'Ambassador',
+            careerSkills: ['charm'],
+          },
+        },
+      },
+    })
+
+    expect(inferIsCareer('cool', {}, actor)).toBe(false)
+  })
+})
+
+describe('getCareerSkillIds', () => {
+  test('collects career and specialization career skills', async () => {
+    const { getCareerSkillIds } = await import('../../module/utils/audit-diff.mjs')
+
+    const actor = makeActor({
+      details: {
+        career: {
+          name: 'Explorer',
+          careerSkills: ['cool', { id: 'athletics' }],
+        },
+        specializations: {
+          ambassador: {
+            careerSkills: ['charm', { id: 'negotiation' }],
+          },
+        },
+      },
+    })
+
+    expect([...getCareerSkillIds(actor)].sort()).toEqual(['athletics', 'charm', 'cool', 'negotiation'])
+  })
+})


### PR DESCRIPTION
## Summary
- add a dedicated `audit-diff.mjs` module to compose audit log entries from Foundry actor diffs
- wire the existing audit log hook infrastructure to the new analyzer and cover the behavior with Vitest tests
- add the implementation plan document for issue #159

## Testing
- `npx vitest run tests/utils/audit-diff.test.mjs tests/utils/audit-log.test.mjs`

Closes #159