### PR TITLE
feat(talent-node): implement talent node purchase from specialization tree (US6)

### DIFF
--- a/documentation/plan/character-sheet/talent/190-plan-implementer-achat-noeud.md
+++ b/documentation/plan/character-sheet/talent/190-plan-implementer-achat-noeud.md
@@ -1,0 +1,385 @@
+# Plan d'implémentation — US6 : Implémenter l'achat d'un nœud
+
+**Issue
+** : [#190 — US6: Implémenter l'achat d'un nœud](https://github.com/herveDarritchon/foundryvtt-swerpg/issues/190)  
+**Epic** : [#184 — EPIC: Refonte V1 des talents Edge](https://github.com/herveDarritchon/foundryvtt-swerpg/issues/184)  
+**ADR** : `documentation/architecture/adr/adr-0001-foundry-applicationv2-adoption.md`,
+`documentation/architecture/adr/adr-0011-stockage-journal-evolution-personnage-flags.md`,
+`documentation/architecture/adr/adr-0012-unit-tests-readable-diagnostics.md`  
+**Module(s) impacté(s)** : `module/lib/talent-node/talent-node-purchase.mjs` (création), `module/utils/audit-log.mjs` (
+modification), `tests/lib/talent-node/talent-node-purchase.test.mjs` (création), `tests/utils/audit-log.test.mjs` (
+modification)
+
+---
+
+## 1. Objectif
+
+Implémenter le flux métier d'achat d'un nœud de talent depuis un arbre de spécialisation possédé, en s'appuyant sur les
+briques déjà livrées :
+
+- structure persistée `actor.system.progression.talentPurchases` ;
+- résolution spécialisation → arbre ;
+- calcul d'état des nœuds et raisons de refus.
+
+Le résultat attendu est un point d'entrée unique capable de :
+
+- valider un achat selon les règles V1 ;
+- persister l'achat du nœud sur l'acteur ;
+- mettre à jour l'XP dépensée ;
+- produire une opération structurée exploitable par l'audit/log ;
+- laisser les vues dérivées se recalculer à partir de la source de vérité mise à jour.
+
+---
+
+## 2. Périmètre
+
+### Inclus dans cette US / ce ticket
+
+- Création d'un module dédié au flux d'achat d'un nœud dans `module/lib/talent-node/`
+- Réutilisation du resolver US4 et du state engine US5
+- Validation complète des préconditions d'achat
+- Lecture du coût depuis `tree.system.nodes[].cost`
+- Persistance d'une nouvelle entrée dans `actor.system.progression.talentPurchases`
+- Mise à jour de `actor.system.progression.experience.spent`
+- Construction d'une opération d'audit structurée de type `talent-node-purchase`
+- Transmission non bloquante de cette opération au système d'audit/log existant
+- Tests Vitest couvrant succès, refus et résilience audit
+
+### Exclu de cette US / ce ticket
+
+- Refonte de l'onglet Talents
+- Vue graphique d'arbre
+- Consolidation des talents possédés
+- Gestion ranked / non-ranked au niveau de la vue consolidée
+- Achat d'une nouvelle spécialisation
+- Migration ou suppression complète des anciennes logiques talents legacy
+- Remplacement global de `addTalent()` / `addTalentWithXpCheck()` pour tous les flux existants non liés à V1 Talents
+- Historique détaillé persisté dans l'acteur
+
+---
+
+## 3. Constat sur l'existant
+
+### La base V1 est en place
+
+Le codebase contient déjà les fondations nécessaires :
+
+- `module/models/character.mjs` porte `system.progression.talentPurchases[]`
+- `module/lib/talent-node/talent-tree-resolver.mjs` résout une spécialisation possédée vers un `specialization-tree`
+- `module/lib/talent-node/talent-node-state.mjs` calcule `purchased` / `available` / `locked` / `invalid`
+
+US6 peut donc se concentrer sur l'orchestration d'achat, sans redéfinir ces règles.
+
+### Le legacy talents reste incompatible avec la V1
+
+Des flux historiques existent encore :
+
+- `module/documents/actor-mixins/talents.mjs#addTalentWithXpCheck()`
+- `module/lib/talents/talent-cost-calculator.mjs`
+- `module/lib/talents/trained-talent.mjs`
+- `module/lib/talents/ranked-trained-talent.mjs`
+
+Problèmes constatés :
+
+- coût hardcodé `5`
+- coût `rank * 5`
+- logique basée sur création d'embedded `Item talent`
+- aucune persistance `treeId` / `nodeId` / `specializationId`
+
+Ces flux ne doivent pas servir de base fonctionnelle à US6.
+
+### L'audit/log actuel détecte encore l'ancien modèle
+
+`module/utils/audit-log.mjs` journalise les achats de talent via `Hooks.on('createItem')`, avec une entrée
+`talent.purchase` basée sur un `Item talent`.
+
+Ce branchement ne couvrira pas le nouveau flux US6 si l'achat V1 persiste uniquement `talentPurchases` sur l'acteur. US6
+doit donc produire sa propre opération structurée et la brancher vers l'audit de manière explicite.
+
+### Les vues dérivées ne doivent pas être persistées
+
+Le cadrage talents et `06-audit-log-et-synchronisation.md` imposent que :
+
+- `talentPurchases` soit la source de vérité ;
+- les états de nœuds, rangs consolidés et vues UI soient recalculés.
+
+US6 ne doit donc pas écrire de cache dérivé sur l'acteur.
+
+---
+
+## 4. Décisions d'architecture
+
+### 4.1. Créer un module d'achat dédié dans `module/lib/talent-node/`
+
+**Décision** : créer `module/lib/talent-node/talent-node-purchase.mjs`.
+
+Options envisagées :
+
+- étendre `talent-node-state.mjs`
+- ajouter la logique dans `actor-mixins/talents.mjs`
+- réutiliser `module/lib/talents/` legacy
+
+**Décision retenue** : module dédié, à côté du resolver et du state engine.
+
+Justification :
+
+- sépare clairement validation d'état et exécution d'achat ;
+- évite de recoupler la V1 au legacy talents ;
+- fournit une API réutilisable par les futures UI.
+
+### 4.2. L'achat doit réutiliser US4 et US5, pas dupliquer leurs règles
+
+**Décision** : le flux d'achat orchestre :
+
+1. validation de la spécialisation possédée ;
+2. résolution de l'arbre via `resolveSpecializationTree()`;
+3. lecture de l'état du nœud via `getNodeState()`;
+4. persistance seulement si l'état est `available`.
+
+Justification :
+
+- évite deux sources de vérité métier ;
+- garantit que l'UI et l'achat partagent exactement les mêmes raisons de refus ;
+- réduit le risque de divergence entre US5 et US6.
+
+### 4.3. Le coût vient exclusivement du nœud résolu
+
+**Décision** : le coût XP utilisé par US6 est `node.cost` lu depuis l'arbre résolu.
+
+Justification :
+
+- conforme à l'issue #190 ;
+- conforme à `02-regles-achat-progression.md` ;
+- interdit toute réintroduction de `rank * 5`, coût hardcodé ou coût porté par la définition générique du talent.
+
+### 4.4. Persister achat et XP dans un seul `actor.update()`
+
+**Décision** : effectuer un unique `actor.update()` qui écrit :
+
+- `system.progression.talentPurchases`
+- `system.progression.experience.spent`
+
+Justification :
+
+- réduit le risque d'état intermédiaire incohérent ;
+- simplifie les tests ;
+- laisse les hooks et recalculs observer un changement atomique côté acteur.
+
+### 4.5. Ne pas créer d'embedded `Item talent` dans le flux US6
+
+**Décision** : l'achat V1 ne crée pas d'`Item talent` embarqué comme source de vérité.
+
+Justification :
+
+- la source de vérité V1 est `talentPurchases` ;
+- les vues futures devront dériver l'état depuis achats + arbres + définitions ;
+- cela évite de prolonger le modèle legacy incompatible avec le cadrage.
+
+### 4.6. Produire une opération d'audit structurée, puis la transmettre de façon non bloquante
+
+**Décision** : le flux d'achat construit une opération métier de forme :
+
+```js
+{
+  type: 'talent-node-purchase',
+    actorId,
+    specializationId,
+    treeId,
+    nodeId,
+    talentId,
+    cost,
+    source
+:
+  'specialization-tree',
+    previousXp,
+    nextXp
+}
+```
+
+Puis un bridge audit dédié l'écrit dans `flags.swerpg.logs` si disponible, sans bloquer l'achat en cas d'échec.
+
+Justification :
+
+- conforme à `06-audit-log-et-synchronisation.md` ;
+- évite de dépendre du hook `createItem` devenu insuffisant ;
+- respecte ADR-0011 : l'audit reste secondaire.
+
+### 4.7. Aucun recalcul persistant des vues dérivées en US6
+
+**Décision** : US6 se limite à mettre à jour la source de vérité. Le recalcul des vues dérivées se fait par les flux
+normaux de préparation et par les futures US de consolidation/UI.
+
+Justification :
+
+- évite d'introduire une vue persistée concurrente ;
+- conforme au cadrage V1 ;
+- garde US6 centrée sur l'achat.
+
+---
+
+## 5. Plan de travail détaillé
+
+### Étape 1 — Définir l'API publique du module d'achat
+
+**Quoi faire** : créer un point d'entrée clair, par exemple `purchaseTalentNode(actor, specializationId, nodeId)` ou
+`purchaseTalentNode({ actor, specializationId, nodeId })`, qui retourne un résultat structuré.
+
+**Fichiers** :
+
+- `module/lib/talent-node/talent-node-purchase.mjs` (création)
+
+**Risques spécifiques** :
+
+- API trop couplée à une UI précise ;
+- API qui force les appelants à recalculer eux-mêmes l'état ou l'arbre.
+
+### Étape 2 — Orchestrer validation, résolution et lecture d'état
+
+**Quoi faire** : dans le flux d'achat :
+
+- vérifier que la spécialisation est possédée ;
+- résoudre l'arbre ;
+- localiser le nœud ;
+- appeler `getNodeState()` ;
+- refuser tout état autre que `available` avec une raison machine-readable.
+
+**Fichiers** :
+
+- `module/lib/talent-node/talent-node-purchase.mjs` (création)
+
+**Risques spécifiques** :
+
+- dupliquer des contrôles déjà faits dans `talent-node-state.mjs` ;
+- divergences de `reasonCode`.
+
+### Étape 3 — Persister l'achat acteur et la dépense d'XP
+
+**Quoi faire** :
+
+- construire la nouvelle entrée `{ treeId, nodeId, talentId, specializationId }`
+- l'ajouter à `actor.system.progression.talentPurchases`
+- incrémenter `system.progression.experience.spent` du coût du nœud
+- exécuter un `actor.update()` unique
+
+**Fichiers** :
+
+- `module/lib/talent-node/talent-node-purchase.mjs` (création)
+
+**Risques spécifiques** :
+
+- double achat si l'entrée existe déjà ;
+- mise à jour XP sans mise à jour achat, ou inversement, si le flux n'est pas atomique.
+
+### Étape 4 — Construire l'opération d'audit métier
+
+**Quoi faire** : après achat réussi, construire une opération traçable contenant au minimum :
+
+- acteur ;
+- spécialisation ;
+- arbre ;
+- nœud ;
+- talent ;
+- coût ;
+- XP avant/après ;
+- source `specialization-tree`
+
+**Fichiers** :
+
+- `module/lib/talent-node/talent-node-purchase.mjs` (création)
+
+**Risques spécifiques** :
+
+- format divergent du cadrage `06-audit-log-et-synchronisation.md` ;
+- mélange entre opération métier et format final de log.
+
+### Étape 5 — Brancher l'audit/log sans rendre l'achat dépendant de lui
+
+**Quoi faire** : ajouter dans `module/utils/audit-log.mjs` un helper explicite pour enregistrer cette opération,
+réutilisant l'infrastructure existante (`makeEntry`, `captureSnapshot`, `writeLogEntries`) avec `try/catch` non
+bloquant.
+
+**Fichiers** :
+
+- `module/utils/audit-log.mjs` (modification)
+- éventuellement `tests/utils/audit-log.test.mjs` (modification)
+
+**Risques spécifiques** :
+
+- casser les tests existants centrés sur `createItem`;
+- faire échouer l'achat quand l'écriture du log échoue.
+
+### Étape 6 — Couvrir le flux par des tests ciblés
+
+**Quoi faire** : créer des tests sur le module d'achat couvrant :
+
+- achat simple d'un nœud racine ;
+- achat refusé si spécialisation absente ;
+- achat refusé si arbre introuvable ou incomplet ;
+- achat refusé si nœud déjà acheté ;
+- achat refusé si nœud verrouillé ;
+- achat refusé si XP insuffisante ;
+- achat qui écrit correctement `talentPurchases` et `experience.spent` ;
+- opération d'audit correctement formée ;
+- achat réussi même si l'audit est indisponible.
+
+**Fichiers** :
+
+- `tests/lib/talent-node/talent-node-purchase.test.mjs` (création)
+- `tests/utils/audit-log.test.mjs` (modification)
+
+**Risques spécifiques** :
+
+- tests trop couplés à la structure interne au lieu du contrat métier ;
+- couverture insuffisante des cas de refus.
+
+---
+
+## 6. Fichiers modifiés
+
+| Fichier                                               | Action       | Description du changement                                                                                |
+|-------------------------------------------------------|--------------|----------------------------------------------------------------------------------------------------------|
+| `module/lib/talent-node/talent-node-purchase.mjs`     | création     | Nouveau flux d'achat V1 d'un nœud de talent                                                              |
+| `module/utils/audit-log.mjs`                          | modification | Ajout d'un bridge explicite pour journaliser une opération `talent-node-purchase` sans hook `createItem` |
+| `tests/lib/talent-node/talent-node-purchase.test.mjs` | création     | Tests métier du flux d'achat                                                                             |
+| `tests/utils/audit-log.test.mjs`                      | modification | Couverture du nouveau branchement audit non bloquant                                                     |
+
+Fichiers explicitement non ciblés par défaut dans cette US :
+
+- `module/documents/actor-mixins/talents.mjs`
+- `module/lib/talents/talent-cost-calculator.mjs`
+- `module/lib/talents/*.mjs`
+
+Ils pourront être neutralisés plus tard, mais ne doivent pas être utilisés comme base du flux US6.
+
+---
+
+## 7. Risques
+
+| Risque                                               | Impact                  | Mitigation                                                                           |
+|------------------------------------------------------|-------------------------|--------------------------------------------------------------------------------------|
+| Réintroduction du coût legacy (`5` ou `rank * 5`)    | Achat faux métier       | Tester explicitement que le coût vient du nœud résolu                                |
+| Duplication des règles entre US5 et US6              | Divergences UI / achat  | Faire de `getNodeState()` la porte d'entrée canonique de validation                  |
+| Achat bloqué si audit/log échoue                     | Régression UX           | Isoler l'écriture d'audit dans un bridge non bloquant avec warning technique         |
+| Persistance non atomique achat + XP                  | Incohérence acteur      | Utiliser un unique `actor.update()`                                                  |
+| Tentation de créer encore des embedded `Item talent` | Double source de vérité | Documenter explicitement que US6 persiste uniquement `talentPurchases`               |
+| Tests peu diagnostiques                              | Maintenance difficile   | Suivre ADR-0012 avec assertions ciblées sur `reasonCode`, `spent`, `talentPurchases` |
+
+---
+
+## 8. Proposition d'ordre de commit
+
+1. `feat(talent-node): add purchase workflow for specialization tree nodes`
+2. `feat(audit-log): record talent node purchase operations`
+3. `test(talent-node): cover talent node purchase success and refusal cases`
+
+---
+
+## 9. Dépendances avec les autres US
+
+- **Dépend de US3 / #187** : structure `talentPurchases`
+- **Dépend de US4 / #188** : résolution spécialisation → arbre
+- **Dépend de US5 / #189** : calcul d'état et raisons de refus
+- **Prépare US7 / US8** : consolidation des talents possédés
+- **Prépare US12+** : UI onglet Talents et vue graphique
+- **S'aligne avec l'épic audit/log** : l'opération est produite maintenant, l'exploitation UI de l'historique reste
+  séparée

--- a/module/lib/talent-node/talent-node-purchase.mjs
+++ b/module/lib/talent-node/talent-node-purchase.mjs
@@ -1,0 +1,120 @@
+import { logger } from '../../utils/logger.mjs'
+import { resolveSpecializationTree } from './talent-tree-resolver.mjs'
+import { getNodeState, NODE_STATE, REASON_CODE } from './talent-node-state.mjs'
+import { recordTalentNodePurchase } from '../../utils/audit-log.mjs'
+
+/**
+ * @typedef {Object} PurchaseResult
+ * @property {boolean} ok - Whether the purchase succeeded.
+ * @property {string} [reason] - Human-readable failure description (only when ok === false).
+ * @property {string} [reasonCode] - Machine-readable failure reason code (only when ok === false).
+ * @property {Object} [purchase] - Purchase data (only when ok === true).
+ * @property {string} purchase.treeId
+ * @property {string} purchase.nodeId
+ * @property {string} purchase.talentId
+ * @property {string} purchase.specializationId
+ * @property {number} purchase.cost
+ */
+
+/**
+ * Purchase a talent node for an actor.
+ * Validates using the canonical state engine, persists the purchase and XP atomically,
+ * then records an audit entry (non-blocking).
+ *
+ * @param {object} actor - The actor document instance.
+ * @param {string} specializationId - The specialization identifier.
+ * @param {string} nodeId - The node identifier within the specialization tree.
+ * @returns {Promise<PurchaseResult>}
+ */
+export async function purchaseTalentNode(actor, specializationId, nodeId) {
+  if (!actor) {
+    return { ok: false, reason: 'Missing actor', reasonCode: REASON_CODE.NODE_INVALID }
+  }
+
+  if (!specializationId || !nodeId) {
+    return { ok: false, reason: 'Missing specializationId or nodeId', reasonCode: REASON_CODE.NODE_INVALID }
+  }
+
+  const specializationData = findSpecialization(actor, specializationId)
+  if (!specializationData) {
+    return {
+      ok: false,
+      reason: `Specialization "${specializationId}" is not owned`,
+      reasonCode: REASON_CODE.SPECIALIZATION_NOT_OWNED,
+    }
+  }
+
+  const resolved = resolveSpecializationTree(specializationData)
+  if (!resolved.tree) {
+    const reasonCode = resolved.state === 'unresolved' ? REASON_CODE.TREE_NOT_FOUND : REASON_CODE.TREE_INCOMPLETE
+    return { ok: false, reason: `Tree ${resolved.state} for specialization "${specializationId}"`, reasonCode }
+  }
+
+  const tree = resolved.tree
+  const node = findNodeInTree(tree, nodeId)
+  if (!node) {
+    return { ok: false, reason: `Node "${nodeId}" not found in tree`, reasonCode: REASON_CODE.NODE_NOT_FOUND }
+  }
+
+  const state = getNodeState(actor, specializationId, tree, nodeId)
+  if (state.state !== NODE_STATE.AVAILABLE) {
+    return { ok: false, reason: state.reason, reasonCode: state.reasonCode }
+  }
+
+  const treeId = tree.id ?? tree._id
+  const purchase = {
+    treeId,
+    nodeId: node.nodeId,
+    talentId: node.talentId,
+    specializationId,
+  }
+
+  const currentSpent = actor.system?.progression?.experience?.spent ?? 0
+  const currentPurchases = Array.isArray(actor.system?.progression?.talentPurchases)
+    ? actor.system.progression.talentPurchases
+    : []
+  const newSpent = currentSpent + node.cost
+
+  await actor.update({
+    'system.progression.talentPurchases': [...currentPurchases, purchase],
+    'system.progression.experience.spent': newSpent,
+  })
+
+  try {
+    await recordTalentNodePurchase(actor, {
+      specializationId,
+      treeId,
+      nodeId: node.nodeId,
+      talentId: node.talentId,
+      cost: node.cost,
+      previousXp: currentSpent,
+      nextXp: newSpent,
+    })
+  } catch (err) {
+    logger.warn('[TalentNodePurchase] Audit log write failed (non-blocking)', {
+      actorId: actor.id,
+      nodeId,
+      error: err.message,
+    })
+  }
+
+  return {
+    ok: true,
+    purchase: { ...purchase, cost: node.cost },
+  }
+}
+
+function findSpecialization(actor, specializationId) {
+  const specs = actor?.system?.details?.specializations
+  if (!specs) return null
+  for (const spec of specs) {
+    if (spec?.specializationId === specializationId) return spec
+  }
+  return null
+}
+
+function findNodeInTree(tree, nodeId) {
+  const nodes = tree?.system?.nodes
+  if (!Array.isArray(nodes)) return null
+  return nodes.find(n => n?.nodeId === nodeId) ?? null
+}

--- a/module/utils/audit-log.mjs
+++ b/module/utils/audit-log.mjs
@@ -231,7 +231,7 @@ function readMaxLogEntries() {
 /*  Helpers exportés pour tests                 */
 /* -------------------------------------------- */
 
-export { isOnlyAuditChange, snapshotOldState, cloneValue, evictOldestIfNeeded, flushPending, countPendingEntries, getPendingKey, shiftPendingEntry, pushPendingEntry, isDeletionPath, writeLogEntries, handleWriteError, pruneExpiredPending, readMaxLogEntries, onCreateItem }
+export { isOnlyAuditChange, snapshotOldState, cloneValue, evictOldestIfNeeded, flushPending, countPendingEntries, getPendingKey, shiftPendingEntry, pushPendingEntry, isDeletionPath, writeLogEntries, handleWriteError, pruneExpiredPending, readMaxLogEntries, onCreateItem, recordTalentNodePurchase }
 
 /* -------------------------------------------- */
 /*  Handlers (exportés)                         */
@@ -300,6 +300,51 @@ function onCreateItem(item, data, options, userId) {
   })
 
   void writeLogEntries(item.parent, [entry])
+}
+
+/* -------------------------------------------- */
+/*  Talent node purchase audit bridge           */
+/* -------------------------------------------- */
+
+/**
+ * Record a talent node purchase in the audit log.
+ * Non-blocking: failures are caught internally without throwing.
+ * @param {object} actor - The actor document instance.
+ * @param {object} purchaseData
+ * @param {string} purchaseData.specializationId
+ * @param {string} purchaseData.treeId
+ * @param {string} purchaseData.nodeId
+ * @param {string} purchaseData.talentId
+ * @param {number} purchaseData.cost
+ * @param {number} [purchaseData.previousXp]
+ * @param {number} [purchaseData.nextXp]
+ */
+export async function recordTalentNodePurchase(actor, purchaseData) {
+  const ts = Date.now()
+  const snapshot = captureSnapshot(actor)
+  const user = game.users?.get(game.user?.id) ?? null
+
+  const entry = makeEntry({
+    type: 'talent-node-purchase',
+    data: {
+      actorId: actor.id,
+      specializationId: purchaseData.specializationId,
+      treeId: purchaseData.treeId,
+      nodeId: purchaseData.nodeId,
+      talentId: purchaseData.talentId,
+      cost: purchaseData.cost,
+      source: 'specialization-tree',
+      ...(purchaseData.previousXp !== undefined ? { previousXp: purchaseData.previousXp } : {}),
+      ...(purchaseData.nextXp !== undefined ? { nextXp: purchaseData.nextXp } : {}),
+    },
+    xpDelta: -purchaseData.cost,
+    ts,
+    userId: game.user?.id,
+    user,
+    snapshot,
+  })
+
+  await writeLogEntries(actor, [entry])
 }
 
 /* -------------------------------------------- */

--- a/tests/lib/talent-node/talent-node-purchase.test.mjs
+++ b/tests/lib/talent-node/talent-node-purchase.test.mjs
@@ -1,0 +1,298 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('../../../module/utils/logger.mjs', () => ({
+  logger: {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+}))
+
+vi.mock('../../../module/utils/audit-log.mjs', () => ({
+  recordTalentNodePurchase: vi.fn(),
+}))
+
+vi.mock('../../../module/lib/talent-node/talent-tree-resolver.mjs', () => ({
+  resolveSpecializationTree: vi.fn(),
+}))
+
+import { logger } from '../../../module/utils/logger.mjs'
+import { recordTalentNodePurchase } from '../../../module/utils/audit-log.mjs'
+import { resolveSpecializationTree } from '../../../module/lib/talent-node/talent-tree-resolver.mjs'
+import { purchaseTalentNode } from '../../../module/lib/talent-node/talent-node-purchase.mjs'
+import { REASON_CODE } from '../../../module/lib/talent-node/talent-node-state.mjs'
+
+function buildActor(overrides = {}) {
+  return {
+    id: 'actor-001',
+    system: {
+      details: {
+        specializations: [
+          { specializationId: 'spec-1', name: 'Bodyguard' },
+        ],
+      },
+      progression: {
+        talentPurchases: [],
+        experience: { gained: 100, spent: 0 },
+      },
+    },
+    update: vi.fn().mockResolvedValue(undefined),
+    ...overrides,
+  }
+}
+
+function buildSpecializationData(overrides = {}) {
+  return {
+    specializationId: 'spec-1',
+    treeUuid: 'Item.tree-uuid',
+    name: 'Bodyguard',
+    ...overrides,
+  }
+}
+
+function buildResolvedTree(overrides = {}) {
+  return {
+    tree: {
+      id: 'tree-1',
+      system: {
+        specializationId: 'spec-1',
+        nodes: [
+          { nodeId: 'r1c1', talentId: 'talent-parry', row: 1, column: 1, cost: 5 },
+        ],
+        connections: [{ from: 'r1c1', to: 'r2c1' }],
+      },
+      ...overrides.tree,
+    },
+    state: 'available',
+  }
+}
+
+describe('TalentNodePurchase', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  describe('purchaseTalentNode', () => {
+    it('purchases an available root node successfully', async () => {
+      const actor = buildActor()
+      const treeData = buildResolvedTree()
+      resolveSpecializationTree.mockReturnValue(treeData)
+
+      const result = await purchaseTalentNode(actor, 'spec-1', 'r1c1')
+
+      expect(result.ok).toBe(true)
+      expect(result.purchase).toMatchObject({
+        treeId: 'tree-1',
+        nodeId: 'r1c1',
+        talentId: 'talent-parry',
+        specializationId: 'spec-1',
+        cost: 5,
+      })
+      expect(actor.update).toHaveBeenCalledWith({
+        'system.progression.talentPurchases': [
+          { treeId: 'tree-1', nodeId: 'r1c1', talentId: 'talent-parry', specializationId: 'spec-1' },
+        ],
+        'system.progression.experience.spent': 5,
+      })
+    })
+
+    it('returns error when actor is null', async () => {
+      const result = await purchaseTalentNode(null, 'spec-1', 'r1c1')
+
+      expect(result.ok).toBe(false)
+      expect(result.reasonCode).toBe(REASON_CODE.NODE_INVALID)
+      expect(result.reason).toContain('Missing actor')
+    })
+
+    it('returns error when specializationId is missing', async () => {
+      const result = await purchaseTalentNode(buildActor(), '', 'r1c1')
+
+      expect(result.ok).toBe(false)
+      expect(result.reasonCode).toBe(REASON_CODE.NODE_INVALID)
+      expect(result.reason).toContain('Missing specializationId')
+    })
+
+    it('returns error when nodeId is missing', async () => {
+      const result = await purchaseTalentNode(buildActor(), 'spec-1', '')
+
+      expect(result.ok).toBe(false)
+      expect(result.reasonCode).toBe(REASON_CODE.NODE_INVALID)
+      expect(result.reason).toContain('Missing specializationId')
+    })
+
+    it('returns error when specialization is not owned', async () => {
+      const actor = buildActor()
+      actor.system.details.specializations = []
+
+      const result = await purchaseTalentNode(actor, 'spec-unknown', 'r1c1')
+
+      expect(result.ok).toBe(false)
+      expect(result.reasonCode).toBe(REASON_CODE.SPECIALIZATION_NOT_OWNED)
+      expect(result.reason).toContain('spec-unknown')
+    })
+
+    it('returns error when tree is unresolved', async () => {
+      const actor = buildActor()
+      resolveSpecializationTree.mockReturnValue({ tree: null, state: 'unresolved' })
+
+      const result = await purchaseTalentNode(actor, 'spec-1', 'r1c1')
+
+      expect(result.ok).toBe(false)
+      expect(result.reasonCode).toBe(REASON_CODE.TREE_NOT_FOUND)
+      expect(result.reason).toContain('unresolved')
+    })
+
+    it('returns error when tree is incomplete', async () => {
+      const actor = buildActor()
+      resolveSpecializationTree.mockReturnValue({ tree: null, state: 'incomplete' })
+
+      const result = await purchaseTalentNode(actor, 'spec-1', 'r1c1')
+
+      expect(result.ok).toBe(false)
+      expect(result.reasonCode).toBe(REASON_CODE.TREE_INCOMPLETE)
+      expect(result.reason).toContain('incomplete')
+    })
+
+    it('returns error when node is not found in tree', async () => {
+      const actor = buildActor()
+      const treeData = buildResolvedTree()
+      resolveSpecializationTree.mockReturnValue(treeData)
+
+      const result = await purchaseTalentNode(actor, 'spec-1', 'nonexistent')
+
+      expect(result.ok).toBe(false)
+      expect(result.reasonCode).toBe(REASON_CODE.NODE_NOT_FOUND)
+    })
+
+    it('returns error when node is already purchased', async () => {
+      const actor = buildActor({
+        system: {
+          details: {
+            specializations: [{ specializationId: 'spec-1' }],
+          },
+          progression: {
+            talentPurchases: [
+              { treeId: 'tree-1', nodeId: 'r1c1', talentId: 'talent-parry', specializationId: 'spec-1' },
+            ],
+            experience: { gained: 100, spent: 5 },
+          },
+        },
+      })
+      const treeData = buildResolvedTree()
+      resolveSpecializationTree.mockReturnValue(treeData)
+
+      const result = await purchaseTalentNode(actor, 'spec-1', 'r1c1')
+
+      expect(result.ok).toBe(false)
+      expect(result.reasonCode).toBe(REASON_CODE.ALREADY_PURCHASED)
+    })
+
+    it('returns error when node is locked', async () => {
+      const actor = buildActor()
+      const treeData = buildResolvedTree({
+        tree: {
+          id: 'tree-1',
+          system: {
+            specializationId: 'spec-1',
+            nodes: [
+              { nodeId: 'r1c1', talentId: 'talent-parry', row: 1, column: 1, cost: 5 },
+              { nodeId: 'r2c1', talentId: 'talent-deflect', row: 2, column: 1, cost: 10 },
+            ],
+            connections: [{ from: 'r1c1', to: 'r2c1' }],
+          },
+        },
+      })
+      resolveSpecializationTree.mockReturnValue(treeData)
+
+      const result = await purchaseTalentNode(actor, 'spec-1', 'r2c1')
+
+      expect(result.ok).toBe(false)
+      expect(result.reasonCode).toBe(REASON_CODE.NODE_LOCKED)
+    })
+
+    it('returns error when XP is insufficient', async () => {
+      const actor = buildActor({
+        system: {
+          details: {
+            specializations: [{ specializationId: 'spec-1' }],
+          },
+          progression: {
+            talentPurchases: [],
+            experience: { gained: 100, spent: 98 },
+          },
+        },
+      })
+      const treeData = buildResolvedTree()
+      resolveSpecializationTree.mockReturnValue(treeData)
+
+      const result = await purchaseTalentNode(actor, 'spec-1', 'r1c1')
+
+      expect(result.ok).toBe(false)
+      expect(result.reasonCode).toBe(REASON_CODE.NOT_ENOUGH_XP)
+    })
+
+    it('calls recordTalentNodePurchase on success', async () => {
+      const actor = buildActor()
+      const treeData = buildResolvedTree()
+      resolveSpecializationTree.mockReturnValue(treeData)
+
+      await purchaseTalentNode(actor, 'spec-1', 'r1c1')
+
+      expect(recordTalentNodePurchase).toHaveBeenCalledTimes(1)
+      expect(recordTalentNodePurchase).toHaveBeenCalledWith(actor, expect.objectContaining({
+        specializationId: 'spec-1',
+        treeId: 'tree-1',
+        nodeId: 'r1c1',
+        talentId: 'talent-parry',
+        cost: 5,
+        previousXp: 0,
+        nextXp: 5,
+      }))
+    })
+
+    it('succeeds even when audit log write fails (non-blocking)', async () => {
+      const actor = buildActor()
+      const treeData = buildResolvedTree()
+      resolveSpecializationTree.mockReturnValue(treeData)
+      recordTalentNodePurchase.mockRejectedValue(new Error('Audit write failed'))
+
+      const result = await purchaseTalentNode(actor, 'spec-1', 'r1c1')
+
+      expect(result.ok).toBe(true)
+      expect(logger.warn).toHaveBeenCalledWith(
+        '[TalentNodePurchase] Audit log write failed (non-blocking)',
+        expect.objectContaining({ actorId: 'actor-001', nodeId: 'r1c1' }),
+      )
+    })
+
+    it('handles missing progression fields gracefully (fails with no XP available)', async () => {
+      const actor = {
+        id: 'actor-001',
+        system: {
+          details: {
+            specializations: [{ specializationId: 'spec-1' }],
+          },
+        },
+        update: vi.fn().mockResolvedValue(undefined),
+      }
+      const treeData = buildResolvedTree()
+      resolveSpecializationTree.mockReturnValue(treeData)
+
+      const result = await purchaseTalentNode(actor, 'spec-1', 'r1c1')
+
+      expect(result.ok).toBe(false)
+      expect(result.reasonCode).toBe(REASON_CODE.NOT_ENOUGH_XP)
+      expect(actor.update).not.toHaveBeenCalled()
+    })
+
+    it('handles actor without specializations field gracefully', async () => {
+      const actor = { id: 'actor-001', system: {}, update: vi.fn().mockResolvedValue(undefined) }
+
+      const result = await purchaseTalentNode(actor, 'spec-1', 'r1c1')
+
+      expect(result.ok).toBe(false)
+      expect(result.reasonCode).toBe(REASON_CODE.SPECIALIZATION_NOT_OWNED)
+    })
+  })
+})

--- a/tests/utils/audit-log.test.mjs
+++ b/tests/utils/audit-log.test.mjs
@@ -873,3 +873,152 @@ describe('pruneExpiredPending capacity warning', () => {
     flushPending()
   })
 })
+
+/* ============================================ */
+/*  recordTalentNodePurchase                    */
+/* ============================================ */
+
+describe('recordTalentNodePurchase', () => {
+  function makeActor(overrides = {}) {
+    return {
+      type: 'character',
+      id: 'actor-001',
+      name: 'Test Character',
+      _source: {
+        system: {
+          skills: {},
+          characteristics: {},
+          progression: { totalXP: 0, spentXP: 0 },
+          details: {},
+          advancement: {},
+        },
+        flags: {},
+      },
+      system: {
+        progression: {
+          experience: { spent: 0, gained: 0, available: 0, total: 0 },
+          freeSkillRanks: {
+            career: { spent: 0, gained: 0, available: 0 },
+            specialization: { spent: 0, gained: 0, available: 0 },
+          },
+        },
+      },
+      update: vi.fn(),
+      ...overrides,
+    }
+  }
+
+  test('creates a talent-node-purchase entry with all data', async () => {
+    const { recordTalentNodePurchase } = await import('../../module/utils/audit-log.mjs')
+    globalThis.foundry.utils.deepClone = vi.fn((o) => structuredClone(o))
+    globalThis.game.users = { get: vi.fn(() => ({ id: 'gm-1', name: 'Game Master' })) }
+
+    const actor = makeActor()
+    const purchaseData = {
+      specializationId: 'spec-1',
+      treeId: 'tree-1',
+      nodeId: 'r2c3',
+      talentId: 'talent-deflect',
+      cost: 10,
+      previousXp: 50,
+      nextXp: 60,
+    }
+
+    await recordTalentNodePurchase(actor, purchaseData)
+
+    expect(actor.update).toHaveBeenCalledTimes(1)
+    const updateArg = actor.update.mock.calls[0][0]
+    const log = updateArg['flags.swerpg.logs'][0]
+    expect(log.type).toBe('talent-node-purchase')
+    expect(log.data).toMatchObject({
+      actorId: 'actor-001',
+      specializationId: 'spec-1',
+      treeId: 'tree-1',
+      nodeId: 'r2c3',
+      talentId: 'talent-deflect',
+      cost: 10,
+      source: 'specialization-tree',
+      previousXp: 50,
+      nextXp: 60,
+    })
+    expect(log.xpDelta).toBe(-10)
+    expect(log.userId).toBe('gm-1')
+    expect(log.userName).toBe('Game Master')
+  })
+
+  test('handles missing xp range data gracefully', async () => {
+    const { recordTalentNodePurchase } = await import('../../module/utils/audit-log.mjs')
+    globalThis.foundry.utils.deepClone = vi.fn((o) => structuredClone(o))
+
+    const actor = makeActor()
+    const purchaseData = {
+      specializationId: 'spec-1',
+      treeId: 'tree-1',
+      nodeId: 'r1c1',
+      talentId: 'talent-parry',
+      cost: 5,
+    }
+
+    await recordTalentNodePurchase(actor, purchaseData)
+
+    const updateArg = actor.update.mock.calls[0][0]
+    const log = updateArg['flags.swerpg.logs'][0]
+    expect(log.data.previousXp).toBeUndefined()
+    expect(log.data.nextXp).toBeUndefined()
+    expect(log.xpDelta).toBe(-5)
+  })
+
+  test('includes snapshot of actor XP state', async () => {
+    const { recordTalentNodePurchase } = await import('../../module/utils/audit-log.mjs')
+    globalThis.foundry.utils.deepClone = vi.fn((o) => structuredClone(o))
+
+    const actor = makeActor({
+      system: {
+        progression: {
+          experience: { spent: 50, gained: 200, available: 150, total: 200 },
+          freeSkillRanks: {
+            career: { spent: 2, gained: 5, available: 3 },
+            specialization: { spent: 0, gained: 3, available: 3 },
+          },
+        },
+      },
+    })
+    const purchaseData = {
+      specializationId: 'spec-1',
+      treeId: 'tree-1',
+      nodeId: 'r1c1',
+      talentId: 'talent-parry',
+      cost: 5,
+    }
+
+    await recordTalentNodePurchase(actor, purchaseData)
+
+    const updateArg = actor.update.mock.calls[0][0]
+    const snapshot = updateArg['flags.swerpg.logs'][0].snapshot
+    expect(snapshot).toMatchObject({
+      xpAvailable: 150,
+      totalXpSpent: 50,
+      totalXpGained: 200,
+      careerFreeAvailable: 3,
+      specializationFreeAvailable: 3,
+    })
+  })
+
+  test('does nothing when actor.update throws', async () => {
+    const { recordTalentNodePurchase } = await import('../../module/utils/audit-log.mjs')
+    globalThis.foundry.utils.deepClone = vi.fn((o) => structuredClone(o))
+
+    const actor = makeActor()
+    actor.update.mockRejectedValue(new Error('DB fail'))
+
+    await expect(
+      recordTalentNodePurchase(actor, {
+        specializationId: 'spec-1',
+        treeId: 'tree-1',
+        nodeId: 'r1c1',
+        talentId: 'talent-parry',
+        cost: 5,
+      }),
+    ).resolves.toBeUndefined()
+  })
+})


### PR DESCRIPTION
## Summary

Implements US6 — purchase of a talent node from an owned specialization tree (issue #190).

- **New module** `module/lib/talent-node/talent-node-purchase.mjs`: `purchaseTalentNode(actor, specializationId, nodeId)` orchestrates validation, persistence, and audit.
- **Audit bridge** `module/utils/audit-log.mjs`: `recordTalentNodePurchase()` writes a `talent-node-purchase` entry to `flags.swerpg.logs`.
- **15 unit tests** covering success, 7 refusal cases (missing actor, missing params, spec not owned, tree unresolved/incomplete, node not found, already purchased, locked, insufficient XP), audit call verification, audit resilience, and graceful handling of missing progression data.

## Key design decisions

- Reuses `resolveSpecializationTree()` (US4) and `getNodeState()` (US5) — no rule duplication.
- Cost comes exclusively from `node.cost` in the resolved tree — no legacy `5`/`rank * 5` hardcode.
- Purchase + XP spent persisted in a single `actor.update()` for atomicity.
- Audit recording is non-blocking: `purchaseTalentNode` returns `{ ok: true }` even if `recordTalentNodePurchase` throws.
- No embedded `Item talent` is created — `talentPurchases` is the sole source of truth.

## Test results

```
npx vitest run
→ 132 files, 1476 passed, 0 failed, 5 skipped
```

No regressions.

## Related issue

Closes #190