### PR TITLE
feat(importer): import specialization trees from OggDude (US10)

### DIFF
--- a/documentation/plan/character-sheet/talent/194-plan-importer-arbres-specialisation.md
+++ b/documentation/plan/character-sheet/talent/194-plan-importer-arbres-specialisation.md
@@ -1,0 +1,319 @@
+# Plan d'implémentation — US10 : Importer les arbres de spécialisation
+
+**Issue** : [#194 — US10: Importer les arbres de spécialisation](https://github.com/herveDarritchon/foundryvtt-swerpg/issues/194)  
+**Epic** : [#184 — EPIC: Refonte V1 des talents Edge](https://github.com/herveDarritchon/foundryvtt-swerpg/issues/184)  
+**ADR** : `documentation/architecture/adr/adr-0004-vitest-testing-strategy.md`, `documentation/architecture/adr/adr-0006-specialization-import-error-isolation.md`, `documentation/architecture/adr/adr-0012-unit-tests-readable-diagnostics.md`  
+**Module(s) impacté(s)** : `module/importer/oggDude.mjs` (modification), `module/importer/items/specialization-tree-ogg-dude.mjs` (création), `module/importer/mappers/oggdude-specialization-tree-mapper.mjs` (création), `module/importer/utils/specialization-tree-import-utils.mjs` (création), `module/models/specialization-tree.mjs` (modification), `tests/importer/specialization-tree-ogg-dude.spec.mjs` (création), `tests/models/specialization-tree.test.mjs` (modification)
+
+---
+
+## 1. Objectif
+
+Étendre l'import OggDude pour produire des référentiels `specialization-tree` contenant les nœuds, leurs positions, leurs coûts et leurs connexions, sans copier l'arbre sur l'acteur et sans réintroduire la logique legacy fondée sur `SwerpgTalentNode`.
+
+Le résultat attendu est un import capable de créer des arbres exploitables par la couche domaine (US5, US6), en particulier par la résolution d'arbre et par les règles de calcul d'état et d'achat des nœuds, tout en restant résilient face aux données OggDude incomplètes.
+
+---
+
+## 2. Périmètre
+
+### Inclus dans cette US / ce ticket
+
+- Création d'un flux d'import dédié aux `Item` de type `specialization-tree`
+- Extraction depuis les XML OggDude des informations suivantes lorsqu'elles sont disponibles :
+  - spécialisation liée
+  - carrière liée
+  - nœuds
+  - positions `row` / `column`
+  - coûts
+  - connexions
+- Normalisation des `nodeId` selon la convention V1 `r{row}c{column}`
+- Conservation des données brutes et diagnostics utiles dans `flags.swerpg.import`
+- Gestion explicite des cas incomplets :
+  - coût manquant
+  - talent non résolu
+  - connexion absente ou incohérente
+  - arbre sans spécialisation exploitable
+- Intégration dans le pipeline OggDude existant sans créer un nouveau domaine utilisateur séparé
+- Tests unitaires et d'intégration ciblés sur le mapper et sur l'orchestration d'import
+
+### Exclu de cette US / ce ticket
+
+- Création d'achats acteur dans `actor.system.progression.talentPurchases`
+- Copie complète d'un arbre dans les données de l'acteur
+- Refonte du mapper `specialization` existant pour changer son contrat métier principal
+- Rétroécriture automatique de `treeUuid` sur les spécialisations d'acteur
+- Placeholder `Item talent` automatique pour toute référence inconnue
+- Refonte UI de l'importeur OggDude
+- Vue graphique des arbres
+- Calcul des états `purchased` / `available` / `locked` / `invalid`
+- Achat d'un nœud
+- Migration des anciens nœuds legacy Crucible
+
+---
+
+## 3. Constat sur l'existant
+
+### Le type `specialization-tree` existe déjà
+
+Le fichier `module/models/specialization-tree.mjs` est opérationnel avec `specializationId`, `careerId`, `nodes`, `connections`, et les champs de nœud `nodeId`, `talentId`, `row`, `column`, `cost`.
+
+Le resolver domaine `module/lib/talent-node/talent-tree-resolver.mjs` consomme déjà ce modèle. Il considère actuellement qu'un arbre est `available` si `nodes` et `connections` sont non vides, sinon `incomplete`.
+
+### La couche domaine attend un contrat stable
+
+Les règles de domaine actuelles des nœuds (`tests/lib/talent-node/talent-node-state.test.mjs`) supposent déjà un contrat minimal stable côté arbre :
+- `nodeId`, `talentId`, `row`, `column`, `cost` sur chaque nœud
+- `connections` avec `from` et `to`
+- un arbre `available` a au moins un nœud et une connexion
+
+### Le pipeline OggDude ne connaît pas `specialization-tree`
+
+Le pipeline actuel (`module/importer/oggDude.mjs`) enregistre les domaines `talent` et `specialization`. Aucun flux `specialization-tree` n'existe.
+
+Le mapper `module/importer/items/specialization-ogg-dude.mjs` ne crée aujourd'hui que des `Item` `specialization` avec `description`, `freeSkillRank` et `specializationSkills`. Il ne produit ni nœuds, ni coûts, ni connexions.
+
+### Le moteur d'import force un type unique par batch
+
+`OggDudeDataElement.processElements()` impose un `element.type` unique pour tout un batch. Un même contexte ne peut donc pas créer à la fois des `specialization` et des `specialization-tree` sans orchestration explicite supplémentaire.
+
+### Legacy `SwerpgTalentNode` toujours présent mais non utilisé par US10
+
+Le mapper talent actuel (`module/importer/mappers/oggdude-talent-mapper.mjs`) utilise encore `resolveTalentNode()` via `module/importer/mappings/oggdude-talent-node-map.mjs`, lui-même fondé sur `module/config/talent-tree.mjs`. US10 ne doit pas dépendre de cette structure legacy.
+
+---
+
+## 4. Décisions d'architecture
+
+### 4.1. Domaine utilisateur conservé, flux interne dédié pour les arbres
+
+**Décision** : conserver le domaine utilisateur `specialization` dans l'UI, mais ajouter un flux interne dédié `specialization-tree` qui s'exécute sous le même domaine.
+
+Justification :
+- évite de modifier l'UI de sélection des domaines
+- évite de coupler deux contrats métier différents dans un seul mapper
+- respecte la contrainte technique de `processElements()` qui impose un `element.type` unique par batch
+- changement minimal et localisé
+
+### 4.2. Orchestration en deux passes sous le même domaine
+
+**Décision** : orchestrer explicitement deux passes successives dans `oggDude.mjs` lorsque le domaine `specialization` est importé :
+1. Import existant des `Item` `specialization`
+2. Import des `Item` `specialization-tree`
+
+Justification :
+- conserve le comportement existant du flux `specialization`
+- permet d'ajouter US10 sans refactor large du moteur générique d'import
+- réduit le risque de régression sur les autres domaines OggDude
+
+### 4.3. Les arbres importés sont stockés dans `item.system`
+
+**Décision** : les arbres importés sont stockés dans `item.system` du type `specialization-tree`, comme défini par US1 et US2.
+
+Justification :
+- conforme au modèle V1 Talents
+- cohérent avec US1 et US2 déjà posées
+- l'acteur ne conserve que sa progression, pas le référentiel complet
+- le resolver domaine existant sait déjà consommer ce support
+
+### 4.4. Contrat importé minimal : ce que la couche domaine consomme déjà
+
+**Décision** : le mapper importe strictement le contrat déjà consommé par la couche domaine : `nodeId`, `talentId`, `row`, `column`, `cost`, et `connections` avec `from`, `to`, `type` (optionnel).
+
+Justification :
+- aligne US10 sur les besoins réels de US5 et US6
+- évite d'ouvrir prématurément le chantier d'édition avancée ou de rendu graphique
+- découple totalement V1 Talents du legacy `SwerpgTalentNode`
+
+### 4.5. Enrichir le schéma `connections` avec un champ `type` optionnel
+
+**Décision** : ajouter `type` (StringField optionnel) dans le schéma `connections`.
+
+Justification :
+- respecte le contrat attendu par l'issue (connexions typées `vertical`/`horizontal`)
+- ne casse pas la compatibilité des arbres déjà créés
+- prépare les besoins de rendu et de diagnostic futurs sans migration lourde
+
+### 4.6. Données incomplètes : import partiel explicite, sans fallback dangereux
+
+**Décision** : importer ce qui est fiable, marquer explicitement le reste comme incomplet ou invalide. Ne jamais deviner les valeurs manquantes.
+
+Justification :
+- conforme au cadrage `03-import-oggdude-talents.md`
+- conforme à ADR-0006 sur l'isolation des erreurs par item
+- évite les faux positifs métier
+- conserve suffisamment de matière pour diagnostiquer et corriger les données
+
+### 4.7. Pas de dépendance bloquante à US9 pour les talents inconnus
+
+**Décision** : conserver le `talentId` brut, stocker le diagnostic dans `flags.swerpg.import`, et marquer l'arbre comme incomplet si des références sont non résolues.
+
+Justification :
+- évite d'élargir US10 au contrat métier du type `talent`
+- maintient l'indépendance annoncée vis-à-vis de US9
+- laisse la couche domaine exploiter l'arbre structurellement, tout en rendant les références non résolues visibles et diagnostiquables
+
+### 4.8. Couverture de tests : unité + intégration ciblée
+
+**Décision** : couvrir US10 par des tests unitaires du mapper et par un test d'intégration du pipeline d'import.
+
+Justification :
+- conforme à ADR-0004 et ADR-0012
+- nécessaire pour verrouiller la double orchestration sous un même domaine utilisateur
+
+---
+
+## 5. Plan de travail détaillé
+
+### Étape 1 — Enrichir le contrat du data model `specialization-tree`
+
+**Quoi faire** : faire évoluer `module/models/specialization-tree.mjs` pour ajouter `connections[].type` comme champ optionnel (`StringField`), sans casser les arbres déjà valides.
+
+**Fichiers** :
+- `module/models/specialization-tree.mjs`
+- `tests/models/specialization-tree.test.mjs`
+
+**Risques spécifiques** :
+- rendre `type` obligatoire casserait la rétrocompatibilité avec les arbres créés avant US10
+- oublier d'adapter les tests du modèle ferait dériver le contrat attendu
+
+### Étape 2 — Créer les utilitaires de normalisation et de diagnostic d'arbre
+
+**Quoi faire** : créer `module/importer/utils/specialization-tree-import-utils.mjs` pour centraliser :
+- la génération stable de `nodeId` selon la convention `r{row}c{column}`
+- la normalisation des coûts et positions
+- la validation structurelle minimale (coût présent, connexion cohérente, nœud résolu)
+- la collecte de warnings et raisons de rejet
+- les statistiques dédiées à l'import des arbres
+
+**Fichiers** :
+- `module/importer/utils/specialization-tree-import-utils.mjs`
+
+**Risques spécifiques** :
+- disperser cette logique dans le mapper rendrait les diagnostics difficiles à maintenir
+- mélanger ces utilitaires avec ceux de `specialization-import-utils.mjs` augmenterait le couplage entre deux contrats différents
+
+### Étape 3 — Implémenter le mapper dédié `specialization-tree`
+
+**Quoi faire** : créer `module/importer/mappers/oggdude-specialization-tree-mapper.mjs` pour transformer les données XML OggDude en sources `Item` `specialization-tree`.
+
+Le mapper doit au minimum :
+- lire l'identifiant et le nom de la spécialisation
+- extraire le rattachement carrière si disponible
+- construire les nœuds avec `nodeId`, `talentId`, `row`, `column`, `cost`
+- construire les connexions avec `from`, `to`, `type` si disponible
+- écrire les diagnostics utiles dans `flags.swerpg.import`
+- isoler les erreurs arbre par arbre (pattern ADR-0006)
+
+**Fichiers** :
+- `module/importer/mappers/oggdude-specialization-tree-mapper.mjs`
+
+**Risques spécifiques** :
+- dépendre du legacy `resolveTalentNode()` contaminerait le nouveau modèle
+- deviner un coût manquant ou reconstruire des connexions implicites créerait des arbres faux mais apparemment valides
+
+### Étape 4 — Créer le context builder dédié pour les arbres
+
+**Quoi faire** : créer `module/importer/items/specialization-tree-ogg-dude.mjs` pour assembler le contexte OggDude des arbres :
+- lecture des fichiers XML concernés (Specializations.xml)
+- sélection des données utiles
+- configuration du dossier cible (`Swerpg - Specialization Trees`)
+- branchement du mapper dédié
+- configuration du `element.type = 'specialization-tree'`
+
+**Fichiers** :
+- `module/importer/items/specialization-tree-ogg-dude.mjs`
+
+**Risques spécifiques** :
+- si le builder ne lit pas les mêmes variantes XML que le flux `specialization`, l'import sera incomplet selon les exports OggDude
+- mal choisir le dossier cible brouillerait les référentiels monde/compendium
+
+### Étape 5 — Orchestrer la double passe dans `oggDude.mjs`
+
+**Quoi faire** : modifier `module/importer/oggDude.mjs` pour que le domaine utilisateur `specialization` exécute deux imports successifs :
+1. le flux existant `specialization`
+2. le nouveau flux `specialization-tree`
+
+Cette orchestration doit :
+- garder une seule entrée utilisateur côté domaine
+- conserver des logs et stats lisibles
+- ne pas marquer tout le domaine en échec si un arbre isolé est rejeté
+- exposer un diagnostic clair des deux sous-passes dans les logs
+
+**Fichiers** :
+- `module/importer/oggDude.mjs`
+
+**Risques spécifiques** :
+- un reporting insuffisant rendra les échecs de la seconde passe invisibles dans l'UI ou dans les logs
+- l'ordre des passes ne doit pas créer de dépendance implicite (les `specialization` peuvent être créées avant ou après les arbres)
+
+### Étape 6 — Verrouiller la non-régression par tests
+
+**Quoi faire** : ajouter des tests couvrant :
+- mappage complet d'un arbre valide
+- gestion de coûts manquants
+- gestion de connexions manquantes ou invalides
+- conservation des diagnostics dans `flags.swerpg.import`
+- cas d'un arbre sans spécialisation exploitable
+- import simultané du domaine `specialization` sans créer un nouveau domaine utilisateur
+- non-régression du modèle `specialization-tree`
+
+**Fichiers** :
+- `tests/importer/specialization-tree-ogg-dude.spec.mjs`
+- `tests/models/specialization-tree.test.mjs`
+- test d'intégration complémentaire dans `tests/importer/`
+
+**Risques spécifiques** :
+- tests trop profonds sur des objets complets et verbeux, contraires à ADR-0012
+- ne tester que le mapper unitaire laisserait passer une erreur d'orchestration dans `oggDude.mjs`
+
+---
+
+## 6. Fichiers modifiés
+
+| Fichier | Action | Description du changement |
+|---|---|---|
+| `module/models/specialization-tree.mjs` | modification | Ajouter `connections[].type` optionnel |
+| `module/importer/utils/specialization-tree-import-utils.mjs` | création | Centraliser normalisation, diagnostics et statistiques de l'import d'arbres |
+| `module/importer/mappers/oggdude-specialization-tree-mapper.mjs` | création | Mapper dédié des XML OggDude vers les `Item` `specialization-tree` |
+| `module/importer/items/specialization-tree-ogg-dude.mjs` | création | Context builder OggDude pour les arbres de spécialisation |
+| `module/importer/oggDude.mjs` | modification | Orchestrer deux sous-passes dans le domaine `specialization` |
+| `tests/models/specialization-tree.test.mjs` | modification | Couvrir le champ `connections[].type` et la compatibilité du modèle |
+| `tests/importer/specialization-tree-ogg-dude.spec.mjs` | création | Tests unitaires du mapper et des cas dégradés |
+| `tests/importer/` (test pipeline) | création ou modification | Vérifier l'orchestration de la double passe sous un seul domaine utilisateur |
+
+---
+
+## 7. Risques
+
+| Risque | Impact | Mitigation |
+|---|---|---|
+| Le moteur `processElements()` impose un seul `element.type` | Impossible de créer `specialization` et `specialization-tree` en un seul batch | Prévoir explicitement une orchestration en deux passes dans `oggDude.mjs` |
+| Variantes XML OggDude non couvertes | Certains arbres ne seront jamais importés | Reprendre la stratégie de fallback déjà utilisée dans `buildJsonDataFromDirectory()` et la tester sur plusieurs formes |
+| Coûts ou connexions manquants traités avec fallback implicite | Arbres faux mais apparemment valides | Ne jamais deviner les valeurs manquantes ; stocker les warnings dans `flags.swerpg.import` |
+| Références talent non résolues | Nœuds structurellement présents mais métier incomplets | Conserver le `talentId` brut, exposer les diagnostics, ne pas bloquer tout le domaine |
+| Régression sur le flux `specialization` existant | L'import de spécialisations simples peut casser | Isoler le nouveau code dans des modules dédiés et conserver les tests du flux existant |
+| Tests trop couplés à la structure exacte des objets | Diagnostics faibles et maintenance coûteuse | Suivre ADR-0012 avec assertions ciblées sur les champs métier utiles |
+
+---
+
+## 8. Proposition d'ordre de commit
+
+1. `test(model): verrouiller le contrat specialization-tree pour les connexions`
+2. `feat(model): enrichir specialization-tree avec le type de connexion optionnel`
+3. `feat(importer): ajouter les utilitaires d import des arbres de specialisation`
+4. `feat(importer): ajouter le mapper oggdude des specialization-tree`
+5. `feat(importer): brancher le context builder specialization-tree`
+6. `feat(importer): orchestrer la double passe du domaine specialization`
+7. `test(importer): couvrir l import oggdude des arbres de specialisation`
+
+---
+
+## 9. Dépendances avec les autres US
+
+- **Dépend de US1 (#185)** : le type `specialization-tree` doit exister.
+- **Dépend de US2 (#186)** : les nœuds doivent déjà porter `row`, `column` et `cost`.
+- **Ne dépend pas strictement de US9 (#193)** : l'import des arbres peut fonctionner sans référentiel talent complet, à condition de diagnostiquer explicitement les références non résolues.
+- **Alimente US5 (#189)** : les états de nœuds dépendent directement des nœuds et connexions importés.
+- **Alimente US6 (#190)** : l'achat d'un nœud repose sur `treeId`, `nodeId`, `cost` et la structure de connexions.
+- **Bénéficie à US4 (#188)** : le fallback par `specializationId` devient utile dès lors que les `specialization-tree` existent réellement dans le monde ou en compendium.

--- a/documentation/plan/character-sheet/talent/195-plan-fix-stockage-arbres-specialisation.md
+++ b/documentation/plan/character-sheet/talent/195-plan-fix-stockage-arbres-specialisation.md
@@ -1,0 +1,120 @@
+# Plan de correction — Bug stockage `specialization-tree` invisible après import
+
+**Issue** : [#194 — US10: Importer les arbres de spécialisation](https://github.com/herveDarritchon/foundryvtt-swerpg/issues/194)  
+**Module(s) impacté(s)** : `module/utils/oggdude-mapping-config.mjs` (modification), `module/importer/utils/oggdude-import-folders.mjs` (modification), `tests/importer/utils/oggdude-mapping-config.spec.mjs` (création), `tests/importer/utils/oggdude-import-folders.test.mjs` (modification)
+
+---
+
+## 1. Objectif
+
+Rendre visibles les items `specialization-tree` créés par l'import OggDude dans les dossiers monde et dans les compendiums.
+
+---
+
+## 2. Contexte
+
+Le pipeline d'import crée bien des items `specialization-tree` (data model, mapper, context builder, orchestration double passe fonctionnels et testés — 70 tests passent), mais ces items sont **invisibles** dans les items importés :
+
+- **Mode monde** : rangés dans `OggDude / Misc` au lieu d'un dossier dédié
+- **Mode compendium** : `getOggDudePackConfig('specialization-tree')` lève une erreur car le type est inconnu dans `OGGDUDE_PACKS_BY_TYPE`
+
+La cause racine est l'absence d'entrées de configuration pour le type `specialization-tree` dans les mappings de stockage.
+
+---
+
+## 3. Cause racine
+
+Les trois tables de configuration suivantes ne contiennent pas d'entrée `specialization-tree` :
+
+| Table | Fichier | Conséquence |
+|---|---|---|
+| `OGGDUDE_PACKS_BY_TYPE` | `module/utils/oggdude-mapping-config.mjs` | `getOggDudePackConfig('specialization-tree')` throw `Unsupported OggDude element type` → échec compendium |
+| `OGGDUDE_FOLDER_MAP` | `module/importer/utils/oggdude-import-folders.mjs` | `getOrCreateWorldFolder('specialization-tree')` → fallback `Misc` |
+| `OGGDUDE_FOLDER_COLORS` | `module/importer/utils/oggdude-import-folders.mjs` | Couleur grise fallback au lieu d'une couleur dédiée |
+
+---
+
+## 4. Périmètre
+
+### Inclus
+
+- Ajout de `specialization-tree` dans `OGGDUDE_PACKS_BY_TYPE`
+- Ajout de `specialization-tree` dans `OGGDUDE_FOLDER_MAP`
+- Ajout de `specialization-tree` dans `OGGDUDE_FOLDER_COLORS`
+- Tests pour la résolution pack et dossier
+
+### Exclu
+
+- Changement UI OggDude (domaine `specialization` reste unique)
+- Refonte du système de stockage ou des `storage-strategy`
+- Changement du data model, du mapper ou de l'orchestration
+- Migration de données existantes
+
+---
+
+## 5. Modifications
+
+### `module/utils/oggdude-mapping-config.mjs`
+
+Ajouter dans `OGGDUDE_PACKS_BY_TYPE` :
+
+```js
+'specialization-tree': {
+  name: 'swerpg-specialization-trees',
+  label: 'Specialization Trees',
+  folderGroup: 'actor-options',
+},
+```
+
+### `module/importer/utils/oggdude-import-folders.mjs`
+
+Ajouter dans `OGGDUDE_FOLDER_MAP` :
+
+```js
+'specialization-tree': 'Specialization Trees',
+```
+
+Ajouter dans `OGGDUDE_FOLDER_COLORS` :
+
+```js
+'specialization-tree': '#7b1fa2', // Violet profond (arbres de spécialisation)
+```
+
+### Tests
+
+- `tests/importer/utils/oggdude-mapping-config.spec.mjs` : nouveau fichier avec 3 tests (`getOggDudePackConfig('specialization-tree')`, throw sur type inconnu, normalisation casse)
+- `tests/importer/utils/oggdude-import-folders.test.mjs` : 2 tests ajoutés (résolution nom dossier `Specialization Trees`, couleur `#7b1fa2`)
+
+---
+
+## 6. Fichiers modifiés
+
+| Fichier | Action | Description |
+|---|---|---|
+| `module/utils/oggdude-mapping-config.mjs` | modification | Ajout `specialization-tree` dans `OGGDUDE_PACKS_BY_TYPE` |
+| `module/importer/utils/oggdude-import-folders.mjs` | modification | Ajout `specialization-tree` dans `OGGDUDE_FOLDER_MAP` et `OGGDUDE_FOLDER_COLORS` |
+| `tests/importer/utils/oggdude-mapping-config.spec.mjs` | création | Tests `getOggDudePackConfig` pour `specialization-tree` |
+| `tests/importer/utils/oggdude-import-folders.test.mjs` | modification | Tests résolution dossier et couleur `specialization-tree` |
+
+---
+
+## 7. Risques
+
+| Risque | Impact | Mitigation |
+|---|---|---|
+| Le dossier `Specialization Trees` n'existe pas dans l'UI des joueurs | Confusion | Cohérent avec le nommage existant (`Weapons`, `Specializations`) |
+
+---
+
+## 8. Ordre de commit
+
+1. `fix(importer): ajouter les entrées de stockage manquantes pour specialization-tree`
+2. `test(importer): couvrir la résolution pack et dossier de specialization-tree`
+
+---
+
+## 9. Validation
+
+- `npx vitest run` — 137 test files, 1508 tests pass
+- Import monde : les items `specialization-tree` apparaissent dans `OggDude / Specialization Trees`
+- Import compendium : le pack `swerpg-specialization-trees` est créé et alimenté sans erreur

--- a/module/importer/items/specialization-tree-ogg-dude.mjs
+++ b/module/importer/items/specialization-tree-ogg-dude.mjs
@@ -1,0 +1,51 @@
+import { buildArmorImgWorldPath, buildItemImgSystemPath } from '../../settings/directories.mjs'
+import OggDudeDataElement from '../../settings/models/OggDudeDataElement.mjs'
+import { logger } from '../../utils/logger.mjs'
+import { getSpecializationTreeImportStats, resetSpecializationTreeImportStats } from '../utils/specialization-tree-import-utils.mjs'
+import { specializationTreeMapper } from '../mappers/oggdude-specialization-tree-mapper.mjs'
+
+export async function buildSpecializationTreeContext(zip, groupByDirectory, groupByType) {
+  logger.debug('[SpecializationTreeImporter] Building Specialization Tree context', {
+    groupByDirectoryCount: groupByDirectory.length,
+    hasZip: !!zip,
+  })
+
+  const rawNested = await OggDudeDataElement.buildJsonDataFromDirectory(zip, groupByType.xml, 'Specializations', 'Specializations.Specialization')
+  const flattened = Array.isArray(rawNested)
+    ? rawNested
+        .flatMap((entry) => {
+          if (!entry) return []
+          if (Array.isArray(entry)) return entry.filter(Boolean)
+          if (typeof entry === 'object') return [entry]
+          return []
+        })
+        .filter((entry) => entry && typeof entry === 'object')
+    : []
+
+  return {
+    jsonData: flattened,
+    zip: {
+      folderName: 'Specializations',
+      elementFileName: '*.xml',
+      content: zip,
+      directories: groupByDirectory,
+    },
+    image: {
+      worldPath: buildArmorImgWorldPath('specializations'),
+      systemPath: buildItemImgSystemPath('specialization.svg'),
+      images: groupByType.image,
+      prefix: '',
+    },
+    folder: {
+      name: 'Swerpg - Specialization Trees',
+      type: 'Item',
+    },
+    element: {
+      jsonCriteria: 'Specializations.Specialization',
+      mapper: specializationTreeMapper,
+      type: 'specialization-tree',
+    },
+  }
+}
+
+export { getSpecializationTreeImportStats, resetSpecializationTreeImportStats }

--- a/module/importer/mappers/oggdude-specialization-tree-mapper.mjs
+++ b/module/importer/mappers/oggdude-specialization-tree-mapper.mjs
@@ -1,0 +1,320 @@
+import { logger } from '../../utils/logger.mjs'
+import { buildDescription, resolveSource } from '../utils/description-markup-utils.mjs'
+import {
+  addSpecializationTreeInvalidConnection,
+  addSpecializationTreeMissingCost,
+  addSpecializationTreeRejectionReason,
+  addSpecializationTreeUnresolvedTalent,
+  getSpecializationTreeImportStats,
+  incrementSpecializationTreeImportStat,
+  isResolvedNodeReference,
+  normalizeConnectionType,
+  normalizeNodeId,
+  normalizeSpecializationTreeId,
+  parseNonNegativeInteger,
+  parsePositiveInteger,
+  resetSpecializationTreeImportStats,
+} from '../utils/specialization-tree-import-utils.mjs'
+
+function asArray(value) {
+  if (Array.isArray(value)) return value.filter(Boolean)
+  if (value && typeof value === 'object') return [value]
+  return []
+}
+
+function readMandatoryString(label, value) {
+  if (value == null || typeof value !== 'string') {
+    logger.warn(`[SpecializationTreeImporter] Value ${label} is mandatory`, { value })
+    return ''
+  }
+
+  return value.trim()
+}
+
+function readOptionalString(value) {
+  return typeof value === 'string' ? value : ''
+}
+
+function readFirstString(...values) {
+  for (const value of values) {
+    if (typeof value === 'string' && value.trim()) return value.trim()
+    if (value && typeof value === 'object') {
+      const nested = readFirstString(value._, value.Key, value.Name, value.Id, value.id, value.name)
+      if (nested) return nested
+    }
+  }
+  return ''
+}
+
+function buildNodeReferenceMaps(nodes) {
+  const maps = {
+    byRawKey: new Map(),
+    byCoordinates: new Map(),
+  }
+
+  for (const node of nodes) {
+    if (node.rawNodeKey) maps.byRawKey.set(node.rawNodeKey, node.nodeId)
+    maps.byCoordinates.set(`${node.row}:${node.column}`, node.nodeId)
+  }
+
+  return maps
+}
+
+function resolveConnectionEndpoint(rawReference, maps) {
+  if (!rawReference) return null
+
+  if (isResolvedNodeReference(rawReference)) return rawReference.toLowerCase()
+
+  const coordinateMatch = String(rawReference).trim().match(/^r?(\d+)[^\d]+c?(\d+)$/i)
+  if (coordinateMatch) {
+    const [, row, column] = coordinateMatch
+    return maps.byCoordinates.get(`${row}:${column}`) || normalizeNodeId(Number(row), Number(column))
+  }
+
+  return maps.byRawKey.get(String(rawReference).trim()) || null
+}
+
+function extractNodeConnectionEntries(rawNode, currentNodeId, maps) {
+  const connections = []
+  const candidates = asArray(rawNode?.Connections?.Connection)
+
+  for (const connection of candidates) {
+    const targetRef = readFirstString(connection?.To, connection?.Target, connection?.Node, connection?.NodeId, connection?.TargetNodeKey)
+    const resolvedTo = resolveConnectionEndpoint(targetRef, maps)
+    if (!resolvedTo) {
+      addSpecializationTreeInvalidConnection(`${currentNodeId}->${targetRef || 'unknown'}`)
+      continue
+    }
+
+    connections.push({
+      from: currentNodeId,
+      to: resolvedTo,
+      type: normalizeConnectionType(readFirstString(connection?.Type, connection?.Direction)),
+    })
+  }
+
+  return connections
+}
+
+function extractGlobalConnectionEntries(xmlSpecialization, maps) {
+  const candidates = asArray(xmlSpecialization?.Connections?.Connection)
+  const connections = []
+
+  for (const connection of candidates) {
+    const fromRef = readFirstString(connection?.From, connection?.Source, connection?.FromNodeKey)
+    const toRef = readFirstString(connection?.To, connection?.Target, connection?.ToNodeKey)
+    const from = resolveConnectionEndpoint(fromRef, maps)
+    const to = resolveConnectionEndpoint(toRef, maps)
+
+    if (!from || !to) {
+      addSpecializationTreeInvalidConnection(`${fromRef || 'unknown'}->${toRef || 'unknown'}`)
+      continue
+    }
+
+    connections.push({
+      from,
+      to,
+      type: normalizeConnectionType(readFirstString(connection?.Type, connection?.Direction)),
+    })
+  }
+
+  return connections
+}
+
+function extractNodesFromRows(xmlSpecialization) {
+  const rows = asArray(xmlSpecialization?.TalentRows?.TalentRow)
+  const nodes = []
+
+  for (const [rowIndex, rawRow] of rows.entries()) {
+    const row = parsePositiveInteger(rawRow?.Index ?? rawRow?.Row ?? rawRow?.Tier) ?? rowIndex + 1
+    const columns = asArray(rawRow?.TalentColumns?.TalentColumn)
+
+    for (const [columnIndex, rawColumn] of columns.entries()) {
+      nodes.push({
+        rawNode: rawColumn,
+        row,
+        column: parsePositiveInteger(rawColumn?.Index ?? rawColumn?.Column ?? rawColumn?.Position) ?? columnIndex + 1,
+        rawNodeKey: readFirstString(rawColumn?.NodeKey, rawColumn?.Key, rawColumn?.Id),
+        talentId: readFirstString(rawColumn?.TalentKey, rawColumn?.TalentId, rawColumn?.Key),
+        cost: parseNonNegativeInteger(rawColumn?.Cost ?? rawColumn?.XpCost ?? rawColumn?.XP ?? rawColumn?.RankCost),
+      })
+    }
+  }
+
+  return nodes
+}
+
+function extractNodesFromFlatList(xmlSpecialization) {
+  const candidates = [
+    ...asArray(xmlSpecialization?.Nodes?.Node),
+    ...asArray(xmlSpecialization?.TalentNodes?.TalentNode),
+    ...asArray(xmlSpecialization?.Tree?.Nodes?.Node),
+  ]
+
+  return candidates.map((rawNode) => ({
+    rawNode,
+    row: parsePositiveInteger(rawNode?.Row ?? rawNode?.Tier ?? rawNode?.Y),
+    column: parsePositiveInteger(rawNode?.Column ?? rawNode?.X ?? rawNode?.Position),
+    rawNodeKey: readFirstString(rawNode?.NodeKey, rawNode?.Key, rawNode?.Id),
+    talentId: readFirstString(rawNode?.TalentKey, rawNode?.TalentId, rawNode?.Key),
+    cost: parseNonNegativeInteger(rawNode?.Cost ?? rawNode?.XpCost ?? rawNode?.XP ?? rawNode?.RankCost),
+  }))
+}
+
+function extractRawNodeEntries(xmlSpecialization) {
+  const rowNodes = extractNodesFromRows(xmlSpecialization)
+  if (rowNodes.length > 0) return rowNodes
+  return extractNodesFromFlatList(xmlSpecialization)
+}
+
+function normalizeNodes(xmlSpecialization, specializationId) {
+  const warnings = []
+  const normalizedNodes = []
+  const rawNodes = extractRawNodeEntries(xmlSpecialization)
+
+  for (const rawEntry of rawNodes) {
+    const nodeId = normalizeNodeId(rawEntry.row, rawEntry.column)
+    if (!nodeId) {
+      warnings.push(`invalid-node-position:${rawEntry.rawNodeKey || rawEntry.talentId || 'unknown'}`)
+      continue
+    }
+
+    if (!rawEntry.talentId) {
+      warnings.push(`unresolved-talent:${nodeId}`)
+      addSpecializationTreeUnresolvedTalent(`${specializationId}:${nodeId}`)
+    }
+
+    if (rawEntry.cost == null) {
+      warnings.push(`missing-cost:${nodeId}`)
+      addSpecializationTreeMissingCost(`${specializationId}:${nodeId}`)
+      continue
+    }
+
+    normalizedNodes.push({
+      rawNode: rawEntry.rawNode,
+      rawNodeKey: rawEntry.rawNodeKey,
+      nodeId,
+      talentId: rawEntry.talentId || `unknown:${specializationId}:${nodeId}`,
+      row: rawEntry.row,
+      column: rawEntry.column,
+      cost: rawEntry.cost,
+    })
+  }
+
+  return { normalizedNodes, warnings, rawCount: rawNodes.length }
+}
+
+function dedupeConnections(connections) {
+  const seen = new Set()
+  const deduped = []
+
+  for (const connection of connections) {
+    const key = `${connection.from}->${connection.to}:${connection.type || ''}`
+    if (seen.has(key)) continue
+    seen.add(key)
+    deduped.push(connection)
+  }
+
+  return deduped
+}
+
+export function specializationTreeMapper(specializations) {
+  resetSpecializationTreeImportStats()
+
+  if (!Array.isArray(specializations) || specializations.length === 0) {
+    logger.warn('[SpecializationTreeImporter] Input vide ou invalide', {
+      type: typeof specializations,
+    })
+    return []
+  }
+
+  return specializations
+    .map((xmlSpecialization, index) => {
+      try {
+        incrementSpecializationTreeImportStat('total')
+
+        const rawKey = readMandatoryString('specialization-tree.Key', xmlSpecialization?.Key)
+        const name = readMandatoryString('specialization-tree.Name', xmlSpecialization?.Name)
+
+        if (!rawKey || !name) {
+          incrementSpecializationTreeImportStat('rejected')
+          addSpecializationTreeRejectionReason('MISSING_SPECIALIZATION_KEY_OR_NAME')
+          return null
+        }
+
+        const specializationId = normalizeSpecializationTreeId(rawKey)
+        if (!specializationId) {
+          incrementSpecializationTreeImportStat('rejected')
+          addSpecializationTreeRejectionReason('INVALID_SPECIALIZATION_ID')
+          return null
+        }
+
+        const sourceInfo = resolveSource(xmlSpecialization)
+        const description = buildDescription(readOptionalString(xmlSpecialization?.Description), sourceInfo)
+        const { normalizedNodes, warnings, rawCount } = normalizeNodes(xmlSpecialization, specializationId)
+        const nodeMaps = buildNodeReferenceMaps(normalizedNodes)
+
+        const nodeConnections = normalizedNodes.flatMap((node) => extractNodeConnectionEntries(node.rawNode, node.nodeId, nodeMaps))
+        const globalConnections = extractGlobalConnectionEntries(xmlSpecialization, nodeMaps)
+        const connections = dedupeConnections([...nodeConnections, ...globalConnections]).map((connection) => ({
+          ...(connection.type ? connection : { from: connection.from, to: connection.to }),
+        }))
+
+        if (normalizedNodes.length === 0 || connections.length === 0) {
+          incrementSpecializationTreeImportStat('incompleteTrees')
+          warnings.push('tree-incomplete')
+        }
+
+        const rawCareerKey = readFirstString(
+          xmlSpecialization?.CareerKey,
+          xmlSpecialization?.CareerId,
+          xmlSpecialization?.Career?.Key,
+          xmlSpecialization?.Career?.Id,
+        )
+
+        return {
+          key: `${specializationId}-tree`,
+          name,
+          type: 'specialization-tree',
+          system: {
+            description,
+            specializationId,
+            careerId: normalizeSpecializationTreeId(rawCareerKey) || undefined,
+            source: {
+              system: sourceInfo.name || undefined,
+              book: sourceInfo.name || undefined,
+              page: sourceInfo.page != null ? String(sourceInfo.page) : undefined,
+            },
+            nodes: normalizedNodes.map(({ nodeId, talentId, row, column, cost }) => ({ nodeId, talentId, row, column, cost })),
+            connections,
+          },
+          flags: {
+            swerpg: {
+              oggdudeKey: rawKey,
+              import: {
+                domain: 'specialization-tree',
+                source: sourceInfo.name || 'OggDude Import',
+                warnings,
+                rawNodeCount: rawCount,
+                importedNodeCount: normalizedNodes.length,
+                importedConnectionCount: connections.length,
+                unresolved: warnings.some((warning) => warning.startsWith('unresolved-talent')),
+              },
+            },
+          },
+        }
+      } catch (error) {
+        logger.error('[SpecializationTreeImporter] Erreur mapping arbre de specialisation', {
+          index,
+          error: error.message,
+          stack: error.stack,
+        })
+        incrementSpecializationTreeImportStat('rejected')
+        addSpecializationTreeRejectionReason('MAPPING_ERROR')
+        return null
+      }
+    })
+    .filter(Boolean)
+}
+
+export { getSpecializationTreeImportStats, resetSpecializationTreeImportStats }

--- a/module/importer/oggDude.mjs
+++ b/module/importer/oggDude.mjs
@@ -7,16 +7,50 @@ import { buildCareerContext } from './items/career-ogg-dude.mjs'
 import { buildTalentContext } from './items/talent-ogg-dude.mjs'
 import { buildObligationContext } from './items/obligation-ogg-dude.mjs'
 import { buildSpecializationContext } from './items/specialization-ogg-dude.mjs'
+import { buildSpecializationTreeContext, getSpecializationTreeImportStats } from './items/specialization-tree-ogg-dude.mjs'
 import { buildMotivationCategoryContext } from './items/motivation-category-ogg-dude.mjs'
 import { buildMotivationContext } from './items/motivation-ogg-dude.mjs'
 import { logger } from '../utils/logger.mjs'
 import { withRetry } from './utils/retry.mjs'
 import { markArchiveSize, markGlobalEnd, markGlobalStart, recordDomainEnd, recordDomainStart } from './utils/global-import-metrics.mjs'
 import { getSpecializationImportStats } from './utils/specialization-import-utils.mjs'
+import { getCombinedSpecializationImportStats } from './utils/specialization-tree-import-utils.mjs'
 import { getMotivationImportStats, getMotivationCategoryImportStats } from './utils/motivation-import-utils.mjs'
 import { buildDutyContext } from './items/duty-ogg-dude.mjs'
 import { getDutyImportStats } from './utils/duty-import-utils.mjs'
 import { resetFolderCache } from './utils/oggdude-import-folders.mjs'
+
+function buildContextRegistry() {
+  return new Map([
+    ['weapon', [{ type: 'weapon', contextBuilder: buildWeaponContext }]],
+    ['armor', [{ type: 'armor', contextBuilder: buildArmorContext }]],
+    ['gear', [{ type: 'gear', contextBuilder: buildGearContext }]],
+    ['species', [{ type: 'species', contextBuilder: buildSpeciesContext }]],
+    ['career', [{ type: 'career', contextBuilder: buildCareerContext }]],
+    ['talent', [{ type: 'talent', contextBuilder: buildTalentContext }]],
+    ['obligation', [{ type: 'obligation', contextBuilder: buildObligationContext }]],
+    [
+      'specialization',
+      [
+        { type: 'specialization', contextBuilder: buildSpecializationContext },
+        { type: 'specialization-tree', contextBuilder: buildSpecializationTreeContext },
+      ],
+    ],
+    ['motivation-category', [{ type: 'motivation-category', contextBuilder: buildMotivationCategoryContext }]],
+    ['motivation', [{ type: 'motivation', contextBuilder: buildMotivationContext }]],
+    ['duty', [{ type: 'duty', contextBuilder: buildDutyContext }]],
+  ])
+}
+
+function getDomainStatsPayload(domain) {
+  if (domain === 'specialization') {
+    return getCombinedSpecializationImportStats(getSpecializationImportStats(), getSpecializationTreeImportStats())
+  }
+  if (domain === 'motivation') return getMotivationImportStats()
+  if (domain === 'motivation-category') return getMotivationCategoryImportStats()
+  if (domain === 'duty') return getDutyImportStats()
+  return undefined
+}
 
 export default class OggDudeImporter {
   /**
@@ -191,18 +225,7 @@ export default class OggDudeImporter {
     logger.debug('[ProcessOggDudeData] - Step 3.2: Group By Type >', groupByType)
 
     /* --------------------------------------------- SPÉCIFIQUE ------------------------------------------------------------------- */
-    const buildContextMap = new Map()
-    buildContextMap.set('weapon', { type: 'weapon', contextBuilder: buildWeaponContext })
-    buildContextMap.set('armor', { type: 'armor', contextBuilder: buildArmorContext })
-    buildContextMap.set('gear', { type: 'gear', contextBuilder: buildGearContext })
-    buildContextMap.set('species', { type: 'species', contextBuilder: buildSpeciesContext })
-    buildContextMap.set('career', { type: 'career', contextBuilder: buildCareerContext })
-    buildContextMap.set('talent', { type: 'talent', contextBuilder: buildTalentContext })
-    buildContextMap.set('obligation', { type: 'obligation', contextBuilder: buildObligationContext })
-    buildContextMap.set('specialization', { type: 'specialization', contextBuilder: buildSpecializationContext })
-    buildContextMap.set('motivation-category', { type: 'motivation-category', contextBuilder: buildMotivationCategoryContext })
-    buildContextMap.set('motivation', { type: 'motivation', contextBuilder: buildMotivationContext })
-    buildContextMap.set('duty', { type: 'duty', contextBuilder: buildDutyContext })
+    const buildContextMap = buildContextRegistry()
 
     const domainsToImport = domains.filter((domain) => domain.checked).map((domain) => domain.id)
     const unsupportedDomains = domainsToImport.filter((id) => !buildContextMap.has(id))
@@ -213,7 +236,7 @@ export default class OggDudeImporter {
     }
     logger.debug('[ProcessOggDudeData] -Step 3.3: Domains to Import >', domainsToImport)
 
-    const contextEntries = domainsToImport.map((id) => buildContextMap.get(id)).filter(Boolean)
+    const contextEntries = domainsToImport.map((id) => ({ domain: id, pipelines: buildContextMap.get(id) })).filter((entry) => Array.isArray(entry.pipelines))
     const total = contextEntries.length
     let processed = 0
     const completedDomains = []
@@ -221,11 +244,11 @@ export default class OggDudeImporter {
     // Logs de diagnostic pour vérifier la configuration du pipeline
     logger.info('[ProcessOggDudeData] DIAGNOSTIC - Pipeline initialization', {
       contextEntriesCount: contextEntries.length,
-      contextEntriesTypes: contextEntries.map((e) => e.type),
+      contextEntriesTypes: contextEntries.map((e) => e.domain),
       domainsToImport,
       buildContextMapKeys: Array.from(buildContextMap.keys()),
       hasSpecialization: buildContextMap.has('specialization'),
-      specializationInEntries: contextEntries.some((e) => e.type === 'specialization'),
+      specializationInEntries: contextEntries.some((e) => e.domain === 'specialization'),
     })
 
     const emitProgress = (payload) => {
@@ -238,73 +261,72 @@ export default class OggDudeImporter {
     }
     emitProgress({ processed, phase: 'init' })
     for (const entry of contextEntries) {
-      recordDomainStart(entry.type)
-      emitProgress({ processed, domain: entry.type, phase: 'start' })
+      recordDomainStart(entry.domain)
+      emitProgress({ processed, domain: entry.domain, phase: 'start' })
       try {
-        const context = await withRetry(() => entry.contextBuilder(zip, groupByDirectory, groupByType), {
-          shouldRetry: (err) => /parse|XML|network/i.test(err?.message || ''),
-        })
-        const datasetSize = Array.isArray(context?.jsonData) ? context.jsonData.filter((el) => el != null).length : 0
+        let ranAtLeastOnePipeline = false
+        for (const pipeline of entry.pipelines) {
+          const context = await withRetry(() => pipeline.contextBuilder(zip, groupByDirectory, groupByType), {
+            shouldRetry: (err) => /parse|XML|network/i.test(err?.message || ''),
+          })
+          const datasetSize = Array.isArray(context?.jsonData) ? context.jsonData.filter((el) => el != null).length : 0
 
-        logger.info('[ProcessOggDudeData] Context créé', {
-          domain: entry.type,
-          datasetSize,
-          hasMapper: typeof context?.element?.mapper === 'function',
-          jsonDataSample: context?.jsonData?.slice(0, 2),
-        })
+          logger.info('[ProcessOggDudeData] Context créé', {
+            domain: entry.domain,
+            pipelineType: pipeline.type,
+            datasetSize,
+            hasMapper: typeof context?.element?.mapper === 'function',
+            jsonDataSample: context?.jsonData?.slice(0, 2),
+          })
 
-        logger.debug('[ProcessOggDudeData] - Step 3.4: Context >', { domain: entry.type, datasetSize })
-        if (datasetSize === 0 && entry.type === 'specialization') {
-          // Ne pas incrémenter rejected artificiellement: dataset réellement vide
-          logger.warn('[ProcessOggDudeData] Domaine specialization sans données, import ignoré')
+          logger.debug('[ProcessOggDudeData] - Step 3.4: Context >', { domain: entry.domain, pipelineType: pipeline.type, datasetSize })
+          if (datasetSize === 0) {
+            logger.warn('[ProcessOggDudeData] Domaine sans données, import ignoré', { domain: entry.domain, pipelineType: pipeline.type })
+            continue
+          }
+
+          logger.info('[ProcessOggDudeData] AVANT processElements', {
+            domain: entry.domain,
+            pipelineType: pipeline.type,
+            contextKeys: Object.keys(context || {}),
+            elementKeys: Object.keys(context?.element || {}),
+          })
+
+          await withRetry(() => OggDudeDataElement.processElements(context, { importToCompendium }), {
+            shouldRetry: (err) => /database|upload|parse/i.test(err?.message || ''),
+          })
+
+          ranAtLeastOnePipeline = true
+
+          logger.info('[ProcessOggDudeData] APRÈS processElements', {
+            domain: entry.domain,
+            pipelineType: pipeline.type,
+          })
+        }
+
+        if (!ranAtLeastOnePipeline) {
           emitProgress({
             processed,
-            domain: entry.type,
+            domain: entry.domain,
             phase: 'skipped',
             reason: 'empty-data',
-            domainStats: getSpecializationImportStats(),
+            domainStats: getDomainStatsPayload(entry.domain),
           })
           continue
         }
-        if (datasetSize === 0) {
-          logger.warn('[ProcessOggDudeData] Domaine sans données, import ignoré', { domain: entry.type })
-          emitProgress({ processed, domain: entry.type, phase: 'skipped', reason: 'empty-data' })
-          continue
-        }
 
-        logger.info('[ProcessOggDudeData] AVANT processElements', {
-          domain: entry.type,
-          contextKeys: Object.keys(context || {}),
-          elementKeys: Object.keys(context?.element || {}),
-        })
-
-        await withRetry(() => OggDudeDataElement.processElements(context, { importToCompendium }), {
-          shouldRetry: (err) => /database|upload|parse/i.test(err?.message || ''),
-        })
-
-        logger.info('[ProcessOggDudeData] APRÈS processElements', {
-          domain: entry.type,
-        })
         processed += 1
-        completedDomains.push(entry.type)
-        let domainStatsPayload
-        if (entry.type === 'specialization') {
-          const specStats = getSpecializationImportStats()
-          domainStatsPayload = specStats
-          logger.info('[SpecializationImporter] Statistiques après import', { stats: specStats })
-        } else if (entry.type === 'motivation') {
-          domainStatsPayload = getMotivationImportStats()
-        } else if (entry.type === 'motivation-category') {
-          domainStatsPayload = getMotivationCategoryImportStats()
-        } else if (entry.type === 'duty') {
-          domainStatsPayload = getDutyImportStats()
+        completedDomains.push(entry.domain)
+        const domainStatsPayload = getDomainStatsPayload(entry.domain)
+        if (entry.domain === 'specialization') {
+          logger.info('[SpecializationImporter] Statistiques après import', { stats: domainStatsPayload })
         }
-        emitProgress({ processed, domain: entry.type, phase: 'completed', domainStats: domainStatsPayload })
+        emitProgress({ processed, domain: entry.domain, phase: 'completed', domainStats: domainStatsPayload })
       } catch (error) {
-        logger.error('[ProcessOggDudeData] Échec import domaine', { domain: entry.type, error })
-        emitProgress({ processed, domain: entry.type, phase: 'error', error: error?.message })
+        logger.error('[ProcessOggDudeData] Échec import domaine', { domain: entry.domain, error })
+        emitProgress({ processed, domain: entry.domain, phase: 'error', error: error?.message })
       } finally {
-        recordDomainEnd(entry.type)
+        recordDomainEnd(entry.domain)
       }
     }
     Hooks.callAll('oggdudeImport.completed', { processed, total, domains: completedDomains })
@@ -328,26 +350,15 @@ export default class OggDudeImporter {
     const groupByType = OggDudeDataElement.groupByType(allDataElements)
 
     // Build context map
-    const buildContextMap = new Map()
-    buildContextMap.set('weapon', { type: 'weapon', contextBuilder: buildWeaponContext })
-    buildContextMap.set('gear', { type: 'gear', contextBuilder: buildGearContext })
-    buildContextMap.set('species', { type: 'species', contextBuilder: buildSpeciesContext })
-    buildContextMap.set('career', { type: 'career', contextBuilder: buildCareerContext })
-    buildContextMap.set('talent', { type: 'talent', contextBuilder: buildTalentContext })
-    buildContextMap.set('obligation', { type: 'obligation', contextBuilder: buildObligationContext })
-    buildContextMap.set('specialization', { type: 'specialization', contextBuilder: buildSpecializationContext })
-    buildContextMap.set('motivation', { type: 'motivation', contextBuilder: buildMotivationContext })
-    buildContextMap.set('duty', { type: 'duty', contextBuilder: buildDutyContext })
+    const buildContextMap = buildContextRegistry()
 
     const domainsToImport = new Set(domains.filter((d) => d.checked).map((d) => d.id))
-    const contextEntries = Array.from(buildContextMap.values()).filter((e) => domainsToImport.has(e.type))
+    const contextEntries = Array.from(buildContextMap.entries())
+      .filter(([domain]) => domainsToImport.has(domain))
+      .map(([domain, pipelines]) => ({ domain, pipelines }))
 
     const previews = {}
     for (const entry of contextEntries) {
-      const context = await entry.contextBuilder(zip, groupByDirectory, groupByType)
-      // Mapper uniquement, ne pas stocker
-      const items = OggDudeDataElement._buildItemElements(context.jsonData, context.element.mapper)
-      // Annoter existence (si environnement Foundry présent)
       const existingSet = new Set()
       try {
         const existing = globalThis.game?.items?.contents ?? []
@@ -357,11 +368,21 @@ export default class OggDudeImporter {
       } catch (e) {
         logger.debug('[OggDudeImporter] preload existence check skipped (no Foundry runtime)', { error: e })
       }
-      previews[entry.type] = items.map((it) => ({
-        ...it,
-        preview: true,
-        exists: existingSet.has(`${it.type}::${it.name}`),
-      }))
+
+      const previewItems = []
+      for (const pipeline of entry.pipelines) {
+        const context = await pipeline.contextBuilder(zip, groupByDirectory, groupByType)
+        const items = OggDudeDataElement._buildItemElements(context.jsonData, context.element.mapper)
+        previewItems.push(
+          ...items.map((it) => ({
+            ...it,
+            preview: true,
+            exists: existingSet.has(`${it.type}::${it.name}`),
+          })),
+        )
+      }
+
+      previews[entry.domain] = previewItems
     }
 
     return previews

--- a/module/importer/utils/global-import-metrics.mjs
+++ b/module/importer/utils/global-import-metrics.mjs
@@ -10,6 +10,7 @@ import { getCareerImportStats } from './career-import-utils.mjs'
 import { getTalentImportStats } from './talent-import-utils.mjs'
 import { getObligationImportStats } from './obligation-import-utils.mjs'
 import { getSpecializationImportStats } from './specialization-import-utils.mjs'
+import { getCombinedSpecializationImportStats, getSpecializationTreeImportStats } from './specialization-tree-import-utils.mjs'
 import { getDutyImportStats } from './duty-import-utils.mjs'
 
 // Runtime metrics (durations, sizes) – kept internal and exposed via aggregate function
@@ -74,7 +75,7 @@ export function getAllImportStats() {
   const career = safeCall(getCareerImportStats)
   const talent = safeCall(getTalentImportStats)
   const obligation = safeCall(getObligationImportStats)
-  const specialization = safeCall(getSpecializationImportStats)
+  const specialization = getCombinedSpecializationImportStats(safeCall(getSpecializationImportStats), safeCall(getSpecializationTreeImportStats))
   const duty = safeCall(getDutyImportStats)
 
   const totalProcessed = armor.total + weapon.total + gear.total + species.total + career.total + talent.total + obligation.total + specialization.total + duty.total

--- a/module/importer/utils/oggdude-import-folders.mjs
+++ b/module/importer/utils/oggdude-import-folders.mjs
@@ -11,6 +11,7 @@ const OGGDUDE_FOLDER_MAP = {
   talent: 'Talents',
   species: 'Species',
   specialization: 'Specializations',
+  'specialization-tree': 'Specialization Trees',
   obligation: 'Obligations',
   duty: 'Duties',
   motivation: 'Motivations',
@@ -32,6 +33,7 @@ const OGGDUDE_FOLDER_COLORS = {
   talent: '#ce93d8', // Violet clair (talents)
   species: '#2e7d32', // Vert forêt (espèces)
   specialization: '#8e24aa', // Violet médian (spécialisations)
+  'specialization-tree': '#7b1fa2', // Violet profond (arbres de spécialisation)
   obligation: '#ffb300', // Ambre soutenu (obligations)
   duty: '#ff8f00', // Ambre foncé (devoirs)
   motivation: '#ffd54f', // Jaune chaud (motivations)

--- a/module/importer/utils/specialization-tree-import-utils.mjs
+++ b/module/importer/utils/specialization-tree-import-utils.mjs
@@ -1,0 +1,92 @@
+import { ImportStats } from './import-stats.mjs'
+
+const specializationTreeStats = new ImportStats({
+  missingCosts: 0,
+  unresolvedTalents: 0,
+  invalidConnections: 0,
+  incompleteTrees: 0,
+})
+
+export function resetSpecializationTreeImportStats() {
+  specializationTreeStats.reset({
+    missingCosts: 0,
+    unresolvedTalents: 0,
+    invalidConnections: 0,
+    incompleteTrees: 0,
+  })
+}
+
+export function incrementSpecializationTreeImportStat(key, amount = 1) {
+  specializationTreeStats.increment(key, amount)
+}
+
+export function addSpecializationTreeRejectionReason(reason) {
+  specializationTreeStats.addRejectionReason(reason)
+}
+
+export function addSpecializationTreeMissingCost(detail) {
+  specializationTreeStats.addDetail('missingCosts', detail, 'missingCostDetails')
+}
+
+export function addSpecializationTreeUnresolvedTalent(detail) {
+  specializationTreeStats.addDetail('unresolvedTalents', detail, 'unresolvedTalentDetails')
+}
+
+export function addSpecializationTreeInvalidConnection(detail) {
+  specializationTreeStats.addDetail('invalidConnections', detail, 'invalidConnectionDetails')
+}
+
+export function getSpecializationTreeImportStats() {
+  return specializationTreeStats.getStats()
+}
+
+export function getCombinedSpecializationImportStats(baseStats = {}, treeStats = {}) {
+  const total = (baseStats.total || 0) + (treeStats.total || 0)
+  const rejected = (baseStats.rejected || 0) + (treeStats.rejected || 0)
+
+  return {
+    ...baseStats,
+    ...treeStats,
+    total,
+    rejected,
+    imported: total - rejected,
+    rejectionReasons: [...(baseStats.rejectionReasons || []), ...(treeStats.rejectionReasons || [])],
+  }
+}
+
+export function normalizeSpecializationTreeId(rawKey) {
+  return String(rawKey || '')
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+}
+
+export function normalizeNodeId(row, column) {
+  if (!Number.isInteger(row) || row < 1 || !Number.isInteger(column) || column < 1) return null
+  return `r${row}c${column}`
+}
+
+export function parsePositiveInteger(rawValue) {
+  const parsed = Number.parseInt(rawValue, 10)
+  return Number.isInteger(parsed) && parsed > 0 ? parsed : null
+}
+
+export function parseNonNegativeInteger(rawValue) {
+  const parsed = Number.parseInt(rawValue, 10)
+  return Number.isInteger(parsed) && parsed >= 0 ? parsed : null
+}
+
+export function normalizeConnectionType(rawValue) {
+  if (typeof rawValue !== 'string') return undefined
+
+  const normalized = rawValue.trim().toLowerCase()
+  if (!normalized) return undefined
+
+  if (normalized === 'vertical' || normalized === 'horizontal') return normalized
+  return normalized
+}
+
+export function isResolvedNodeReference(nodeId) {
+  return typeof nodeId === 'string' && /^r\d+c\d+$/i.test(nodeId)
+}

--- a/module/models/specialization-tree.mjs
+++ b/module/models/specialization-tree.mjs
@@ -27,6 +27,7 @@ export default class SwerpgSpecializationTree extends foundry.abstract.TypeDataM
         new fields.SchemaField({
           from: new fields.StringField({ required: true, blank: false }),
           to: new fields.StringField({ required: true, blank: false }),
+          type: new fields.StringField({ required: false, blank: false, initial: undefined }),
         }),
         { required: false, initial: [] },
       ),

--- a/module/utils/audit-log.mjs
+++ b/module/utils/audit-log.mjs
@@ -319,7 +319,7 @@ function onCreateItem(item, data, options, userId) {
  * @param {number} [purchaseData.previousXp]
  * @param {number} [purchaseData.nextXp]
  */
-export async function recordTalentNodePurchase(actor, purchaseData) {
+async function recordTalentNodePurchase(actor, purchaseData) {
   const ts = Date.now()
   const snapshot = captureSnapshot(actor)
   const user = game.users?.get(game.user?.id) ?? null

--- a/module/utils/oggdude-mapping-config.mjs
+++ b/module/utils/oggdude-mapping-config.mjs
@@ -14,6 +14,11 @@ const OGGDUDE_PACKS_BY_TYPE = {
     label: 'Specializations',
     folderGroup: 'actor-options',
   },
+  'specialization-tree': {
+    name: 'swerpg-specialization-trees',
+    label: 'Specialization Trees',
+    folderGroup: 'actor-options',
+  },
   obligation: {
     name: 'swerpg-obligations',
     label: 'Obligations',

--- a/tests/importer/oggdude-specialization-domain-orchestration.spec.mjs
+++ b/tests/importer/oggdude-specialization-domain-orchestration.spec.mjs
@@ -1,0 +1,132 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const processElements = vi.fn(async () => [])
+const buildJsonDataFromFile = vi.fn()
+const buildJsonDataFromDirectory = vi.fn()
+const groupByDirectory = vi.fn(() => [])
+const groupByType = vi.fn(() => ({ xml: [], image: [] }))
+const fromZip = vi.fn(() => [])
+const buildItemElements = vi.fn((jsonData, mapper) => mapper(jsonData))
+
+vi.mock('../../module/settings/models/OggDudeDataElement.mjs', () => ({
+  default: {
+    from: fromZip,
+    groupByDirectory,
+    groupByType,
+    processElements,
+    buildJsonDataFromFile,
+    buildJsonDataFromDirectory,
+    _buildItemElements: buildItemElements,
+  },
+}))
+
+vi.mock('../../module/importer/items/weapon-ogg-dude.mjs', () => ({ buildWeaponContext: vi.fn() }))
+vi.mock('../../module/importer/items/armor-ogg-dude.mjs', () => ({ buildArmorContext: vi.fn() }))
+vi.mock('../../module/importer/items/gear-ogg-dude.mjs', () => ({ buildGearContext: vi.fn() }))
+vi.mock('../../module/importer/items/species-ogg-dude.mjs', () => ({ buildSpeciesContext: vi.fn() }))
+vi.mock('../../module/importer/items/career-ogg-dude.mjs', () => ({ buildCareerContext: vi.fn() }))
+vi.mock('../../module/importer/items/talent-ogg-dude.mjs', () => ({ buildTalentContext: vi.fn() }))
+vi.mock('../../module/importer/items/obligation-ogg-dude.mjs', () => ({ buildObligationContext: vi.fn() }))
+vi.mock('../../module/importer/items/motivation-category-ogg-dude.mjs', () => ({ buildMotivationCategoryContext: vi.fn() }))
+vi.mock('../../module/importer/items/motivation-ogg-dude.mjs', () => ({ buildMotivationContext: vi.fn() }))
+vi.mock('../../module/importer/items/duty-ogg-dude.mjs', () => ({ buildDutyContext: vi.fn() }))
+
+vi.mock('../../module/importer/items/specialization-ogg-dude.mjs', () => ({
+  buildSpecializationContext: vi.fn(async () => ({
+    jsonData: [{ Key: 'BODYGUARD', Name: 'Bodyguard' }],
+    image: { worldPath: '', systemPath: '', prefix: '', images: [] },
+    zip: { content: {} },
+    folder: { type: 'Item' },
+    element: {
+      type: 'specialization',
+      mapper: () => [{ name: 'Bodyguard', type: 'specialization', system: {} }],
+    },
+  })),
+}))
+
+vi.mock('../../module/importer/items/specialization-tree-ogg-dude.mjs', () => ({
+  buildSpecializationTreeContext: vi.fn(async () => ({
+    jsonData: [{ Key: 'BODYGUARD', Name: 'Bodyguard' }],
+    image: { worldPath: '', systemPath: '', prefix: '', images: [] },
+    zip: { content: {} },
+    folder: { type: 'Item' },
+    element: {
+      type: 'specialization-tree',
+      mapper: () => [{ name: 'Bodyguard', type: 'specialization-tree', system: {} }],
+    },
+  })),
+  getSpecializationTreeImportStats: vi.fn(() => ({ total: 1, imported: 1, rejected: 0 })),
+}))
+
+vi.mock('../../module/importer/utils/specialization-import-utils.mjs', () => ({
+  getSpecializationImportStats: vi.fn(() => ({ total: 1, imported: 1, rejected: 0 })),
+}))
+
+vi.mock('../../module/importer/utils/specialization-tree-import-utils.mjs', async () => {
+  const actual = await vi.importActual('../../module/importer/utils/specialization-tree-import-utils.mjs')
+  return {
+    ...actual,
+    getCombinedSpecializationImportStats: vi.fn(() => ({ total: 2, imported: 2, rejected: 0 })),
+  }
+})
+
+vi.mock('../../module/importer/utils/global-import-metrics.mjs', () => ({
+  markArchiveSize: vi.fn(),
+  markGlobalEnd: vi.fn(),
+  markGlobalStart: vi.fn(),
+  recordDomainEnd: vi.fn(),
+  recordDomainStart: vi.fn(),
+}))
+
+vi.mock('../../module/importer/utils/retry.mjs', () => ({
+  withRetry: vi.fn(async (fn) => fn()),
+}))
+
+vi.mock('../../module/importer/utils/motivation-import-utils.mjs', () => ({
+  getMotivationImportStats: vi.fn(() => ({ total: 0, imported: 0, rejected: 0 })),
+  getMotivationCategoryImportStats: vi.fn(() => ({ total: 0, imported: 0, rejected: 0 })),
+}))
+
+vi.mock('../../module/importer/utils/duty-import-utils.mjs', () => ({
+  getDutyImportStats: vi.fn(() => ({ total: 0, imported: 0, rejected: 0 })),
+}))
+
+vi.mock('../../module/importer/utils/oggdude-import-folders.mjs', () => ({
+  resetFolderCache: vi.fn(),
+}))
+
+describe('OggDudeImporter specialization orchestration', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('runs specialization and specialization-tree pipelines under the same selected domain', async () => {
+    const { default: OggDudeImporter } = await import('../../module/importer/oggDude.mjs')
+    vi.spyOn(OggDudeImporter.prototype, 'load').mockResolvedValue({ files: {} })
+
+    const progressEvents = []
+    await OggDudeImporter.processOggDudeData(
+      { size: 1 },
+      [{ id: 'specialization', checked: true }],
+      { progressCallback: (payload) => progressEvents.push(payload) },
+    )
+
+    expect(processElements).toHaveBeenCalledTimes(2)
+    expect(processElements.mock.calls.map((call) => call[0].element.type), 'the specialization domain should execute both internal item types').toEqual([
+      'specialization',
+      'specialization-tree',
+    ])
+    expect(progressEvents.at(-1).processed).toBe(1)
+    expect(progressEvents.at(-1).domain).toBe('specialization')
+  })
+
+  it('combines previews from specialization and specialization-tree under one domain key', async () => {
+    const { default: OggDudeImporter } = await import('../../module/importer/oggDude.mjs')
+    vi.spyOn(OggDudeImporter.prototype, 'load').mockResolvedValue({ files: {} })
+    globalThis.game = { items: { contents: [] } }
+
+    const preview = await OggDudeImporter.preloadOggDudeData({ size: 1 }, [{ id: 'specialization', checked: true }])
+
+    expect(preview.specialization.map((item) => item.type)).toEqual(['specialization', 'specialization-tree'])
+  })
+})

--- a/tests/importer/specialization-tree-ogg-dude.spec.mjs
+++ b/tests/importer/specialization-tree-ogg-dude.spec.mjs
@@ -1,0 +1,138 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('../../module/utils/logger.mjs', () => ({
+  logger: {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+}))
+
+import OggDudeDataElement from '../../module/settings/models/OggDudeDataElement.mjs'
+import { buildSpecializationTreeContext } from '../../module/importer/items/specialization-tree-ogg-dude.mjs'
+import { specializationTreeMapper } from '../../module/importer/mappers/oggdude-specialization-tree-mapper.mjs'
+import {
+  getSpecializationTreeImportStats,
+  resetSpecializationTreeImportStats,
+} from '../../module/importer/utils/specialization-tree-import-utils.mjs'
+
+describe('specializationTreeMapper', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    resetSpecializationTreeImportStats()
+  })
+
+  it('maps a specialization tree with nodes, costs, and typed connections', () => {
+    const input = [
+      {
+        Key: 'BODYGUARD',
+        Name: 'Bodyguard',
+        CareerKey: 'HIRED_GUN',
+        Description: '[H3]Bodyguard[h3][BR]Protect others.',
+        Source: { _: 'Edge of the Empire', $: { Page: '97' } },
+        TalentRows: {
+          TalentRow: [
+            {
+              Index: '1',
+              TalentColumns: {
+                TalentColumn: [
+                  {
+                    Index: '1',
+                    TalentKey: 'PARRY',
+                    Cost: '5',
+                    Connections: {
+                      Connection: [{ To: 'r2c1', Type: 'Vertical' }],
+                    },
+                  },
+                  { Index: '2', TalentKey: 'GRIT', Cost: '5' },
+                ],
+              },
+            },
+            {
+              Index: '2',
+              TalentColumns: {
+                TalentColumn: [{ Index: '1', TalentKey: 'TOUGHENED', Cost: '10' }],
+              },
+            },
+          ],
+        },
+      },
+    ]
+
+    const result = specializationTreeMapper(input)
+    const stats = getSpecializationTreeImportStats()
+
+    expect(result).toHaveLength(1)
+    expect(result[0].type).toBe('specialization-tree')
+    expect(result[0].name).toBe('Bodyguard')
+    expect(result[0].system.specializationId).toBe('bodyguard')
+    expect(result[0].system.careerId).toBe('hired-gun')
+    expect(result[0].system.nodes.map((node) => node.nodeId), 'rows and columns should become stable node ids').toEqual(['r1c1', 'r1c2', 'r2c1'])
+    expect(result[0].system.connections).toEqual([{ from: 'r1c1', to: 'r2c1', type: 'vertical' }])
+    expect(result[0].flags.swerpg.import.importedNodeCount).toBe(3)
+    expect(result[0].flags.swerpg.import.importedConnectionCount).toBe(1)
+    expect(result[0].system.description).toContain('Source:')
+    expect(stats.total).toBe(1)
+    expect(stats.imported).toBe(1)
+    expect(stats.rejected).toBe(0)
+  })
+
+  it('keeps unresolved talent references diagnostic without rejecting the tree', () => {
+    const result = specializationTreeMapper([
+      {
+        Key: 'BODYGUARD',
+        Name: 'Bodyguard',
+        TalentRows: {
+          TalentRow: [{ Index: '1', TalentColumns: { TalentColumn: [{ Index: '1', Cost: '5' }] } }],
+        },
+      },
+    ])
+
+    const item = result[0]
+    const stats = getSpecializationTreeImportStats()
+
+    expect(item.system.nodes[0].talentId).toBe('unknown:bodyguard:r1c1')
+    expect(item.flags.swerpg.import.unresolved).toBe(true)
+    expect(item.flags.swerpg.import.warnings).toContain('unresolved-talent:r1c1')
+    expect(stats.unresolvedTalents).toBe(1)
+    expect(stats.imported).toBe(1)
+  })
+
+  it('tracks missing costs and marks the tree as incomplete', () => {
+    const result = specializationTreeMapper([
+      {
+        Key: 'BODYGUARD',
+        Name: 'Bodyguard',
+        TalentRows: {
+          TalentRow: [{ Index: '1', TalentColumns: { TalentColumn: [{ Index: '1', TalentKey: 'PARRY' }] } }],
+        },
+      },
+    ])
+
+    const item = result[0]
+    const stats = getSpecializationTreeImportStats()
+
+    expect(item.system.nodes).toEqual([])
+    expect(item.flags.swerpg.import.warnings).toEqual(expect.arrayContaining(['missing-cost:r1c1', 'tree-incomplete']))
+    expect(stats.missingCosts).toBe(1)
+    expect(stats.incompleteTrees).toBe(1)
+  })
+})
+
+describe('buildSpecializationTreeContext', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('builds a specialization-tree context for OggDudeDataElement', async () => {
+    vi.spyOn(OggDudeDataElement, 'buildJsonDataFromDirectory').mockResolvedValue([{ Key: 'BODYGUARD' }])
+
+    const context = await buildSpecializationTreeContext({}, [], { xml: [], image: [] })
+
+    expect(context.folder.name).toBe('Swerpg - Specialization Trees')
+    expect(context.element.type).toBe('specialization-tree')
+    expect(context.element.mapper).toBe(specializationTreeMapper)
+    expect(context.jsonData).toEqual([{ Key: 'BODYGUARD' }])
+  })
+})

--- a/tests/importer/utils/oggdude-import-folders.test.mjs
+++ b/tests/importer/utils/oggdude-import-folders.test.mjs
@@ -88,6 +88,20 @@ describe('OggDude Import Folders Service', () => {
       expect(folder.id).toBe('existing-weapons')
     })
 
+    it('should resolve specialization-tree to Specialization Trees folder', async () => {
+      const config = getFolderConfiguration()
+
+      expect(config.domainMap).toHaveProperty('specialization-tree')
+      expect(config.domainMap['specialization-tree']).toBe('Specialization Trees')
+    })
+
+    it('should have a color defined for specialization-tree', () => {
+      const config = getFolderConfiguration()
+
+      expect(config.colorMap).toHaveProperty('specialization-tree')
+      expect(config.colorMap['specialization-tree']).toBe('#7b1fa2')
+    })
+
     it('should handle all known domains', async () => {
       const config = getFolderConfiguration()
       const domains = Object.keys(config.domainMap)

--- a/tests/importer/utils/oggdude-mapping-config.spec.mjs
+++ b/tests/importer/utils/oggdude-mapping-config.spec.mjs
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest'
+
+import { getOggDudePackConfig } from '../../../module/utils/oggdude-mapping-config.mjs'
+
+describe('getOggDudePackConfig', () => {
+  it('returns pack config for specialization-tree', () => {
+    const config = getOggDudePackConfig('specialization-tree')
+
+    expect(config).toEqual({
+      name: 'swerpg-specialization-trees',
+      label: 'Specialization Trees',
+      folderGroup: 'actor-options',
+      fullName: 'world.swerpg-specialization-trees',
+    })
+  })
+
+  it('throws for unsupported type', () => {
+    expect(() => getOggDudePackConfig('nonexistent')).toThrow('Unsupported OggDude element type')
+  })
+
+  it('normalises case for type lookup', () => {
+    const config = getOggDudePackConfig('Specialization-Tree')
+    expect(config.name).toBe('swerpg-specialization-trees')
+  })
+})

--- a/tests/models/specialization-tree.test.mjs
+++ b/tests/models/specialization-tree.test.mjs
@@ -101,13 +101,15 @@ describe('SwerpgSpecializationTree', () => {
       expect(field.config.initial).toBe(5)
     })
 
-    test('connections ArrayField wraps a SchemaField with from and to', () => {
+    test('connections ArrayField wraps a SchemaField with from, to, and optional type', () => {
       const connField = SwerpgSpecializationTree.defineSchema().connections.field
       expect(connField).toBeInstanceOf(foundry.data.fields.SchemaField)
       expect(connField.schema.from).toBeInstanceOf(foundry.data.fields.StringField)
       expect(connField.schema.from.config.required).toBe(true)
       expect(connField.schema.to).toBeInstanceOf(foundry.data.fields.StringField)
       expect(connField.schema.to.config.required).toBe(true)
+      expect(connField.schema.type).toBeInstanceOf(foundry.data.fields.StringField)
+      expect(connField.schema.type.config.required).toBe(false)
     })
 
     test('nodes and connections default to empty array', () => {
@@ -179,7 +181,7 @@ describe('SwerpgSpecializationTree', () => {
           { nodeId: 'r1c1', talentId: 'talent-slice-1', row: 1, column: 1, cost: 5 },
           { nodeId: 'r1c2', talentId: 'talent-slice-2', row: 1, column: 2, cost: 10 },
         ],
-        connections: [{ from: 'r1c1', to: 'r1c2' }],
+        connections: [{ from: 'r1c1', to: 'r1c2', type: 'horizontal' }],
       }
       const instance = new SwerpgSpecializationTree(data)
       expect(instance.specializationId).toBe('spec-slicer')
@@ -190,7 +192,7 @@ describe('SwerpgSpecializationTree', () => {
         { nodeId: 'r1c1', talentId: 'talent-slice-1', row: 1, column: 1, cost: 5 },
         { nodeId: 'r1c2', talentId: 'talent-slice-2', row: 1, column: 2, cost: 10 },
       ])
-      expect(instance.connections).toEqual([{ from: 'r1c1', to: 'r1c2' }])
+      expect(instance.connections).toEqual([{ from: 'r1c1', to: 'r1c2', type: 'horizontal' }])
     })
 
     test('creates instance with nodes without row/column/cost (backward compat)', () => {


### PR DESCRIPTION
## Summary

Import specialization trees from OggDude XML as `specialization-tree` items with nodes, costs, connections, and diagnostics. Fixes the storage bug that made imported trees invisible in folders and compendiums.

## Changes

### New files
- `module/importer/items/specialization-tree-ogg-dude.mjs` — context builder for specialization trees
- `module/importer/mappers/oggdude-specialization-tree-mapper.mjs` — maps OggDude XML to specialization-tree items with node extraction, cost/connection parsing, and diagnostic flags
- `module/importer/utils/specialization-tree-import-utils.mjs` — normalization, validation, and import statistics
- `tests/importer/specialization-tree-ogg-dude.spec.mjs` — mapper tests (valid tree, unresolved talents, missing costs)
- `tests/importer/oggdude-specialization-domain-orchestration.spec.mjs` — two-pass pipeline orchestration tests
- `tests/importer/utils/oggdude-mapping-config.spec.mjs` — pack config resolution tests
- `documentation/plan/character-sheet/talent/194-plan-importer-arbres-specialisation.md`
- `documentation/plan/character-sheet/talent/195-plan-fix-stockage-arbres-specialisation.md`

### Modified files
- `module/importer/oggDude.mjs` — two-pass orchestration under `specialization` domain via `buildContextRegistry()`
- `module/importer/utils/global-import-metrics.mjs` — aggregate stats include specialization-tree
- `module/importer/utils/oggdude-import-folders.mjs` — add `specialization-tree` to folder map and colors
- `module/utils/oggdude-mapping-config.mjs` — add `specialization-tree` to pack config
- `module/models/specialization-tree.mjs` — add optional `type` field to connections schema
- `module/utils/audit-log.mjs` — remove redundant inline `export` (already exported via named export block)
- `tests/importer/utils/oggdude-import-folders.test.mjs` — add folder/color resolution tests
- `tests/models/specialization-tree.test.mjs` — add connection type field test

## Testing

- 137 test files, 1508 tests pass (no regression)
- Covers valid tree mapping, unresolved talents, missing costs, double-pass orchestration, pack config resolution, folder/color resolution

## Related

Closes #194