### PR TITLE
feat(character-sheet): consolider les talents ranked et non-ranked (US8)

### DIFF
--- a/documentation/plan/character-sheet/talent/192-plan-gerer-ranked-non-ranked-dupliques.md
+++ b/documentation/plan/character-sheet/talent/192-plan-gerer-ranked-non-ranked-dupliques.md
@@ -1,0 +1,257 @@
+# Plan d'implémentation — US8 : Gérer ranked et non-ranked dupliqués
+
+**Issue** : [#192 — US8: Gérer ranked et non-ranked dupliqués](https://github.com/herveDarritchon/foundryvtt-swerpg/issues/192)
+**Epic** : [#184 — EPIC: Refonte V1 des talents Edge](https://github.com/herveDarritchon/foundryvtt-swerpg/issues/184)
+**ADR** : `documentation/architecture/adr/adr-0001-foundry-applicationv2-adoption.md`, `documentation/architecture/adr/adr-0004-vitest-testing-strategy.md`, `documentation/architecture/adr/adr-0005-localization-strategy.md`, `documentation/architecture/adr/adr-0012-unit-tests-readable-diagnostics.md`
+**Module(s) impacté(s)** : `module/lib/talent-node/owned-talent-summary.mjs` (modification), `module/applications/sheets/character-sheet.mjs` (modification), `templates/sheets/actor/talents.hbs` (modification), `lang/fr.json` (modification), `lang/en.json` (modification), `tests/lib/talent-node/owned-talent-summary.test.mjs` (modification), `tests/applications/sheets/character-sheet-talents.test.mjs` (création)
+
+---
+
+## 1. Objectif
+
+Finaliser le comportement V1 des talents dupliqués entre plusieurs arbres de spécialisation, en couvrant à la fois :
+
+- la règle métier de consolidation ;
+- l'affichage sans doublon dans l'onglet Talents actuel.
+
+Le résultat attendu est :
+
+- un talent ranked acheté depuis plusieurs arbres s'affiche une seule fois avec le bon rang consolidé ;
+- un talent non-ranked acheté depuis plusieurs arbres s'affiche une seule fois avec plusieurs sources ;
+- l'onglet Talents n'induit plus de faux double bénéfice ni de duplication visuelle.
+
+---
+
+## 2. Périmètre
+
+### Inclus dans cette US / ce ticket
+
+- Validation finale des règles de consolidation ranked / non-ranked dans `owned-talent-summary`
+- Durcissement des cas limites si nécessaire :
+  - plusieurs achats du même `talentId` sur plusieurs spécialisations ;
+  - plusieurs achats du même non-ranked pour progression d'arbres différents ;
+  - définition de talent absente ou partielle ;
+  - source arbre / spécialisation incomplète
+- Création d'un adaptateur fiche personnage pour consommer la vue consolidée au lieu de lire directement `actor.items`
+- Adaptation du template `templates/sheets/actor/talents.hbs` pour afficher :
+  - nom ;
+  - activation ;
+  - ranked / non-ranked ;
+  - rang consolidé si applicable ;
+  - source(s)
+- Suppression du comportement UI ambigu sur les lignes consolidées :
+  - pas d'édition directe d'un talent consolidé ;
+  - pas de suppression directe d'une ligne consolidée
+- Ajout des tests unitaires et UI minimaux couvrant l'absence de doublons visuels
+
+### Exclu de cette US / ce ticket
+
+- Refonte complète visuelle de l'onglet Talents prévue par US12 / US13
+- Achat de talents depuis l'onglet Talents
+- Vue graphique des arbres de spécialisation
+- Migration complète du legacy talents hors des zones nécessaires à cet affichage
+- Automatisation mécanique des talents
+- Refonte du flux d'import OggDude
+- Création d'une nouvelle ApplicationV2 dédiée aux talents
+
+---
+
+## 3. Constat sur l'existant
+
+- La source de vérité V1 existe déjà dans `actor.system.progression.talentPurchases` via `module/models/character.mjs`.
+- La consolidation métier existe déjà dans `module/lib/talent-node/owned-talent-summary.mjs`.
+- Les tests `tests/lib/talent-node/owned-talent-summary.test.mjs` couvrent déjà :
+  - ranked multi-achats ;
+  - non-ranked dédupliqué ;
+  - plusieurs sources ;
+  - cas dégradés de résolution.
+- En revanche, aucune UI ne consomme aujourd'hui cette consolidation.
+- La fiche actuelle continue à construire l'onglet Talents depuis `this.actor.items` dans `module/applications/sheets/character-sheet.mjs#buildTalentList()`.
+- Le regroupement actuel des ranked se fait par `name`, pas par `talentId`.
+- Les non-ranked restent listés item par item.
+- Le template `templates/sheets/actor/talents.hbs` suppose qu'une ligne correspond à un `Item` unique éditable/supprimable.
+- Cette hypothèse est incompatible avec une ligne consolidée issue de plusieurs achats de nœuds.
+- Le legacy `module/documents/actor-mixins/talents.mjs` et les anciens flux `module/lib/talents/*` restent présents mais ne doivent pas redevenir source de vérité.
+
+---
+
+## 4. Décisions d'architecture
+
+### 4.1. La consolidation canonique reste `buildOwnedTalentSummary()`
+
+**Décision** : US8 réutilise `module/lib/talent-node/owned-talent-summary.mjs` comme point d'entrée canonique, au lieu d'introduire une seconde logique côté sheet.
+
+Justification :
+
+- conforme au cadrage `01-modele-domaine-talents.md` ;
+- évite deux interprétations métier concurrentes ;
+- garde la logique testable sans Foundry UI ;
+- capitalise sur US7 au lieu de la contourner.
+
+### 4.2. Le regroupement UI se fait par `talentId`, jamais par `name`
+
+**Décision** : l'onglet Talents doit afficher une ligne par entrée consolidée issue de `talentId`.
+
+Justification :
+
+- conforme à l'issue #192 ;
+- corrige la faiblesse actuelle du regroupement par nom ;
+- évite les collisions éditoriales ou de traduction.
+
+### 4.3. L'onglet Talents actuel est branché sur une vue dérivée, pas sur `actor.items`
+
+**Décision** : la fiche personnage construit un adaptateur d'affichage à partir de `buildOwnedTalentSummary()`.
+
+Justification :
+
+- l'AC UI de l'issue ne peut pas être satisfaite sans brancher la fiche ;
+- conforme au cadrage `04-ui-onglet-talents.md` ;
+- limite le changement à l'onglet Talents sans lancer toute la refonte US12/US13.
+
+### 4.4. Les définitions de talents restent résolues en lecture seule
+
+**Décision** : l'adaptateur sheet résout les métadonnées d'affichage des talents depuis les référentiels disponibles du monde / compendiums talent, sans utiliser les embedded `Item` acteur comme source de possession.
+
+Justification :
+
+- conforme à la séparation modèle métier / vue dérivée ;
+- cohérent avec le rôle transitoire déjà décrit dans le plan US7 ;
+- évite de recoupler la V1 à l'ancien modèle "un talent possédé = un Item acteur".
+
+### 4.5. Une ligne consolidée n'est plus éditable ni supprimable directement
+
+**Décision** : les contrôles `edit` / `delete` du template talents sont retirés, masqués ou désactivés pour les lignes issues de la vue consolidée.
+
+Justification :
+
+- une ligne consolidée peut représenter plusieurs achats ;
+- il n'existe plus de correspondance 1 ligne = 1 document supprimable ;
+- conforme au cadrage `04-ui-onglet-talents.md` qui exclut modification / suppression depuis l'onglet.
+
+### 4.6. La règle ranked / non-ranked est reflétée explicitement dans le contrat d'affichage
+
+**Décision** :
+- ranked : `rank = nombre d'achats consolidés` ;
+- non-ranked : une seule ligne, `rank = null`, plusieurs sources possibles.
+
+Justification :
+
+- conforme à `02-regles-achat-progression.md` ;
+- évite toute ambiguïté visuelle sur un double bénéfice ;
+- aligne l'UI sur le contrat domaine existant.
+
+### 4.7. Les chaînes visibles doivent passer par l'i18n
+
+**Décision** : les nouveaux libellés ou tags affichés dans l'onglet Talents utilisent des clés `lang/fr.json` et `lang/en.json`.
+
+Justification :
+
+- conforme à l'ADR-0005 ;
+- évite de prolonger les textes hardcodés déjà présents dans la fiche ;
+- prépare la réutilisation par les futures US UI.
+
+---
+
+## 5. Plan de travail détaillé
+
+### Étape 1 — Verrouiller le contrat métier des talents dupliqués
+
+**Quoi faire** : relire et compléter `owned-talent-summary` pour s'assurer que le contrat final couvre explicitement les règles US8.
+
+**Fichiers** :
+- `module/lib/talent-node/owned-talent-summary.mjs`
+- `tests/lib/talent-node/owned-talent-summary.test.mjs`
+
+**Risques spécifiques** :
+- considérer US8 comme déjà terminée alors que seule la couche domaine l'est partiellement ;
+- laisser des cas ambigus non documentés dans le contrat retourné.
+
+### Étape 2 — Ajouter un adaptateur fiche personnage → vue consolidée
+
+**Quoi faire** : remplacer la construction actuelle basée sur `actor.items` par une transformation de la vue `buildOwnedTalentSummary()` vers les données attendues par le template.
+
+**Fichiers** :
+- `module/applications/sheets/character-sheet.mjs`
+
+**Risques spécifiques** :
+- dépendance trop forte aux embedded items legacy ;
+- résolution incomplète des définitions de talents si le référentiel n'est pas chargé.
+
+### Étape 3 — Faire évoluer le template talents vers une ligne consolidée
+
+**Quoi faire** : adapter `templates/sheets/actor/talents.hbs` pour afficher une entrée consolidée et ses sources, sans contrôles incohérents.
+
+**Fichiers** :
+- `templates/sheets/actor/talents.hbs`
+
+**Risques spécifiques** :
+- conserver des actions `edit` / `delete` devenues trompeuses ;
+- afficher les sources de façon illisible si plusieurs spécialisations existent.
+
+### Étape 4 — Localiser les nouveaux libellés d'affichage
+
+**Quoi faire** : introduire ou réutiliser les clés i18n nécessaires pour `Active`, `Passive`, `Ranked`, `Sources`, états inconnus ou incomplets si affichés.
+
+**Fichiers** :
+- `lang/fr.json`
+- `lang/en.json`
+
+**Risques spécifiques** :
+- introduire des libellés hardcodés supplémentaires ;
+- divergence entre FR et EN.
+
+### Étape 5 — Couvrir la non-régression UI et métier
+
+**Quoi faire** : compléter les tests domaine et ajouter des tests ciblés sur l'adaptateur sheet pour vérifier l'absence de doublons visuels.
+
+**Fichiers** :
+- `tests/lib/talent-node/owned-talent-summary.test.mjs`
+- `tests/applications/sheets/character-sheet-talents.test.mjs`
+
+**Risques spécifiques** :
+- se limiter à des tests domaine alors que l'issue impose un effet visible dans l'UI ;
+- écrire des tests trop couplés à une structure HTML fragile.
+
+---
+
+## 6. Fichiers modifiés
+
+| Fichier | Action | Description du changement |
+|---|---|---|
+| `module/lib/talent-node/owned-talent-summary.mjs` | modification | Verrouiller ou compléter le contrat métier de consolidation ranked / non-ranked |
+| `module/applications/sheets/character-sheet.mjs` | modification | Construire les données de l'onglet Talents depuis la vue consolidée V1 |
+| `templates/sheets/actor/talents.hbs` | modification | Afficher une ligne consolidée par talent avec sources et rang si applicable |
+| `lang/fr.json` | modification | Ajouter les libellés FR nécessaires à l'affichage consolidé |
+| `lang/en.json` | modification | Ajouter les libellés EN correspondants |
+| `tests/lib/talent-node/owned-talent-summary.test.mjs` | modification | Compléter les cas métiers ciblés par l'issue |
+| `tests/applications/sheets/character-sheet-talents.test.mjs` | création | Vérifier l'absence de duplication visuelle et la bonne projection de la vue consolidée |
+
+---
+
+## 7. Risques
+
+| Risque | Impact | Mitigation |
+|---|---|---|
+| La fiche continue à lire `actor.items` dans un sous-chemin oublié | L'UI garde des doublons malgré la consolidation | Centraliser toute la préparation talents dans un seul adaptateur sheet |
+| Le référentiel de définitions talent n'est pas résolu en lecture | L'onglet affiche des talents partiellement vides | Prévoir un affichage dégradé explicite et des tests associés |
+| Une ligne consolidée garde des actions legacy | Suppression ou édition incohérente d'un talent multi-source | Retirer ou neutraliser les contrôles sur les lignes consolidées |
+| Les tests ne couvrent que le domaine | L'AC "aucune duplication visuelle" n'est pas réellement prouvée | Ajouter un test ciblé sur la préparation de données de la fiche |
+| Le changement empiète trop sur US12/US13 | Rework futur plus coûteux | Limiter cette US à un branchement minimal sans refonte graphique complète |
+
+---
+
+## 8. Proposition d'ordre de commit
+
+1. `test(talent): compléter les cas de consolidation ranked et non-ranked dupliqués`
+2. `feat(talent): stabiliser le résumé consolidé des talents possédés`
+3. `feat(character-sheet): brancher l'onglet talents sur la vue consolidée`
+4. `feat(i18n): localiser les libellés de l'onglet talents consolidé`
+
+---
+
+## 9. Dépendances avec les autres US
+
+- **Dépend de US7 / #191** : la vue consolidée existe déjà et constitue la base métier de cette US.
+- **Réutilise US4 et US6 indirectement** : résolution spécialisation → arbre et achats persistés dans `talentPurchases`.
+- **Prépare US12 / US13** : l'onglet Talents commencera déjà à consommer la bonne donnée, ce qui réduira la refonte ultérieure à un travail d'UX et de présentation.
+- **N'absorbe pas US12 / US13** : cette US ne doit pas devenir une refonte complète de la fiche ou des arbres.

--- a/lang/en.json
+++ b/lang/en.json
@@ -1105,6 +1105,12 @@
         "hint": "This configuration tab involves advanced features for automating talent effects. Mis-configuring data on this tab can have serious consequences. Do not attempt to make changes here unless you are confident in your own knowledge."
       }
     },
+    "ACTIVE": "Active",
+    "PASSIVE": "Passive",
+    "RANKED": "Ranked",
+    "UNKNOWN": "Unknown Talent",
+    "UNKNOWN_SOURCE": "Unknown Source",
+    "SOURCES": "Sources",
     "ACTIONS": {
       "ADD": "Add Action",
       "DELETE": "Delete Action",

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -1097,6 +1097,12 @@
         "hint": "This configuration tab involves advanced features for automating talent effects. Mis-configuring data on this tab can have serious consequences. Do not attempt to make changes here unless you are confident in your own knowledge."
       }
     },
+    "ACTIVE": "Actif",
+    "PASSIVE": "Passif",
+    "RANKED": "Ranked",
+    "UNKNOWN": "Talent inconnu",
+    "UNKNOWN_SOURCE": "Source inconnue",
+    "SOURCES": "Sources",
     "ACTIONS": {
       "ADD": "Add Action",
       "DELETE": "Delete Action",

--- a/module/applications/sheets/character-sheet.mjs
+++ b/module/applications/sheets/character-sheet.mjs
@@ -5,6 +5,7 @@ import SkillFactory from '../../lib/skills/skill-factory.mjs'
 import ErrorSkill from '../../lib/skills/error-skill.mjs'
 import TalentFactory from '../../lib/talents/talent-factory.mjs'
 import ErrorTalent from '../../lib/talents/error-talent.mjs'
+import { buildOwnedTalentSummary } from '../../lib/talent-node/owned-talent-summary.mjs'
 import { logger } from '../../utils/logger.mjs'
 import { getPositiveDicePoolPreview } from '../../utils/skill-costs.mjs'
 import SkillCostCalculator from '../../lib/skills/skill-cost-calculator.mjs'
@@ -17,27 +18,6 @@ import SkillCostCalculator from '../../lib/skills/skill-cost-calculator.mjs'
  * @property {string} type - The type of defense, which is typically the same as `extraCss`.
  * @property {string} label - The label for the defense, typically the same as the type.
  * @property {number} value - The current value of the jauge.
- */
-
-/**
- * @typedef {Object} TalentTag
- * Represents a visual tag or label associated with a talent.
- *
- * @property {string} label - The visible label of the tag (e.g., "Active", "Ranked", "Combat").
- * @property {string} [cssClass] - Optional CSS class for styling the tag (e.g., "tag-active", "tag-passive").
- * @property {string} [tooltip] - Optional tooltip text for the tag.
- */
-
-/**
- * @typedef {Object} TalentDisplayData
- * Represents the data structure used to render a talent on the character sheet.
- *
- * @property {string} id - Unique ID of the Talent Item.
- * @property {string} name - Name of the talent.
- * @property {string} img - Image path used for the talent icon.
- * @property {string} [cssClass] - Optional CSS class applied to the container (e.g., "highlighted", "disabled").
- * @property {boolean} isFree - Indicates if the talent is free by any mean.
- * @property {TalentTag[]} tags - List of tags to display under the talent.
  */
 
 /**
@@ -149,7 +129,7 @@ export default class CharacterSheet extends SwerpgBaseActorSheet {
       i.creationTooltip += '</ol>'
     }
 
-    context.talents = this.#buildTalentList()
+    context.talents = this.#buildConsolidatedTalentList()
 
     context.obligations = this.#buildObligationList()
     context.obligationPoints = this.#computeObligationPoints(context.obligations)
@@ -919,87 +899,63 @@ export default class CharacterSheet extends SwerpgBaseActorSheet {
   }
 
   /**
-   * Builds the display-ready data for a talent item.
-   * @param {Item} item A Foundry VTT Item of type "talent".
-   * @returns {TalentDisplayData}
+   * Build a Map of talent definitions from world items for owned-talent-summary resolution.
+   * @returns {Map<string, {name: string, activation: string, isRanked: boolean}>}
    */
-  #buildTalentDisplayData(item) {
-    const tags = this.#buildTags(item)
-
-    return {
-      id: item.id,
-      name: item.name,
-      img: item.img,
-      isFree: item.system.isFree,
-      cssClass: item.system.disabled ? 'disabled' : '',
-      tags,
-      rank: '-',
+  #buildTalentDefinitions() {
+    const defs = new Map()
+    if (!game?.items?.find) return defs
+    for (const item of game.items) {
+      if (item.type === 'talent') {
+        defs.set(item.id, {
+          name: item.name,
+          activation: item.system?.activation,
+          isRanked: item.system?.isRanked,
+        })
+      }
     }
+    return defs
   }
 
   /**
-   * Builds the tags for a talent item.
-   * @param item {Item} - A Foundry VTT Item of type "talent".
-   * @returns {*[]} A list of tags to display under the talent.
+   * Build a consolidated talent list for the character sheet using OwnedTalentSummary.
+   * Groups by talentId, deduplicates, and enriches with definition metadata.
+   * @returns {object[]} Template-ready talent display entries.
    */
-  #buildTags(item) {
-    const tags = []
+  #buildConsolidatedTalentList() {
+    const definitions = this.#buildTalentDefinitions()
+    const summary = buildOwnedTalentSummary(this.actor, definitions)
 
-    if (item.system.activation === 'active') {
-      tags.push({ label: 'Active', cssClass: 'tag-active' })
-    } else {
-      tags.push({ label: 'Passive', cssClass: 'tag-passive' })
-    }
+    return summary.map((entry) => {
+      const tags = []
+      if (entry.activation === 'active') {
+        tags.push({ label: game.i18n.localize('SWERPG.TALENT.ACTIVE'), cssClass: 'tag-active' })
+      } else if (entry.activation === 'passive') {
+        tags.push({ label: game.i18n.localize('SWERPG.TALENT.PASSIVE'), cssClass: 'tag-passive' })
+      }
+      if (entry.isRanked) {
+        tags.push({ label: game.i18n.localize('SWERPG.TALENT.RANKED') })
+      }
 
-    if (item.system.isRanked) {
-      tags.push({ label: 'Ranked' })
-    }
+      const sourceLabels = entry.sources.map((s) => {
+        if (s.resolutionState === 'ok') {
+          return s.specializationName || s.treeName || game.i18n.localize('SWERPG.TALENT.UNKNOWN_SOURCE')
+        }
+        return game.i18n.localize('SWERPG.TALENT.UNKNOWN_SOURCE')
+      })
 
-    if (item.system.category) {
-      tags.push({ label: item.system.category })
-    }
-
-    if (item.system.isFree) {
-      tags.push({ label: 'Species', cssClass: 'tag-free', tooltip: 'Talent is free thanks to the Species' })
-    }
-    return tags
-  }
-
-  /**
-   * Builds a list of talents for the character sheet.
-   * @returns {TalentDisplayData[]}
-   */
-  #buildTalentList() {
-    const simpleTalents = this.actor.items.filter((item) => (item.type === 'talent') & !item.system.isRanked)
-    const rankedTalents = this.actor.items.filter((item) => item.type === 'talent' && item.system.isRanked)
-    const rankedTalentsData = this.#buildAggregateTalentDisplayData(rankedTalents)
-    const simpleTalentsData = simpleTalents.map((talent) => this.#buildTalentDisplayData(talent))
-
-    return simpleTalentsData.concat(rankedTalentsData)
-  }
-
-  #buildAggregateTalentDisplayData(talents) {
-    const groupedByName = talents.reduce((acc, talent) => {
-      const key = talent.name
-      if (!acc[key]) acc[key] = []
-      acc[key].push(talent)
-      return acc
-    }, {})
-    return Object.entries(groupedByName).map(([name, group], index) => {
-      // Trouver le talent avec le rank maximal
-      const maxRankTalent = group.reduce((a, b) => (a.idx > b.idx ? a : b))
-
-      // Exemple de génération de tags — à adapter à ton système
-      const tags = this.#buildTags(maxRankTalent) // ← Ajoute ici une logique si nécessaire
+      let rankValue = '-'
+      if (entry.isRanked && entry.rank !== null) {
+        rankValue = entry.rank
+      }
 
       return {
-        id: maxRankTalent.id,
-        name: maxRankTalent.name,
-        img: maxRankTalent.img,
-        isFree: maxRankTalent.system.isFree,
-        cssClass: maxRankTalent.system.disabled ? 'disabled' : '',
+        talentId: entry.talentId,
+        name: entry.name || game.i18n.localize('SWERPG.TALENT.UNKNOWN'),
         tags,
-        rank: maxRankTalent.system.rank.idx,
+        isRanked: entry.isRanked,
+        rank: rankValue,
+        sourceLabels,
       }
     })
   }

--- a/templates/sheets/actor/talents.hbs
+++ b/templates/sheets/actor/talents.hbs
@@ -4,23 +4,26 @@
   data-group="{{tabs.talents.group}}"
 >
 
-  {{#each talents as |talent s|}}
-    <div class="line-item {{talent.cssClass}}" data-item-id="{{talent.id}}" data-delete-action="deleteTalent" data-item-type="talent">
+  {{#each talents as |talent|}}
+    <div class="line-item talent-consolidated" data-talent-id="{{talent.talentId}}">
       <div class="title">
-        <img class="icon" src="{{talent.img}}" alt="{{talent.name}}" />
         <h4 class="item-header">{{talent.name}}</h4>
         <div class="tags">
-          {{#each talent.tags as |tag i|}}
-            <span class="tag {{tag.cssClass}}" data-tooltip="{{tag.tooltip}}">{{tag.label}}</span>
+          {{#each talent.tags as |tag|}}
+            <span class="tag {{tag.cssClass}}">{{tag.label}}</span>
           {{/each}}
         </div>
       </div>
-      <div class="value">{{talent.rank}}</div>
-      <div class="controls">
-        {{#unless talent.isFree}}
-          <a class="button icon fa-solid fa-trash" data-action="itemDelete" data-tooltip="Delete Talent"></a>
-        {{/unless}}
-        <a class="button icon fa-solid fa-edit" data-action="itemEdit" data-tooltip="Edit Talent"></a>
+      <div class="talent-rank">
+        {{#if talent.isRanked}}
+          {{talent.rank}}
+        {{/if}}
+      </div>
+      <div class="talent-sources">
+        <span class="source-label">{{localize 'SWERPG.TALENT.SOURCES'}}:</span>
+        {{#each talent.sourceLabels as |source i|}}
+          <span class="source-name">{{source}}{{#unless @last}}, {{/unless}}</span>
+        {{/each}}
       </div>
     </div>
   {{/each}}

--- a/tests/applications/sheets/character-sheet-talents.test.mjs
+++ b/tests/applications/sheets/character-sheet-talents.test.mjs
@@ -1,0 +1,221 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+
+vi.mock('../../../module/utils/logger.mjs', () => ({
+  logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}))
+
+vi.mock('../../../module/lib/skills/skill-factory.mjs', () => ({ default: {} }))
+vi.mock('../../../module/lib/talents/talent-factory.mjs', () => ({ default: {} }))
+vi.mock('../../../module/lib/jauges/jauge-factory.mjs', () => ({
+  default: { build: vi.fn(() => ({ create: vi.fn(() => ({})) })) },
+}))
+vi.mock('../../../module/lib/featured-equipment.mjs', () => ({
+  computeFeaturedEquipment: vi.fn(() => []),
+}))
+
+vi.mock('../../../module/lib/talent-node/owned-talent-summary.mjs', () => ({
+  buildOwnedTalentSummary: vi.fn(),
+}))
+
+import { buildOwnedTalentSummary } from '../../../module/lib/talent-node/owned-talent-summary.mjs'
+
+describe('CharacterSheet talent consolidation (US8)', () => {
+  let CharacterSheet
+  let SwerpgBaseActorSheet
+
+  beforeEach(async () => {
+    vi.clearAllMocks()
+
+    if (!globalThis.game.system.tree) globalThis.game.system.tree = {}
+    globalThis.game.system.tree.actor = null
+
+    SwerpgBaseActorSheet = (await import('../../../module/applications/sheets/base-actor-sheet.mjs')).default
+    CharacterSheet = (await import('../../../module/applications/sheets/character-sheet.mjs')).default
+  })
+
+  function buildBaseContext(actor) {
+    return {
+      actor,
+      source: actor.toObject(),
+      incomplete: {},
+      progression: {
+        experience: actor.system.progression.experience,
+        freeSkillRanks: {
+          career: { ...actor.system.progression.freeSkillRanks.career },
+          specialization: { ...actor.system.progression.freeSkillRanks.specialization },
+        },
+      },
+      tabs: [{ id: 'talents', group: 'sheet' }],
+      skillCategories: {},
+    }
+  }
+
+  function buildMockActor(overrides = {}) {
+    const actor = {
+      items: [],
+      system: {
+        skills: {},
+        progression: {
+          freeSkillRanks: {
+            career: { spent: 0, gained: 4, available: 4 },
+            specialization: { spent: 0, gained: 0, available: 0 },
+          },
+          experience: { available: 0, spent: 0, gained: 0, total: 0 },
+        },
+        characteristics: {
+          brawn: { rank: { value: 2 } },
+        },
+        details: {
+          career: null,
+          specializations: new Set(),
+          species: { name: 'Test Species' },
+        },
+        resources: {
+          wounds: { value: 0, threshold: 10 },
+          strain: { value: 0, threshold: 10 },
+          encumbrance: { value: 0, threshold: 10 },
+        },
+        points: {},
+      },
+      hasFreeSkillsAvailable: vi.fn(() => false),
+      ...overrides,
+    }
+    actor.toObject = () => JSON.parse(JSON.stringify(actor))
+    return actor
+  }
+
+  async function getContext(actor) {
+    vi.spyOn(SwerpgBaseActorSheet.prototype, '_prepareContext').mockResolvedValue(buildBaseContext(actor))
+    const sheet = new CharacterSheet({ document: actor })
+    sheet.actor = actor
+    sheet.document = actor
+    return await sheet._prepareContext({})
+  }
+
+  it('produces empty talents array when buildOwnedTalentSummary returns empty', async () => {
+    buildOwnedTalentSummary.mockReturnValue([])
+    const actor = buildMockActor()
+    const context = await getContext(actor)
+
+    expect(context.talents).toEqual([])
+  })
+
+  it('builds consolidated talent entry with tags, rank, and source labels', async () => {
+    buildOwnedTalentSummary.mockReturnValue([
+      {
+        talentId: 'talent-parry',
+        name: 'Parry',
+        activation: 'active',
+        isRanked: true,
+        rank: 2,
+        sources: [
+          { specializationName: 'Bodyguard', treeName: null, resolutionState: 'ok' },
+          { specializationName: 'Mercenary Soldier', treeName: null, resolutionState: 'ok' },
+        ],
+      },
+    ])
+    const actor = buildMockActor()
+    const context = await getContext(actor)
+
+    expect(context.talents).toHaveLength(1)
+    const entry = context.talents[0]
+    expect(entry.talentId).toBe('talent-parry')
+    expect(entry.name).toBe('Parry')
+    expect(entry.isRanked).toBe(true)
+    expect(entry.rank).toBe(2)
+    expect(entry.sourceLabels).toEqual(['Bodyguard', 'Mercenary Soldier'])
+    expect(entry.tags).toEqual([
+      { label: 'SWERPG.TALENT.ACTIVE', cssClass: 'tag-active' },
+      { label: 'SWERPG.TALENT.RANKED' },
+    ])
+  })
+
+  it('builds non-ranked talent entry without rank value', async () => {
+    buildOwnedTalentSummary.mockReturnValue([
+      {
+        talentId: 'talent-toughness',
+        name: 'Toughness',
+        activation: 'passive',
+        isRanked: false,
+        rank: null,
+        sources: [
+          { specializationName: 'Bodyguard', resolutionState: 'ok' },
+        ],
+      },
+    ])
+    const actor = buildMockActor()
+    const context = await getContext(actor)
+
+    const entry = context.talents[0]
+    expect(entry.isRanked).toBe(false)
+    expect(entry.rank).toBe('-')
+    expect(entry.tags).toEqual([
+      { label: 'SWERPG.TALENT.PASSIVE', cssClass: 'tag-passive' },
+    ])
+  })
+
+  it('uses localized unknown name when definition is missing', async () => {
+    buildOwnedTalentSummary.mockReturnValue([
+      {
+        talentId: 'talent-unknown',
+        name: null,
+        activation: null,
+        isRanked: null,
+        rank: null,
+        sources: [
+          { specializationName: null, resolutionState: 'specialization-not-found' },
+        ],
+      },
+    ])
+    const actor = buildMockActor()
+    const context = await getContext(actor)
+
+    const entry = context.talents[0]
+    expect(entry.name).toBe('SWERPG.TALENT.UNKNOWN')
+    expect(entry.tags).toEqual([])
+    expect(entry.rank).toBe('-')
+  })
+
+  it('uses unknown source label when resolution state is not ok', async () => {
+    buildOwnedTalentSummary.mockReturnValue([
+      {
+        talentId: 'talent-parry',
+        name: 'Parry',
+        activation: 'active',
+        isRanked: true,
+        rank: 1,
+        sources: [
+          { specializationName: null, treeName: null, resolutionState: 'tree-unresolved' },
+        ],
+      },
+    ])
+    const actor = buildMockActor()
+    const context = await getContext(actor)
+
+    const entry = context.talents[0]
+    expect(entry.sourceLabels).toEqual(['SWERPG.TALENT.UNKNOWN_SOURCE'])
+  })
+
+  it('deduplicates same talentId into single entry with consolidated sources', async () => {
+    buildOwnedTalentSummary.mockReturnValue([
+      {
+        talentId: 'talent-parry',
+        name: 'Parry',
+        activation: 'active',
+        isRanked: true,
+        rank: 2,
+        sources: [
+          { specializationName: 'Bodyguard', resolutionState: 'ok' },
+          { specializationName: 'Mercenary Soldier', resolutionState: 'ok' },
+        ],
+      },
+    ])
+    const actor = buildMockActor()
+    const context = await getContext(actor)
+
+    expect(context.talents).toHaveLength(1)
+    const entry = context.talents[0]
+    expect(entry.sourceLabels).toHaveLength(2)
+    expect(entry.sourceLabels).toEqual(['Bodyguard', 'Mercenary Soldier'])
+  })
+})


### PR DESCRIPTION
## Summary

Apply US8 consolidation rules for talents purchased across multiple specialization trees. Replaces the per-embedded-item talent list with a derived view backed by `buildOwnedTalentSummary()`, eliminating visual duplicates in the character sheet talents tab.

## Changes

### `module/applications/sheets/character-sheet.mjs`
- Import `buildOwnedTalentSummary` from `owned-talent-summary.mjs`
- Add `#buildTalentDefinitions()` — builds definition map from `game.items` (V1 pragmatic approach, degrades gracefully when `talentId` keys mismatch)
- Add `#buildConsolidatedTalentList()` — calls `buildOwnedTalentSummary()`, transforms entries for template; uses i18n for all visible strings
- Remove `#buildTalentList()`, `#buildTalentDisplayData()`, `#buildAggregateTalentDisplayData()`, `#buildTags()` — replaced by consolidated method
- Remove `TalentTag` / `TalentDisplayData` typedefs (no longer used)

### `templates/sheets/actor/talents.hbs`
- One consolidated line per `talentId`, no icon, no edit/delete controls
- Show: name, tags (activation + ranked), rank value (if ranked), source labels
- Uses `localize` helper for "Sources:" label

### `lang/en.json`, `lang/fr.json`
- Added: `TALENT.ACTIVE`, `TALENT.PASSIVE`, `TALENT.RANKED`, `TALENT.UNKNOWN`, `TALENT.UNKNOWN_SOURCE`, `TALENT.SOURCES`

### `tests/applications/sheets/character-sheet-talents.test.mjs` (new)
- 6 tests covering: empty summary, consolidated entry with tags/rank/sources, non-ranked entry, unknown definition fallback, unknown source display, deduplication

## Validation
- `pnpm test --run tests/applications/sheets/character-sheet-talents.test.mjs` — 6/6 pass
- `pnpm test --run tests/lib/talent-node/` — 40/40 pass (no regression)
- `pnpm test --run tests/applications/sheets/character-sheet-skills.test.mjs` — 34/34 pass (no regression)

## Notes
- `buildOwnedTalentSummary()` contract unchanged — already covers US8 grouping, rank, and source resolution
- Definitions map uses `item.id` keys (Foundry UUID); when `talentId` mismatch occurs, display degrades gracefully (localized "Unknown Talent") — acceptable V1 trade-off
- Talents tab now branches on derived view, not `actor.items`
- No edit/delete UI on consolidated lines (plan §4.5)
- Closes #192