### PR TITLE
feat(audit-log): implement onCreateItem hook for talent purchase detection

### DIFF
--- a/documentation/plan/tests/US1-plan-tests-audit-log.md
+++ b/documentation/plan/tests/US1-plan-tests-audit-log.md
@@ -1,0 +1,279 @@
+# Plan d'implémentation — TECH : Tests Vitest du système d'audit log
+
+**Issue** : [#163 — TECH: Tests Vitest du système d'audit log](https://github.com/herveDarritchon/foundryvtt-swerpg/issues/163)
+**Epic** : [#150 — EPIC: Système de logs d'évolution du personnage (Character Audit Log)](https://github.com/herveDarritchon/foundryvtt-swerpg/issues/150)
+**US parente** : [#151 — US1: Enregistrer chaque action d'évolution du personnage dans un journal de bord](https://github.com/herveDarritchon/foundryvtt-swerpg/issues/151)
+**ADR** : `documentation/architecture/adr/adr-0011-stockage-journal-evolution-personnage-flags.md`
+**Plan de référence** : `documentation/plan/character-sheet/evolution-logs/US1-plan-audit-log-hooks.md` (§5, Étape 4)
+**Module(s) impacté(s)** : `tests/utils/audit-log.test.mjs` (modification), `tests/utils/audit-diff.test.mjs` (modification), `documentation/tests/manuel/audit-log/README.md` (création)
+
+---
+
+## 1. Objectif
+
+Couvrir le système d'audit log (analyseur de diff, helpers, hooks simulés, gestion d'erreur) avec des tests Vitest automatisés et des scénarios de test manuel, sans modifier le code métier existant.
+
+---
+
+## 2. Périmètre
+
+### Inclus dans ce ticket
+
+- Vérification que tous les tests Vitest existants dans `tests/utils/audit-log.test.mjs` et `tests/utils/audit-diff.test.mjs` passent
+- Ajout des tests manquants identifiés par rapport à la spec de l'issue #163
+- Création d'un sous-répertoire `documentation/tests/manuel/audit-log/` avec un `README.md` de scénarios de test manuel dédiés à l'audit log
+- Mise à jour de `tests/README.md` avec une ligne de référence vers les tests d'audit log
+- Mise à jour de `documentation/tests/manuel/README.md` pour ajouter la famille "Audit Log" dans l'index
+
+### Exclu de ce ticket
+
+- Tests pour `onCreateItem` / `talent.purchase` — la fonction `onCreateItem` n'existe pas dans le code de `audit-log.mjs` (gap documenté, renvoi vers US4 ou implémentation future)
+- Modification du code métier dans `module/utils/audit-log.mjs` ou `module/utils/audit-diff.mjs` — seuls les tests et la documentation sont modifiés
+- Tests E2E Playwright pour l'audit log — non demandés dans l'issue
+- Tests d'intégration avec une instance Foundry réelle
+- Implémentation de nouvelles fonctionnalités d'audit log
+
+---
+
+## 3. Constat sur l'existant
+
+### Tests Vitest déjà écrits et très complets
+
+Deux fichiers de tests existent déjà et couvrent la quasi-totalité de la spec :
+
+**`tests/utils/audit-log.test.mjs`** (718 lignes, ~35 tests)
+
+| Groupe | Tests | Statut |
+|--------|-------|--------|
+| `isOnlyAuditChange` | 4 tests (true/false/vide/autres clés) | ✅ Complet |
+| `cloneValue` | 3 tests (objets simples/nested/undefined) | ✅ Complet |
+| `snapshotOldState` | 5 tests (chemins modifiés, clone défensif, chemins vides, deletion paths, chemins multiples) | ⚠️ Manque : chemin imbriqué profond |
+| `isDeletionPath` | 2 tests | ✅ Complet |
+| `pending queue` | 1 test FIFO | ✅ Complet |
+| `writeLogEntries max size` | 6 tests (éviction, seuil non atteint, limite basse 100, setting dynamique, fallback 500, multi-entries) | ✅ Complet |
+| `evictOldestIfNeeded` | 2 tests (overflow, under limit) | ✅ Complet |
+| `onPreUpdateActor` | 4 tests (non-character, only audit, swerpg option, capture) | ✅ Complet |
+| `onUpdateActor` | 4 tests (non-character, swerpg option, no pending, expired pending) | ✅ Complet |
+| `writeLogEntries` | 3 tests (batch, empty, swerpgAuditLog option) | ✅ Complet |
+| `registerAuditLogHooks` | 1 test (2 hooks registrés) | ✅ Complet |
+| `handleWriteError` | 5 tests (logger.error, ui.warn, GM whisper, non-GM, chat failure catch) | ✅ Complet |
+| `writeLogEntries retry` | 3 tests (retry success, retry exhausted, first attempt) | ✅ Complet |
+| `pruneExpiredPending` | 2 tests (warning threshold) | ✅ Complet |
+
+**`tests/utils/audit-diff.test.mjs`** (1311 lignes, ~30 tests)
+
+| Groupe | Tests | Statut |
+|--------|-------|--------|
+| `captureSnapshot` | 2 tests (XP snapshot complet, progression manquante → zéros) | ✅ Complet |
+| `makeEntry` | 4 tests (bien formé, Unknown fallback, -0 normalisation, shallow clone) | ✅ Complet |
+| `cost helpers` | 5 tests (skill train career/non-career, forget, characteristic) | ✅ Complet |
+| `reconstructPreviousValue` | 2 tests | ✅ Complet |
+| `skill changes` | 5 tests (train career, train non-career, forget, unchanged → empty, isFree) | ✅ Complet |
+| `characteristic changes` | 2 tests (increase, decrease → empty) | ✅ Complet |
+| `XP changes` | 6 tests (spend, refund, grant, remove, unchanged, composite skill+XP) | ✅ Complet |
+| `detail changes` | 5 tests (species.set, career.set, spec.add, spec.add existant, spec.remove) | ✅ Complet |
+| `advancement changes` | 2 tests (level change, unchanged) | ✅ Complet |
+| `composeEntries` | 4 tests (empty changes, non-system, unknown user, flat Foundry diff, analyse failure) | ✅ Complet |
+| `inferIsCareer` | 3 tests (career skill, spec skill, non-career) | ✅ Complet |
+| `getCareerSkillIds` | 1 test (collecte career + spec skills avec objets) | ✅ Complet |
+
+### Tests manuels existants
+
+Des tests manuels d'audit log sont déjà intégrés dans `documentation/tests/manuel/personnage/README.md` :
+- Vérification d'entrée `characteristic.increase` (l.108)
+- Vérification d'entrée `skill.train` (l.135)
+- Vérification d'entrée `xp.grant` (l.201)
+- Vérification des limites (l.259-261)
+
+Cependant, il n'existe pas de fichier dédié `documentation/tests/manuel/audit-log/README.md`.
+
+### Gap identifié : `onCreateItem` non implémenté
+
+Le plan US1 (§5) et la spec de l'issue #163 mentionnent un hook `createItem` pour détecter les achats de talent. Ce hook n'est pas présent dans `module/utils/audit-log.mjs` — seuls `onPreUpdateActor` et `onUpdateActor` sont exportés et câblés via `registerAuditLogHooks()`. Les tests correspondants ne peuvent donc pas être écrits sans modifier le code métier. Ce gap est documenté et renvoie vers une implémentation future (US4 ou ticket dédié).
+
+---
+
+## 4. Décisions d'architecture
+
+### 4.1. Aucune modification du code métier
+
+**Décision** : Conforme à la règle inviolable de l'issue, aucun fichier dans `module/` n'est modifié. Les tests sont purement additifs et ne touchent que `tests/` et `documentation/tests/`.
+
+Justification :
+- L'audit log est déjà implémenté et opérationnel
+- L'objectif est la couverture de test, pas l'évolution fonctionnelle
+- Réduit le risque de régression
+
+### 4.2. Nouveaux tests ajoutés dans les fichiers existants
+
+**Décision** : Ajouter les tests manquants dans `tests/utils/audit-log.test.mjs` plutôt que de créer un nouveau fichier.
+
+Justification :
+- Cohérence : tous les tests du module `audit-log.mjs` sont déjà dans ce fichier
+- Pas de fragmentation
+- La spec de l'issue liste des tests qui s'ajoutent naturellement aux `describe` existants
+
+### 4.3. Fichier de tests manuels dédié
+
+**Décision** : Créer `documentation/tests/manuel/audit-log/README.md` avec des scénarios spécifiques, en extrayant et complétant les tests déjà présents dans `personnage/README.md`.
+
+Justification :
+- L'issue le demande explicitement
+- L'audit log est un aspect transverse (touche skills, caracs, XP, talents, espèces)
+- Un fichier dédié permet une couverture plus systématique
+- Les tests `personnage/README.md` ne seront pas modifiés (ils référencent l'audit log comme point de vérification, pas comme objet de test principal)
+
+### 4.4. Gap documenté pour `onCreateItem`
+
+**Décision** : Les tests pour `onCreateItem` sont exclus du périmètre. Le gap est documenté dans ce plan et dans le README de tests manuels.
+
+Justification :
+- La fonction `onCreateItem` n'existe pas dans le code (seulement `onPreUpdateActor` et `onUpdateActor`)
+- La règle "Aucune modification du code métier" interdit de l'ajouter dans ce ticket
+- US4 (talents) prévoit l'instrumentation des achats de talent via `createItem`
+
+---
+
+## 5. Plan de travail détaillé
+
+### Étape 1 : Vérifier que tous les tests existants passent
+
+**Quoi** : Lancer `npx vitest run tests/utils/audit-log.test.mjs tests/utils/audit-diff.test.mjs` et analyser les résultats. Identifier les échecs.
+
+Si des tests échouent, investiguer :
+- Est-ce un problème de mock (mock-foundry qui a changé) ?
+- Est-ce un problème de code métier (régression) ?
+- Est-ce un problème de test lui-même (assertion incorrecte) ?
+
+**Actions possibles** :
+- Si le test est mal écrit : corriger le test
+- Si le mock est obsolète : corriger le mock dans le test (pas dans le code métier)
+- Si le code métier est en cause : ne pas modifier, documenter l'écart et reporter
+
+**Fichiers** : `tests/utils/audit-log.test.mjs`, `tests/utils/audit-diff.test.mjs`
+**Risque** : Découverte de bugs dans le code métier → ne pas corriger, documenter et reporter.
+
+### Étape 2 : Ajouter les tests manquants dans `audit-log.test.mjs`
+
+**Quoi** : Ajouter les tests spécifiques de la spec #163 qui ne sont pas encore couverts.
+
+Tests à ajouter :
+
+**snapshotOldState (chemin profond imbriqué)** :
+```
+test('captures deeply nested paths like system.skills.stealth.rank.trained')
+  source = { system: { skills: { stealth: { rank: { base: 0, trained: 2, careerFree: 0, specializationFree: 0 } } } } }
+  changes = { 'system.skills.stealth.rank.trained': 3 }
+  → oldState doit contenir system.skills.stealth.rank avec trained = 2
+```
+
+Ce test manque dans le `describe('snapshotOldState')` existant. Le test actuel le plus proche est "extracts system paths from source matching changes" mais il utilise un chemin à 2 niveaux (`skills.Athletics.rank`), pas 3+.
+
+**Fichiers** : `tests/utils/audit-log.test.mjs` (modification)
+**Risque** : Faible — simple ajout de test.
+
+### Étape 3 : Créer `documentation/tests/manuel/audit-log/README.md`
+
+**Quoi** : Créer un fichier de tests manuels dédié à l'audit log, structuré comme les autres fichiers dans `documentation/tests/manuel/` (tableaux Action → Résultat attendu).
+
+Contenu à couvrir :
+
+1. **Prérequis** : Personnage character créé, au moins un MJ connecté
+2. **1. Vérification de base** : accès à `flags.swerpg.logs` via console, structure d'une entrée
+3. **2. Compétences** : achat (skill.train), revente (skill.forget), rang gratuit (isFree), achat carrière vs non-carrière
+4. **3. Caractéristiques** : augmentation (characteristic.increase)
+5. **4. XP** : dépense (xp.spend), gain (xp.grant), remboursement (xp.refund)
+6. **5. Détails** : changement d'espèce (species.set), changement de carrière (career.set)
+7. **6. Limite et éviction** : vérifier la taille max (500), comportement FIFO
+8. **7. Résilience** : comportement en cas d'erreur d'écriture (simulation)
+9. **8. Gap connu** : les achats de talent (talent.purchase) ne sont pas encore loggés — renvoi vers US4
+
+Inspiration du format : `documentation/tests/manuel/talents/README.md`
+
+**Fichiers** : `documentation/tests/manuel/audit-log/README.md` (création)
+**Risque** : Faible.
+
+### Étape 4 : Mettre à jour `tests/README.md`
+
+**Quoi** : Ajouter une ligne dans la section "Structure du dossier `tests/`" (l.90-111) pour mentionner les fichiers d'audit log.
+
+Ajout dans l'arborescence :
+```
+  utils/
+    audit-log.test.mjs          # Tests du module d'audit log (hooks, écriture, résilience)
+    audit-diff.test.mjs          # Tests de l'analyseur de diff (composeEntries, détecteurs)
+```
+
+**Fichiers** : `tests/README.md` (modification)
+**Risque** : Faible — simple mise à jour documentaire.
+
+### Étape 5 : Mettre à jour `documentation/tests/manuel/README.md`
+
+**Quoi** : Ajouter une ligne dans le tableau des familles de test pour l'audit log, et mettre à jour les compteurs.
+
+Ajout dans le tableau :
+```
+| [Audit Log](audit-log/README.md) | Hooks, entrées, résilience, éviction FIFO | ~12 scénarios |
+```
+
+Mettre à jour "Total scénarios documentés" (12 de plus).
+
+**Fichiers** : `documentation/tests/manuel/README.md` (modification)
+**Risque** : Faible.
+
+### Étape 6 : Vérification finale
+
+**Quoi** :
+- Lancer tous les tests audit-log et audit-diff : `npx vitest run tests/utils/audit-log.test.mjs tests/utils/audit-diff.test.mjs`
+- Vérifier que le coverage est satisfaisant sur les chemins critiques (analyseur de diff, écriture, résilience)
+- Vérifier la cohérence de la documentation (liens, format des tableaux)
+- Vérifier que `documentation/tests/manuel/README.md` référence bien le nouveau dossier
+
+**Fichiers** : Aucune modification
+**Risque** : Si les tests échouent, revenir à l'étape 1.
+
+---
+
+## 6. Fichiers modifiés
+
+| Fichier | Action | Description |
+|---------|--------|-------------|
+| `tests/utils/audit-log.test.mjs` | Modification | Ajout du test manquant `snapshotOldState` pour chemin profond imbriqué |
+| `documentation/tests/manuel/audit-log/README.md` | Création | Tests manuels dédiés à l'audit log (~12 scénarios) |
+| `tests/README.md` | Modification | Ajout des lignes pour les fichiers d'audit log dans l'arborescence |
+| `documentation/tests/manuel/README.md` | Modification | Ajout de la famille "Audit Log" dans l'index |
+
+---
+
+## 7. Risques
+
+| Risque | Impact | Mitigation |
+|--------|--------|------------|
+| **Tests existants qui échouent** (mock obsolète, régression code métier) | Bloquant pour l'étape 1 | Debug du test ou du mock (pas du code métier). Si régression code métier, documenter et reporter. |
+| **`onCreateItem` gap non documenté** | Confusion pour le développeur suivant | Documenter explicitement dans ce plan §4.4 et dans le README de tests manuels |
+| **Tests manuels redondants** avec `personnage/README.md` | Duplication, désynchronisation possible | Référencer les tests existants plutôt que de copier |
+| **Oubli de mise à jour de l'index** | Lien mort dans `documentation/tests/manuel/README.md` | Vérification finale incluse dans l'étape 6 |
+
+---
+
+## 8. Proposition d'ordre de commit
+
+1. `test(audit-log): add snapshotOldState test for deeply nested paths` — ajout du test manquant
+2. `docs(tests): create manual test scenarios for audit log` — création du README de tests manuels
+3. `docs(tests): update tests README with audit log references` — mise à jour des index de documentation
+4. `test(audit-log): verify all tests pass` — validation finale
+
+---
+
+## 9. Dépendances avec les autres US
+
+```
+US1 (infrastructure audit log) — déjà implémentée
+  └── #163 (ce ticket) — tests et documentation
+        └── US4 (talents) — devra implémenter onCreateItem + ses tests
+```
+
+**Gap connu** : Les tests pour `talent.purchase` (via `createItem`) ne peuvent pas être écrits car le hook `onCreateItem` n'est pas encore implémenté dans `module/utils/audit-log.mjs`. Ce gap sera résolu par US4 ou par un ticket dédié qui :
+1. Ajoutera `onCreateItem` dans `audit-log.mjs`
+2. Câblera `Hooks.on('createItem', auditLog.onCreateItem)` dans `registerAuditLogHooks()`
+3. Ajoutera les tests Vitest correspondants dans `audit-log.test.mjs`

--- a/documentation/tests/manuel/GRILLE_TEST_RAPIDE.md
+++ b/documentation/tests/manuel/GRILLE_TEST_RAPIDE.md
@@ -1,0 +1,223 @@
+# Grille de test rapide
+
+Grille de suivi pour les tests manuels. Imprimable ou consultable en numérique.
+
+Instructions :
+- Cocher ✅ quand le test passe
+- Cocher ❌ quand le test échoue (noter le bug)
+- Cocher ⏭️ quand le test est non applicable (N/A)
+- Noter la date et le testeur en pied de grille
+
+---
+
+## Personnage
+
+| # | Scénario | ✅/❌/⏭️ | Notes |
+|---|----------|----------|-------|
+| 1 | Création d'un personnage type `character` | | |
+| 2 | Ouverture de la CharacterSheet (8 tabs) | | |
+| 3 | Drag & drop d'une espèce | | |
+| 4 | Drag & drop d'une carrière | | |
+| 5 | Drag & drop d'une spécialisation | | |
+| 6 | Spécialisations multiples | | |
+| 7 | Augmentation de caractéristique | | |
+| 8 | Diminution de caractéristique (forget) | | |
+| 9 | Achat de rang de compétence | | |
+| 10 | Rangs gratuits carrière | | |
+| 11 | Rangs gratuits spécialisation | | |
+| 12 | Oubli d'un rang de compétence | | |
+| 13 | Blessures (wounds) → KO → Mort | | |
+| 14 | Fatigue (strain) → Incapacité | | |
+| 15 | Encombrement | | |
+| 16 | Suivi XP (spent/gained/available) | | |
+| 17 | Obligation / Duty / Motivation | | |
+| 18 | Biographie (public/privé/HTML) | | |
+| 19 | Actions (favorite, use, edit) | | |
+| 20 | Effets (création, toggle, suppression) | | |
+| 21 | Audit log (entrées, format, limite) | | |
+| 22 | Changement d'espèce après XP dépensée | | |
+| 23 | Suppression de spécialisation → rangs recalculés | | |
+| 24 | Chargement d'un personnage existant | | |
+
+---
+
+## Combat
+
+| # | Scénario | ✅/❌/⏭️ | Notes |
+|---|----------|----------|-------|
+| 1 | Initialisation du combat (initiative) | | |
+| 2 | Ordre d'initiative décroissant | | |
+| 3 | Début de tour (onStartTurn) | | |
+| 4 | Fin de tour (onEndTurn) | | |
+| 5 | Action Delay (repositionnement initiative) | | |
+| 6 | Leave Combat (nettoyage) | | |
+| 7 | Attaque armée (weaponAttack) | | |
+| 8 | Attaque de compétence (skillAttack) | | |
+| 9 | Jet de défense (testDefense - dodge/parry/block/armor) | | |
+| 10 | Résultat MISS/DODGE/PARRY/BLOCK/ARMOR/HIT | | |
+| 11 | Calcul des dégâts (overflow × multiplier + base + bonus - resistance) | | |
+| 12 | Clamp dégâts [1, 2×preMitigation] | | |
+| 13 | Boon/Bane de cible (Guarded, Prone, Flanked) | | |
+| 14 | Distance et portée d'arme | | |
+| 15 | Résistance par type de dégâts (12 types) | | |
+| 16 | Application des statuts (weakened, broken, etc.) | | |
+| 17 | KO et Mort (wounds threshold ×1, ×2) | | |
+| 18 | DOT : Bleeding, Burning, etc. | | |
+| 19 | Expiration des effets (début/fin de tour) | | |
+| 20 | Héroïsme (trackHeroismDamage) | | |
+| 21 | Ressources : actions, focus | | |
+| 22 | Combat complet 3+ tours | | |
+
+---
+
+## Dés narratifs
+
+| # | Scénario | ✅/❌/⏭️ | Notes |
+|---|----------|----------|-------|
+| 1 | Pool de base 3d8 | | |
+| 2 | 1 boon → d8 → d10 | | |
+| 3 | 2 boons → d8 → d12 ou 2× d10 | | |
+| 4 | 1 bane → d8 → d6 | | |
+| 5 | 2 banes → d8 → d4 ou 2× d6 | | |
+| 6 | Limite 6 boons/banes | | |
+| 7 | Min d4, max d12 | | |
+| 8 | Total = pool + ability + skill + enchantment | | |
+| 9 | Seuils de difficulté (Trivial→Impossible) | | |
+| 10 | Succès/Échec critique (DC ± 6) | | |
+| 11 | AttackRoll : target, defenseType, result | | |
+| 12 | Dégâts = overflow × multiplier + base + bonus - resistance | | |
+| 13 | StandardCheckDialog (difficulté, DC, boon/bane, roll mode) | | |
+| 14 | ActionUseDialog (template targeting, cibles) | | |
+| 15 | Rendu chat (cartes de jet) | | |
+| 16 | Confirmation d'action (KeyX / autoConfirm) | | |
+| 17 | Socket : diceCheck, roll modes | | |
+
+---
+
+## Import OggDude
+
+| # | Scénario | ✅/❌/⏭️ | Notes |
+|---|----------|----------|-------|
+| 1 | Ouverture de l'importateur (Settings → System) | | |
+| 2 | Upload d'un fichier ZIP valide | | |
+| 3 | Parsing via JSZip + xml2js | | |
+| 4 | Sélection des domaines (11 domaines) | | |
+| 5 | Import d'armes (skill, range, damage, crit, qualities) | | |
+| 6 | Import d'armures (defense, soak, qualities) | | |
+| 7 | Import d'équipement (category, price, encumbrance...) | | |
+| 8 | Import de talents (node, ranked, activation, actions) | | |
+| 9 | Import d'espèces (6 caracs, thresholds, XP, free skills) | | |
+| 10 | Import de carrières (careerSkills, freeSkillRank) | | |
+| 11 | Import de spécialisations (specializationSkills) | | |
+| 12 | Import d'obligations/devoirs/motivations | | |
+| 13 | Stockage monde (dossiers "SWERPG OggDude Import") | | |
+| 14 | Stockage compendium (packs world.swerpg-{type}) | | |
+| 15 | Mapping des IDs OggDude → SWERPG | | |
+| 16 | ZIP invalide / corrompu → message d'erreur | | |
+| 17 | Retry logic (1 tentative, 1000ms) | | |
+| 18 | Métriques globales d'import | | |
+
+---
+
+## Talents
+
+| # | Scénario | ✅/❌/⏭️ | Notes |
+|---|----------|----------|-------|
+| 1 | Onglet Talents (signature, actifs, passifs) | | |
+| 2 | Drag & drop d'un talent sur la fiche | | |
+| 3 | Ouverture de l'arbre de talents (canvas PIXI) | | |
+| 4 | Panoramique (clic droit glissé) | | |
+| 5 | Zoom (molette) | | |
+| 6 | Clic sur noeud → roue de choix | | |
+| 7 | Hover → HUD avec prérequis | | |
+| 8 | Achat d'un talent (clic gauche dans la roue) | | |
+| 9 | Connexions entre noeuds achetés | | |
+| 10 | Suppression d'un talent (clic droit → confirm) | | |
+| 11 | Blocage en chaîne des prérequis | | |
+| 12 | Talent ranked : achat de rangs multiples | | |
+| 13 | Talent passif → effet appliqué automatiquement | | |
+| 14 | Talent actif → action disponible | | |
+| 15 | Sons (click1-5.wav) | | |
+| 16 | Fermeture de l'arbre → fiche restaurée | | |
+| 17 | Persistance après F5 | | |
+
+---
+
+## Équipement
+
+| # | Scénario | ✅/❌/⏭️ | Notes |
+|---|----------|----------|-------|
+| 1 | Création d'une arme (weapon) | | |
+| 2 | Configuration des qualités d'arme (30 qualités) | | |
+| 3 | Création d'une armure (armor) | | |
+| 4 | Propriétés d'armure (bulky, organic, sealed, full-body) | | |
+| 5 | Création d'un équipement (gear) | | |
+| 6 | Drag & drop dans l'inventaire | | |
+| 7 | Toggle equip (arme/armure) | | |
+| 8 | Encombrement total | | |
+| 9 | Qualité (shoddy → masterwork) | | |
+| 10 | Enchantement (mundane → legendary) | | |
+| 11 | Hard points | | |
+| 12 | Niveau de restriction (none → illegal) | | |
+| 13 | Item broken → bonus désactivés | | |
+| 14 | Actions liées à l'équipement | | |
+
+---
+
+## Véhicules
+
+| # | Scénario | ✅/❌/⏭️ | Notes |
+|---|----------|----------|-------|
+| 1 | Création d'un adversaire configuré comme véhicule | | |
+| 2 | Armes de catégorie vehicle | | |
+| 3 | Combat de véhicule (attaque/défense) | | |
+| 4 | Compétence gunnery | | |
+
+---
+
+## UI Sheets
+
+| # | Scénario | ✅/❌/⏭️ | Notes |
+|---|----------|----------|-------|
+| 1 | CharacterSheet : 8 tabs, header, sidebar | | |
+| 2 | AdversarySheet : pas d'engagements, caracs simplifiées | | |
+| 3 | WeaponSheet (V1) : skill, range, damage, crit, qualities | | |
+| 4 | ArmorSheet (V2) : defense, soak, qualities | | |
+| 5 | GearSheet (V1) : category, price, encumbrance, broken | | |
+| 6 | TalentSheet (V1) : node, ranked, activation, actions | | |
+| 7 | SpeciesSheet (V1) : 6 caracs, thresholds, XP, free skills | | |
+| 8 | CareerSheet (V1) : careerSkills, freeSkillRank | | |
+| 9 | SpecializationSheet (V1) : skills, freeSkillRank | | |
+| 10 | ObligationSheet / DutySheet (V1) | | |
+| 11 | JournalSheet (V2) + SkillPageSheet (V2) | | |
+| 12 | Navigation entre tabs | | |
+| 13 | Drag & drop de tous les types d'items | | |
+| 14 | Boutons d'action sur les items (favorite, edit, use, equip, delete) | | |
+| 15 | Redimensionnement à 1024×768 | | |
+| 16 | Responsive : 1920×1080, 1366×768, 1024×768 | | |
+| 17 | StandardCheckDialog (difficulté, boon/bane, roll mode) | | |
+| 18 | ActionUseDialog (template targeting, cibles) | | |
+| 19 | Token HUD (wounds, strain, pips) | | |
+| 20 | Combat Tracker sidebar | | |
+| 21 | i18n : basculer français/anglais | | |
+| 22 | Performance : ouverture fiche chargée < 1s | | |
+
+---
+
+## Résumé
+
+| Famille | Total | ✅ | ❌ | ⏭️ |
+|---------|-------|----|----|-----|
+| Personnage | 24 | | | |
+| Combat | 22 | | | |
+| Dés narratifs | 17 | | | |
+| Import OggDude | 18 | | | |
+| Talents | 17 | | | |
+| Équipement | 14 | | | |
+| Véhicules | 4 | | | |
+| UI Sheets | 22 | | | |
+| **Total** | **138** | | | |
+
+---
+
+**Testeur :** _____________  **Date :** _____________  **Version système :** _____________

--- a/documentation/tests/manuel/README.md
+++ b/documentation/tests/manuel/README.md
@@ -1,0 +1,67 @@
+# Tests manuels — Index
+
+Ce dossier contient les scénarios de tests manuels organisés par fonctionnalité du système **Star Wars Edge RPG (SWERPG)** pour Foundry VTT.
+
+Chaque sous-dossier détaille les actions à effectuer et les résultats attendus sous forme de tableaux Action → Résultat.
+
+---
+
+## Familles de tests
+
+| Famille | Description | Pages |
+|---------|-------------|-------|
+| [Personnage](personnage/README.md) | Création, espèces, carrières, spécialisations, caractéristiques, compétences, ressources, XP, audit log | ~30 scénarios |
+| [Combat](combat/README.md) | Tours, attaque/défense, dégâts, résistances, effets de statut (23), DOT (13), héroïsme | ~35 scénarios |
+| [Dés narratifs](des-narratifs/README.md) | StandardCheck, AttackRoll, pools boon/bane, dialogs, chat, socket | ~25 scénarios |
+| [Import OggDude](import-oggdude/README.md) | Pipeline ZIP → parsing → mapping (11 domaines), stockage, erreurs | ~30 scénarios |
+| [Talents](talents/README.md) | Arbre de talents (canvas PIXI), achat/suppression, ranked, hooks | ~20 scénarios |
+| [Équipement](equipement/README.md) | Armes (7 catégories, 30 qualités), armures (5 catégories), gear, hard points | ~25 scénarios |
+| [Véhicules](vehicules/README.md) | Adversary comme véhicule, armes vehicle, combat (partiellement implémenté) | ~10 scénarios |
+| [UI Sheets](ui-sheets/README.md) | Sheets V1/V2, tabs, drag & drop, responsive, i18n, performances | ~30 scénarios |
+
+---
+
+## Résumé des counts
+
+| Métrique | Valeur |
+|----------|--------|
+| Familles de test | 8 |
+| Total scénarios documentés | ~200 |
+| Statuts couverts | 23 |
+| Types de dégâts | 12 |
+| Qualités d'arme | 30 |
+| Domaines d'import OggDude | 11 |
+| Templates HBS | 56 |
+
+---
+
+## Comment utiliser ces documents
+
+1. **Préparer un environnement de test** : monde Foundry avec le système `swerpg` activé, quelques acteurs et items de test.
+2. **Choisir une famille** : sélectionner la fonctionnalité à tester.
+3. **Suivre les tableaux** : chaque ligne est une action → résultat attendu.
+4. **Cocher au fur et à mesure** : utiliser la [grille de test rapide](GRILLE_TEST_RAPIDE.md) pour le suivi.
+5. **Signaler les anomalies** : toute différence entre le résultat attendu et le résultat observé est un bug à reporter.
+
+---
+
+## Environnement de test recommandé
+
+- **Foundry VTT** v13+ (compatible jusqu'à v14)
+- **Navigateurs** : Chrome/Chromium (primaire), Firefox (secondaire)
+- **Résolutions** : 1920×1080 et 1366×768 minimum
+- **Mode** : GM (la plupart des tests nécessitent les droits GM)
+- **Build** : `pnpm run rollup && pnpm run less` avant de tester
+
+---
+
+## Guide de signalement d'anomalie
+
+Toute anomalie constatée doit être signalée avec :
+
+1. **Famille et scénario** : ex. "Personnage > 5.1 Augmentation de caractéristique"
+2. **Action effectuée** : ce qui a été fait
+3. **Résultat attendu** : ce qui devrait se produire
+4. **Résultat observé** : ce qui s'est réellement produit
+5. **Environnement** : navigateur, résolution, version du système
+6. **Logs** : captures d'écran et/ou messages de la console développeur (F12)

--- a/documentation/tests/manuel/README.md
+++ b/documentation/tests/manuel/README.md
@@ -10,6 +10,7 @@ Chaque sous-dossier détaille les actions à effectuer et les résultats attendu
 
 | Famille | Description | Pages |
 |---------|-------------|-------|
+| [Audit Log](audit-log/README.md) | Hooks, entrées (skill/carac/XP/talents), snapshot, résilience, éviction FIFO | ~25 scénarios |
 | [Personnage](personnage/README.md) | Création, espèces, carrières, spécialisations, caractéristiques, compétences, ressources, XP, audit log | ~30 scénarios |
 | [Combat](combat/README.md) | Tours, attaque/défense, dégâts, résistances, effets de statut (23), DOT (13), héroïsme | ~35 scénarios |
 | [Dés narratifs](des-narratifs/README.md) | StandardCheck, AttackRoll, pools boon/bane, dialogs, chat, socket | ~25 scénarios |
@@ -25,8 +26,8 @@ Chaque sous-dossier détaille les actions à effectuer et les résultats attendu
 
 | Métrique | Valeur |
 |----------|--------|
-| Familles de test | 8 |
-| Total scénarios documentés | ~200 |
+| Familles de test | 9 |
+| Total scénarios documentés | ~225 |
 | Statuts couverts | 23 |
 | Types de dégâts | 12 |
 | Qualités d'arme | 30 |

--- a/documentation/tests/manuel/audit-log/README.md
+++ b/documentation/tests/manuel/audit-log/README.md
@@ -1,0 +1,227 @@
+# Tests manuels — Audit Log
+
+Tests du système de journalisation d'évolution du personnage (Character Audit Log).  
+Ce système intercepte les modifications des acteurs `character` via des hooks Foundry et enregistre des entrées structurées dans `actor.flags.swerpg.logs`.
+
+---
+
+## Prérequis
+
+- Monde SWERPG créé et système `swerpg` activé
+- Droits GM pour ouvrir la console développeur (F12)
+- Un personnage `character` avec espèces/carrière/spécialisations appliquées
+- Build à jour : `pnpm run rollup && pnpm run less`
+
+---
+
+## 1. Vérification de base
+
+### 1.1. Lecture des logs
+
+| Action | Résultat attendu |
+|--------|------------------|
+| Ouvrir la console développeur (F12) | Console visible |
+| Sélectionner le personnage dans le répertoire des acteurs | Acteur sélectionné |
+| Exécuter dans la console : `game.actors.getName("NomDuPJ").flags.swerpg.logs` | Un tableau (vide si aucun log) ou la liste des entrées existantes |
+| Vérifier la structure d'une entrée | Chaque entrée contient : `id`, `schemaVersion`, `timestamp`, `userId`, `userName`, `type`, `data`, `xpDelta`, `snapshot` |
+
+### 1.2. Vérification de l'enregistrement des hooks
+
+| Action | Résultat attendu |
+|--------|------------------|
+| Exécuter dans la console : `Hooks.events` | Rechercher `preUpdateActor`, `updateActor`, `createItem` dans la liste |
+| Vérifier que les 3 hooks sont actifs | Les hooks sont bien enregistrés par le système |
+
+---
+
+## 2. Compétences
+
+### 2.1. Achat de rang (skill.train)
+
+| Action | Résultat attendu |
+|--------|------------------|
+| Ouvrir la fiche du personnage, onglet Compétences | Onglet visible |
+| Cliquer sur le "+" d'une compétence de carrière (ex: Cool) | Le rang augmente, l'XP est déduite |
+| Vérifier l'audit log : `flags.swerpg.logs` | Une entrée `skill.train` est créée |
+| Vérifier les champs : `skillId`, `oldRank`, `newRank`, `cost`, `isCareer`, `isFree` | Tous les champs sont présents et cohérents |
+| Vérifier `xpDelta` = -cost | Le delta correspond au coût négatif |
+
+### 2.2. Achat de rang hors carrière
+
+| Action | Résultat attendu |
+|--------|------------------|
+| Acheter un rang sur une compétence NON carrière | Le coût est plus élevé (rang × 5 + 5) |
+| Vérifier l'entrée `skill.train` | `isCareer` = false, le `cost` reflète le surcoût |
+
+### 2.3. Rang gratuit (isFree)
+
+| Action | Résultat attendu |
+|--------|------------------|
+| Utiliser un rang gratuit carrière sur une compétence de carrière | Le rang `careerFree` augmente, aucune XP déduite |
+| Vérifier l'entrée `skill.train` | `isFree` = true, `cost` = 0, `xpDelta` = 0 |
+
+### 2.4. Oubli de rang (skill.forget)
+
+| Action | Résultat attendu |
+|--------|------------------|
+| Cliquer sur le "-" d'une compétence avec des rangs achetés | Le rang diminue, l'XP est remboursée |
+| Vérifier l'audit log | Une entrée `skill.forget` est créée |
+| Vérifier `xpDelta` positif | Le montant remboursé est créditeur |
+
+---
+
+## 3. Caractéristiques
+
+### 3.1. Augmentation (characteristic.increase)
+
+| Action | Résultat attendu |
+|--------|------------------|
+| Cliquer sur le "+" d'une caractéristique (ex: Brawn) | La valeur augmente, coût = nouvelle valeur × 10 XP |
+| Vérifier l'audit log | Une entrée `characteristic.increase` est créée |
+| Vérifier les champs : `characteristicId`, `oldValue`, `newValue`, `cost` | Les données correspondent |
+| Vérifier `xpDelta` = -cost | Le delta est négatif (dépense) |
+
+---
+
+## 4. XP
+
+### 4.1. Dépense d'XP (xp.spend)
+
+| Action | Résultat attendu |
+|--------|------------------|
+| Acheter une compétence ou une caractéristique | `system.progression.experience.spent` augmente |
+| Vérifier l'audit log | Une entrée `xp.spend` peut être créée (si pas déjà couverte par skill.train) |
+
+### 4.2. Gain d'XP (xp.grant)
+
+| Action | Résultat attendu |
+|--------|------------------|
+| Accorder de l'XP via un script : `actor.update({"system.progression.experience.gained": valeur})` | `gained` augmente |
+| Vérifier l'audit log | Une entrée `xp.grant` est créée avec `amount` positif |
+| Vérifier `xpDelta` = +amount | Le delta est positif (gain) |
+
+### 4.3. Remboursement d'XP (xp.refund)
+
+| Action | Résultat attendu |
+|--------|------------------|
+| Oublier un rang de compétence | `spent` diminue du remboursement |
+| Vérifier l'audit log | Une entrée `xp.refund` est créée (si le changement XP est pur, sans skill associé) |
+
+---
+
+## 5. Détails
+
+### 5.1. Changement d'espèce (species.set)
+
+| Action | Résultat attendu |
+|--------|------------------|
+| Glisser une nouvelle espèce sur la fiche | L'espèce est remplacée |
+| Vérifier l'audit log | Une entrée `species.set` est créée |
+| Vérifier `data.oldSpecies` et `data.newSpecies` | Les valeurs avant/après sont correctes |
+
+### 5.2. Changement de carrière (career.set)
+
+| Action | Résultat attendu |
+|--------|------------------|
+| Glisser une nouvelle carrière sur la fiche | La carrière est remplacée |
+| Vérifier l'audit log | Une entrée `career.set` est créée |
+| Vérifier `data.oldCareer` et `data.newCareer` | Les valeurs avant/après sont correctes |
+
+---
+
+## 6. Avancement
+
+### 6.1. Changement de niveau (advancement.level)
+
+| Action | Résultat attendu |
+|--------|------------------|
+| Modifier `actor.update({"system.advancement.level": 2})` depuis la console | Le niveau change |
+| Vérifier l'audit log | Une entrée `advancement.level` est créée |
+| Vérifier `data.oldLevel` et `data.newLevel` | Les niveaux avant/après sont corrects |
+
+---
+
+## 7. Talents
+
+### 7.1. Achat de talent (talent.purchase)
+
+| Action | Résultat attendu |
+|--------|------------------|
+| Ajouter un item de type `talent` au personnage (drag & drop depuis un compendium) | Le talent est ajouté |
+| Vérifier l'audit log | Une entrée `talent.purchase` est créée |
+| Vérifier les champs : `talentId`, `talentName`, `cost`, `ranks` | Les données correspondent au talent ajouté |
+| Vérifier `xpDelta` = -cost | Le delta est négatif (dépense) |
+
+### 7.2. Item non-talent ignoré
+
+| Action | Résultat attendu |
+|--------|------------------|
+| Ajouter un item de type `weapon` ou `gear` au personnage | L'item est ajouté |
+| Vérifier l'audit log | Aucune entrée `talent.purchase` créée (les items non-talent sont ignorés) |
+
+---
+
+## 8. Snapshot XP
+
+### 8.1. Vérification du snapshot dans une entrée
+
+| Action | Résultat attendu |
+|--------|------------------|
+| Effectuer une action qui génère un log (ex: acheter une compétence) | Une entrée est créée |
+| Inspecter `entry.snapshot` dans la console | Le snapshot contient : `xpAvailable`, `totalXpSpent`, `totalXpGained`, `careerFreeAvailable`, `specializationFreeAvailable` |
+| Vérifier la cohérence | `xpAvailable` = `totalXpGained` - `totalXpSpent` (ou valeur stockée) |
+
+---
+
+## 9. Limite et éviction FIFO
+
+### 9.1. Taille max par défaut (500)
+
+| Action | Résultat attendu |
+|--------|------------------|
+| Remplir le log avec 500+ entrées (script : boucle d'update avec des modifications mineures) | Le log ne dépasse pas 500 entrées |
+| Vérifier que les plus anciennes sont supprimées | Les premières entrées (timestamp le plus bas) disparaissent |
+
+### 9.2. Taille max configurable via setting
+
+| Action | Résultat attendu |
+|--------|------------------|
+| Modifier le setting : `game.settings.set("swerpg", "auditLogMaxEntries", 100)` | La limite est abaissée à 100 |
+| Déclencher une nouvelle entrée | Si le log a déjà 100+ entrées, les plus anciennes sont évincées |
+| Restaurer la valeur par défaut : `game.settings.set("swerpg", "auditLogMaxEntries", 500)` | Limite restaurée |
+
+---
+
+## 10. Résilience
+
+### 10.1. Erreur d'écriture simulée
+
+| Action | Résultat attendu |
+|--------|------------------|
+| (Test indirect) Forcer une erreur en désactivant les permissions d'écriture sur l'acteur (via un module externe) | L'action utilisateur n'est PAS bloquée |
+| Vérifier la console développeur | Un message `logger.error` est émis par le système d'audit |
+| Vérifier la notification UI | `ui.notifications.warn` est affiché |
+| Si l'utilisateur est GM : vérifier le message chuchoté | Un whisper GM est envoyé avec les détails de l'erreur |
+
+---
+
+## 11. Scénario de bout en bout
+
+| Action | Résultat attendu |
+|--------|------------------|
+| Créer un nouveau personnage `character` | La fiche s'ouvre |
+| Appliquer une espèce (drag & drop) | Entrée `species.set` créée |
+| Appliquer une carrière (drag & drop) | Entrée `career.set` créée |
+| Appliquer une spécialisation (drag & drop) | Entrée `specialization.add` créée |
+| Acheter 3 rangs de compétence (dont 1 gratuit) | 3 entrées `skill.train` créées |
+| Augmenter une caractéristique de 2→3 | Entrée `characteristic.increase` créée |
+| Ajouter un talent (drag & drop) | Entrée `talent.purchase` créée |
+| Vérifier le nombre total d'entrées dans `flags.swerpg.logs` | Au moins 8 entrées (species + career + spec + 3 skills + carac + talent) |
+| Vérifier que `xpDelta` cumulé = `totalXpSpent` final | La somme des `xpDelta` de toutes les entrées correspond à la dépense totale |
+
+---
+
+## 12. Gap connu
+
+Les entrées `specialization.remove` ne peuvent pas être testées facilement via l'UI car la suppression d'une spécialisation n'est pas encore exposée dans l'interface.  
+Les entrées `xp.remove` (diminution de `gained`) ne se produisent pas dans l'UI standard — uniquement via script direct.

--- a/documentation/tests/manuel/combat/README.md
+++ b/documentation/tests/manuel/combat/README.md
@@ -1,0 +1,269 @@
+# Tests manuels — Combat
+
+Test du système de combat : attaque, défense, dégâts, résistances, effets de statut, tour de combat et ressources.
+
+---
+
+## Prérequis
+
+- Au moins 2 acteurs dans la scène (un PJ ou adversary attaquant, une cible)
+- Une arme équipée sur l'attaquant
+- Optionnel : token avec barres wounds/strain visibles
+
+---
+
+## 1. Tour de combat
+
+### 1.1. Initialisation
+
+| Action | Résultat attendu |
+|--------|------------------|
+| Ouvrir le combat tracker (`SwerpgCombatTracker`) | La fenêtre latérale du combat s'affiche |
+| Cliquer "Démarrer le combat" | L'initiative est rollée pour chaque participant |
+| Vérifier l'ordre d'initiative | Les participants sont triés par initiative décroissante |
+| Vérifier que le premier combattant est actif | Son tour est marqué visuellement |
+
+### 1.2. Déroulement d'un tour
+
+| Action | Résultat attendu |
+|--------|------------------|
+| Cliquer "Tour suivant" → `onStartTurn()` est appelé | Les effets expirent, les ressources sont récupérées |
+| Vérifier la récupération de ressources | `wounds.value`, `strain.value` ajustés selon les règles |
+| Vérifier l'application des DOT (bleeding, burning...) | Les dégâts sur durée sont appliqués |
+
+### 1.3. Fin de tour
+
+| Action | Résultat attendu |
+|--------|------------------|
+| Cliquer "Fin de tour" → `onEndTurn()` est appelé | Les effets de fin de tour s'appliquent |
+| Vérifier la capacité "Conserve Effort" si applicable | Les ressources sont gérées selon le talent |
+| Vérifier l'expiration des effets basés sur le tour | Les effets "jusqu'à la fin du tour" disparaissent |
+
+### 1.4. Action Delay
+
+| Action | Résultat attendu |
+|--------|------------------|
+| Utiliser l'action "Delay" sur un personnage | L'initiative du personnage passe à une valeur inférieure |
+| Vérifier que le personnage est replacé dans l'ordre d'initiative | Sa nouvelle position reflète l'initiative réduite |
+
+### 1.5. Leave Combat
+
+| Action | Résultat attendu |
+|--------|------------------|
+| Retirer un personnage du combat | `onLeaveCombat()` est appelé, nettoyage effectué |
+| Vérifier que les effets temporaires sont nettoyés | Aucun état résiduel |
+
+---
+
+## 2. Attaque
+
+### 2.1. Attaque armée (weaponAttack)
+
+| Action | Résultat attendu |
+|--------|------------------|
+| Sélectionner l'attaquant, cliquer sur une action d'attaque | `weaponAttack(action, target, weapon)` est invoqué |
+| Vérifier que `prepareStandardCheck` est hooké | Le check standard est préparé avec les bons paramètres |
+| Vérifier que `prepareWeaponAttack` est hooké | Les modificateurs de l'arme sont inclus |
+| Vérifier que `defendWeaponAttack` est hooké sur la cible | La défense de la cible est testée |
+
+### 2.2. Attaque de compétence (skillAttack)
+
+| Action | Résultat attendu |
+|--------|------------------|
+| Utiliser `skillAttack(action, target)` | L'attaque utilise la compétence comme base |
+| Vérifier que le pool de dés est correct | Compétence + caractéristique associée |
+
+### 2.3. Jets de défense (testDefense)
+
+| Action | Résultat attendu |
+|--------|------------------|
+| Attaquer une cible → la défense est testée | `testDefense(defenseType, roll)` est appelé |
+| Vérifier les types de défense physique : esquive (dodge), parade (parry), blocage (block), armure (armor), ricochet (glance), touché (hit) | Le type de défense utilisé est conforme à l'arme et à la cible |
+| Vérifier les défenses basées sur les compétences | Les compétences de défense sont utilisées si applicable |
+
+### 2.4. Résultat d'attaque (AttackRoll RESULT_TYPES)
+
+| Action | Résultat attendu |
+|--------|------------------|
+| Attaquer une cible sans défense → MISS(0) | L'attaque manque |
+| Cible avec esquive → DODGE(1) | Message "Esquivé" |
+| Cible avec parade → PARRY(2) | Message "Paré" |
+| Cible avec blocage → BLOCK(3) | Message "Bloqué" |
+| Cible avec armure → ARMOR(4) ou RESIST(5) | Dégâts réduits par l'armure |
+| Cible touchée → HIT(7) | Dégâts pleins appliqués |
+
+### 2.5. Calcul des dégâts
+
+| Action | Résultat attendu |
+|--------|------------------|
+| Vérifier la formule de dégâts : `overflow * multiplier + base + bonus - resistance` | Le nombre final est cohérent |
+| `overflow = totalRoll - DC` | Le surplus au-dessus du DC est ajouté aux dégâts |
+| Dégâts clampés entre 1 et `2 * preMitigation` | Minimum 1 dégât, maximum double des dégâts avant réduction |
+
+---
+
+## 3. Ciblage et modificateurs
+
+### 3.1. Boons/Banes de cible (applyTargetBoons)
+
+| Action | Résultat attendu |
+|--------|------------------|
+| Cible `Guarded` → l'attaque recoit un bane | `applyTargetBoons` ajoute un bane pour la garde |
+| Cible `Prone` → modificateur selon la portée | À courte portée : boon, à longue portée : bane |
+| Cible `Flanked` → boon pour l'attaquant | `commitFlanking(engagement)` active le flanking |
+
+### 3.2. Distance et portée
+
+| Action | Résultat attendu |
+|--------|------------------|
+| Arme de portée "Engaged" → ne peut cibler qu'à portée de contact | Vérifier la validation |
+| Arme de portée "Short" → peut cibler jusqu'à courte distance | Fonctionne |
+| Arme de portée "Extreme" → peut cibler à très longue distance | Fonctionne |
+
+---
+
+## 4. Résistances et types de dégâts
+
+### 4.1. Résistance aux dégâts
+
+| Action | Résultat attendu |
+|--------|------------------|
+| `getResistance(resource, damageType, restoration)` | La résistance est calculée |
+| Vérifier les modificateurs : `isBroken` → résistance réduite, `isWeakened` → résistance réduite | Les statuts affectent la résistance |
+| Vérifier les 12 types de dégâts : bludgeoning, piercing, slashing, poison, acid, fire, cold, electricity, psychic, radiant, void, corruption | Chaque type est traité correctement |
+
+### 4.2. Résistance par type
+
+| Action | Résultat attendu |
+|--------|------------------|
+| Attaque feu sur une cible avec résistance au feu | Les dégâts sont réduits de la valeur de résistance |
+| Attaque feu sur une cible sans résistance | Dégâts pleins |
+| Attaque physique sur une cible avec armure | L'armure s'applique |
+
+---
+
+## 5. Effets de statut
+
+### 5.1. Application via ActionOutcome
+
+| Action | Résultat attendu |
+|--------|------------------|
+| `applyActionOutcome(action, outcome, options)` | L'effet de l'action est appliqué |
+| Vérifier `_applyOutcomeEffects(outcome, reverse)` | Les ActiveEffects sont créés/mis à jour/supprimés |
+
+### 5.2. Statuts disponibles (23)
+
+| Statut | Test |
+|--------|------|
+| **weakened** | Appliquer → `isWeakened` = true, dégâts réduits |
+| **dead** | Blessures critiques → `isDead` = true, token marqué mort |
+| **broken** | Appliquer → `isBroken` = true |
+| **insane** | Appliquer → `isInsane` = true |
+| **incapacitated** | Fatigue excessive → `isIncapacitated` = true |
+| **staggered** | Appliquer → limite 1 action par tour |
+| **stunned** | Appliquer → aucune action possible |
+| **prone** | Appliquer → modificateurs d'attaque (boon à courte portée, bane à longue) |
+| **restrained** | Appliquer → immobilisé |
+| **slowed / hastened** | Appliquer → modificateur de vitesse |
+| **disoriented** | Appliquer → malus aux tests |
+| **blinded / deafened / silenced** | Appliquer → pénalités sensorielles |
+| **enraged / frightened** | Appliquer → modificateurs moraux |
+| **invisible** | Appliquer → bonus en attaque |
+| **resolute** | Appliquer → bonus en défense morale |
+| **guarded** | Appliquer → `isGuarded` = true, bane à l'attaque |
+| **exposed** | Appliquer → bonus à l'attaque adverse |
+| **flanked** | `commitFlanking(engagement)` → `isFlanked` = true |
+| **diseased / paralyzed** | Appliquer → effets de maladie/paralysie |
+
+### 5.3. Points de vie à zéro
+
+| Action | Résultat attendu |
+|--------|------------------|
+| `wounds.value >= wounds.threshold` → `isKnockedOut` = true | KO |
+| `wounds.value >= wounds.threshold × 2` → `isDead` = true | Mort |
+| `isL0` via statut | Niveau 0 (hors-combat) |
+
+---
+
+## 6. Dégâts sur durée (DOT)
+
+### 6.1. Application DOT
+
+| Action | Résultat attendu |
+|--------|------------------|
+| Appliquer un effet `bleeding` via ActiveEffect | `applyDamageOverTime()` l'applique au début du tour |
+| Appliquer `burning` | Dégâts de feu appliqués chaque tour |
+
+### 6.2. Types DOT disponibles
+
+bleeding, burning, chilled, confusion, corroding, decay, entropy, irradiated, mended, inspired, poisoned, shocked, staggered
+
+| Action | Résultat attendu |
+|--------|------------------|
+| Appliquer chaque type de DOT | Vérifier que l'effet DOT est bien actif |
+| Vérifier l'expiration au début du tour (`expireEffects(start)`) | Les effets basés sur le tour expirent |
+| Vérifier l'expiration en fin de tour (`expireEffects()`) | Les effets "jusqu'à fin de tour" expirent |
+
+---
+
+## 7. Héroïsme
+
+| Action | Résultat attendu |
+|--------|------------------|
+| `_trackHeroismDamage(resources, reverse)` | Le score d'héroïsme (`settings.heroism`) est mis à jour |
+| Vérifier que le score peut être dépensé | Les actions avec coût en heroism fonctionnent |
+
+---
+
+## 8. Ressources en combat
+
+### 8.1. Actions
+
+| Action | Résultat attendu |
+|--------|------------------|
+| `resources.action.value` → chaque action dépense une action | Le compteur d'actions décrémente |
+| `resources.action.threshold` → nombre d'actions par tour | Défini par le type de personnage |
+
+### 8.2. Focus
+
+| Action | Résultat attendu |
+|--------|------------------|
+| Vérifier le coût en focus des actions | Les actions avec focus cost consomment du focus |
+| Les pips de focus sur le token sont mis à jour | Affichage correct |
+
+---
+
+## 9. Actions spéciales
+
+### 9.1. castSpell
+
+| Action | Résultat attendu |
+|--------|------------------|
+| Tenter `castSpell(action, target)` | Erreur "not yet implemented" (non implémenté) |
+
+### 9.2. useAction
+
+| Action | Résultat attendu |
+|--------|------------------|
+| `useAction(actionId, options)` | L'action est utilisée selon son ID |
+
+---
+
+## 10. Gestion des ressources via `modifyResource`
+
+| Action | Résultat attendu |
+|--------|------------------|
+| `modifyResource(resourceId, delta)` | La ressource est modifiée du montant delta |
+| Vérifier les ressources : wounds, strain, encumbrance, action | Chaque ressource réagit correctement |
+
+---
+
+## 11. Scénarios de régression
+
+- Combat complet : dérouler 3+ tours avec attaques, dégâts, guérison, et vérifier que tous les compteurs sont corrects.
+- Combat avec effets de statut : appliquer Guarded, Prone, Flanked → vérifier les boons/banes.
+- Combat avec DOT : appliquer Bleeding → vérifier les dégâts au début de chaque tour.
+- Combat avec Delay : utiliser Delay → vérifier le repositionnement dans l'ordre d'initiative.
+- Combat multi-cibles : attaquer avec une AOE → vérifier que toutes les cibles sont touchées.
+- Combat et mort : amener un personnage à 0 wounds → vérifier `isKnockedOut` puis `isDead`.
+- Combat et héroïsme : dépenser des points d'héroïsme → vérifier le tracking.

--- a/documentation/tests/manuel/des-narratifs/README.md
+++ b/documentation/tests/manuel/des-narratifs/README.md
@@ -1,0 +1,206 @@
+# Tests manuels — Dés narratifs
+
+Tests du système de dés narratifs (StandardCheck, AttackRoll) : construction du pool, jets, résultats, dialog et rendu chat.
+
+---
+
+## Prérequis
+
+- Personnage avec des caractéristiques et compétences définies
+- Optionnel : arme équipée pour tester AttackRoll
+- Acteur avec des actions configurées
+
+---
+
+## 1. StandardCheck — Jet de base
+
+### 1.1. Construction du pool de dés
+
+Le `StandardCheck` hérite de `Roll` Foundry.
+
+**Pool de base :** 3d8
+
+| Action | Résultat attendu |
+|--------|------------------|
+| Construire un StandardCheck sans modificateur | Pool = 3d8 |
+| Appliquer 1 boon (augmente un dé de +2 steps) | Un d8 passe en d10 |
+| Appliquer 2 boons | Deux d8 passent en d10, ou un d8 en d12 |
+| Appliquer 1 bane | Un d8 descend en d6 |
+| Appliquer 2 banes | Un d8 descend en d4, ou deux en d6 |
+| Boons appliqués Left-To-Right (d'abord les dés les plus faibles) | Ordre correct |
+| Banes appliqués Right-To-Left (d'abord les dés les plus forts) | Ordre correct |
+
+### 1.2. Limites de boons/banes
+
+| Action | Résultat attendu |
+|--------|------------------|
+| Appliquer 6 boons maximum | Au-delà, les boons supplémentaires sont ignorés |
+| Appliquer 6 banes maximum | Au-delà, les banes sont ignorés |
+| Pool minimum : `minDie = 4` (d4) | Aucun dé ne descend sous d4 |
+| Pool maximum : `maxDie = 12` (d12) | Aucun dé ne dépasse d12 |
+| Boon/Bane step : 2 | Step fixe de 2 (d8 → d10, d8 → d6) |
+
+### 1.3. Jet final
+
+| Action | Résultat attendu |
+|--------|------------------|
+| Vérifier le total : `pool dice + ability bonus + skill bonus + enchantment bonus` | Total correct |
+| `ability = valeur de caractéristique (0-12)` | Ajouté |
+| `skill = rang de compétence (-4 à 12)` | Ajouté |
+| `enchantment = bonus d'enchantement (0-6)` | Ajouté |
+
+### 1.4. Seuils de difficulté
+
+| Action | Résultat attendu |
+|--------|------------------|
+| Chaque niveau de difficulté a un DC : Trivial(10), Easy(15), Moderate(20), Challenging(25), Difficult(30), Formidable(35), Impossible(45) | Le DC est correct pour chaque niveau |
+| Mode passif : `PassiveCheck = 10` | Vérifier le calcul passif |
+
+### 1.5. Résultats
+
+| Action | Résultat attendu |
+|--------|------------------|
+| `total > DC` → `isSuccess = true` | Succès |
+| `total > DC + 6` → `isCriticalSuccess = true` | Succès critique |
+| `total <= DC` → `isFailure = true` | Échec |
+| `total < DC - 6` → `isCriticalFailure = true` | Échec critique |
+
+---
+
+## 2. AttackRoll — Jet d'attaque
+
+### 2.1. Pool étendu
+
+| Action | Résultat attendu |
+|--------|------------------|
+| `AttackRoll` étend `StandardCheck` | Même mécanismes que StandardCheck |
+| Attributs supplémentaires : `target`, `defenseType`, `result` | Présents dans le roll |
+| `result` est un type de `RESULT_TYPES` | MISS(0), DODGE(1), PARRY(2), BLOCK(3), ARMOR(4), RESIST(5), GLANCE(6), HIT(7) |
+
+### 2.2. Calcul des dégâts
+
+| Action | Résultat attendu |
+|--------|------------------|
+| `overflow = total - DC` | Le surplus est calculé |
+| `damage = overflow * multiplier + base + bonus - resistance` | Formule appliquée |
+| `overflow * multiplier` → bonus de réussite | Plus le jet est haut, plus les dégâts sont élevés |
+| Dégâts clampés entre 1 et `2 * preMitigation` | Minimum 1, maximum double avant réduction |
+
+---
+
+## 3. StandardCheckDialog — Dialogue de jet
+
+### 3.1. Ouverture
+
+| Action | Résultat attendu |
+|--------|------------------|
+| Déclencher un check standard (clic sur compétence ou action) | `StandardCheckDialog` s'ouvre |
+| Le dialogue est une sous-classe de `DialogV2` | Fenêtre Foundry standard |
+
+### 3.2. Configuration du jet
+
+| Action | Résultat attendu |
+|--------|------------------|
+| Sélecteur de niveau de difficulté | Trivial → Impossible (7 niveaux) |
+| Saisie manuelle du DC | Champ DC éditable |
+| Boutons Boon/Bane (+/-, jusqu'à 6 chaque) | Les valeurs s'incrémentent/décrémentent |
+| Roll Mode : public, gm, blind, self | Le mode choisi est appliqué |
+
+### 3.3. Boutons d'action
+
+| Action | Résultat attendu |
+|--------|------------------|
+| Cliquer "Roll" | Le jet est effectué et affiché dans le chat |
+| Cliquer "Request" | Une demande de jet est envoyée (socket) |
+
+---
+
+## 4. ActionUseDialog — Dialogue d'utilisation d'action
+
+### 4.1. Ciblage
+
+| Action | Résultat attendu |
+|--------|------------------|
+| `ActionUseDialog` étend `StandardCheckDialog` | Mêmes fonctionnalités que le check standard |
+| Template targeting : cône, cercle, rayon, rectangle pour les AOE | Les gabarits sont plaçables |
+| Bouton "Place Template" pour les AOE | Le template apparaît sur la scène |
+
+### 4.2. Liste de cibles
+
+| Action | Résultat attendu |
+|--------|------------------|
+| La liste des cibles s'affiche dans le dialogue | Les tokens sélectionnés sont listés |
+| Les cibles invalides (hors portée) sont signalées | Tooltip d'erreur sur les cibles hors-limite |
+
+### 4.3. Tags de contexte
+
+| Action | Résultat attendu |
+|--------|------------------|
+| Les tags d'activation et de contexte de l'action sont affichés | Tags visibles (30+ définis) |
+
+---
+
+## 5. Affichage dans le chat
+
+### 5.1. Rendu du jet
+
+| Action | Résultat attendu |
+|--------|------------------|
+| Template `standard-check-chat.hbs` | Carte de jet affichée dans le chat |
+| Template `action-use-chat.hbs` | Carte d'action affichée |
+| Template `standard-check-roll.hbs` (partial) | Détails du roll |
+| Template `standard-check-details.hbs` (partial) | Détails supplémentaires |
+
+### 5.2. Informations affichées
+
+| Action | Résultat attendu |
+|--------|------------------|
+| Pool de dés (d8/d10/d12/d6/d4) | Visible dans la carte |
+| Total du jet | Visible |
+| DC | Visible |
+| Résultat Succès/Échec + Critique | Visible |
+| Boons/Banes appliqués | Visible |
+
+### 5.3. Confirmation d'action
+
+| Action | Résultat attendu |
+|--------|------------------|
+| Action non confirmée → indicateur visuel dans le chat | Badge "à confirmer" |
+| Touche de raccourci `KeyX` (confirm keybinding) → confirme l'action | L'état passe à "confirmé" |
+| `autoConfirm` setting : 0=none, 1=self, 2=all | Comportement de confirmation automatique |
+
+---
+
+## 6. Socket et multi-joueur
+
+### 6.1. Événements socket
+
+| Action | Résultat attendu |
+|--------|------------------|
+| `diceCheck` → `StandardCheck.handle(data)` | Le jet est traité côté MJ |
+| `diceContest` → stub | Non implémenté (attend développement) |
+| `diceGroupCheck` → stub | Non implémenté (attend développement) |
+
+### 6.2. Jet en mode GM
+
+| Action | Résultat attendu |
+|--------|------------------|
+| Lancer un jet en mode GM | Le résultat est visible par le MJ uniquement |
+| Lancer un jet en mode Blind | Le MJ voit le résultat, le joueur non |
+| Lancer un jet en mode Self | Seul le lanceur voit le résultat |
+
+---
+
+## 7. Scénarios de régression
+
+- Lancer un StandardCheck avec 0 boon/0 bane → vérifier 3d8.
+- Lancer avec 6 boons → vérifier que les dés sont tous en d12 (max).
+- Lancer avec 6 banes → vérifier que les dés sont tous en d4 (min).
+- Vérifier les seuils critiques : `DC + 6` = critique succès, `DC - 6` = critique échec.
+- Attaque avec une arme : vérifier les dégâts = `overflow * multiplier + base + bonus - resistance`.
+- Attaque avec overflow = 0 → vérifier que les dégâts sont au moins 1 (clamp min).
+- Ouvrir le dialogue StandardCheckDialog → vérifier le rendu du template.
+- Ouvrir ActionUseDialog avec une AOE → vérifier le bouton "Place Template".
+- Changer le roll mode dans le dialogue → vérifier que le mode est pris en compte.
+- Utiliser KeyX pour confirmer → vérifier que l'action est confirmée.
+- Lancer un jet en tant que joueur → vérifier que le résultat apparaît dans le chat.

--- a/documentation/tests/manuel/equipement/README.md
+++ b/documentation/tests/manuel/equipement/README.md
@@ -1,0 +1,246 @@
+# Tests manuels — Équipement
+
+Tests des items d'équipement : armes, armures, équipement général, encaissement, attaches/modifications.
+
+---
+
+## Prérequis
+
+- Personnage avec inventaire
+- Items de test disponibles : armes, armures, équipement divers
+
+---
+
+## 1. Types d'items d'équipement
+
+Le système SWERPG distingue 3 types d'équipement physique :
+
+| Type | Classe | Catégories |
+|------|--------|------------|
+| **weapon** | `SwerpgWeapon` | melee, ranged, gunnery, explosive, thrown, vehicle, natural |
+| **armor** | `SwerpgArmor` | unarmored, light, medium, heavy, natural |
+| **gear** | `SwerpgGear` | défini par `category` |
+
+---
+
+## 2. Création et configuration
+
+### 2.1. Création d'une arme
+
+| Action | Résultat attendu |
+|--------|------------------|
+| Créer un item de type `weapon` | L'item est créé, la `WeaponSheet` s'ouvre |
+| Configurer `skill` : rangedLight, rangedHeavy, gunnery, brawl, melee, lightSaber | La compétence est enregistrée |
+| Configurer `range` : engaged, short, medium, long, extreme | La portée est enregistrée |
+| Configurer `damage` (0-20) | Les dégâts de base sont définis |
+| Configurer `crit` (0-20) | Le seuil de critique est défini |
+| Configurer `hardPoints` (0+) | Points d'attache configurés |
+
+### 2.2. Qualités d'arme
+
+| Action | Résultat attendu |
+|--------|------------------|
+| Ouvrir le widget des qualités | La liste des 30 qualités est visible |
+| Activer `accurate` → définir le rang | `{ key: 'accurate', rank: 2, hasRank: true }` |
+| Activer `autoFire` (booléenne) | `{ key: 'autoFire', hasRank: false }` |
+| Activer `blast` → définir le rang | Qualité blast avec rang |
+| Vérifier les qualités avec `hasRank: true` : accurate, blast, breach, burn, concussive, cortosis, cumbersome, defensive, deflection, disorient, ensnare, guided, inaccurate, inferior, ion, knockdown, linked, pierce, prepare, slowFiring, stun, stunDamage, sunder, superior, tractor, unwieldy, twoHanded, vicious | Chaque qualité est correctement configurable |
+| Désactiver une qualité | La qualité n'est plus active |
+
+### 2.3. Création d'une armure
+
+| Action | Résultat attendu |
+|--------|------------------|
+| Créer un item de type `armor` | L'item est créé, la `ArmorSheet` s'ouvre |
+| Configurer `defense.base` (0+) | La défense de base est définie |
+| Configurer `soak.base` (0+) | L'encaissement est défini |
+| Configurer les propriétés : bulky, organic, sealed, full-body (0-4 propriétés) | Les propriétés sont actives |
+| Configurer `hardPoints` (0+) | Points d'attache configurables |
+
+### 2.4. Création d'un équipement
+
+| Action | Résultat attendu |
+|--------|------------------|
+| Créer un item de type `gear` | L'item est créé, la `GearSheet` s'ouvre |
+| Configurer `category` | La catégorie est choisie parmi `ITEM_CATEGORIES` |
+| Configurer `quantity` (0+, défaut 1) | Quantité enregistrée |
+| Configurer `price` | Prix défini |
+| Configurer `quality` : shoddy, standard, fine, superior, masterwork | Qualité définie avec modificateur correspondant |
+| Configurer `restrictionLevel` : none, restricted, military, illegal | Niveau de restriction défini |
+| Configurer `encumbrance` (0+, défaut 1) | Encombrement défini |
+| Configurer `rarity` (0+) | Rareté définie |
+| Marquer `broken` | L'item est marqué comme cassé |
+
+---
+
+## 3. Inventaire du personnage
+
+### 3.1. Onglet Inventaire
+
+| Action | Résultat attendu |
+|--------|------------------|
+| Ouvrir l'onglet Inventaire de la fiche | La liste de l'équipement s'affiche |
+| Vérifier les groupes : équipé et sac à dos | Les items sont répartis selon leur état `equipped` |
+
+### 3.2. Drag & drop dans l'inventaire
+
+| Action | Résultat attendu |
+|--------|------------------|
+| Glisser une arme du répertoire vers l'inventaire | L'arme apparaît dans l'inventaire |
+| Glisser une armure | L'armure apparaît |
+| Glisser un équipement | L'équipement apparaît |
+
+### 3.3. Equipement/Déséquipement
+
+| Action | Résultat attendu |
+|--------|------------------|
+| Cliquer sur le toggle equip d'une arme | `equipWeapon(item)` est appelé, `equipped` = true |
+| Cliquer à nouveau → déséquiper | `equipped` = false |
+| Équiper une armure | `equipArmor(item)` est appelé |
+| Vérifier que les bonus de l'armure sont appliqués à la fiche | `defenses.armor` et `soak` mis à jour |
+| Vérifier que les qualités de l'équipement s'appliquent (si actives) | Bonus visibles |
+
+### 3.4. Suppression d'un item
+
+| Action | Résultat attendu |
+|--------|------------------|
+| Clic droit → Delete sur un item de l'inventaire | L'item est supprimé |
+| L'item disparaît de l'inventaire | Confirmé |
+
+---
+
+## 4. Calcul de l'encombrement
+
+### 4.1. Encombrement total
+
+| Action | Résultat attendu |
+|--------|------------------|
+| Ajouter des items avec `encumbrance` > 0 | `resources.encumbrance.value` augmente |
+| Ajouter 3 items d'encumbrance 2 chacun | Total = 6 |
+| Retirer un item | L'encumbrance diminue |
+| Dépasser le seuil d'encombrement | Pénalité applicable (ralentissement, malus) |
+
+---
+
+## 5. Catégories d'équipement
+
+### 5.1. Catégories d'armes (7)
+
+| Catégorie | Test |
+|-----------|------|
+| melee | Arme de corps à corps |
+| ranged | Arme à distance |
+| gunnery | Arme lourde |
+| explosive | Explosif |
+| thrown | Arme de jet |
+| vehicle | Arme de véhicule |
+| natural | Arme naturelle (griffes, crocs) |
+
+### 5.2. Catégories d'armure (5)
+
+| Catégorie | Test |
+|-----------|------|
+| unarmored | Pas d'armure |
+| light | Armure légère |
+| medium | Armure moyenne |
+| heavy | Armure lourde |
+| natural | Armure naturelle (carapace) |
+
+---
+
+## 6. Qualité et enchantement
+
+### 6.1. Qualité
+
+| Qualité | Modificateur | Test |
+|---------|-------------|------|
+| shoddy | -2 | Défense/dégâts réduits de 2 |
+| standard | 0 | Aucun modificateur |
+| fine | +1 | Bonus +1 |
+| superior | +2 | Bonus +2 |
+| masterwork | +3 | Bonus +3 |
+
+| Action | Résultat attendu |
+|--------|------------------|
+| Changer la qualité d'une arme | Les `derivedData` sont recalculés |
+| Vérifier `config.quality` | La qualité est correcte |
+| Vérifier `rarity = quality.rarity + enchantment.rarity` | Rareté dérivée correcte |
+
+### 6.2. Enchantement
+
+| Enchantement | Modificateur | Test |
+|-------------|-------------|------|
+| mundane | 0 | Aucun bonus |
+| minor | +1 | Bonus +1 |
+| major | +2 | Bonus +2 |
+| legendary | +3 | Bonus +3 |
+
+---
+
+## 7. Points d'attache (Hard Points)
+
+| Action | Résultat attendu |
+|--------|------------------|
+| Configurer `hardPoints` sur une arme | La valeur est affichée dans la fiche |
+| Ajouter des modifications/mounts (via actions ou qualités) | Les hard points disponibles diminuent |
+| Dépasser le nombre de hard points disponibles | Message d'erreur ou blocage |
+
+---
+
+## 8. Niveau de restriction
+
+| Niveau | Test |
+|--------|------|
+| none | Aucune restriction |
+| restricted | Nécessite une licence ou permis |
+| military | Usage militaire uniquement |
+| illegal | Interdit, possession illégale |
+
+| Action | Résultat attendu |
+|--------|------------------|
+| `getTags()` sur un item gear | Le badge de restriction s'affiche |
+| Changer le restrictionLevel | Le tag est mis à jour |
+
+---
+
+## 9. Actions liées à l'équipement
+
+### 9.1. Actions des armes
+
+| Action | Résultat attendu |
+|--------|------------------|
+| Les armes ont des `actions` embarquées (tir, attaque, etc.) | Les actions sont listées dans l'onglet Actions |
+| Utiliser une action d'arme | `weaponAttack(action, target, weapon)` est invoqué |
+
+### 9.2. Actions de l'armure
+
+| Action | Résultat attendu |
+|--------|------------------|
+| Les armures peuvent avoir des actions (ex: réparation, activation de bouclier) | Actions disponibles si configurées |
+
+---
+
+## 10. Items cassés (broken)
+
+| Action | Résultat attendu |
+|--------|------------------|
+| Marquer un item comme `broken: true` | L'item est visuellement marqué comme cassé |
+| Les bonus de l'item ne s'appliquent plus | Les stats ne tiennent pas compte de l'item cassé |
+| Réparer l'item (`broken: false`) | Les bonus sont restaurés |
+
+---
+
+## 11. Scénarios de régression
+
+- Créer une arme avec toutes les qualités actives → vérifier que toutes les qualités sont bien persistées et affichées.
+- Créer une armure avec les 4 propriétés → vérifier que bulky, organic, sealed, full-body sont tous actifs.
+- Équiper une arme → vérifier qu'elle passe dans la section "Équipé".
+- Déséquiper une armure → vérifier que les bonus de défense/soak sont retirés.
+- Ajouter des items jusqu'à dépasser l'encumbrance → vérifier la pénalité.
+- Changer la qualité d'une arme en "masterwork" → vérifier que le bonus +3 est appliqué.
+- Marquer un item comme "broken" → vérifier qu'il n'apporte plus ses bonus.
+- Créer un item avec restriction "illegal" → vérifier le tag dans l'inventaire.
+- Supprimer un item équipé → vérifier que les bonus sont retirés avant la suppression.
+- Vérifier que les hard points sont correctement suivis (utilisés/disponibles).
+- Modifier un item dans la feuille → vérifier que les changements se reflètent dans l'inventaire du personnage.
+- Recharger la page → vérifier que tous les équipements sont persistés.

--- a/documentation/tests/manuel/import-oggdude/README.md
+++ b/documentation/tests/manuel/import-oggdude/README.md
@@ -1,0 +1,257 @@
+# Tests manuels — Import OggDude
+
+Tests de l'importateur de données OggDude : pipeline ZIP → parsing → mapping → création d'items Foundry.
+
+---
+
+## Prérequis
+
+- Monde SWERPG avec droits GM
+- Un fichier ZIP OggDude valide (export de OggDude Data Editor)
+- Optionnel : compendiums configurés pour le stockage
+
+---
+
+## 1. Ouverture de l'importateur
+
+### 1.1. Accès via les paramètres
+
+| Action | Résultat attendu |
+|--------|------------------|
+| Ouvrir Game Settings → Configure Settings | La fenêtre des paramètres s'affiche |
+| Cliquer sur le bouton "Star Wars Edge RPG" | Les paramètres système s'affichent |
+| Localiser la section "OggDude Data Importer" | La section est visible |
+| Cliquer "Import data from OggDude" | La fenêtre `OggDudeDataImporter` s'ouvre |
+| Vérifier que le bouton "OggDude Zip Data File" est présent | Le bouton de sélection de fichier est visible |
+
+### 1.2. Upload du fichier ZIP
+
+| Action | Résultat attendu |
+|--------|------------------|
+| Cliquer "OggDude Zip Data File" | Un sélecteur de fichier s'ouvre |
+| Sélectionner un fichier `.zip` OggDude valide | Le fichier est chargé via `JSZip` |
+| Vérifier que les données sont parsées | `OggDudeDataElement.from(zip)` extrait tous les éléments |
+| Vérifier le groupement par répertoire et type | Les éléments sont organisés par domaine |
+
+---
+
+## 2. Domaines d'import
+
+### 2.1. Sélection des domaines
+
+L'importateur supporte 11 domaines :
+
+| Domaine | Classe Builder | Fichier de mapping |
+|---------|----------------|-------------------|
+| weapon | `weapon-ogg-dude.mjs` | weapon-quality-map, weapon-skill-map, weapon-range-map... |
+| armor | `armor-ogg-dude.mjs` | armor-category-map, armor-property-map |
+| gear | `gear-ogg-dude.mjs` | gear-utils |
+| species | `species-ogg-dude.mjs` | — |
+| career | `career-ogg-dude.mjs` | career-skill-map |
+| specialization | `specialization-ogg-dude.mjs` | — |
+| talent | `talent-ogg-dude.mjs` | talent-node-map, talent-rank-map... |
+| obligation | `obligation-ogg-dude.mjs` | — |
+| motivation | `motivation-ogg-dude.mjs` | — |
+| motivation-category | `motivation-category-ogg-dude.mjs` | — |
+| duty | `duty-ogg-dude.mjs` | — |
+
+| Action | Résultat attendu |
+|--------|------------------|
+| Cocher "weapon" uniquement | Seules les armes seront importées |
+| Cocher tous les domaines | Tous les types seront importés |
+| Décocher un domaine | Ce domaine est exclu de l'import |
+
+---
+
+## 3. Pipeline d'import
+
+### 3.1. Parsing du ZIP
+
+| Action | Résultat attendu |
+|--------|------------------|
+| Vérifier que tous les fichiers XML du ZIP sont parsés | `xml2js` convertit chaque fichier |
+| Les fichiers mal formés sont ignorés avec un warning | Log d'erreur visible |
+
+### 3.2. Mapping des données
+
+Pour chaque élément importé :
+
+| Action | Résultat attendu |
+|--------|------------------|
+| Les IDs OggDude sont traduits en IDs SWERPG via les fichiers de mapping | Mapping correct |
+| Les qualités d'armes sont mappées (`oggdude-weapon-quality-map.mjs`) | Qualité correspondante trouvée |
+| Les compétences sont mappées (`oggdude-skill-map.mjs`) | Skill ID correct |
+| Les catégories d'armure sont mappées | Catégorie correcte |
+| Les noeuds de talent sont mappés (`oggdude-talent-node-map.mjs`) | Node ID correct |
+
+### 3.3. Création des items Foundry
+
+| Action | Résultat attendu |
+|--------|------------------|
+| Pour chaque élément parsé, un item Foundry est créé | Item du type approprié |
+| Vérifier les champs : name, img, system (type-specific) | Tous les champs sont renseignés |
+| Vérifier la stratégie de stockage | `WorldItemStorageTarget` ou `CompendiumItemStorageTarget` selon la config |
+
+---
+
+## 4. Stratégies de stockage
+
+### 4.1. Stockage dans le monde
+
+| Action | Résultat attendu |
+|--------|------------------|
+| Sélectionner "Importer dans le monde" | Les items sont créés dans le répertoire des items du monde |
+| Vérifier l'organisation des dossiers | Dossier racine "SWERPG OggDude Import" créé |
+| Vérifier les sous-dossiers : "Actor Options" (careers, species, specializations, obligations, motivations, talents, duties) et "Equipments" (armors, gears, weapons) | Structure de dossiers correcte |
+
+### 4.2. Stockage dans les compendiums
+
+| Action | Résultat attendu |
+|--------|------------------|
+| Sélectionner "Importer dans les compendiums" | Les items sont créés dans des packs |
+| Vérifier le nommage : `world.swerpg-{type}` | Pack créé avec le bon nom |
+| Vérifier l'organisation des dossiers dans le compendium | Même structure que le stockage monde |
+
+---
+
+## 5. Import d'armes (weapon)
+
+| Action | Résultat attendu |
+|--------|------------------|
+| Importer une arme du ZIP | Item de type `weapon` créé |
+| Vérifier les champs : `skill`, `range`, `damage`, `crit`, `qualities` | Tous les champs sont mappés correctement |
+| Vérifier les qualités : accurate, autoFire, breach, burn, blast... (30 qualités) | Chaque qualité est soit active avec rang, soit booléenne |
+| Vérifier la catégorie d'arme : melee, ranged, gunnery, explosive, thrown, vehicle, natural | Catégorie correctement attribuée |
+| Vérifier `hardPoints` et `equipped` | Valeurs par défaut ou mappées |
+
+---
+
+## 6. Import d'armures (armor)
+
+| Action | Résultat attendu |
+|--------|------------------|
+| Importer une armure du ZIP | Item de type `armor` créé |
+| Vérifier les champs : `defense.base`, `soak.base`, `qualities` | Champs corrects |
+| Vérifier les propriétés d'armure : bulky, organic, sealed, full-body | Propriétés correctement mappées |
+| Vérifier la catégorie : unarmored, light, medium, heavy, natural | Catégorie correcte |
+
+---
+
+## 7. Import d'équipement (gear)
+
+| Action | Résultat attendu |
+|--------|------------------|
+| Importer un équipement du ZIP | Item de type `gear` créé |
+| Vérifier les champs : `category`, `quantity`, `price`, `quality`, `restrictionLevel`, `encumbrance`, `rarity` | Champs corrects |
+
+---
+
+## 8. Import de talents (talent)
+
+| Action | Résultat attendu |
+|--------|------------------|
+| Importer un talent du ZIP | Item de type `talent` créé |
+| Vérifier : `node` (talent tree node), `isRanked`, `rank`, `activation`, `isFree` | Champs corrects |
+| Vérifier le mapping du noeud de talent | `oggdude-talent-node-map.mjs` utilisé |
+| Vérifier les actions associées au talent | Les actions sont créées dans `actions` |
+
+---
+
+## 9. Import d'espèces (species)
+
+| Action | Résultat attendu |
+|--------|------------------|
+| Importer une espèce du ZIP | Item de type `species` créé |
+| Vérifier les 6 caractéristiques (brawn, agility, intellect, cunning, willpower, presence) avec valeurs 1-5 | Caractéristiques correctes |
+| Vérifier `woundThreshold`, `strainThreshold` (modifier + abilityKey) | Seuils corrects |
+| Vérifier `startingExperience` (100-300) | XP de départ correct |
+| Vérifier `freeSkills` et `freeTalents` | Listes correctes |
+
+---
+
+## 10. Import de carrières (career)
+
+| Action | Résultat attendu |
+|--------|------------------|
+| Importer une carrière du ZIP | Item de type `career` créé |
+| Vérifier `careerSkills` | Compétences de carrière correctement mappées |
+| Vérifier `freeSkillRank` (0-8, défaut 4) | Rangs gratuits corrects |
+
+---
+
+## 11. Import de spécialisations (specialization)
+
+| Action | Résultat attendu |
+|--------|------------------|
+| Importer une spécialisation du ZIP | Item de type `specialization` créé |
+| Vérifier `specializationSkills` | Compétences de spécialisation correctes |
+| Vérifier `freeSkillRank` (0-8, défaut 4) | Rangs gratuits corrects |
+
+---
+
+## 12. Import d'obligations/devoirs/motivations
+
+### 12.1. Obligation
+
+| Action | Résultat attendu |
+|--------|------------------|
+| Importer une obligation | Item `obligation` créé |
+| Vérifier `value` (0-50, step 5) | Valeur correcte |
+| Vérifier `isExtra`, `extraXp`, `extraCredits` | Champs optionnels corrects |
+
+### 12.2. Duty
+
+| Action | Résultat attendu |
+|--------|------------------|
+| Importer un devoir | Item `duty` créé |
+| Vérifier `value` (0-50, step 5) | Valeur correcte |
+| Vérifier `sources` (book, page) | Sources correctes |
+
+### 12.3. Motivation
+
+| Action | Résultat attendu |
+|--------|------------------|
+| Importer une motivation | Item `motivation` ou `motivation-category` créé |
+| Vérifier `description` et `category` | Champs corrects |
+
+---
+
+## 13. Gestion des erreurs et reprise
+
+### 13.1. Retry logic
+
+| Action | Résultat attendu |
+|--------|------------------|
+| Simuler un échec d'import | `retry.mjs` tente 1 nouvelle tentative après 1000ms |
+| Vérifier `global-import-metrics.mjs` | Les métriques d'import sont mises à jour (succès, échecs, durée) |
+
+### 13.2. Fichier ZIP invalide
+
+| Action | Résultat attendu |
+|--------|------------------|
+| Uploader un fichier non-ZIP | Message d'erreur : format invalide |
+| Uploader un ZIP corrompu | Message d'erreur : impossible de lire le fichier |
+| Uploader un ZIP sans données OggDude | Message : aucun élément trouvé |
+
+---
+
+## 14. Import SW Adversaries
+
+| Action | Résultat attendu |
+|--------|------------------|
+| `swAdversaries.mjs` parse le format FFG SW Adversaries | Crée des acteurs de type `adversary` |
+
+---
+
+## 15. Scénarios de régression
+
+- Importer un ZIP complet contenant tous les domaines → vérifier que les 11 domaines sont importés sans erreur.
+- Importer uniquement les armes → vérifier que seuls les items `weapon` sont créés.
+- Importer avec stockage monde → vérifier la structure de dossiers.
+- Importer avec stockage compendium → vérifier les packs créés.
+- Importer une arme avec qualité "autoFire" → vérifier que la qualité est présente avec `hasRank: true/false`.
+- Importer une espèce → vérifier que les 6 caractéristiques sont à la bonne valeur.
+- Importer un ZIP vide → vérifier le message approprié.
+- Vérifier que les métriques globales sont mises à jour après chaque import.
+- Vérifier que le bouton "Import data from OggDude" n'est pas cliquable pendant un import en cours.
+- Tester l'import avec un fichier ZIP contenant des données spéciales (caractères Unicode, descriptions longues).

--- a/documentation/tests/manuel/personnage/README.md
+++ b/documentation/tests/manuel/personnage/README.md
@@ -1,0 +1,271 @@
+# Tests manuels — Fiche Personnage
+
+Création, modification, progression et gestion d'un personnage joueur.
+
+---
+
+## Prérequis
+
+- Monde SWERPG créé et système `swerpg` activé
+- Droits GM pour créer/modifier des acteurs
+- Packs de compendium système disponibles (espèces, carrières, spécialisations)
+
+---
+
+## 1. Création d'un personnage
+
+### 1.1. Création via le répertoire
+
+| Action | Résultat attendu |
+|--------|------------------|
+| Cliquer "Créer un acteur" dans le répertoire des acteurs | La fenêtre de création s'ouvre |
+| Choisir le type `character` | Le type personnage est sélectionné |
+| Nommer le personnage "Test-PJ-1" | Nom enregistré |
+| Valider | Un nouvel acteur `character` apparaît dans le répertoire |
+
+### 1.2. Ouverture de la fiche
+
+| Action | Résultat attendu |
+|--------|------------------|
+| Double-clic sur le personnage | La `CharacterSheet` s'ouvre (ApplicationV2) |
+| Vérifier la présence de 8 tabs | Attributs, Actions, Inventaire, Compétences, Talents, Effets, Biographie, Engagements |
+| Vérifier l'en-tête (portrait, nom, barres wounds/strain) | En-tête affiché avec barres de ressources |
+| Vérifier le sidebar (caractéristiques) | Les 6 caractéristiques (Brawn, Agility...) sont listées |
+
+---
+
+## 2. Application d'une espèce
+
+### 2.1. Drag & drop depuis le compendium
+
+| Action | Résultat attendu |
+|--------|------------------|
+| Ouvrir un compendium contenant des items `species` | Liste des espèces visible |
+| Glisser-déposer une espèce (ex: "Bothan") sur la fiche | Les champs suivants sont mis à jour automatiquement : |
+| | — `details.species` : espèce renseignée avec nom, image |
+| | — `characteristics` : valeurs de base positionnées (1-5) selon l'espèce |
+| | — `thresholds.wounds` : seuil de blessures modifié |
+| | — `thresholds.strain` : seuil de fatigue modifié |
+| | — `progression.experience` : `gained` = startingExperience de l'espèce |
+| | — `details.biography.public` : description de l'espèce copiée |
+
+### 2.2. Changement d'espèce
+
+| Action | Résultat attendu |
+|--------|------------------|
+| Glisser une autre espèce par-dessus | L'espèce est remplacée, les caractéristiques sont réinitialisées |
+| Les points d'expérience sont-ils recalculés ? | Vérifier que `gained` reflète la nouvelle espèce |
+
+---
+
+## 3. Application d'une carrière
+
+### 3.1. Drag & drop
+
+| Action | Résultat attendu |
+|--------|------------------|
+| Glisser une `career` (ex: "Bounty Hunter") sur la fiche | `details.career` est renseigné |
+| Les `careerSkills` de la carrière sont marquées comme compétences de carrière sur l'onglet Compétences | Indicateur visuel (icône ou couleur) sur les compétences concernées |
+| `freeSkillRank` de la carrière est crédité dans `progression.freeSkillRanks.career` | `gained` = 4 (ou valeur configurée) |
+
+### 3.2. Changement de carrière
+
+| Action | Résultat attendu |
+|--------|------------------|
+| Glisser une autre carrière | La carrière est remplacée |
+| Les compétences de carrière sont mises à jour | Nouvelles compétences marquées, anciennes dé-marquées |
+
+---
+
+## 4. Application d'une spécialisation
+
+### 4.1. Drag & drop
+
+| Action | Résultat attendu |
+|--------|------------------|
+| Glisser une `specialization` (ex: "Assassin") sur la fiche | `details.specializations` contient la spécialisation |
+| Les `specializationSkills` sont marquées | Indicateur visuel distinct de celui des compétences de carrière |
+| `freeSkillRank` est crédité dans `progression.freeSkillRanks.specialization` | `gained` = 4 (ou valeur configurée) |
+
+### 4.2. Spécialisations multiples
+
+| Action | Résultat attendu |
+|--------|------------------|
+| Ajouter une seconde spécialisation | Les deux apparaissent dans `details.specializations` |
+| Les compétences des deux sont marquées | Les deux jeux de compétences sont visibles |
+| Vérifier que les rangs gratuits sont additionnés | `gained` = 4 + 4 = 8 |
+
+---
+
+## 5. Caractéristiques
+
+### 5.1. Augmentation
+
+| Action | Résultat attendu |
+|--------|------------------|
+| Cliquer sur le bouton "+" d'une caractéristique (ex: Brawn) | La valeur `base` augmente de 1 (max 5) |
+| Vérifier la dépense d'XP | Coût = nouvelle valeur × 10 (ex: passer de 3 à 4 coûte 40 XP) |
+| Vérifier le log d'audit | Une entrée `characteristic.increase` est créée |
+
+### 5.2. Diminution (forget)
+
+| Action | Résultat attendu |
+|--------|------------------|
+| Cliquer sur le bouton "-" d'une caractéristique au-dessus du niveau de base | La valeur diminue, l'XP est remboursée |
+| Impossible de descendre sous le `base` de l'espèce | Le bouton "-" est désactivé ou le minimum est bloqué à la valeur d'espèce |
+
+### 5.3. Bonus externes
+
+| Action | Résultat attendu |
+|--------|------------------|
+| Appliquer un effet qui donne un bonus de caractéristique (via ActiveEffect ou Talent) | Le champ `bonus` est mis à jour |
+| Vérifier que la valeur effective (base + trained + bonus) est correcte dans le header | La somme s'affiche |
+
+---
+
+## 6. Compétences
+
+### 6.1. Achat de rang
+
+| Action | Résultat attendu |
+|--------|------------------|
+| Sur l'onglet Compétences, identifier une compétence de carrière | La compétence est marquée visuellement |
+| Cliquer sur le bouton "+" pour acheter un rang | Coût calculé : carrière → rang × 5, hors carrière → rang × 5 + 5 |
+| Vérifier la déduction d'XP | `progression.experience.spent` augmente du coût |
+| Vérifier le log d'audit | Entrée `skill.train` créée |
+
+### 6.2. Rangs gratuits (carrière)
+
+| Action | Résultat attendu |
+|--------|------------------|
+| Utiliser un rang gratuit carrière sur une compétence de carrière | `careerFree` passe de 0 à 1, aucune XP déduite |
+| Vérifier que `freeSkillRanks.career.spent` s'incrémente | Le compteur de rangs gratuits disponibles diminue |
+
+### 6.3. Rangs gratuits (spécialisation)
+
+| Action | Résultat attendu |
+|--------|------------------|
+| Utiliser un rang gratuit spécialisation sur une compétence de spécialisation | `specializationFree` passe de 0 à 1, aucune XP déduite |
+| Vérifier que `freeSkillRanks.specialization.spent` s'incrémente | Même mécanisme que carrière |
+
+### 6.4. Oubli d'un rang
+
+| Action | Résultat attendu |
+|--------|------------------|
+| Cliquer sur le bouton "-" pour retirer un rang acheté | Le rang est retiré, l'XP est remboursée |
+| Impossible de retirer un rang gratuit | Le bouton "-" ne descend pas sous les rangs gratuits |
+
+### 6.5. Palier de compétence
+
+| Action | Résultat attendu |
+|--------|------------------|
+| Vérifier les paliers : untrained(0), novice(1), apprentice(2), specialist(3), adept(4), master(5) | Les paliers s'affichent correctement |
+| Vérifier le total = base(0) + careerFree + specializationFree + trained | Le total est la somme des 4 sources |
+
+---
+
+## 7. Ressources
+
+### 7.1. Blessures (Wounds)
+
+| Action | Résultat attendu |
+|--------|------------------|
+| Modifier `resources.wounds.value` via un effet ou une action | La barre de token se met à jour |
+| Si `wounds.value >= wounds.threshold` → `isKnockedOut` = true | Vérifier le statut KO |
+| Si `wounds.value >= wounds.threshold × 2` → `isDead` = true | Vérifier le statut Mort |
+
+### 7.2. Fatigue (Strain)
+
+| Action | Résultat attendu |
+|--------|------------------|
+| Modifier `resources.strain.value` | Barre fatigue mise à jour |
+| Si `strain.value > strain.threshold` → `isIncapacitated` = true | Vérifier le statut Incapacité |
+
+### 7.3. Encumbrance
+
+| Action | Résultat attendu |
+|--------|------------------|
+| Ajouter des objets à l'inventaire | `resources.encumbrance.value` augmente |
+| Si `encumbrance.value > encumbrance.threshold` → pénalité applicable | Vérifier le message ou l'indicateur visuel |
+
+---
+
+## 8. Progression et XP
+
+### 8.1. Suivi de l'XP
+
+| Action | Résultat attendu |
+|--------|------------------|
+| Noter les valeurs initiales : `spent`, `gained` | `gained` = startingExperience de l'espèce |
+| Acheter une compétence | `spent` augmente, le disponible = gained - spent diminue |
+| Accorder de l'XP (via un effet ou script) | `gained` augmente, une entrée `xp.grant` est créée dans l'audit log |
+
+### 8.2. XP négative
+
+| Action | Résultat attendu |
+|--------|------------------|
+| Retirer de l'XP (via script) | `gained` diminue, entrée `xp.remove` créée |
+| Vérifier que l'XP disponible ne passe pas en négatif | Minimum à 0 |
+
+---
+
+## 9. Engagements (onglet Commitments)
+
+| Action | Résultat attendu |
+|--------|------------------|
+| Glisser une `obligation` sur la fiche | L'obligation s'affiche dans l'onglet Engagements |
+| Modifier la valeur de l'obligation (0-50 par pallier de 5) | La valeur est persistée |
+| Glisser une `duty` | Le devoir s'affiche |
+| Glisser une `motivation` | La motivation s'affiche |
+
+---
+
+## 10. Biographie
+
+| Action | Résultat attendu |
+|--------|------------------|
+| Onglet Biographie : éditer le champ Public (HTML) | Le texte enrichi est sauvegardé |
+| Éditer le champ Privé (HTML) | Texte privé sauvegardé (visible GM seulement) |
+| Éditer les champs Notable Features, Age, Gender, Height, Build, Hair, Eyes | Tous les champs sont persistés |
+| Vérifier le rendu dans la fiche | Le HTML s'affiche correctement (pas de XSS, pas de balises cassées) |
+
+---
+
+## 11. Actions
+
+| Action | Résultat attendu |
+|--------|------------------|
+| Onglet Actions : vérifier la liste des actions disponibles | Les actions sont groupées par type (Attaque, Réaction, Mouvement, Général) |
+| Cliquer sur l'icône étoile d'une action → Favorite | L'action est marquée comme favorite |
+| Cliquer sur l'icône d'utilisation → `actionUse()` | Le dialogue `ActionUseDialog` s'ouvre ou l'action est exécutée |
+| Cliquer sur l'icône d'édition → `actionEdit()` | La fenêtre de configuration d'action s'ouvre |
+
+---
+
+## 12. Effets
+
+| Action | Résultat attendu |
+|--------|------------------|
+| Onglet Effets : ajouter un effet temporaire | L'effet apparaît dans la liste |
+| Basculer l'effet actif/inactif (toggle) | Le state est mis à jour |
+| Supprimer un effet | L'effet disparaît |
+
+---
+
+## 13. Audit log
+
+| Action | Résultat attendu |
+|--------|------------------|
+| Effectuer plusieurs achats/oublis | L'audit log (`flags.swerpg.logs`) contient des entrées |
+| Vérifier le format d'une entrée : `type`, `data`, `xpDelta`, `snapshot`, `timestamp`, `userId`, `userName` | Tous les champs sont présents et cohérents |
+| Vérifier la limite (`auditLogMaxEntries`, défaut 500) | Au-delà de 500 entrées, les plus anciennes sont supprimées |
+
+---
+
+## 14. Scénarios de régression
+
+- Créer un personnage, lui assigner espèce + carrière + spécialisation, dépenser toute l'XP, vérifier que les totaux sont cohérents.
+- Ré-affecter une nouvelle espèce après avoir dépensé de l'XP : les caractéristiques se réinitialisent-elles correctement ?
+- Supprimer une spécialisation : les rangs gratuits sont-ils recalculés ?
+- Charger un personnage existant : vérifier que toutes les données sont correctement hydratées.
+- Créer 2 personnages avec des espèces différentes et comparer les valeurs de base.

--- a/documentation/tests/manuel/talents/README.md
+++ b/documentation/tests/manuel/talents/README.md
@@ -1,0 +1,194 @@
+# Tests manuels — Talents
+
+Tests du système de talents : arbre de talents, achat, activation, effets mécaniques, cumul (ranked).
+
+---
+
+## Prérequis
+
+- Personnage avec espèces/carrière/spécialisations appliquées
+- Talents disponibles dans le répertoire ou compendium
+- Écran suffisamment large pour afficher le canvas secondaire de l'arbre de talents
+
+---
+
+## 1. Onglet Talents de la fiche
+
+### 1.1. Organisation
+
+| Action | Résultat attendu |
+|--------|------------------|
+| Ouvrir l'onglet Talents de la `CharacterSheet` | Les talents sont visibles |
+| Vérifier les groupes : Signature, Actifs, Passifs | Les talents sont triés par type d'activation |
+| Vérifier le bouton d'ouverture de l'arbre de talents | Le bouton "Talent Tree" est présent |
+
+### 1.2. Ajout d'un talent via drag & drop
+
+| Action | Résultat attendu |
+|--------|------------------|
+| Glisser un talent du répertoire sur l'onglet Talents | Le talent est ajouté au personnage |
+| Vérifier que `trees` (spécialisation/career) est renseigné | L'UUID de l'item parent est stocké |
+| Vérifier que `isRanked` impacte l'affichage | Les talents ranked montrent un compteur de rangs |
+
+---
+
+## 2. Arbre de talents (Talent Tree Canvas)
+
+### 2.1. Ouverture
+
+| Action | Résultat attendu |
+|--------|------------------|
+| Cliquer sur le bouton "Talent Tree" de la fiche | Un canvas PIXI.js secondaire s'ouvre (`SwerpgTalentTree`) |
+| Vérifier que l'arbre est centré et visible | Tous les noeuds s'affichent |
+| Vérifier les tiers (tiers) : -1 (origin/root), 0 (12 nodes), 1 (16 nodes), 2 (20 nodes), 3 (signature, ~28 nodes), 4 (30 nodes) | Les noeuds sont répartis par tiers |
+
+### 2.2. Navigation
+
+| Action | Résultat attendu |
+|--------|------------------|
+| Clic droit glissé → panoramique | Le canvas se déplace |
+| Molette → zoom avant/arrière | Le canvas zoome |
+| Les contrôles (boutons Close/Reset) sont visibles (`SwerpgTalentTreeControls`) | Les boutons overlay fonctionnent |
+
+### 2.3. Interaction avec les noeuds
+
+| Action | Résultat attendu |
+|--------|------------------|
+| Cliquer sur un noeud verrouillé → rien ne se passe | Noeud inactif |
+| Cliquer sur un noeud déverrouillé → la roue de choix apparaît | `SwerpgTalentChoiceWheel` s'ouvre |
+| La roue affiche les talents disponibles pour ce noeud | Liste des talents du noeud |
+| Survoller un noeud → `SwerpgTalentHUD` avec infobulle | Le HUD montre les prérequis et le nom du noeud |
+| Survoller un talent dans la roue → infobulle du talent | Description du talent visible |
+
+### 2.4. Achat d'un talent
+
+| Action | Résultat attendu |
+|--------|------------------|
+| Dans la roue de choix, clic gauche sur un talent | Le talent est acheté |
+| Vérifier que le noeud passe à l'état "acheté" | L'icône du noeud change (couleur, coche) |
+| Vérifier que les connexions (arêtes) sont dessinées entre les noeuds achetés | Les liens sont visibles |
+| Vérifier que les noeuds enfants sont déverrouillés | Les prérequis sont satisfaits |
+
+### 2.5. Suppression d'un talent
+
+| Action | Résultat attendu |
+|--------|------------------|
+| Clic droit sur un talent acheté | Un dialogue de confirmation s'affiche |
+| Confirmer la suppression | Le talent est retiré, l'XP est remboursée |
+| Vérifier que le noeud revient à l'état "déverrouillé" | L'icône revient à l'état normal |
+| Vérifier que les noeuds enfants sont verrouillés si prérequis non satisfaits | Blocage en chaîne |
+
+### 2.6. Sons
+
+| Action | Résultat attendu |
+|--------|------------------|
+| Cliquer sur un noeud ou un talent | Un son `click1-5.wav` est joué |
+| Les sons sont optionnels (pas d'erreur si fichiers absents) | Pas de crash si audio manquant |
+
+### 2.7. Fermeture
+
+| Action | Résultat attendu |
+|--------|------------------|
+| Cliquer le bouton Close | Le canvas secondaire se ferme, la fiche acteur est restaurée |
+| Aucun état résiduel | Le canvas PIXI est détruit proprement |
+
+---
+
+## 3. Types de talents
+
+### 3.1. Talents passifs
+
+| Action | Résultat attendu |
+|--------|------------------|
+| Ajouter un talent avec `activation: passive` | Le talent est listé dans la section "Passifs" |
+| L'effet est appliqué automatiquement (sans intervention du joueur) | Bonus permanent actif |
+
+### 3.2. Talents actifs
+
+| Action | Résultat attendu |
+|--------|------------------|
+| Ajouter un talent avec `activation: active` | Le talent est listé dans la section "Actifs" |
+| Le talent peut être utilisé comme une action | Les `actions` du talent sont disponibles |
+
+### 3.3. Talents ranked
+
+| Action | Résultat attendu |
+|--------|------------------|
+| Ajouter un talent `isRanked: true` | Le compteur de rang s'affiche (ex: rank 1/5) |
+| Augmenter le rang → `rank.idx` s'incrémente, `rank.cost` est déduit | L'XP est dépensée |
+| L'effet du talent évolue avec le rang | Bonus × rang |
+
+### 3.4. Talents signatures (Tier 3)
+
+| Action | Résultat attendu |
+|--------|------------------|
+| Atteindre le Tier 3 dans l'arbre | Les noeuds signature sont déverrouillés |
+| Les talents signatures ont des capacités de groupe (group teleport) | Fonctionnalité spécifique active |
+
+---
+
+## 4. Effets mécaniques des talents
+
+### 4.1. Modificateurs de caractéristiques
+
+| Action | Résultat attendu |
+|--------|------------------|
+| Ajouter un talent qui donne +1 Brawn | `characteristics.brawn.bonus` passe à 1 |
+| La caractéristique effective dans le header est mise à jour | Total = base + trained + bonus |
+
+### 4.2. Modificateurs de compétences
+
+| Action | Résultat attendu |
+|--------|------------------|
+| Ajouter un talent qui donne un bonus de compétence | Le rang effectif de la compétence est augmenté |
+| Le bonus s'affiche dans l'onglet Compétences | Indicateur de bonus visible |
+
+### 4.3. Modificateurs de pool de dés
+
+| Action | Résultat attendu |
+|--------|------------------|
+| Les talents avec `diemodifiers` (mappés par `oggdude-talent-diemodifiers-map.mjs`) | Les modificateurs de dés sont appliqués au pool |
+
+---
+
+## 5. Actor hooks des talents
+
+| Action | Résultat attendu |
+|--------|------------------|
+| Les talents avec `actorHooks` sont enregistrés | Les hooks sont appelés aux moments appropriés (début de tour, fin de tour, etc.) |
+| `hook: 'onStartTurn'` → exécuté au début du tour | Fonctionne |
+| `hook: 'onEndTurn'` → exécuté en fin de tour | Fonctionne |
+
+---
+
+## 6. Règles de précédence et cumul
+
+### 6.1. Cumul de ranked talents
+
+| Action | Résultat attendu |
+|--------|------------------|
+| Ajouter 3 rangs d'un talent ranked | L'effet est appliqué 3 fois (ex: +3 au lieu de +1) |
+| Retirer un rang → l'effet diminue | Correct |
+
+### 6.2. Conflit entre talents
+
+| Action | Résultat attendu |
+|--------|------------------|
+| Deux talents qui modifient la même caractéristique | Le dernier appliqué prend-il le dessus ? Les deux se cumulent-ils ? |
+| Vérifier la règle métier : les bonus de même type se cumulent-ils ou seul le plus grand s'applique ? | Conforme aux règles SW |
+
+---
+
+## 7. Scénarios de régression
+
+- Ouvrir l'arbre de talents → vérifier que le canvas PIXI se charge sans erreur.
+- Acheter un talent dans l'arbre → vérifier qu'il apparaît dans l'onglet Talents de la fiche.
+- Supprimer un talent dans l'arbre → vérifier qu'il disparaît de la fiche et que l'XP est remboursée.
+- Acheter des talents en chaîne (A → B → C) → vérifier que C est verrouillé tant que B n'est pas acheté.
+- Ajouter un talent ranked → augmenter/réduire le rang → vérifier que l'XP suit.
+- Ajouter un talent avec `activation: active` → vérifier qu'une action est disponible.
+- Ajouter un talent passif → vérifier que l'effet est appliqué sans action requise.
+- Ouvrir/fermer l'arbre de talents 10 fois → vérifier qu'il n'y a pas de fuite mémoire PIXI.
+- Acheter un talent signature → vérifier ses capacités spéciales.
+- Appliquer un talent avec `actorHooks` → vérifier que le hook se déclenche au moment attendu.
+- Vérifier que les talents sont persistés après rechargement de la page (F5).

--- a/documentation/tests/manuel/ui-sheets/README.md
+++ b/documentation/tests/manuel/ui-sheets/README.md
@@ -1,0 +1,331 @@
+# Tests manuels — UI Sheets
+
+Tests de l'interface utilisateur : fiches d'acteur, d'item, tabs, responsive, drag & drop, context menu, recherche.
+
+---
+
+## Prérequis
+
+- Monde SWERPG avec au moins un personnage et des items
+- Navigateur à différentes résolutions (1920×1080, 1366×768, 1024×768)
+- Connaissances des différences entre sheets V1 et V2
+
+---
+
+## 1. Architecture des sheets
+
+Le système utilise deux API Foundry :
+
+| API | Classe parente | Utilisé par |
+|-----|----------------|-------------|
+| **V2** (`ApplicationV2`, `HandlebarsApplicationMixin`, `DocumentSheetV2`) | `SwerpgBaseActorSheet`, `ArmorSheet`, `SwerpgJournalSheet`, `SkillPageSheet` | CharacterSheet, AdversarySheet, ArmorSheet, JournalSheet |
+| **V1** (`FormApplication`) | Classe de base Foundry V1 | WeaponSheet, GearSheet, TalentSheet, SpeciesSheet, CareerSheet, SpecializationSheet, ObligationSheet, DutySheet |
+
+---
+
+## 2. Fiche de personnage (CharacterSheet) — V2
+
+### 2.1. Structure générale
+
+| Action | Résultat attendu |
+|--------|------------------|
+| Ouvrir la fiche d'un personnage | `CharacterSheet` s'affiche (ApplicationV2) |
+| Vérifier les dimensions : 900×750 par défaut | Taille correcte |
+| Vérifier la présence du header (portrait, nom, barres de ressources) | Header visible |
+| Vérifier le sidebar (caractéristiques) | Sidebar avec les 6 caractéristiques |
+| Vérifier le body (tabs) | Body avec les tabs |
+
+### 2.2. Tabs
+
+| Action | Résultat attendu |
+|--------|------------------|
+| Cliquer sur chaque tab | Le contenu change, le tab est actif |
+| **Attributs** : caractéristiques, défenses, résistances, ressources, progression | Toutes les sections affichées |
+| **Actions** : liste groupée par type (Attaque, Réaction, Mouvement, Général) | Groupes visibles |
+| **Inventaire** : équipement + toggle equip | Items listés |
+| **Compétences** : liste avec achats/remboursements | Compétences avec indicateurs carrière/spécialisation |
+| **Talents** : signature, actifs, passifs + bouton arbre | Talents listés |
+| **Effets** : temporaires, persistants, désactivés | Effets listés |
+| **Biographie** : public, privé, apparence, champs texte | Éditeurs HTML fonctionnels |
+| **Engagements** : obligations, devoirs, motivations (personnage seulement) | Engagements listés |
+
+### 2.3. Navigation entre tabs
+
+| Action | Résultat attendu |
+|--------|------------------|
+| Cliquer sur Tab 1 → Tab 5 → Tab 2 | Navigation fluide, pas de re-render complet |
+| Pas de flash ou de saut visuel | Transition propre |
+| Les données du tab précédent sont conservées | Pas de perte de données en naviguant |
+
+### 2.4. Drag & drop
+
+| Action | Résultat attendu |
+|--------|------------------|
+| Glisser une espèce du compendium vers la fiche | L'espèce est appliquée (`_applyDetailItem`) |
+| Glisser une carrière | Carrière appliquée |
+| Glisser une spécialisation | Spécialisation ajoutée |
+| Glisser une arme | Arme ajoutée à l'inventaire |
+| Glisser un talent | Talent ajouté |
+
+### 2.5. Boutons d'action sur les items
+
+| Action | Résultat attendu |
+|--------|------------------|
+| Icône étoile → `actionFavorite` | Action marquée favorite |
+| Icône crayon → `actionEdit` | Fenêtre de configuration d'action |
+| Icône utiliser → `actionUse` | Action exécutée |
+| Icône équiper → `equipToggle` | Item équipé/déséquipé |
+| Icône corbeille → `itemDelete` / `effectDelete` | Suppression avec confirmation |
+| Icône + → `itemCreate` | Nouvel item créé |
+| Icône effet → `effectCreate`, `effectEdit`, `effectToggle`, `effectDelete` | Gestion des effets |
+
+---
+
+## 3. Fiche d'adversaire (AdversarySheet) — V2
+
+### 3.1. Différences avec la fiche personnage
+
+| Action | Résultat attendu |
+|--------|------------------|
+| Ouvrir la fiche d'un adversaire | `AdversarySheet` s'affiche |
+| Vérifier l'absence des sections personnage | Pas de progression, pas d'espèce/carrière/spécialisation |
+| Vérifier les tabs disponibles | Attributs, Actions, Inventaire, Compétences, Effets, Biographie |
+| Vérifier l'absence de l'onglet Engagements | Pas d'engagements pour les adversaires |
+
+### 3.2. Caractéristiques adversaire
+
+| Action | Résultat attendu |
+|--------|------------------|
+| Les caractéristiques sont en mode `value` (pas base/trained/bonus) | Valeur unique |
+| Modifier `advancement.level` | Les compétences s'adaptent (auto-scale) |
+| Modifier `advancement.threat` (minion/normal/elite/boss) | Les actions max changent |
+
+---
+
+## 4. Fiches d'item (Item Sheets)
+
+### 4.1. WeaponSheet (V1)
+
+| Action | Résultat attendu |
+|--------|------------------|
+| Ouvrir une arme | `WeaponSheet` s'affiche (FormApplication V1) |
+| Configurer `skill`, `range`, `damage`, `crit` | Champs fonctionnels |
+| Widget qualités : 30 qualités listées, toggle actif/inactif, rang pour celles avec `hasRank` | Widget fonctionnel |
+| Configurer `hardPoints` | Point d'attache configurable |
+| Configurer `weaponType` (narrative subtype) | Type défini |
+
+### 4.2. ArmorSheet (V2)
+
+| Action | Résultat attendu |
+|--------|------------------|
+| Ouvrir une armure | `ArmorSheet` s'affiche (ApplicationV2) |
+| Configurer `defense.base`, `soak.base` | Champs fonctionnels |
+| Widget qualités d'armure : bulky, organic, sealed, full-body | Propriétés configurables |
+| Configurer `hardPoints` | Points d'attache |
+
+### 4.3. GearSheet (V1)
+
+| Action | Résultat attendu |
+|--------|------------------|
+| Ouvrir un équipement | `GearSheet` s'affiche (V1) |
+| Configurer `category`, `quantity`, `price`, `quality`, `restrictionLevel`, `encumbrance`, `rarity` | Tous les champs fonctionnels |
+| Marquer `broken` | Checkbox fonctionnelle |
+
+### 4.4. TalentSheet (V1)
+
+| Action | Résultat attendu |
+|--------|------------------|
+| Ouvrir un talent | `TalentSheet` s'affiche (V1) |
+| Configurer `node`, `isRanked`, `rank`, `activation`, `isFree` | Champs fonctionnels |
+| Lier à une spécialisation/carrière (`trees`) | Lien fonctionnel |
+| Configurer les actions du talent | Actions configurables |
+
+### 4.5. SpeciesSheet (V1)
+
+| Action | Résultat attendu |
+|--------|------------------|
+| Ouvrir une espèce | `SpeciesSheet` s'affiche (V1) |
+| Configurer les 6 caractéristiques (1-5) | Champs fonctionnels |
+| Configurer `woundThreshold`, `strainThreshold` | Seuils configurables |
+| Configurer `startingExperience` (100-300) | XP de départ |
+| Configurer `freeSkills`, `freeTalents` | Listes modifiables |
+
+### 4.6. CareerSheet (V1)
+
+| Action | Résultat attendu |
+|--------|------------------|
+| Ouvrir une carrière | `CareerSheet` s'affiche (V1) |
+| Configurer `careerSkills` | Liste de skills modifiable |
+| Configurer `freeSkillRank` (0-8, défaut 4) | Rangs gratuits configurables |
+
+### 4.7. SpecializationSheet (V1)
+
+| Action | Résultat attendu |
+|--------|------------------|
+| Ouvrir une spécialisation | `SpecializationSheet` s'affiche (V1) |
+| Configurer `specializationSkills` | Liste de skills modifiable |
+| Configurer `freeSkillRank` (0-8, défaut 4) | Rangs gratuits configurables |
+
+### 4.8. ObligationSheet / DutySheet (V1)
+
+| Action | Résultat attendu |
+|--------|------------------|
+| Configurer `value` obligation (0-50, step 5) | Valeur fonctionnelle |
+| Configurer `isExtra`, `extraXp`, `extraCredits` | Champs optionnels fonctionnels |
+| Configurer `value` duty (0-50, step 5) | Valeur fonctionnelle |
+| Configurer `sources` (book, page) | Sources fonctionnelles |
+
+---
+
+## 5. Journal et compétences
+
+### 5.1. SwerpgJournalSheet (V2)
+
+| Action | Résultat attendu |
+|--------|------------------|
+| Ouvrir un JournalEntry | `SwerpgJournalSheet` s'affiche |
+| Navigation entre les pages | Fonctionnelle |
+
+### 5.2. SkillPageSheet (V2)
+
+| Action | Résultat attendu |
+|--------|------------------|
+| Ouvrir une page de type `skill` | `SkillPageSheet` s'affiche |
+| Vérifier `skillId`, `overview`, `ranks`, `paths` | Tous les champs visibles |
+| Chaque rang a une description | Descriptions par rang affichées |
+| Les `paths` (voies) sont listés avec leur description | Voies affichées |
+
+---
+
+## 6. Fenêtres de dialogue (Dialogs)
+
+### 6.1. StandardCheckDialog (V2, DialogV2)
+
+| Action | Résultat attendu |
+|--------|------------------|
+| Déclencher un check | `StandardCheckDialog` s'ouvre |
+| Vérifier le sélecteur de difficulté | 7 niveaux : Trivial → Impossible |
+| Vérifier le champ DC manuel | Éditable |
+| Vérifier les boutons Boon/Bane (+/-) | Fonctionnels, max 6 |
+| Vérifier le roll mode : public, gm, blind, self | Sélecteur fonctionnel |
+| Bouton Roll | Le jet est lancé |
+| Bouton Request | Requête envoyée |
+
+### 6.2. ActionUseDialog (Étend StandardCheckDialog)
+
+| Action | Résultat attendu |
+|--------|------------------|
+| Utiliser une action avec AOE | Template targeting disponible |
+| Bouton "Place Template" pour les gabarits | Template plaçable (cône, cercle, rayon, rectangle) |
+| Liste de cibles avec statut | Cibles listées, invalides signalées |
+
+### 6.3. ActionConfig & SkillConfig
+
+| Action | Résultat attendu |
+|--------|------------------|
+| Ouvrir `ActionConfig` (config/action.mjs) | Configuration d'action modifiable |
+| Ouvrir `SkillConfig` (config/skill.mjs) | Dialogue d'achat de compétence |
+
+---
+
+## 7. Token HUD
+
+### 7.1. SwerpgTokenHUD
+
+| Action | Résultat attendu |
+|--------|------------------|
+| Cliquer sur un token | Le HUD personnalisé s'affiche |
+| Vérifier les barres de ressources | Wounds (haut), Strain (bas) |
+| Vérifier les action pips et focus pips | Pips visibles sur le token |
+
+---
+
+## 8. Combat Tracker
+
+### 8.1. SwerpgCombatTracker
+
+| Action | Résultat attendu |
+|--------|------------------|
+| Ouvrir le combat tracker | `SwerpgCombatTracker` s'affiche dans la sidebar |
+| Démarrer un combat | Initiative rollée |
+| Navigation des tours | Fonctionnelle |
+| Affichage des statuts sur les participants | Statuts visibles |
+
+---
+
+## 9. Responsive et redimensionnement
+
+### 9.1. Test de résolution
+
+| Résolution | Comportement attendu |
+|------------|---------------------|
+| 1920×1080 (bureau) | Tout est visible, layout normal |
+| 1366×768 (bureau standard) | Layout compact mais fonctionnel |
+| 1024×768 (tablette/écran réduit) | Tabs accessibles, pas de débordement horizontal |
+
+### 9.2. Redimensionnement
+
+| Action | Résultat attendu |
+|--------|------------------|
+| Redimensionner la fenêtre du navigateur | Les sheets s'adaptent |
+| Redimensionner une sheet (poignée) | La sheet se redimensionne |
+| Vérifier les scrollbars internes | Présentes si nécessaire, pas de contenu caché |
+| Vérifier le contenu des tabs sur sheet réduite | Pas de perte d'information |
+
+---
+
+## 10. Templates et rendu
+
+### 10.1. Templates HBS (56 fichiers)
+
+| Action | Résultat attendu |
+|--------|------------------|
+| Les templates sont correctement compilés | Aucune erreur Handlebars |
+| Les partials sont chargés | Templates inclus fonctionnels |
+| Chaque template se rend sans erreur JS | Console propre |
+
+### 10.2. Vérification visuelle
+
+| Action | Résultat attendu |
+|--------|------------------|
+| Vérifier le rendu CSS (`styles/swerpg.css`) | Styles corrects, pas de régression |
+| Vérifier les icônes et images | Toutes les ressources chargées (pas de 404) |
+| Vérifier l'espacement et l'alignement | Layout cohérent entre les sections |
+| Vérifier les couleurs des caractéristiques | `attributes-swerpg.mjs` définit les couleurs par caractéristique |
+
+---
+
+## 11. Performances
+
+| Action | Résultat attendu |
+|--------|------------------|
+| Ouvrir une fiche avec beaucoup de données | Pas de freeze > 1 seconde |
+| Naviguer entre les tabs | Réponse instantanée |
+| Drag & drop d'un item avec beaucoup de données | Opération < 2 secondes |
+| Ouvrir l'arbre de talents (canvas PIXI) | Canvas chargé en < 3 secondes |
+
+---
+
+## 12. Internationalisation (i18n)
+
+| Action | Résultat attendu |
+|--------|------------------|
+| Basculer Foundry en français | Tous les textes du système sont en français (`lang/fr.json`) |
+| Basculer Foundry en anglais | Tous les textes sont en anglais (`lang/en.json`) |
+| Vérifier qu'aucun texte n'est manquant | Pas de `[object Object]` ou de clés non traduites |
+| Vérifier les textes dans les dialogues et notifications | Messages traduits |
+
+---
+
+## 13. Scénarios de régression
+
+- Ouvrir toutes les sheets (character, adversary, weapon, armor, gear, talent, species, career, specialization, obligation, duty, motivation, journal, skill) → vérifier qu'aucune erreur JS n'apparaît.
+- Naviguer dans tous les tabs de la CharacterSheet → vérifier que les données sont correctes et persistées.
+- Drag & drop tous les types d'items sur une fiche personnage → vérifier que chaque type s'applique correctement.
+- Redimensionner la fenêtre à 1024×768 → vérifier que toutes les sheets sont utilisables.
+- Basculer entre français et anglais → vérifier la couverture i18n.
+- Ouvrir un dialogue StandardCheckDialog → vérifier le rendu.
+- Vérifier que les sheets V1 et V2 cohabitent sans conflit.
+- Tester l'accessibilité : tabulation, labels ARIA, rôles dans les sheets V2.
+- Créer des sheets avec des données très longues (descriptions HTML, listes de talents) → vérifier qu'il n'y a pas de débordement.
+- Recharger la page avec une sheet ouverte → vérifier que les données sont persistées.

--- a/documentation/tests/manuel/vehicules/README.md
+++ b/documentation/tests/manuel/vehicules/README.md
@@ -1,0 +1,104 @@
+# Tests manuels — Véhicules
+
+Tests des véhicules : création, pilotage et combat naval.
+
+> **Note :** Le module véhicules est actuellement en développement partiel. Les fonctionnalités marquées [Non implémenté] sont des stubs ou absentes.
+
+---
+
+## Prérequis
+
+- Acteur de type adversaire configuré pour représenter un véhicule
+- Compréhension des règles de véhicules SWRPG (manoeuvrabilité, équipage, armement)
+
+---
+
+## 1. Création d'un véhicule
+
+### 1.1. Type d'acteur
+
+| Action | Résultat attendu |
+|--------|------------------|
+| Créer un nouvel acteur | La fenêtre de création s'ouvre |
+| Choisir le type `adversary` pour représenter un véhicule | Le type adversaire est sélectionné (pas de type vehicle dédié) |
+| Configurer `advancement.level` (-5 à 24) | Le niveau correspond à la puissance du véhicule |
+| Configurer `advancement.threat` (minion/normal/elite/boss) | La menace définit les actions max |
+
+### 1.2. Adversary comme véhicule
+
+| Action | Résultat attendu |
+|--------|------------------|
+| Les caractéristiques sont en mode `value` (pas de base/trained) | Les valeurs sont des entiers simples |
+| Les compétences s'auto-scale : `_autoSkillRank = ceil(threatLevel / 6)` | Le rank automatique est calculé (0-5) |
+| `maxAction = threatConfig.actionMax` | Nombre d'actions défini par la menace |
+
+---
+
+## 2. Équipement du véhicule
+
+### 2.1. Armes de véhicule
+
+| Action | Résultat attendu |
+|--------|------------------|
+| Créer une arme avec `weaponType: 'vehicle'` | L'arme est catégorisée comme arme de véhicule |
+| Configurer `range` adapté au combat spatial (long, extreme) | Portée configurable |
+| Ajouter des qualités spécifiques (linked, blast, etc.) | Qualités configurables |
+| Glisser l'arme dans l'inventaire du véhicule | L'arme apparaît dans l'inventaire |
+
+### 2.2. Attaches et modifications
+
+| Action | Résultat attendu |
+|--------|------------------|
+| Configurer `hardPoints` | Points d'attache définis |
+| Les modifications sont-elles supportées ? | [Vérifier l'état d'avancement] |
+
+---
+
+## 3. Combat de véhicules
+
+### 3.1. Attaque de véhicule
+
+| Action | Résultat attendu |
+|--------|------------------|
+| Utiliser `weaponAttack(action, target, weapon)` sur un véhicule | L'attaque fonctionne avec les mêmes mécanismes que le combat PJ |
+| Vérifier la compétence utilisée : `gunnery` pour les armes lourdes | La compétence est correcte |
+
+### 3.2. Défense de véhicule
+
+| Action | Résultat attendu |
+|--------|------------------|
+| `testDefense(defenseType, roll)` sur un véhicule | Les défenses s'appliquent (armor, dodge, etc.) |
+| Vérifier `getResistance(resource, damageType, restoration)` | Les résistances sont calculées |
+
+### 3.3. Dégâts et réparations
+
+| Action | Résultat attendu |
+|--------|------------------|
+| Appliquer des dégâts au véhicule | `resources.wounds` se met à jour |
+| Vérifier les statuts : `isBroken`, `isDisabled` (si véhicule) | [Vérifier la présence des statuts] |
+
+---
+
+## 4. Fonctionnalités non implémentées
+
+| Fonctionnalité | Statut |
+|----------------|--------|
+| Type d'acteur `vehicle` dédié | Non implémenté (utiliser `adversary`) |
+| Fiche de véhicule spécifique | Non implémenté (utiliser `AdversarySheet`) |
+| Manoeuvrabilité (silhouette, vitesse) | Non implémenté |
+| Équipage et passagers | Non implémenté |
+| Système de dégâts critiques véhicule | Non implémenté |
+| Compétences de pilotage dédiées | À vérifier |
+| Règles de crash/ collision | Non implémenté |
+
+---
+
+## 5. Scénarios de régression
+
+- Créer un adversaire configuré comme vaisseau (niveau, menace) → vérifier que la fiche s'affiche correctement.
+- Ajouter une arme de catégorie `vehicle` → vérifier qu'elle apparaît dans l'inventaire.
+- Équiper l'arme sur le véhicule → vérifier le toggle equip.
+- Simuler une attaque de véhicule → vérifier que `gunnery` est utilisé comme compétence.
+- Appliquer des dégâts → vérifier que les wounds du véhicule se mettent à jour.
+- Vérifier que les compétences auto-scale fonctionnent correctement pour le niveau du véhicule.
+- Documenter les fonctionnalités manquantes pour le planning de développement.

--- a/module/utils/audit-log.mjs
+++ b/module/utils/audit-log.mjs
@@ -1,5 +1,5 @@
 import { logger } from './logger.mjs'
-import { composeEntries } from './audit-diff.mjs'
+import { composeEntries, makeEntry, captureSnapshot } from './audit-diff.mjs'
 
 /* -------------------------------------------- */
 /*  Constantes                                  */
@@ -213,7 +213,7 @@ function readMaxLogEntries() {
 /*  Helpers exportés pour tests                 */
 /* -------------------------------------------- */
 
-export { isOnlyAuditChange, snapshotOldState, cloneValue, evictOldestIfNeeded, flushPending, countPendingEntries, getPendingKey, shiftPendingEntry, pushPendingEntry, isDeletionPath, writeLogEntries, handleWriteError, pruneExpiredPending, readMaxLogEntries }
+export { isOnlyAuditChange, snapshotOldState, cloneValue, evictOldestIfNeeded, flushPending, countPendingEntries, getPendingKey, shiftPendingEntry, pushPendingEntry, isDeletionPath, writeLogEntries, handleWriteError, pruneExpiredPending, readMaxLogEntries, onCreateItem }
 
 /* -------------------------------------------- */
 /*  Handlers (exportés)                         */
@@ -253,12 +253,45 @@ export function onUpdateActor(actor, changes, options, userId) {
 }
 
 /* -------------------------------------------- */
+/*  createItem handler (talent detection)        */
+/* -------------------------------------------- */
+
+export function onCreateItem(item, data, options, userId) {
+  if (item.parent?.type !== 'character') return
+  if (item.type !== 'talent') return
+
+  const ts = Date.now()
+  const snapshot = captureSnapshot(item.parent)
+  const user = game.users?.get(userId) ?? null
+  const cost = item.system?.cost ?? 5
+  const ranks = item.system?.ranks ?? 1
+
+  const entry = makeEntry({
+    type: 'talent.purchase',
+    data: {
+      talentId: item.id,
+      talentName: item.name,
+      cost,
+      ranks,
+    },
+    xpDelta: -cost,
+    ts,
+    userId,
+    user,
+    snapshot,
+  })
+
+  void writeLogEntries(item.parent, [entry])
+}
+
+/* -------------------------------------------- */
 /*  Point d'entrée unique                       */
 /* -------------------------------------------- */
 
 export function registerAuditLogHooks() {
   Hooks.on('preUpdateActor', onPreUpdateActor)
   Hooks.on('updateActor', onUpdateActor)
+  Hooks.on('createItem', onCreateItem)
 }
 
 /* -------------------------------------------- */

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,335 @@
+# Tests du système SWERPG pour Foundry VTT
+
+Ce dossier contient toute l'infrastructure de tests du projet : tests unitaires, tests d'intégration, et tests
+end-to-end (E2E).
+
+---
+
+## 1. Types de tests
+
+| Type                 | Runner     | Emplacement                                  | Filtre d'inclusion                     |
+|----------------------|------------|----------------------------------------------|----------------------------------------|
+| **Unitaires (TU)**   | Vitest     | `tests/**/*.test.mjs`, `tests/**/*.spec.mjs` | Métier pur, sans Foundry ou avec mocks |
+| **Intégration (TI)** | Vitest     | `tests/**/*.integration.spec.mjs`            | Combinaison de modules, imports réels  |
+| **End-to-End (E2E)** | Playwright | `e2e/**/*.spec.ts`                           | Instance Foundry réelle, navigateur    |
+
+---
+
+## 2. Prérequis
+
+- Node.js **LTS** (>=18)
+- **pnpm** installé globalement
+- Dépendances du projet installées :
+
+```bash
+pnpm install
+```
+
+Pour les tests E2E, installer aussi les navigateurs Playwright :
+
+```bash
+pnpm exec playwright install --with-deps
+```
+
+---
+
+## 3. Tests unitaires et d'intégration (Vitest)
+
+### 3.1. Lancement
+
+```bash
+# Toute la suite Vitest (headless)
+pnpm test
+
+# Mode watch (re-run automatique aux changements)
+pnpm test:watch
+
+# Avec couverture de code
+pnpm test:coverage
+```
+
+### 3.2. Fichier de configuration
+
+Deux fichiers coexistent :
+
+- **`vitest.config.mjs`** — utilisé par défaut par `pnpm test`. Inclut les fichiers `tests/**/*.test.mjs` avec le setup
+  `tests/setup.mjs` (mocks Foundry minimaux).
+- **`vitest.config.js`** — config secondaire avec `coverage` et `clearMocks`/`restoreMocks`. Utilise
+  `tests/vitest-setup.js` (mocks Foundry complets via `tests/helpers/mock-foundry.mjs`).
+
+Pour utiliser la config secondaire :
+
+```bash
+pnpm vitest run --config vitest.config.js
+```
+
+### 3.3. Convention de nommage
+
+| Suffixe                  | Nature                                                                     |
+|--------------------------|----------------------------------------------------------------------------|
+| `*.test.mjs`             | Test unitaire standard (inclus automatiquement)                            |
+| `*.spec.mjs`             | Spec unitaire (doit être run explicitement ou via le second vitest.config) |
+| `*.unit.spec.mjs`        | Test unitaire explicite                                                    |
+| `*.integration.spec.mjs` | Test d'intégration                                                         |
+
+### 3.4. Filtrer des tests spécifiques
+
+```bash
+# Par chemin
+pnpm vitest run tests/documents/actor-creation.test.mjs
+
+# Par pattern (grep)
+pnpm vitest run --grep "OggDude"
+
+# Par dossier
+pnpm vitest run tests/documents/
+```
+
+### 3.5. Structure du dossier `tests/`
+
+```
+tests/
+  setup.mjs                          # Setup minimal (mocks Foundry de base)
+  vitest-setup.js                    # Setup complet (mock-foundry)
+  setupTests.js                      # Setup utilitaire (deepClone, mergeObject...)
+  helpers/
+    mock-foundry.mjs                 # Mock central Foundry VTT (686 lignes)
+    mock-foundry.test.mjs            # Tests du mock lui-même (27 tests)
+  unit/                              # Tests unitaires explicites
+  integration/                       # Tests d'intégration
+  documents/                         # Tests des modèles de données (actor, item...)
+  dice/                              # Tests du système de dés narratifs
+  applications/                      # Tests des sheets et UI ApplicationV2
+  config/                            # Tests de configuration système
+  chat/                              # Tests du rendu chat
+  importer/                          # Tests de l'import OggDude (45+ fichiers)
+  settings/                          # Tests des settings OggDude importer
+  lib/                               # Tests des sous-systèmes (skills, talents...)
+  module/                            # Tests des modules internes (socket, logger...)
+  utils/                             # Utilities de test partagées
+  fixtures/                          # Données de fixture (XML, JSON...)
+```
+
+### 3.6. Mocks Foundry (`tests/helpers/mock-foundry.mjs`)
+
+Le système de mock central fournit des simulacres pour :
+
+- `foundry.applications.api` (HandlebarsApplicationMixin, DocumentSheetV2, DialogV2)
+- `foundry.abstract` (DataModel, TypeDataModel)
+- `foundry.data.fields` (StringField, NumberField, BooleanField, etc.)
+- `foundry.utils` (deepClone, mergeObject, randomID, etc.)
+- `game.i18n`, `game.user`, `game.settings`, `game.combats`, `game.packs`, etc.
+- `ui.notifications`, `Color`, `Roll`, `Item`, `Hooks`, `CONFIG`, etc.
+
+Utilisation dans un test :
+
+```javascript
+import { setupFoundryMock, teardownFoundryMock } from '../helpers/mock-foundry.mjs'
+
+beforeEach(() => setupFoundryMock())
+afterEach(() => teardownFoundryMock())
+```
+
+---
+
+## 4. Tests End-to-End (Playwright)
+
+Les tests E2E vivent dans le dossier `e2e/` à la racine du projet, **pas** dans `tests/`.
+
+### 4.1. Configuration de l'environnement
+
+1. Copier le fichier d'exemple :
+
+```bash
+cp .env.e2e.example .env.e2e.local
+```
+
+2. Éditer `.env.e2e.local` avec les valeurs de votre instance Foundry :
+
+```ini
+E2E_FOUNDRY_BASE_URL=http://localhost:30000
+E2E_FOUNDRY_ADMIN_PASSWORD=your_admin_password
+E2E_FOUNDRY_USERNAME=Gamemaster
+E2E_FOUNDRY_PASSWORD=changeme
+E2E_FOUNDRY_WORLD=Swerpg-E2E-World
+```
+
+### 4.2. Lancement
+
+```bash
+# Suite complète (Chromium + Firefox, headless)
+pnpm e2e
+
+# Mode headed (navigateur visible)
+pnpm e2e:headed
+
+# Mode UI interactif (debug)
+pnpm e2e:ui
+
+# CI : Chromium uniquement, tests taggés [ci]
+pnpm e2e:ci
+```
+
+### 4.3. Démarrer une instance Foundry dédiée
+
+```bash
+pnpm foundry:e2e:start    # Démarre un container Docker Foundry v13
+pnpm foundry:e2e:stop     # Arrête le container
+pnpm foundry:e2e:restart  # Redémarre
+```
+
+### 4.4. Filtrer les tests E2E
+
+```bash
+# Par navigateur
+pnpm e2e -- --project=chromium
+pnpm e2e -- --project=firefox
+
+# Par fichier
+pnpm e2e -- e2e/specs/bootstrap.spec.ts
+
+# Par nom (grep)
+pnpm e2e -- --grep "OggDude"
+```
+
+### 4.5. E2E : marquage CI
+
+Seuls les tests avec le tag `[ci]` dans leur titre sont exécutés en CI :
+
+```typescript
+test('Import OggDude [ci] - critical path', async ({ page }) => { ...
+})
+```
+
+### 4.6. Débogage E2E
+
+```bash
+# Inspecteur Playwright (pas à pas)
+pnpm exec playwright test --debug
+
+# Visualiser le rapport HTML
+pnpm exec playwright show-report
+
+# Analyser une trace
+pnpm exec playwright show-trace test-results/path/to/trace.zip
+```
+
+### 4.7. Structure du dossier `e2e/`
+
+```
+e2e/
+  fixtures/
+    index.ts           # Fixture worldReady (setup/teardown automatique)
+    global-setup.ts    # Validation des variables d'environnement
+  helper/
+    overlay.ts         # Fermeture des overlays Foundry (tour, data sharing...)
+  specs/
+    bootstrap.spec.ts           # Test de chargement du monde [ci]
+    oggdude-import.spec.ts      # Test UI de l'import OggDude
+  utils/
+    foundrySession.ts  # Primitives de navigation Foundry (login, join, etc.)
+    foundryUI.ts       # Helpers UI récurrents (Game Settings...)
+    playwrightTest.ts  # setUp / tearDown haut niveau
+```
+
+**Documentation détaillée E2E :** `documentation/tests/e2e/playwright-e2e-guide.md`
+
+---
+
+## 5. Tests manuels
+
+### 5.1. Instance Foundry locale
+
+1. Installer Foundry VTT v13+ sur votre machine.
+2. Créer un monde de test et activer le système `swerpg`.
+3. Lancer le build du système (les sources doivent être compilées) :
+
+```bash
+pnpm run rollup    # Compile les modules JS
+pnpm run less      # Compile les feuilles de style CSS
+```
+
+### 5.2. Mode watch (développement itératif)
+
+Pour recompiler automatiquement les sources à chaque modification :
+
+```bash
+pnpm run rollup:watch   # JS watch
+# dans un autre terminal :
+pnpm run less           # ou gulp css pour rebuild CSS
+```
+
+### 5.3. Scénarios de test manuel recommandés
+
+| Fonctionnalité       | Actions à tester                                                              |
+|----------------------|-------------------------------------------------------------------------------|
+| **Fiche Personnage** | Création, modification des caractéristiques, compétences, talents, équipement |
+| **Combat**           | Init, attaque, défense, dégâts, effets de statut, tour de combat              |
+| **Dés narratifs**    | Pool de dés, upgrade/downgrade, symboles, Triumph/Despair, Force              |
+| **Import OggDude**   | Import d'un fichier ZIP, mapping des données, vérification des装备 et talents   |
+| **Talents**          | Ajout, suppression, activation, effets mécaniques, cumul (ranked)             |
+| **Équipement**       | Armes, armures, équipement général, encaissement, attaches/modifications      |
+| **Véhicules**        | Création, pilotage, combat naval                                              |
+| **UI Sheets**        | Tabs, responsive, drag & drop, context menu, recherche                        |
+
+### 5.4. Points d'attention pour les tests manuels
+
+- **Navigateurs supportés :** Chrome/Chromium, Firefox (Edge et Safari en test secondaire)
+- **Foundry v13+** uniquement (API v13, concepts V2)
+- **Résolution d'écran :** tester au moins en 1920×1080 et 1366×768 (responsive)
+- **Packs de compendium :** vérifier que les packs se décompressent et affichent correctement les données
+- **i18n :** basculer entre français et anglais pour vérifier la couverture des traductions
+- **Logs :** surveiller la console développeur (F12) pour les warnings/erreurs
+
+---
+
+## 6. Bonnes pratiques
+
+### 6.1. Écriture de tests Vitest
+
+- Toujours utiliser `setupFoundryMock()` / `teardownFoundryMock()` pour les tests qui interagissent avec Foundry.
+- Nommer les fichiers selon la convention : `ma-feature.test.mjs` pour les TU, `ma-feature.integration.spec.mjs` pour
+  les TI.
+- Un test = un scénario métier clair (éviter les `it` qui testent 3 choses différentes).
+- Privilégier les imports ES modules (`import`) — le projet est en `"type": "module"`.
+
+### 6.2. Écriture de tests E2E
+
+- Toujours utiliser la fixture `worldReady` (la page est déjà sur `/game`).
+- Privilégier les **locators accessibles** : `getByRole`, `getByLabel` — éviter les sélecteurs CSS fragiles.
+- Ne pas utiliser `page.waitForTimeout(n)` (source de flakiness) ; préférer `expect(locator).toBeVisible()`,
+  `page.waitForURL()`.
+- Suivre le squelette fourni dans `documentation/tests/e2e/playwright-spec-squelette-mon-parcours.md`.
+
+### 6.3. Tests et CI
+
+- La CI exécute `pnpm test` (Vitest) et `pnpm e2e:ci` (Playwright, Chromium, tag `[ci]` seulement).
+- Ajouter le tag `[ci]` aux scénarios E2E critiques qui doivent passer en CI.
+- Le rapport de couverture est publié sur : `https://herdev.hervedarritchon.fr/foundryvtt-swerpg/index.html`
+
+---
+
+## 7. Débogage rapide
+
+| Problème                         | Solution                                                                        |
+|----------------------------------|---------------------------------------------------------------------------------|
+| `vitest` ne trouve pas les tests | Vérifier le pattern dans `vitest.config.mjs` : `tests/**/*.test.mjs`            |
+| Erreur `foundry is not defined`  | Ajouter `setupFoundryMock()` dans `beforeEach`                                  |
+| E2E : navigation impossible      | Vérifier `.env.e2e.local` et que Foundry tourne bien sur `E2E_FOUNDRY_BASE_URL` |
+| E2E : timeout                    | `PLAYWRIGHT_TEST_TIMEOUT=120000 pnpm e2e:headed`                                |
+| Playwright : navigateur manquant | `pnpm exec playwright install --with-deps`                                      |
+| Tests instables (flaky)          | Vérifier les locators (préférer getByRole), éviter les waitForTimeout           |
+
+---
+
+## 8. Références
+
+| Ressource                                                           | Description                                                  |
+|---------------------------------------------------------------------|--------------------------------------------------------------|
+| `documentation/tests/e2e/playwright-e2e-guide.md`                   | Guide E2E complet (configuration, debugging, best practices) |
+| `documentation/tests/e2e/playwright-spec-squelette-mon-parcours.md` | Squelette pour écrire une nouvelle spec E2E                  |
+| `.env.e2e.example`                                                  | Modèle de configuration E2E                                  |
+| `scripts/e2e-foundry-start.sh`                                      | Script Docker E2E (démarrage/arrêt d'une instance Foundry)   |
+| `playwright.config.ts`                                              | Configuration Playwright                                     |
+| `vitest.config.mjs`                                                 | Configuration Vitest (défaut)                                |
+| `vitest.config.js`                                                  | Configuration Vitest (coverage)                              |

--- a/tests/utils/audit-log.test.mjs
+++ b/tests/utils/audit-log.test.mjs
@@ -552,16 +552,167 @@ describe('writeLogEntries', () => {
 })
 
 /* ============================================ */
+/*  onCreateItem                                */
+/* ============================================ */
+
+describe('onCreateItem', () => {
+  function makeCharacterActor(overrides = {}) {
+    return {
+      type: 'character',
+      id: 'actor-001',
+      uuid: 'Actor.actor-001',
+      name: 'Test Character',
+      _source: {
+        system: {
+          skills: {},
+          characteristics: {},
+          progression: { totalXP: 0, spentXP: 0 },
+          details: {},
+          advancement: {},
+        },
+        flags: {},
+      },
+      system: {
+        progression: {
+          experience: { spent: 0, gained: 0, available: 0, total: 0 },
+          freeSkillRanks: {
+            career: { spent: 0, gained: 0, available: 0 },
+            specialization: { spent: 0, gained: 0, available: 0 },
+          },
+        },
+      },
+      update: vi.fn(),
+      ...overrides,
+    }
+  }
+
+  function makeTalentItem(actor, overrides = {}) {
+    return {
+      type: 'talent',
+      id: 'talent-001',
+      name: 'Test Talent',
+      parent: actor,
+      system: {
+        cost: 10,
+        ranks: 1,
+      },
+      ...overrides,
+    }
+  }
+
+  test('creates talent.purchase entry for talent on character', async () => {
+    const { onCreateItem } = await import('../../module/utils/audit-log.mjs')
+    globalThis.foundry.utils.deepClone = vi.fn((o) => structuredClone(o))
+
+    const actor = makeCharacterActor()
+    const item = makeTalentItem(actor)
+
+    await onCreateItem(item, {}, {}, 'user-1')
+
+    expect(actor.update).toHaveBeenCalledTimes(1)
+    const updateArg = actor.update.mock.calls[0][0]
+    const logs = updateArg['flags.swerpg.logs']
+    expect(logs).toHaveLength(1)
+    expect(logs[0]).toMatchObject({
+      type: 'talent.purchase',
+      data: {
+        talentId: 'talent-001',
+        talentName: 'Test Talent',
+        cost: 10,
+        ranks: 1,
+      },
+      xpDelta: -10,
+      userId: 'user-1',
+    })
+  })
+
+  test('uses default cost and ranks when system values are missing', async () => {
+    const { onCreateItem } = await import('../../module/utils/audit-log.mjs')
+    globalThis.foundry.utils.deepClone = vi.fn((o) => structuredClone(o))
+
+    const actor = makeCharacterActor()
+    const item = makeTalentItem(actor, { system: {} })
+
+    await onCreateItem(item, {}, {}, 'user-1')
+
+    expect(actor.update).toHaveBeenCalledTimes(1)
+    const updateArg = actor.update.mock.calls[0][0]
+    const logs = updateArg['flags.swerpg.logs']
+    expect(logs[0].data.cost).toBe(5)
+    expect(logs[0].data.ranks).toBe(1)
+    expect(logs[0].xpDelta).toBe(-5)
+  })
+
+  test('ignores non-talent items', async () => {
+    const { onCreateItem } = await import('../../module/utils/audit-log.mjs')
+    const actor = makeCharacterActor()
+    const item = makeTalentItem(actor, { type: 'weapon' })
+
+    await onCreateItem(item, {}, {}, 'user-1')
+
+    expect(actor.update).not.toHaveBeenCalled()
+  })
+
+  test('ignores items on non-character actors', async () => {
+    const { onCreateItem } = await import('../../module/utils/audit-log.mjs')
+    const npc = { type: 'npc', id: 'npc-001', name: 'NPC', update: vi.fn(), system: {} }
+    const item = makeTalentItem(npc)
+
+    await onCreateItem(item, {}, {}, 'user-1')
+
+    expect(npc.update).not.toHaveBeenCalled()
+  })
+
+  test('handles null parent gracefully', async () => {
+    const { onCreateItem } = await import('../../module/utils/audit-log.mjs')
+    const item = makeTalentItem(null)
+
+    expect(() => onCreateItem(item, {}, {}, 'user-1')).not.toThrow()
+  })
+
+  test('includes valid snapshot fields', async () => {
+    const { onCreateItem } = await import('../../module/utils/audit-log.mjs')
+    globalThis.foundry.utils.deepClone = vi.fn((o) => structuredClone(o))
+
+    const actor = makeCharacterActor({
+      system: {
+        progression: {
+          experience: { spent: 50, gained: 200, available: 150, total: 200 },
+          freeSkillRanks: {
+            career: { spent: 2, gained: 5, available: 3 },
+            specialization: { spent: 0, gained: 3, available: 3 },
+          },
+        },
+      },
+    })
+    const item = makeTalentItem(actor)
+
+    await onCreateItem(item, {}, {}, 'user-1')
+
+    const updateArg = actor.update.mock.calls[0][0]
+    const snapshot = updateArg['flags.swerpg.logs'][0].snapshot
+    expect(snapshot).toMatchObject({
+      xpAvailable: 150,
+      totalXpSpent: 50,
+      totalXpGained: 200,
+      careerFreeAvailable: 3,
+      specializationFreeAvailable: 3,
+    })
+  })
+})
+
+/* ============================================ */
 /*  registerAuditLogHooks                       */
 /* ============================================ */
 
 describe('registerAuditLogHooks', () => {
-  test('registers two hooks via Hooks.on (no onCreateItemAction)', async () => {
+  test('registers three hooks via Hooks.on', async () => {
     const { registerAuditLogHooks } = await import('../../module/utils/audit-log.mjs')
     registerAuditLogHooks()
-    expect(globalThis.Hooks.on).toHaveBeenCalledTimes(2)
+    expect(globalThis.Hooks.on).toHaveBeenCalledTimes(3)
     expect(globalThis.Hooks.on).toHaveBeenCalledWith('preUpdateActor', expect.any(Function))
     expect(globalThis.Hooks.on).toHaveBeenCalledWith('updateActor', expect.any(Function))
+    expect(globalThis.Hooks.on).toHaveBeenCalledWith('createItem', expect.any(Function))
   })
 })
 


### PR DESCRIPTION
## Description

Implémente le hook `onCreateItem` manquant dans le système d audit log, conformément au plan US1 (§4.4 et §5 Étape 1).

### Changements

- **`module/utils/audit-log.mjs`** : Ajout de la fonction `onCreateItem` qui détecte la création d items de type `talent` sur les acteurs `character` et génère une entrée `talent.purchase` dans l audit log
- **`tests/utils/audit-log.test.mjs`** : 6 nouveaux tests couvrant les cas nominaux et aux limites

### Tests

- `onCreateItem` crée une entrée `talent.purchase` pour un talent sur un character
- `onCreateItem` ignore les items non-talent (type=weapon)
- `onCreateItem` ignore les items sur des acteurs non-character (type=npc)
- `onCreateItem` gère `parent=null` sans erreur
- `onCreateItem` inclut un snapshot XP valide

### Validation

`npx vitest run tests/utils/audit-log.test.mjs tests/utils/audit-diff.test.mjs` → 2 files, 93 tests passed

Closes #163