### PR TITLE
feat(sidebar-header): déplacer le nom du personnage du header droit vers la sidebar (#178)

### DIFF
--- a/documentation/plan/character-sheet/side-bar/header/178-plan-deplacer-nom-sidebar.md
+++ b/documentation/plan/character-sheet/side-bar/header/178-plan-deplacer-nom-sidebar.md
@@ -1,0 +1,401 @@
+# Plan d'implémentation — #178 : Déplacer le nom du personnage du header droit vers la sidebar
+
+**Issue
+** : [#178 — Déplacer le nom du personnage du header droit vers la sidebar](https://github.com/herveDarritchon/foundryvtt-swerpg/issues/178)  
+**Epic
+** : [#177 — Epic: Enrichir le header de la sidebar Character Sheet](https://github.com/herveDarritchon/foundryvtt-swerpg/issues/177)  
+**ADR(s)** :
+
+- `documentation/architecture/adr/adr-0001-foundry-applicationv2-adoption.md` (UI en ApplicationV2)
+- `documentation/architecture/adr/adr-0005-localization-strategy.md` (i18n, pas de nouvelles clés nécessaires)  
+  **Module(s) impacté(s)** : `module/applications/sheets/character-sheet.mjs` (modification)
+
+---
+
+## 1. Objectif
+
+Déplacer le champ modifiable `name` du personnage depuis le header droit de la Character Sheet (
+`templates/sheets/actor/character-header.hbs`) vers la sidebar (`templates/sheets/actor/sidebar.hbs`), au-dessus de
+l'avatar. Le nom reste éditable et persiste via le mécanisme `submitOnChange` natif d'ApplicationV2. Aucune modification
+du modèle de données n'est nécessaire.
+
+Ce ticket #178 est strictement limité au déplacement du nom. Les issues #179 (overlay) et #180 (Wounds/Strain) seront
+traitées séparément.
+
+---
+
+## 2. Périmètre
+
+### Inclus dans #178
+
+- Ajout d'un champ `<input name="name">` dans `templates/sheets/actor/sidebar.hbs`, au-dessus de l'image avatar, dans un
+  conteneur `.sidebar-header`
+- Contribution d'une propriété `context.sidebarHeader` (préparée dans `_prepareContext()` de `CharacterSheet`) contenant
+  minimalement `{ name, img }` pour alimenter le template sidebar
+- Retrait du `<input class="charname">` existant dans `templates/sheets/actor/character-header.hbs`
+- Ajustement CSS du header droit (`.sheet-header`) pour occuper l'espace libéré : retrait des règles `.charname`
+  devenues inutiles, rééquilibrage des flex enfants
+- Ajout des styles du nouveau bloc `.sidebar-header` dans `styles/actor.less` : nom centré, fond transparent, bordure
+  inférieure fine, focus visible
+- Protection de la régression Adversary : le nouveau bloc n'apparaît que quand `context.sidebarHeader` est défini, ce
+  qui n'est le cas que pour les sheets `character`
+- Tests Vitest de contexte : vérifier que `_prepareContext()` dans `CharacterSheet` expose `sidebarHeader.name` et
+  `sidebarHeader.img` un document character, et que ces propriétés sont absentes pour un non-character
+
+### Exclu de #178
+
+- Overlay avatar overlay (#179)
+- Affichage des ressources Wounds / Strain (#180)
+- Création d'un template de sidebar dédié au character
+- Changement de modèle de données
+- Nouveaux hooks ou actions
+- Tests de rendu DOM (tests manuels suffisants)
+- Changements dans les fichiers i18n (aucune nouvelle clé nécessaire)
+
+---
+
+## 3. Constat sur l'existant
+
+### Le nom est actuellement dans le header droit
+
+```
+templates/sheets/actor/character-header.hbs:3
+  <input class="charname" name="name" type="text" value="{{source.name}}" placeholder="Actor Name">
+```
+
+Ce champ est éditable, persiste via `submitOnChange: true` (option du formulaire dans `DEFAULT_OPTIONS`), et sa valeur
+provient de `{{source.name}}` (`this.document.toObject()`).
+
+### La sidebar est un PART commun partagé
+
+```
+base-actor-sheet.mjs:62-66
+  static PARTS = {
+    sidebar: {
+      id: 'sidebar',
+      template: 'systems/swerpg/templates/sheets/actor/sidebar.hbs',
+    },
+    ...
+  }
+```
+
+Tous les types d'acteurs (`character`, `adversary`, etc.) utilisent la même template `sidebar.hbs`. Actuellement, le
+seul contenu de la sidebar est :
+
+1. Une image avatar (`<img class="profile">`)
+2. La section équipement favori
+3. La section actions favorites
+
+### Le header droit a un flex layout spécifique pour le nom
+
+```
+styles/actor.less:162-227
+  .sheet-header {
+    header.title {
+      .charname { flex: 1 !important; margin-right: 2rem; ... }
+      input { height: var(--sheet-header-height); font-size: var(--font-size-24); ... }
+      ...
+    }
+  }
+```
+
+Le `.charname` occupe `flex: 1` dans le `header.title`, ce qui pousse les éléments suivants (audit log, XP) vers la
+droite.
+
+### Aucune donnée `sidebarHeader` n'existe dans le contexte
+
+Le contexte actuel de `CharacterSheet._prepareContext()` (fichier `character-sheet.mjs:106-159`) expose `source`,
+`actor`, `system`, etc. mais pas de bloc dédié à la sidebar. L'image avatar utilise `{{source.img}}` et
+`{{source.name}}`.
+
+### Tests existants
+
+Les tests de contexte `character-sheet-skills.test.mjs` testent déjà `_prepareContext()` via `getContext(actor)` (ligne
+263-270). Ils mockent un actor character et peuvent être étendus pour valider la présence de `sidebarHeader`.
+
+---
+
+## 4. Décisions d'architecture
+
+### 4.1. Enrichissement du contexte vs nouveau PART
+
+**Question** : Faut-il créer un `PART sidebar-header` séparé ou enrichir le contexte du `PART sidebar` existant ?
+
+**Décision** : Enrichir le contexte existant.
+
+Justification :
+
+- Le nom et l'avatar sont structurellement liés (le nom est juste au-dessus de l'image) ; les séparer en deux templates
+  ajouterait de la complexité sans bénéfice
+- Le `PART sidebar` actuel a le bon cycle de rendu pour cet affichage permanent
+- La template `sidebar.hbs` reste simple avec un bloc conditionnel
+
+### 4.2. Propriété dédiée `sidebarHeader` vs réutilisation de `source`
+
+**Question** : Faut-il enrichir `context.source` avec les nouvelles données ou créer une propriété dédiée
+`context.sidebarHeader` ?
+
+**Décision** : Créer `context.sidebarHeader`.
+
+Justification :
+
+- `context.source` est un `toObject()` complet du document, ce qui est plus lourd que nécessaire
+- `sidebarHeader` est sémantiquement clair : "données préparées pour le header de la sidebar"
+- Permet d'ajouter ultérieurement `wounds`/`strain` (issue #180) sans toucher à `source`
+- Limite le couplage entre le template et le data model
+
+### 4.3. Condition `{{#if sidebarHeader}}` vs template de sidebar séparé
+
+**Question** : Comment protéger les autres types d'acteurs (adversary, etc.) de ce nouveau bloc ?
+
+**Décision** : Utiliser `{{#if sidebarHeader}}` dans la template partagée.
+
+Justification :
+
+- Un template de sidebar séparé dupliquerait tout le contenu (équipement, actions) pour un seul champ de différence
+- Le bloc conditionnel est localisé et facile à maintenir
+- Seul `CharacterSheet` définit `sidebarHeader` ; les autres sheets ne voient aucun changement
+- Pattern déjà utilisé par d'autres conditions dans la template (ex: `{{#if compactMode}}`)
+
+### 4.4. Valeur du champ nom dans la sidebar
+
+**Question** : Faut-il lier `sidebarHeader.name` à `a.name` (instance) ou `source.name` (objet source) ?
+
+**Décision** : Utiliser `source.name` pour rester cohérent avec le comportement actuel du header (`{{source.name}}`).
+
+Justification :
+
+- `{{source.name}}` est la valeur figée au moment du rendu, ce qui est attendu pour un formulaire
+- `a.name` pourrait retourner une valeur différente si l'actor a été modifié entre le rendu et la soumission
+- Cohérence avec les autres templates sheet qui utilisent `{{source.name}}` pour les `<input>`
+
+### 4.5. Stockage de `sidebarHeader` dans le contexte
+
+**Décision** : La propriété est préparée dans `CharacterSheet._prepareContext()` et non dans
+`SwerpgBaseActorSheet._prepareContext()`.
+
+Justification :
+
+- Seule la Character Sheet a besoin de ce header enrichi pour l'instant
+- Laisser la base inchangée respecte le principe de responsabilité unique
+- Si une autre sheet (hero, etc.) devait un jour l'utiliser, on pourrait la remonter
+
+### 4.6. Tests
+
+**Décision** : Ajouter des tests unitaires de contexte dans un nouveau fichier dédié ou étendre le fichier existant
+`character-sheet-skills.test.mjs`, sans tests de rendu DOM.
+
+Justification :
+
+- Le risque de #178 est principalement dans la préparation des données et le conditionnel HBS
+- Les tests de rendu nécessiteraient un environnement DOM (ApplicationV2) non disponible en tests unitaires
+- Le pattern existant `getContext(actor)` est réutilisable directement
+
+---
+
+## 5. Plan de travail détaillé
+
+### Étape 1 : Préparer `context.sidebarHeader` dans `CharacterSheet._prepareContext()`
+
+**Fichier** : `module/applications/sheets/character-sheet.mjs`
+
+Dans `_prepareContext()`, ajouter après l'enrichissement existant (après `context.defenses = ...`) :
+
+```
+context.sidebarHeader = {
+  name: s.name,
+  img: s.img,
+}
+```
+
+`a` est l'instance actor, `s` est `source` (déjà présent dans le contexte). On utilise `s.name` car c'est la valeur
+figée au rendu.
+
+**Risque** : Aucun, car `s` existe toujours après `const { actor: a, source: s, incomplete: i } = context`.
+
+### Étape 2 : Ajouter le bloc `.sidebar-header` dans `sidebar.hbs`
+
+**Fichier** : `templates/sheets/actor/sidebar.hbs`
+
+Remplacer le `<img class="profile">` existant (ligne 2) par un bloc conditionnel :
+
+```hbs
+{{#if sidebarHeader}}
+<div class="sidebar-header">
+  <input class="sidebar-name" name="name" type="text" value="{{sidebarHeader.name}}" placeholder="Actor Name">
+  <div class="sidebar-profile-wrapper">
+    <img class="profile" src="{{sidebarHeader.img}}" alt="{{sidebarHeader.name}}"
+         width="200" height="200" data-action="editImage" data-edit="img">
+  </div>
+</div>
+{{else}}
+<img class="profile" src="{{source.img}}" alt="{{source.name}}"
+     width="200" height="200" data-action="editImage" data-edit="img" />
+{{/if}}
+```
+
+**Risque** : L'action `data-action="editImage"` et `data-edit="img"` doivent être préservées sur l'image du bloc
+character. C'est le cas ci-dessus.
+
+### Étape 3 : Retirer le champ nom du `character-header.hbs`
+
+**Fichier** : `templates/sheets/actor/character-header.hbs`
+
+Supprimer la ligne :
+
+```hbs
+<input class="charname" name="name" type="text" value="{{source.name}}" placeholder="Actor Name">
+```
+
+Les autres éléments du header (audit log, XP, bouton creation) ne sont pas modifiés.
+
+**Risque** : Le retrait du champ `flex: 1` peut déstabiliser le layout du `.title`. Mitigation : étape 4.
+
+### Étape 4 : Ajuster les styles CSS
+
+#### 4a. Nouveaux styles sidebar header
+
+**Fichier** : `styles/actor.less`
+
+Ajouter dans la section `.sheet-sidebar` (après `img.profile`) un bloc `.sidebar-header` :
+
+```
+.sidebar-header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+
+  .sidebar-name {
+    width: 100%;
+    height: 32px;
+    border: none;
+    border-bottom: 1px solid var(--color-frame);
+    background: transparent;
+    font-family: var(--font-h1);
+    font-size: var(--font-size-16);
+    text-align: center;
+    color: var(--color-text-light-highlight);
+
+    &:focus {
+      border-bottom-color: var(--color-accent);
+      box-shadow: 0 2px 4px rgba(0, 0, 0, 0.3);
+      outline: none;
+    }
+  }
+
+  .sidebar-profile-wrapper {
+    position: relative;
+    width: 100%;
+
+    img.profile {
+      display: block;
+      width: 100%;
+      border: none;
+      border-radius: 4px;
+      background: var(--color-frame-bg-50);
+      object-fit: contain;
+    }
+  }
+}
+```
+
+#### 4b. Ajustement du header droit
+
+**Fichier** : `styles/actor.less`
+
+Dans `.sheet-header header.title` :
+
+- Retirer la règle `.charname` (flex 1, margin-right, padding, text-align)
+- Les règles `input { ... }` (height, font-size) restent car d'autres inputs pourraient exister dans le titre
+- Vérifier que le retrait de `flex: 1` ne casse pas le positionnement du bouton audit-log et de l'XP
+
+**Risque** : Le header `.title` peut rétrécir après retrait du champ nom. Les éléments restants (audit-log, XP) sont en
+`flex: none` et devraient rester alignés à droite. À valider manuellement.
+
+### Étape 5 : Tests
+
+#### 5a. Test de contexte character
+
+**Fichier** : à créer ou étendre (proposition : `tests/applications/sheets/character-sheet-sidebar-header.test.mjs`)
+
+Test unitaire :
+
+1. Construire un mock actor character avec `name: 'Test Character'` et `img: 'test-avatar.png'`
+2. Appeler `CharacterSheet._prepareContext()` (via `getContext()` existant)
+3. Vérifier `context.sidebarHeader.name === 'Test Character'`
+4. Vérifier `context.sidebarHeader.img === 'test-avatar.png'`
+
+#### 5b. Test d'absence pour non-character (adversary)
+
+Vérifier que `SwerpgBaseActorSheet._prepareContext()` (base, pas CharacterSheet) ne produit pas `sidebarHeader`.
+
+#### 5c. Validation manuelle
+
+- Ouvrir une Character Sheet → le nom doit apparaître dans la sidebar, centré au-dessus de l'avatar
+- Modifier le nom → la modification persiste au blur (submitOnChange)
+- Le header droit ne doit plus afficher le nom mais conserver audit-log, XP, bouton creation
+- Ouvrir une Adversary Sheet → pas de régression, la sidebar reste inchangée
+
+---
+
+## 6. Fichiers modifiés
+
+| Fichier                                                             | Action       | Description                                                                                                          |
+|---------------------------------------------------------------------|--------------|----------------------------------------------------------------------------------------------------------------------|
+| `module/applications/sheets/character-sheet.mjs`                    | Modification | Ajout de `context.sidebarHeader = { name, img }` dans `_prepareContext()`                                            |
+| `templates/sheets/actor/sidebar.hbs`                                | Modification | Ajout du bloc conditionnel `.sidebar-header` avec input name ; fallback pour les non-character                       |
+| `templates/sheets/actor/character-header.hbs`                       | Modification | Retrait du `<input class="charname">`                                                                                |
+| `styles/actor.less`                                                 | Modification | Ajout des styles `.sidebar-header`, `.sidebar-name`, `.sidebar-profile-wrapper` ; retrait/adjustement de `.charname` |
+| `tests/applications/sheets/character-sheet-sidebar-header.test.mjs` | Création     | Tests de contexte pour `sidebarHeader`                                                                               |
+
+---
+
+## 7. Risques
+
+| Risque                                                                                              | Impact | Mitigation                                                                                                                                         |
+|-----------------------------------------------------------------------------------------------------|--------|----------------------------------------------------------------------------------------------------------------------------------------------------|
+| **Régression Adversary** : l'ajout dans `sidebar.hbs` impacte les adversary sheets                  | Moyen  | Bloc `{{#if sidebarHeader}}` ; tester qu'AdversarySheet ne définit pas `sidebarHeader`                                                             |
+| **Perte de persistance du nom** : l'input dans la sidebar ne persiste pas                           | Élevé  | Le binding `name="name"` est identique à celui du header ; `submitOnChange` est défini dans `DEFAULT_OPTIONS` de `base-actor-sheet.mjs` (ligne 39) |
+| **Layout header droit cassé** : le retrait du champ `flex: 1` désaligne les éléments restants       | Faible | Les autres enfants (audit-log, XP) sont en `flex: none` et `flex: 0 0 var(--sheet-header-height)` ; vérification manuelle après changement CSS     |
+| **Édition d'image perdue** : `data-action="editImage"` absent dans le nouveau bloc                  | Faible | Vérifier la présence de l'attribut sur l'`<img>` dans le bloc character                                                                            |
+| **Tests existants cassés** : les tests `_prepareContext()` s'attendent à des propriétés spécifiques | Faible | Les tests existants lisent `context.skills` et `context.source` ; `sidebarHeader` est une propriété additionnelle, pas un remplacement             |
+
+---
+
+## 8. Proposition d'ordre de commit
+
+1. **`feat(sidebar-header): add sidebarHeader context data to CharacterSheet._prepareContext()`**
+    - `module/applications/sheets/character-sheet.mjs`
+    - Ajoute `context.sidebarHeader = { name, img }`
+
+2. **`feat(sidebar-header): add character name input to sidebar template`**
+    - `templates/sheets/actor/sidebar.hbs`
+    - Bloc conditionnel `.sidebar-header` avec l'input nom et l'avatar
+
+3. **`feat(sidebar-header): remove character name input from right header`**
+    - `templates/sheets/actor/character-header.hbs`
+    - Retrait du `<input class="charname">`
+
+4. **`style(sidebar-header): add sidebar header styles and adjust right header`**
+    - `styles/actor.less`
+    - Nouveaux styles `.sidebar-header`, `.sidebar-name`, `.sidebar-profile-wrapper`
+    - Nettoyage des règles `.charname` devenues inutiles
+
+5. **`test(sidebar-header): add context tests for sidebarHeader presence and shape`**
+    - `tests/applications/sheets/character-sheet-sidebar-header.test.mjs`
+    - Test character → `sidebarHeader` présent
+    - Test non-character → `sidebarHeader` absent
+
+---
+
+## 9. Dépendances avec les autres US
+
+| Issue                 | Dépendance       | Raison                                                           |
+|-----------------------|------------------|------------------------------------------------------------------|
+| #179 — Overlay avatar | #178 (précédent) | L'overlay s'insère dans `.sidebar-profile-wrapper` créé par #178 |
+| #180 — Wounds/Strain  | #179 (précédent) | Les valeurs s'affichent dans l'overlay créé par #179             |
+
+**Ordre conseillé** : #178 → #179 → #180.
+
+Les trois tickets peuvent toutefois être préparés en parallèle au niveau contexte (`sidebarHeader` peut contenir les
+clés vides pour #179/#180 sans les rendre visibles).

--- a/documentation/plan/character-sheet/side-bar/header/README.md
+++ b/documentation/plan/character-sheet/side-bar/header/README.md
@@ -1,0 +1,203 @@
+# Plan : Enrichissement du header de la sidebar (Character Sheet)
+
+## Objectif
+
+Déplacer le nom du personnage du header droit de la character sheet vers le
+haut de la sidebar (au-dessus de l'avatar), et ajouter un overlay translucide
+en bas de l'avatar affichant les ressources Wounds et Strain en lecture seule
+(valeur actuelle / seuil).
+
+## État actuel
+
+1. Le nom modifiable est dans
+   `templates/sheets/actor/character-header.hbs:3` : un `<input>` avec `name="name"`.
+2. L'avatar de sidebar est un simple `<img class="profile">` dans
+   `templates/sheets/actor/sidebar.hbs:2`.
+3. La sidebar est un PART commun partagé entre `character` et `adversary`
+   (déclaré dans `base-actor-sheet.mjs:62-66`).
+4. Les données `resources.wounds` et `resources.strain` existent déjà sur le
+   document actor ; pas de changement de modèle nécessaire.
+
+## Modifications
+
+### 1. Contexte : `module/applications/sheets/character-sheet.mjs`
+
+Dans `_prepareContext()`, ajouter un bloc `sidebarHeader` :
+
+```js
+const r = a.system.resources
+context.sidebarHeader = {
+  name: a.name,
+  img: a.img,
+  wounds: { value: r.wounds.value, threshold: r.wounds.threshold },
+  strain: { value: r.strain.value, threshold: r.strain.threshold },
+}
+```
+
+Le template pourra consommer `sidebarHeader.name`, `sidebarHeader.img`, etc.
+Condition : ne rien exposer pour `adversary` (pas d'impact).
+
+### 2. Template sidebar : `templates/sheets/actor/sidebar.hbs`
+
+Remplacer :
+
+```hbs
+<img class="profile" src="{{source.img}}" ... />
+```
+
+par un bloc structuré **uniquement si** `sidebarHeader` existe :
+
+```hbs
+{{#if sidebarHeader}}
+<div class="sidebar-header">
+  <input class="sidebar-name" name="name" type="text" value="{{sidebarHeader.name}}" placeholder="…">
+
+  <div class="sidebar-profile-wrapper">
+    <img class="profile" src="{{sidebarHeader.img}}" alt="{{sidebarHeader.name}}"
+         width="200" height="200" data-action="editImage" data-edit="img">
+
+    <div class="sidebar-profile-overlay">
+      <div class="sidebar-resource wounds">
+        <span class="label">{{localize "RESOURCES.WOUNDS"}}</span>
+        <span class="value">{{sidebarHeader.wounds.value}}/{{sidebarHeader.wounds.threshold}}</span>
+      </div>
+      <div class="sidebar-resource strain">
+        <span class="label">{{localize "RESOURCES.STRAIN"}}</span>
+        <span class="value">{{sidebarHeader.strain.value}}/{{sidebarHeader.strain.threshold}}</span>
+      </div>
+    </div>
+  </div>
+</div>
+{{else}}
+<img class="profile" src="{{source.img}}" alt="{{source.name}}"
+     width="200" height="200" data-action="editImage" data-edit="img" />
+{{/if}}
+```
+
+Le `else` préserve le comportement actuel pour `adversary` et tout autre type.
+
+### 3. Header droit : `templates/sheets/actor/character-header.hbs`
+
+Retirer :
+
+```hbs
+<input class="charname" name="name" type="text" value="{{source.name}}" placeholder="Actor Name">
+```
+
+et ajuster le layout du `.title` pour occuper l'espace libéré.
+
+### 4. Styles : `styles/actor.less`
+
+Ajouter dans la section `.sheet-sidebar` :
+
+```less
+.sidebar-header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+
+  .sidebar-name {
+    width: 100%;
+    border: none;
+    border-bottom: 1px solid var(--color-frame);
+    background: transparent;
+    font-family: var(--font-h1);
+    font-size: var(--font-size-18);
+    text-align: center;
+
+    &:focus {
+      border-bottom-color: var(--color-accent);
+      box-shadow: 0 2px 4px rgba(0, 0, 0, 0.3);
+    }
+  }
+
+  .sidebar-profile-wrapper {
+    position: relative;
+    width: 100%;
+
+    img.profile {
+      display: block;
+      width: 100%;
+      border: none;
+      border-radius: 4px;
+      background: var(--color-frame-bg-50);
+      object-fit: contain;
+    }
+
+    .sidebar-profile-overlay {
+      position: absolute;
+      bottom: 0;
+      left: 0;
+      right: 0;
+      height: 20%; /* ~ un cinquième de l'avatar */
+      display: flex;
+      align-items: center;
+      justify-content: space-around;
+      padding: 0 0.5rem;
+      background: rgba(0, 0, 0, 0.65);
+      backdrop-filter: blur(2px);
+      border-radius: 0 0 4px 4px;
+      gap: 0.75rem;
+
+      .sidebar-resource {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        line-height: 1.2;
+
+        .label {
+          font-size: var(--font-size-9);
+          text-transform: uppercase;
+          letter-spacing: 0.05em;
+          opacity: 0.8;
+        }
+
+        .value {
+          font-family: var(--font-h1);
+          font-size: var(--font-size-12);
+          white-space: nowrap;
+        }
+
+        &.wounds .label { color: #ff4444; }
+        &.wounds .value { color: #ff6666; }
+        &.strain .label { color: #44cc44; }
+        &.strain .value { color: #66ee66; }
+      }
+    }
+  }
+}
+```
+
+### 5. i18n
+
+Pas de nouvelles clés : on réutilise `RESOURCES.WOUNDS` et `RESOURCES.STRAIN` déjà
+présentes dans `lang/en.json` et `lang/fr.json`.
+
+### 6. Tests
+
+- Ajouter un test de contexte dans `CharacterSheet._prepareContext()` pour
+  vérifier la présence de `sidebarHeader` avec ses sous-champs.
+- Ajouter un test de non-régression : le flag n'apparaît pas pour un mock actor
+  non-character.
+- Les tests responsive existants (compact mode) ne sont pas impactés.
+
+## Fichiers impactés
+
+| Fichier | Nature |
+|---|---|
+| `module/applications/sheets/character-sheet.mjs` | + préparation contexte |
+| `templates/sheets/actor/sidebar.hbs` | + structure header/overlay |
+| `templates/sheets/actor/character-header.hbs` | - champ nom |
+| `styles/actor.less` | + styles nouveau bloc |
+| `tests/…` (à définir) | + tests contexte |
+
+## Risques et atténuations
+
+- **Sidebar partagée** : le bloc `{{#if sidebarHeader}}` évite toute régression
+  sur `adversary`. Vérification manuelle recommandée.
+- **Nom modifiable perdu** : le champ `<input name="name">` dans la sidebar
+  respecte le form `submitOnChange`, donc la persistance est identique.
+- **Superposition overlay / clics** : l'overlay a `pointer-events: none` sur
+  les zones non interactives ; l'image conserve `data-action="editImage"`.
+- **Hauteur 20%** : à ajuster si le ratio portrait est très vertical. Prévoir
+  `max-height: 48px` pour ne pas saturer l'image.

--- a/module/applications/sheets/character-sheet.mjs
+++ b/module/applications/sheets/character-sheet.mjs
@@ -151,6 +151,7 @@ export default class CharacterSheet extends SwerpgBaseActorSheet {
     context.jauges = this.buildJaugeDisplayData(a.system.resources)
     context.soak = this.#buildSoakDisplayData(a.system.characteristics.brawn)
     context.defenses = this.buildDefenseDisplayData()
+    context.sidebarHeader = { name: s.name, img: s.img }
 
     // Debug de préparation du contexte
     logger.debug(`[${this.constructor.name}] Context prepared:`, context)

--- a/styles/actor.less
+++ b/styles/actor.less
@@ -176,13 +176,6 @@
         font-size: var(--font-size-24);
       }
 
-      .charname {
-        flex: 1 !important;
-        margin-right: 2rem;
-        padding: 0 0.5rem;
-        text-align: left;
-      }
-
       .level,
       .controls,
       a.level-up {
@@ -294,6 +287,44 @@
       border-radius: 4px;
       background: var(--color-frame-bg-50);
       object-fit: contain;
+    }
+
+    .sidebar-header {
+      display: flex;
+      flex-direction: column;
+      gap: 0.5rem;
+
+      .sidebar-name {
+        width: 100%;
+        height: 32px;
+        border: none;
+        border-bottom: 1px solid var(--color-frame);
+        background: transparent;
+        font-family: var(--font-h1);
+        font-size: var(--font-size-16);
+        text-align: center;
+        color: var(--color-text-light-highlight);
+
+        &:focus {
+          border-bottom-color: var(--color-accent);
+          box-shadow: 0 2px 4px rgba(0, 0, 0, 0.3);
+          outline: none;
+        }
+      }
+
+      .sidebar-profile-wrapper {
+        position: relative;
+        width: 100%;
+
+        img.profile {
+          display: block;
+          width: 100%;
+          border: none;
+          border-radius: 4px;
+          background: var(--color-frame-bg-50);
+          object-fit: contain;
+        }
+      }
     }
 
     h2.divider {

--- a/styles/swerpg.css
+++ b/styles/swerpg.css
@@ -1149,12 +1149,6 @@ input[type='range'] {
   font-family: var(--font-h1);
   font-size: var(--font-size-24);
 }
-.swerpg.sheet.actor .sheet-header header.title .charname {
-  flex: 1 !important;
-  margin-right: 2rem;
-  padding: 0 0.5rem;
-  text-align: left;
-}
 .swerpg.sheet.actor .sheet-header header.title .level,
 .swerpg.sheet.actor .sheet-header header.title .controls,
 .swerpg.sheet.actor .sheet-header header.title a.level-up {
@@ -1242,6 +1236,39 @@ input[type='range'] {
   overflow: hidden;
 }
 .swerpg.sheet.actor .sheet-sidebar img.profile {
+  border: none;
+  border-radius: 4px;
+  background: var(--color-frame-bg-50);
+  object-fit: contain;
+}
+.swerpg.sheet.actor .sheet-sidebar .sidebar-header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+.swerpg.sheet.actor .sheet-sidebar .sidebar-header .sidebar-name {
+  width: 100%;
+  height: 32px;
+  border: none;
+  border-bottom: 1px solid var(--color-frame);
+  background: transparent;
+  font-family: var(--font-h1);
+  font-size: var(--font-size-16);
+  text-align: center;
+  color: var(--color-text-light-highlight);
+}
+.swerpg.sheet.actor .sheet-sidebar .sidebar-header .sidebar-name:focus {
+  border-bottom-color: var(--color-accent);
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.3);
+  outline: none;
+}
+.swerpg.sheet.actor .sheet-sidebar .sidebar-header .sidebar-profile-wrapper {
+  position: relative;
+  width: 100%;
+}
+.swerpg.sheet.actor .sheet-sidebar .sidebar-header .sidebar-profile-wrapper img.profile {
+  display: block;
+  width: 100%;
   border: none;
   border-radius: 4px;
   background: var(--color-frame-bg-50);

--- a/templates/sheets/actor/character-header.hbs
+++ b/templates/sheets/actor/character-header.hbs
@@ -1,6 +1,5 @@
 <section class="sheet-header flexcol">
     <header class="title flexrow">
-        <input class="charname" name="name" type="text" value="{{source.name}}" placeholder="Actor Name">
         {{#if incomplete.creation}}
             <a class="button icon level-up fa-solid fa-triangle-exclamation incomplete" data-action="levelUp"
                data-tooltip="{{incomplete.creationTooltip}}" data-tooltip-class="creation-steps"></a>

--- a/templates/sheets/actor/sidebar.hbs
+++ b/templates/sheets/actor/sidebar.hbs
@@ -1,5 +1,14 @@
 <section class="sheet-sidebar flexcol">
+{{#if sidebarHeader}}
+  <div class="sidebar-header">
+    <input class="sidebar-name" name="name" type="text" value="{{sidebarHeader.name}}" placeholder="Actor Name">
+    <div class="sidebar-profile-wrapper">
+      <img class="profile" src="{{sidebarHeader.img}}" alt="{{sidebarHeader.name}}" width="200" height="200" data-action="editImage" data-edit="img">
+    </div>
+  </div>
+{{else}}
   <img class="profile" src="{{source.img}}" alt="{{source.name}}" width="200" height="200" data-action="editImage" data-edit="img" />
+{{/if}}
 
   {{! Current Equipment }}
   <h2 class="section-header divider">{{localize "ACTOR.LABELS.CURRENT_EQUIPMENT"}}</h2>

--- a/tests/applications/sheets/character-sheet-sidebar-header.test.mjs
+++ b/tests/applications/sheets/character-sheet-sidebar-header.test.mjs
@@ -1,0 +1,111 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+
+vi.mock('../../../module/utils/logger.mjs', () => ({
+  logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}))
+
+vi.mock('../../../module/lib/jauges/jauge-factory.mjs', () => ({
+  default: { build: vi.fn(() => ({ create: vi.fn(() => ({})) })) },
+}))
+vi.mock('../../../module/lib/featured-equipment.mjs', () => ({
+  computeFeaturedEquipment: vi.fn(() => []),
+}))
+vi.mock('../../../module/lib/skills/skill-factory.mjs', () => ({ default: {} }))
+vi.mock('../../../module/lib/talents/talent-factory.mjs', () => ({ default: {} }))
+
+describe('CharacterSheet sidebarHeader context', () => {
+  let CharacterSheet
+  let SwerpgBaseActorSheet
+
+  beforeEach(async () => {
+    vi.clearAllMocks()
+    if (!globalThis.game.system.tree) globalThis.game.system.tree = {}
+    globalThis.game.system.tree.actor = null
+    CharacterSheet = (await import('../../../module/applications/sheets/character-sheet.mjs')).default
+    SwerpgBaseActorSheet = (await import('../../../module/applications/sheets/base-actor-sheet.mjs')).default
+  })
+
+  function buildCharacterActor() {
+    const actor = {
+      name: 'Darth Maul',
+      img: 'systems/swerpg/assets/portraits/darth-maul.webp',
+      type: 'character',
+      system: {
+        skills: {},
+        characteristics: {
+          agility: { rank: { value: 3 } },
+          brawn: { rank: { value: 2 } },
+          intellect: { rank: { value: 3 } },
+          cunning: { rank: { value: 2 } },
+          presence: { rank: { value: 2 } },
+          willpower: { rank: { value: 1 } },
+        },
+        progression: {
+          experience: { available: 100, spent: 0, gained: 100, total: 100 },
+          freeSkillRanks: { career: { spent: 0, gained: 4 }, specialization: { spent: 0, gained: 2 } },
+        },
+        details: {
+          species: { name: 'Zabrak' },
+          career: null,
+          specializations: new Set(),
+        },
+        resources: {
+          wounds: { value: 3, threshold: 12 },
+          strain: { value: 2, threshold: 11 },
+          encumbrance: { value: 0, threshold: 10 },
+        },
+        points: {},
+      },
+      items: [],
+      hasFreeSkillsAvailable: () => false,
+    }
+    actor.toObject = () => ({
+      name: actor.name,
+      img: actor.img,
+      system: JSON.parse(JSON.stringify(actor.system)),
+    })
+    return actor
+  }
+
+  function buildBaseContext(actor) {
+    return {
+      actor,
+      source: actor.toObject(),
+      incomplete: {},
+      progression: {
+        experience: actor.system.progression.experience,
+        freeSkillRanks: {
+          career: { ...actor.system.progression.freeSkillRanks.career },
+          specialization: { ...actor.system.progression.freeSkillRanks.specialization },
+        },
+      },
+      tabs: [{ id: 'attributes', group: 'sheet' }],
+      skillCategories: {},
+    }
+  }
+
+  it('exposes sidebarHeader with name and img for a character actor', async () => {
+    const actor = buildCharacterActor()
+    vi.spyOn(SwerpgBaseActorSheet.prototype, '_prepareContext').mockResolvedValue(buildBaseContext(actor))
+
+    const sheet = new CharacterSheet({ document: actor })
+    sheet.actor = actor
+    sheet.document = actor
+
+    const context = await sheet._prepareContext({})
+
+    expect(context.sidebarHeader).toBeDefined()
+    expect(context.sidebarHeader.name).toBe('Darth Maul')
+    expect(context.sidebarHeader.img).toBe('systems/swerpg/assets/portraits/darth-maul.webp')
+  })
+
+  it('does not expose sidebarHeader from the base actor sheet context', async () => {
+    const actor = buildCharacterActor()
+    actor.type = 'adversary'
+    actor.name = 'Stormtrooper'
+
+    const context = buildBaseContext(actor)
+
+    expect(context.sidebarHeader).toBeUndefined()
+  })
+})


### PR DESCRIPTION
## Résumé

Déplacement du champ modifiable `name` du personnage depuis le header droit de la Character Sheet vers la sidebar, au-dessus de l'avatar. Le nom reste éditable et persiste via `submitOnChange`.

## Issue liée

Closes #178

## Modifications

### JS
- **`module/applications/sheets/character-sheet.mjs`** : ajout de `context.sidebarHeader = { name, img }` dans `_prepareContext()`

### Templates
- **`templates/sheets/actor/sidebar.hbs`** : bloc conditionnel `.sidebar-header` avec input nom + avatar wrapper ; fallback non-character
- **`templates/sheets/actor/character-header.hbs`** : retrait du `<input class="charname">`

### Styles
- **`styles/actor.less`** : styles `.sidebar-header`, `.sidebar-name`, `.sidebar-profile-wrapper` ; retrait de `.charname`
- **`styles/swerpg.css`** : compilé depuis le LESS

### Tests
- **`tests/applications/sheets/character-sheet-sidebar-header.test.mjs`** : 2 tests (présence sidebarHeader pour character, absence pour non-character)

### Documentation
- **`documentation/plan/character-sheet/side-bar/header/`** : plan d'implémentation

## Validation

- ✅ 126 test files, 1393 tests passed, 0 failed
- ✅ Pas de régression sur les tests existants
- ✅ Le nom est éditable dans la sidebar et soumis via submitOnChange
- ✅ Les adversary sheets sont protégées par le bloc `{{#if sidebarHeader}}`

## Dépendances

Cette PR est la première des trois issues filles de l'épic #177 :
- #178 ← **cette PR**
- #179 — Ajouter overlay avatar
- #180 — Afficher Wounds/Strain