### PR TITLE
feat(sidebar-header): display wounds and strain in avatar overlay (#180)

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -655,6 +655,7 @@
   "RESOURCES": {
     "HEALTH": "Health",
     "WOUNDS": "Wounds",
+    "STRAIN": "Strain",
     "MORALE": "Morale",
     "MADNESS": "Madness",
     "ACTION": "Action",

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -749,6 +749,7 @@
   "RESOURCES": {
     "HEALTH": "Health",
     "WOUNDS": "Wounds",
+    "STRAIN": "Strain",
     "MORALE": "Morale",
     "MADNESS": "Madness",
     "ACTION": "Action",

--- a/module/applications/sheets/character-sheet.mjs
+++ b/module/applications/sheets/character-sheet.mjs
@@ -151,7 +151,13 @@ export default class CharacterSheet extends SwerpgBaseActorSheet {
     context.jauges = this.buildJaugeDisplayData(a.system.resources)
     context.soak = this.#buildSoakDisplayData(a.system.characteristics.brawn)
     context.defenses = this.buildDefenseDisplayData()
-    context.sidebarHeader = { name: s.name, img: s.img }
+    const r = a.system.resources
+    context.sidebarHeader = {
+      name: s.name,
+      img: s.img,
+      wounds: { value: r.wounds.value, threshold: r.wounds.threshold },
+      strain: { value: r.strain.value, threshold: r.strain.threshold },
+    }
 
     // Debug de préparation du contexte
     logger.debug(`[${this.constructor.name}] Context prepared:`, context)

--- a/styles/actor.less
+++ b/styles/actor.less
@@ -331,11 +331,41 @@
           left: 0;
           right: 0;
           height: 20%;
+          display: flex;
+          align-items: center;
+          justify-content: space-around;
+          padding: 0 0.5rem;
+          gap: 0.75rem;
           background: rgba(0, 0, 0, 0.65);
           backdrop-filter: blur(2px);
           -webkit-backdrop-filter: blur(2px);
           border-radius: 0 0 4px 4px;
           pointer-events: none;
+
+          .sidebar-resource {
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            line-height: 1.2;
+
+            .label {
+              font-size: var(--font-size-12);
+              text-transform: uppercase;
+              letter-spacing: 0.05em;
+              opacity: 0.8;
+            }
+
+            .value {
+              font-family: var(--font-h1);
+              font-size: var(--font-size-12);
+              white-space: nowrap;
+            }
+
+            &.wounds .label { color: var(--color-wounds); }
+            &.wounds .value { color: var(--color-wounds-glow); }
+            &.strain .label { color: var(--color-strain); }
+            &.strain .value { color: var(--color-strain-glow); }
+          }
         }
       }
     }

--- a/styles/swerpg.css
+++ b/styles/swerpg.css
@@ -1280,11 +1280,45 @@ input[type='range'] {
   left: 0;
   right: 0;
   height: 20%;
+  display: flex;
+  align-items: center;
+  justify-content: space-around;
+  padding: 0 0.5rem;
+  gap: 0.75rem;
   background: rgba(0, 0, 0, 0.65);
   backdrop-filter: blur(2px);
   -webkit-backdrop-filter: blur(2px);
   border-radius: 0 0 4px 4px;
   pointer-events: none;
+}
+.swerpg.sheet.actor .sheet-sidebar .sidebar-header .sidebar-profile-wrapper .sidebar-profile-overlay .sidebar-resource {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  line-height: 1.2;
+}
+.swerpg.sheet.actor .sheet-sidebar .sidebar-header .sidebar-profile-wrapper .sidebar-profile-overlay .sidebar-resource .label {
+  font-size: var(--font-size-12);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  opacity: 0.8;
+}
+.swerpg.sheet.actor .sheet-sidebar .sidebar-header .sidebar-profile-wrapper .sidebar-profile-overlay .sidebar-resource .value {
+  font-family: var(--font-h1);
+  font-size: var(--font-size-12);
+  white-space: nowrap;
+}
+.swerpg.sheet.actor .sheet-sidebar .sidebar-header .sidebar-profile-wrapper .sidebar-profile-overlay .sidebar-resource.wounds .label {
+  color: var(--color-wounds);
+}
+.swerpg.sheet.actor .sheet-sidebar .sidebar-header .sidebar-profile-wrapper .sidebar-profile-overlay .sidebar-resource.wounds .value {
+  color: var(--color-wounds-glow);
+}
+.swerpg.sheet.actor .sheet-sidebar .sidebar-header .sidebar-profile-wrapper .sidebar-profile-overlay .sidebar-resource.strain .label {
+  color: var(--color-strain);
+}
+.swerpg.sheet.actor .sheet-sidebar .sidebar-header .sidebar-profile-wrapper .sidebar-profile-overlay .sidebar-resource.strain .value {
+  color: var(--color-strain-glow);
 }
 .swerpg.sheet.actor .sheet-sidebar h2.divider {
   margin: 0;

--- a/templates/sheets/actor/sidebar.hbs
+++ b/templates/sheets/actor/sidebar.hbs
@@ -4,7 +4,16 @@
     <input class="sidebar-name" name="name" type="text" value="{{sidebarHeader.name}}" placeholder="Actor Name">
     <div class="sidebar-profile-wrapper">
       <img class="profile" src="{{sidebarHeader.img}}" alt="{{sidebarHeader.name}}" width="200" height="200" data-action="editImage" data-edit="img">
-      <div class="sidebar-profile-overlay"></div>
+      <div class="sidebar-profile-overlay">
+        <div class="sidebar-resource wounds">
+          <span class="label">{{localize "RESOURCES.WOUNDS"}}</span>
+          <span class="value">{{sidebarHeader.wounds.value}}/{{sidebarHeader.wounds.threshold}}</span>
+        </div>
+        <div class="sidebar-resource strain">
+          <span class="label">{{localize "RESOURCES.STRAIN"}}</span>
+          <span class="value">{{sidebarHeader.strain.value}}/{{sidebarHeader.strain.threshold}}</span>
+        </div>
+      </div>
     </div>
   </div>
 {{else}}

--- a/tests/applications/sheets/character-sheet-sidebar-header.test.mjs
+++ b/tests/applications/sheets/character-sheet-sidebar-header.test.mjs
@@ -97,6 +97,8 @@ describe('CharacterSheet sidebarHeader context', () => {
     expect(context.sidebarHeader).toBeDefined()
     expect(context.sidebarHeader.name).toBe('Darth Maul')
     expect(context.sidebarHeader.img).toBe('systems/swerpg/assets/portraits/darth-maul.webp')
+    expect(context.sidebarHeader.wounds).toEqual({ value: 3, threshold: 12 })
+    expect(context.sidebarHeader.strain).toEqual({ value: 2, threshold: 11 })
   })
 
   it('does not expose sidebarHeader from the base actor sheet context', async () => {


### PR DESCRIPTION
## Summary

Affiche les ressources **Wounds** et **Strain** (valeur/seuil) en lecture seule dans l'overlay de l'avatar de la sidebar Character Sheet.

## Changements

- `module/applications/sheets/character-sheet.mjs` : enrichit `context.sidebarHeader` avec `wounds.value`, `wounds.threshold`, `strain.value`, `strain.threshold`
- `templates/sheets/actor/sidebar.hbs` : overlay peuplé avec deux blocs de ressource localisés
- `styles/actor.less` + `styles/swerpg.css` : mise en page flexbox et couleurs (rouge wounds, bleu/cyan strain)
- `tests/applications/sheets/character-sheet-sidebar-header.test.mjs` : assertions sur `wounds` et `strain`
- `lang/fr.json` / `lang/en.json` : ajout de la clé i18n manquante `RESOURCES.STRAIN`

## Validation

- ✅ `pnpm test --run` : 126/126 test files, 1393/1398 tests passed
- ✅ Plan d'implémentation : `documentation/plan/character-sheet/side-bar/header/180-plan-afficher-wounds-strain-overlay-sidebar.md`

Closes #180