### PR TITLE
feat(importer): add structured diagnostic logging to OggDude specialization-tree mapper

### DIFF
--- a/documentation/plan/character-sheet/specialization-tree/218-plan-mapper-noeuds-format-reel-oggdude.md
+++ b/documentation/plan/character-sheet/specialization-tree/218-plan-mapper-noeuds-format-reel-oggdude.md
@@ -1,0 +1,246 @@
+# Plan d'implémentation — US1 : Mapper les nœuds depuis le format réel OggDude
+
+**Issue** : [#218 — US1: Mapper les nœuds depuis le format réel OggDude (TalentRows/Talents/Key)](https://github.com/herveDarritchon/foundryvtt-swerpg/issues/218)
+**Epic** : [#217 — EPIC: Fix OggDude Specialization Tree Import — Arbres de spécialisation vides](https://github.com/herveDarritchon/foundryvtt-swerpg/issues/217)
+**ADR** : `documentation/architecture/adr/adr-0004-vitest-testing-strategy.md`, `documentation/architecture/adr/adr-0006-specialization-import-error-isolation.md`, `documentation/architecture/adr/adr-0012-unit-tests-readable-diagnostics.md`
+**Module(s) impacté(s)** : `module/importer/mappers/oggdude-specialization-tree-mapper.mjs` (modification), `tests/importer/specialization-tree-ogg-dude.spec.mjs` (modification ciblée), `module/importer/utils/specialization-tree-import-utils.mjs` (vérification)
+
+---
+
+## 1. Objectif
+
+Corriger la lecture des nœuds d'arbres de spécialisation OggDude dans le mapper `specialization-tree` pour qu'il comprenne le format réel `TalentRows.TalentRow[].Talents.Key[]` au lieu de dépendre en priorité d'un ancien format à colonnes.
+
+Le résultat attendu pour cette US est limité mais structurant :
+- les arbres importés ne doivent plus avoir `system.nodes = []` lorsque le XML OggDude réel contient des talents ;
+- chaque nœud importé doit porter un `nodeId` stable, un `row`, un `column`, un `talentId` et un `cost` ;
+- le support de l'ancien format doit rester disponible en fallback ;
+- la correction doit rester localisée au mapper, sans élargir le ticket aux connexions directionnelles, au durcissement complet des logs ni à la validation d'intégration Foundry.
+
+---
+
+## 2. Périmètre
+
+### Inclus dans cette US / ce ticket
+
+- Prioriser la lecture du format réel OggDude : `TalentRows.TalentRow[].Talents.Key[]`
+- Déterminer `row` par ordre d'apparition dans le XML : `rowIndex + 1`
+- Déterminer `column` par ordre d'apparition dans la ligne : `columnIndex + 1`
+- Hériter le coût depuis `rawRow.Cost` pour tous les nœuds de la ligne
+- Normaliser `talentId` depuis la valeur du `Key`
+- Générer un `nodeId` déterministe selon la convention `r{row}c{column}`
+- Conserver le fallback existant vers les formats anciens ou hypothétiques : `TalentColumns.TalentColumn`, `Nodes.Node`, `TalentNodes.TalentNode`, `Connections.Connection`
+- Vérifier la robustesse des helpers utilisés par ce flux : `asArray()`, `readFirstString()`, `parseNonNegativeInteger()`, `normalizeSpecializationTreeId()`
+- Ajouter une couverture de test minimale ciblée sur ce contrat de mapping
+
+### Exclu de cette US / ce ticket
+
+- Génération des connexions depuis `Directions` → issue #219
+- Ajout des logs de diagnostic détaillés de format détecté / rowCount / nodeCount → issue #220
+- Campagne complète de tests de non-régression avec fixture Advisor.xml étendu → issue #221
+- Vérification d'intégration Foundry après import complet → issue #222
+- Modification du data model `specialization-tree`
+- Modification du resolver domaine `talent-tree-resolver`
+- Refonte de l'orchestrateur `module/importer/oggDude.mjs`
+- Refonte globale de l'import OggDude
+
+---
+
+## 3. Constat sur l'existant
+
+Le code actuel lit les lignes via `extractNodesFromRows()` dans `module/importer/mappers/oggdude-specialization-tree-mapper.mjs`, mais cherche des colonnes dans `rawRow?.TalentColumns?.TalentColumn`. C'est incompatible avec le XML réel décrit dans le cadrage, où les talents sont sous `rawRow?.Talents?.Key`.
+
+Conséquences actuelles :
+- le mapper peut construire un `specialization-tree` valide en surface ;
+- mais il ne produit aucun nœud pour un export OggDude réel de type `Advisor.xml` ;
+- les compteurs `rawNodeCount`, `importedNodeCount` et `importedConnectionCount` existent déjà dans `flags.swerpg.import`, mais restent inexacts pour ce format si aucun nœud n'est extrait ;
+- le resolver domaine considère encore un arbre comme `available` seulement si `nodes.length > 0` et `connections.length > 0`, donc après cette US l'arbre pourra encore rester `incomplete` tant que #219 n'aura pas ajouté les connexions directionnelles.
+
+L'existant montre aussi que :
+- `normalizeNodeId()`, `normalizeSpecializationTreeId()` et `parseNonNegativeInteger()` existent déjà dans `module/importer/utils/specialization-tree-import-utils.mjs` ;
+- `asArray()` et `readFirstString()` sont aujourd'hui locales au mapper ;
+- le mapper applique déjà un pattern d'isolation des erreurs par item cohérent avec ADR-0006 ;
+- un test existe déjà pour l'ancien format à colonnes dans `tests/importer/specialization-tree-ogg-dude.spec.mjs`, mais pas pour le vrai format `TalentRows/Talents/Key`.
+
+---
+
+## 4. Décisions d'architecture
+
+### 4.1. Garder la correction dans le mapper, pas dans l'orchestrateur ni le modèle
+
+**Décision** : corriger `module/importer/mappers/oggdude-specialization-tree-mapper.mjs` comme couche de compréhension du XML OggDude.
+
+Justification :
+- le bug est un problème de mapping XML vers modèle métier, pas de création d'item Foundry ;
+- le cadrage insiste explicitement sur ce point ;
+- la correction la plus petite et la plus sûre reste locale au mapper.
+
+### 4.2. Priorité au format réel `TalentRows/Talents/Key`, fallback ancien conservé
+
+**Décision** : lire d'abord `TalentRows.TalentRow[].Talents.Key[]`, puis retomber sur les structures anciennes seulement si ce format n'est pas présent.
+
+Justification :
+- c'est le format réellement observé ;
+- l'issue demande explicitement de ne pas casser les anciens exports potentiels ;
+- cela limite la régression tout en corrigeant le cas principal.
+
+### 4.3. `row` et `column` viennent de l'ordre XML, pas des pseudo-index OggDude
+
+**Décision** : utiliser `rowIndex + 1` et `columnIndex + 1` comme source principale de vérité.
+
+Justification :
+- le cadrage signale que `<Index>` peut être à `0` ou ne pas refléter correctement la position réelle ;
+- la convention V1 du projet repose sur des identifiants stables `r{row}c{column}` ;
+- cela rend le comportement déterministe et testable.
+
+### 4.4. Conserver les helpers locaux tant qu'ils ne sont pas réutilisés ailleurs
+
+**Décision** : ne pas extraire `asArray()` ni `readFirstString()` dans un utilitaire partagé dans cette US.
+
+Justification :
+- la consigne projet privilégie les plus petits changements corrects ;
+- ce ticket ne demande pas une mutualisation transversale ;
+- déplacer des helpers maintenant élargirait le périmètre sans bénéfice immédiat.
+
+### 4.5. Ne pas anticiper les connexions directionnelles dans cette US
+
+**Décision** : limiter cette US à l'extraction correcte des nœuds et ne pas ajouter ici la lecture de `Directions`.
+
+Justification :
+- #219 est explicitement dédié à cette responsabilité ;
+- cela évite de mélanger correction bloquante et enrichissement structurel ;
+- le découpage reste cohérent avec les issues créées.
+
+### 4.6. Ajouter un test ciblé sur le nouveau format, mais pas la campagne complète
+
+**Décision** : ajouter ou adapter une couverture de test minimale pour figer le nouveau comportement du mapper, tout en laissant la suite exhaustive à #221.
+
+Justification :
+- conforme à ADR-0004 ;
+- évite une correction sans filet ;
+- reste compatible avec le périmètre strict de #218.
+
+---
+
+## 5. Plan de travail détaillé
+
+### Étape 1 — Vérifier et fiabiliser les helpers utilisés par le mapper
+
+**Quoi faire** :
+- relire le comportement réel de `asArray()` et `readFirstString()` dans le mapper ;
+- confirmer que `parseNonNegativeInteger()` et `normalizeSpecializationTreeId()` suffisent pour le contrat du ticket ;
+- corriger seulement les cas qui bloquent la lecture du format réel : `undefined`, objet seul, tableau, chaîne simple si elle peut apparaître comme valeur de `Key`.
+
+**Fichiers** :
+- `module/importer/mappers/oggdude-specialization-tree-mapper.mjs`
+- `module/importer/utils/specialization-tree-import-utils.mjs` uniquement si une adaptation ciblée est réellement nécessaire
+
+**Risques spécifiques** :
+- changer le comportement de `asArray()` trop largement pourrait casser les anciens formats ;
+- surcorriger les helpers peut diluer le ticket.
+
+### Étape 2 — Réécrire l'extraction des nœuds par lignes pour le format réel
+
+**Quoi faire** :
+- faire évoluer `extractNodesFromRows()` pour qu'elle lise en priorité : `TalentRows.TalentRow`, `rawRow.Talents.Key`, `rawRow.Cost` ;
+- construire des entrées brutes de nœuds avec `row`, `column`, `rawNodeKey`, `talentId`, `cost`, `rawNode` minimal utile au traitement existant ;
+- ne plus dépendre du sous-arbre `TalentColumns.TalentColumn` comme chemin principal.
+
+**Fichiers** :
+- `module/importer/mappers/oggdude-specialization-tree-mapper.mjs`
+
+**Risques spécifiques** :
+- utiliser encore `rawRow.Index` comme source prioritaire ferait persister le bug ;
+- mal normaliser `talentId` pourrait produire des IDs incohérents avec le reste des imports.
+
+### Étape 3 — Préserver le fallback ancien format sans ambiguïté
+
+**Quoi faire** :
+- garder `extractNodesFromFlatList()` et la logique existante pour les anciens formats ;
+- faire en sorte que le fallback ne s'active que si le format réel n'a produit aucun nœud exploitable ;
+- éviter tout mélange implicite entre nœuds issus du nouveau format et nœuds issus d'un ancien format dans un même arbre.
+
+**Fichiers** :
+- `module/importer/mappers/oggdude-specialization-tree-mapper.mjs`
+
+**Risques spécifiques** :
+- un fallback trop agressif peut masquer un problème de lecture du format réel ;
+- un fallback supprimé casserait la rétrocompatibilité souhaitée par l'issue.
+
+### Étape 4 — Aligner la normalisation finale et les métriques existantes
+
+**Quoi faire** :
+- vérifier que `normalizeNodes()` transforme correctement les entrées extraites depuis `Talents.Key` ;
+- conserver le placeholder `unknown:<specializationId>:<nodeId>` si un talent est absent ;
+- conserver les compteurs existants dans `flags.swerpg.import` : `rawNodeCount`, `importedNodeCount`, `importedConnectionCount` ;
+- accepter qu'après cette US les connexions puissent rester vides tant que #219 n'est pas implémentée.
+
+**Fichiers** :
+- `module/importer/mappers/oggdude-specialization-tree-mapper.mjs`
+
+**Risques spécifiques** :
+- considérer l'absence de connexions comme une régression de #218 alors qu'elle relève de #219 ;
+- produire des métriques incohérentes entre nœuds bruts et nœuds normalisés.
+
+### Étape 5 — Ajouter une couverture de test minimale du nouveau chemin
+
+**Quoi faire** :
+- ajouter un test nominal de mapping depuis `TalentRows/Talents/Key` ;
+- vérifier au minimum : le nombre de nœuds produits, les `nodeId`, les coûts par ligne simples, la normalisation de `talentId` ;
+- ajouter un test de robustesse sur absence de `Talents.Key` ou ligne vide ;
+- garder des assertions lisibles et ciblées, conformément à ADR-0012.
+
+**Fichiers** :
+- `tests/importer/specialization-tree-ogg-dude.spec.mjs`
+
+**Risques spécifiques** :
+- refaire dans #218 toute la matrice de tests prévue pour #221 ;
+- écrire des assertions trop profondes et fragiles.
+
+---
+
+## 6. Fichiers modifiés
+
+| Fichier | Action | Description du changement |
+|---|---|---|
+| `module/importer/mappers/oggdude-specialization-tree-mapper.mjs` | Modification | Corriger la lecture prioritaire des nœuds depuis `TalentRows.TalentRow[].Talents.Key[]`, générer `row`/`column` par ordre XML, conserver le fallback ancien format |
+| `tests/importer/specialization-tree-ogg-dude.spec.mjs` | Modification | Ajouter une couverture minimale du vrai format OggDude pour figer le contrat de #218 |
+| `module/importer/utils/specialization-tree-import-utils.mjs` | Vérification, modification ciblée éventuelle | Ajustement uniquement si un helper existant empêche une correction locale propre dans le mapper |
+| `module/importer/items/specialization-tree-ogg-dude.mjs` | Vérification seule | Confirmer qu'aucun changement n'est nécessaire dans le context builder |
+| `module/models/specialization-tree.mjs` | Vérification seule | Confirmer que le contrat `nodeId/talentId/row/column/cost` reste déjà compatible |
+
+---
+
+## 7. Risques
+
+| Risque | Impact | Mitigation |
+|---|---|---|
+| Le vrai format est lu, mais les arbres restent `incomplete` faute de connexions | La correction peut sembler partielle côté domaine | Documenter explicitement la dépendance à #219 et ne pas élargir #218 |
+| Régression sur les anciens exports à colonnes | Perte de compatibilité sur des datasets déjà supportés | Conserver un fallback explicite et le vérifier par test ciblé si possible |
+| Mauvaise interprétation de `Index` OggDude | `nodeId` instables ou positions fausses | Utiliser l'ordre d'apparition XML comme source principale |
+| Helpers insuffisamment robustes | Nœuds silencieusement perdus | Vérifier les cas `undefined`, objet seul, tableau, chaîne simple |
+| Tests trop ambitieux dans #218 | Glissement de périmètre vers #221 | Limiter la couverture à la preuve du nouveau chemin nominal et à un cas de robustesse |
+
+---
+
+## 8. Proposition d'ordre de commit
+
+1. `fix(importer): read specialization-tree nodes from OggDude TalentRows keys`
+2. `test(importer): cover specialization-tree row key node mapping`
+
+Si l'implémentation reste très compacte, un seul commit est aussi acceptable :
+1. `fix(importer): map specialization-tree nodes from real OggDude row format`
+
+---
+
+## 9. Dépendances avec les autres US
+
+- **Dépend de** : aucune issue bloquante
+- **Bloque directement** : #219 (connexions), #220 (logs), #221 (tests)
+- **Conditionne indirectement** : #222 (intégration Foundry)
+
+Ordre recommandé :
+1. #218 — correction du mapping des nœuds
+2. #219 — génération des connexions
+3. #220 et #221 — logs et couverture exhaustive
+4. #222 — validation d'intégration Foundry

--- a/documentation/plan/character-sheet/specialization-tree/220-plan-ajouter-logs-diagnostic-mapper-oggdude.md
+++ b/documentation/plan/character-sheet/specialization-tree/220-plan-ajouter-logs-diagnostic-mapper-oggdude.md
@@ -1,0 +1,245 @@
+# Plan d'implémentation — US3 : Ajouter les logs de diagnostic dans le mapper OggDude
+
+**Issue** : [#220 — US3: Ajouter les logs de diagnostic dans le mapper OggDude](https://github.com/herveDarritchon/foundryvtt-swerpg/issues/220)
+**Epic** : [#217 — EPIC: Fix OggDude Specialization Tree Import — Arbres de spécialisation vides](https://github.com/herveDarritchon/foundryvtt-swerpg/issues/217)
+**ADR** : `documentation/architecture/adr/adr-0004-vitest-testing-strategy.md`, `documentation/architecture/adr/adr-0006-specialization-import-error-isolation.md`, `documentation/architecture/adr/adr-0012-unit-tests-readable-diagnostics.md`
+**Module(s) impacté(s)** : `module/importer/mappers/oggdude-specialization-tree-mapper.mjs` (modification), `tests/importer/specialization-tree-ogg-dude.spec.mjs` (modification)
+
+---
+
+## 1. Objectif
+
+Ajouter des logs de diagnostic structurés dans le mapper `specialization-tree` pour rendre le format XML réellement utilisé et les métriques de mapping visibles dans la console Foundry sans nécessiter de debug interactif.
+
+Le résultat attendu est le suivant :
+- le format XML réellement rencontré (TalentRows/Keys, TalentRows/Columns, flat list, ou inconnu) est loggé en `debug` ;
+- une synthèse du mapping (rawNodeCount, importedNodeCount, connectionCount) est loggée en `debug` ;
+- les anomalies structurelles (lignes sans nœuds, format non reconnu, cibles directionnelles absentes) sont loggées en `warn` ;
+- les compteurs et warnings déjà stockés dans `flags.swerpg.import` sont réutilisés sans nouveau contrat de sortie ;
+- la couverture de test existante est étendue pour vérifier les appels au logger.
+
+---
+
+## 2. Périmètre
+
+### Inclus dans cette US / ce ticket
+
+- Détection explicite du format XML rencontré (via l'examen des chemins OggDude)
+- Log `debug` du format détecté avec `specializationId`
+- Log `debug` du résumé de mapping : `rawNodeCount`, `importedNodeCount`, `connectionCount`
+- Log `warn` pour les anomalies :
+  - format non reconnu (aucun chemin XML connu n'a produit de nœuds)
+  - lignes sans nœuds exploitables dans le format rows
+  - cibles directionnelles absentes (déjà dans `directionalWarnings`, à journaliser aussi en runtime)
+- Réutilisation des compteurs et warnings existants sans refactor des flags
+- Vérification des appels `logger.debug` / `logger.warn` dans les tests
+
+### Exclu de cette US / ce ticket
+
+- Création d'un nouveau contrat de sortie ou de nouvelles métriques dans `flags.swerpg.import`
+- Refonte du mécanisme de détection de format (reste dans le mapper)
+- Remplacement des warnings existants dans `warnings[]`
+- Validation d'intégration Foundry bout en bout → #222
+- Campagne de tests exhaustive avec fixtures larges → #221
+
+---
+
+## 3. Constat sur l'existant
+
+Le mapper `oggdude-specialization-tree-mapper.mjs` contient déjà :
+
+- **import de `logger`** (ligne 1)
+- **`logger.warn`** pour valeurs obligatoires manquantes (ligne 28), input vide (ligne 280), erreur de mapping (ligne 365)
+- **`logger.error`** pour erreurs bloquantes (ligne 365)
+- **Aucun `logger.debug`** structuré
+- **Aucune fonction de détection de format explicite** — la sélection du chemin XML est implicite dans `extractNodesFromRows()` (tente `Talents.Key` puis `TalentColumns.TalentColumn`) et dans `extractRawNodeEntries()` (tente rows puis flat list)
+
+Les compteurs et diagnostics suivants existent déjà :
+- `rawCount` : nombre brut d'entrées XML avant normalisation
+- `normalizedNodes.length` : nœuds effectivement importés
+- `connections.length` : connexions après déduplication
+- `warnings[]` : tableau de chaînes (unresolved-talent, missing-cost, tree-incomplete, directional-target-missing)
+- `flags.swerpg.import.rawNodeCount`, `.importedNodeCount`, `.importedConnectionCount`
+
+`extractDirectionalConnections()` retourne déjà des `warnings` de cibles manquantes (lignes 258, 268), mais ne journalise rien en runtime.
+
+Le logger mocké est déjà présent dans les tests (lignes 3-10 du spec), avec `vi.fn()` pour toutes les méthodes.
+
+---
+
+## 4. Décisions d'architecture
+
+### 4.1. Garder les diagnostics dans le mapper (inchangé depuis #218/#219)
+
+**Décision** : toute la logique de détection de format et de journalisation reste dans `oggdude-specialization-tree-mapper.mjs`, pas dans l'orchestrateur ni dans le context builder.
+
+**Justification** : le problème est un problème de compréhension du XML OggDude ; le mapper est déjà responsable de l'interprétation du format.
+
+### 4.2. Séparer logs `debug` et `warn`
+
+**Décision** :
+- `logger.debug` pour la télémétrie de mapping : format détecté, résumé des compteurs
+- `logger.warn` pour les anomalies récupérables : lignes sans nœuds, format non reconnu, cibles directionnelles absentes
+
+**Justification** : les anomalies sont visibles même sans mode debug ; la télémétrie de mapping est utile en debug uniquement pour ne pas polluer la console en production.
+
+### 4.3. Détecter explicitement le format rencontré
+
+**Décision** : introduire une fonction `detectInputFormat(xmlSpecialization)` qui examine les chemins XML et retourne un identifiant de format :
+- `'talent-rows-keys'` : format réel OggDude `TalentRows.TalentRow[].Talents.Key[]`
+- `'talent-rows-columns'` : format legacy `TalentRows.TalentRow[].TalentColumns.TalentColumn[]`
+- `'talent-rows-unknown'` : format rows présent mais sous-format non reconnu
+- `'flat-list'` : format plat `Nodes.Node` / `TalentNodes.TalentNode` / `Tree.Nodes.Node`
+- `'unknown'` : aucun format reconnu
+
+**Justification** : la détection implicite actuelle empêche de savoir quel chemin a été emprunté sans lire le code ; une fonction dédiée est testable et documente les formats supportés.
+
+### 4.4. Réutiliser les warnings et compteurs existants
+
+**Décision** : les logs de diagnostic lisent les compteurs déjà calculés (`rawCount`, `normalizedNodes.length`, `connections.length`, `warnings[]`), sans ajouter de nouveau champ dans `flags.swerpg.import`.
+
+**Justification** : les flags contiennent déjà toute l'information nécessaire ; ajouter des champs redondants augmenterait la surface de contrat sans bénéfice.
+
+### 4.5. Journaliser les cibles directionnelles absentes en runtime
+
+**Décision** : dans `specializationTreeMapper()`, après avoir récupéré les `directionalWarnings`, appeler `logger.warn` pour chaque warning de cible manquante, en incluant `specializationId`.
+
+**Justification** : actuellement les warnings de cibles manquantes sont stockés mais jamais visibles dans la console ; cela rend le diagnostic des imports partiels difficile.
+
+### 4.6. Étendre la spec existante sans nouvelle suite de tests isolée
+
+**Décision** : enrichir `tests/importer/specialization-tree-ogg-dude.spec.mjs` avec des tests qui vérifient les appels à `logger.debug` et `logger.warn`.
+
+**Justification** : conforme aux décisions #218 (4.6) et #219 (4.6) ; le logger est déjà mocké ; une seule spec par mapper simplifie la navigation.
+
+---
+
+## 5. Plan de travail détaillé
+
+### Étape 1 — Formaliser la détection de format
+
+**Quoi faire** :
+- créer `detectInputFormat(xmlSpecialization)` dans le mapper
+- la fonction examine les chemins XML et retourne un identifiant de format parmi `'talent-rows-keys'`, `'talent-rows-columns'`, `'talent-rows-unknown'`, `'flat-list'`, `'unknown'`
+- appeler cette fonction dans `specializationTreeMapper()` avant la normalisation
+
+**Fichiers** :
+- `module/importer/mappers/oggdude-specialization-tree-mapper.mjs`
+
+**Risques spécifiques** :
+- détecter un format différent de celui que le mapper utilisera effectivement (si la logique de fallback change)
+
+### Étape 2 — Ajouter le log `debug` du format détecté
+
+**Quoi faire** :
+- après la détection de format et la résolution de `specializationId`, ajouter :
+  ```js
+  logger.debug('[SpecializationTreeImporter] Format détecté', { specializationId, format: detectedFormat })
+  ```
+
+**Fichiers** :
+- `module/importer/mappers/oggdude-specialization-tree-mapper.mjs`
+
+**Risques spécifiques** :
+- logger avant que `specializationId` soit résolu → impossible, donc placer après la validation de `specializationId`
+
+### Étape 3 — Ajouter le log `debug` du résumé de mapping
+
+**Quoi faire** :
+- après la construction des connexions et avant le `return`, ajouter :
+  ```js
+  logger.debug('[SpecializationTreeImporter] Résumé du mapping', {
+    specializationId,
+    rawNodeCount: rawCount,
+    importedNodeCount: normalizedNodes.length,
+    connectionCount: connections.length,
+  })
+  ```
+
+**Fichiers** :
+- `module/importer/mappers/oggdude-specialization-tree-mapper.mjs`
+
+**Risques spécifiques** : aucun — les compteurs sont déjà calculés à ce stade.
+
+### Étape 4 — Ajouter les logs `warn` pour les anomalies structurelles
+
+**Quoi faire** :
+- si `detectedFormat === 'unknown'`, logger un `warn` avec `specializationId`
+- si `detectedFormat === 'talent-rows-unknown'`, logger un `warn` avec `specializationId`, `rowCount`
+- si `normalizedNodes.length === 0 && rawCount > 0`, logger un `warn` avec `specializationId`, `rawCount` (toutes les entrées brutes ont été rejetées)
+- après `extractDirectionalConnections()`, itérer sur `directionalWarnings` et logger chaque cible manquante :
+  ```js
+  for (const warning of directionalWarnings) {
+    logger.warn(`[SpecializationTreeImporter] ${warning}`, { specializationId })
+  }
+  ```
+
+**Fichiers** :
+- `module/importer/mappers/oggdude-specialization-tree-mapper.mjs`
+
+**Risques spécifiques** :
+- doubler les warnings si `logger.warn` est appelé en plus du stockage dans `warnings[]` → acceptable, c'est le comportement voulu (visible console + stocké flags)
+
+### Étape 5 — Ajouter la couverture de test du contrat de logging
+
+**Quoi faire** :
+- ajouter un test qui vérifie `logger.debug` appelé avec le bon format et le bon `specializationId` pour le format `talent-rows-keys`
+- ajouter un test qui vérifie `logger.debug` appelé avec le résumé de mapping (rawNodeCount, importedNodeCount, connectionCount)
+- ajouter un test qui vérifie `logger.warn` appelé pour une cible directionnelle absente
+- ajouter un test qui vérifie `logger.warn` appelé pour format non reconnu (XML vide ou sans structure connue)
+- ne pas sur-tester les appels internes : vérifier la présence et le contenu des appels, pas le nombre exact
+
+**Fichiers** :
+- `tests/importer/specialization-tree-ogg-dude.spec.mjs`
+
+**Risques spécifiques** :
+- trop de coupling aux chaînes exactes de log (fragile au refactor) → mitiger en vérifiant `toContain` ou `toMatchObject` plutôt que des assertions rigides sur `toHaveBeenCalledWith`
+
+---
+
+## 6. Fichiers modifiés
+
+| Fichier | Action | Description du changement |
+|---|---|---|
+| `module/importer/mappers/oggdude-specialization-tree-mapper.mjs` | Modification | Ajouter `detectInputFormat()`, logs `debug` de format et résumé, logs `warn` pour anomalies structurelles et cibles manquantes |
+| `tests/importer/specialization-tree-ogg-dude.spec.mjs` | Modification | Ajouter la couverture des appels `logger.debug` et `logger.warn` pour les formats et anomalies |
+| `module/importer/items/specialization-tree-ogg-dude.mjs` | Vérification seule | Confirmer qu'aucun log supplémentaire n'est nécessaire au niveau du context builder |
+| `module/importer/utils/specialization-tree-import-utils.mjs` | Vérification seule | Confirmer que les compteurs existants suffisent sans ajout |
+
+---
+
+## 7. Risques
+
+| Risque | Impact | Mitigation |
+|---|---|---|
+| Logs `debug` visibles en production sans activation volontaire | Bruit console | `logger.debug` est désactivé par défaut ; activé uniquement via `logger.enableDebug()` ou `game.settings.set('swerpg', 'debug', true)` |
+| Doublon entre `warnings[]` existant et `logger.warn` | Information redondante mais pas trompeuse | Documenter que les warnings sont volontairement dupliqués (console + flags) pour le diagnostic support |
+| Test trop couplé au message exact de log | Refactor coûteux | Utiliser `expect.stringContaining` ou `toMatchObject` partiel sur les arguments du logger |
+| Détection de format divergente de la réalité du mapper | Logs trompeurs | Tester `detectInputFormat()` isolément et comparer son résultat avec le comportement réel de `extractRawNodeEntries()` |
+| Ajout de logs dans la boucle `specializations.map()` sans garde | Logs répétés pour chaque arbre | C'est le comportement attendu (un log par arbre) ; les tests vérifient que chaque arbre produit ses logs |
+
+---
+
+## 8. Proposition d'ordre de commit
+
+1. `feat(importer): add diagnostic logging to specialization-tree mapper`
+2. `test(importer): cover diagnostic logging contract for specialization-tree`
+
+Si l'implémentation reste compacte, un seul commit est acceptable :
+
+1. `feat(importer): add structured diagnostic logging to OggDude specialization-tree mapper`
+
+---
+
+## 9. Dépendances avec les autres US
+
+- **Dépend de** : `#218` (les nœuds doivent être correctement extraits avant de pouvoir logger leur comptage), `#219` (les connexions directionnelles doivent exister pour logger les cibles manquantes)
+- **Bloque directement** : aucune (US d'observabilité, indépendante)
+- **Facilite** : `#221` (les logs aident à comprendre les fixtures de test), `#222` (les logs aident à valider les imports complets)
+
+Ordre recommandé :
+1. `#218` — mapping des nœuds (done)
+2. `#219` — génération des connexions (done)
+3. `#220` — logs de diagnostic
+4. `#221` — campagne de tests (peut être parallélisé avec #220)
+5. `#222` — validation d'intégration Foundry (dépend de #220 et #221 pour le diagnostic)

--- a/module/importer/mappers/oggdude-specialization-tree-mapper.mjs
+++ b/module/importer/mappers/oggdude-specialization-tree-mapper.mjs
@@ -186,6 +186,39 @@ function extractRawNodeEntries(xmlSpecialization) {
   return extractNodesFromFlatList(xmlSpecialization)
 }
 
+function detectInputFormat(xmlSpecialization) {
+  const rows = asArray(xmlSpecialization?.TalentRows?.TalentRow)
+
+  if (rows.length > 0) {
+    let hasKeys = false
+    let hasColumns = false
+
+    for (const row of rows) {
+      if (row?.Talents?.Key) {
+        hasKeys = true
+        break
+      }
+      if (row?.TalentColumns?.TalentColumn) {
+        hasColumns = true
+      }
+    }
+
+    if (hasKeys) return 'talent-rows-keys'
+    if (hasColumns) return 'talent-rows-columns'
+    return 'talent-rows-unknown'
+  }
+
+  if (
+    xmlSpecialization?.Nodes?.Node ||
+    xmlSpecialization?.TalentNodes?.TalentNode ||
+    xmlSpecialization?.Tree?.Nodes?.Node
+  ) {
+    return 'flat-list'
+  }
+
+  return 'unknown'
+}
+
 function normalizeNodes(xmlSpecialization, specializationId) {
   const warnings = []
   const normalizedNodes = []
@@ -304,6 +337,9 @@ export function specializationTreeMapper(specializations) {
           return null
         }
 
+        const detectedFormat = detectInputFormat(xmlSpecialization)
+        logger.debug('[SpecializationTreeImporter] Format détecté', { specializationId, format: detectedFormat })
+
         const sourceInfo = resolveSource(xmlSpecialization)
         const description = buildDescription(readOptionalString(xmlSpecialization?.Description), sourceInfo)
         const { normalizedNodes, warnings, rawCount } = normalizeNodes(xmlSpecialization, specializationId)
@@ -311,12 +347,37 @@ export function specializationTreeMapper(specializations) {
 
         const { connections: directionalConnections, warnings: directionalWarnings } = extractDirectionalConnections(normalizedNodes)
         warnings.push(...directionalWarnings)
+        for (const warning of directionalWarnings) {
+          logger.warn(`[SpecializationTreeImporter] ${warning}`, { specializationId })
+        }
 
         const nodeConnections = normalizedNodes.flatMap((node) => extractNodeConnectionEntries(node.rawNode, node.nodeId, nodeMaps))
         const globalConnections = extractGlobalConnectionEntries(xmlSpecialization, nodeMaps)
         const connections = dedupeConnections([...nodeConnections, ...globalConnections, ...directionalConnections]).map((connection) => ({
           ...(connection.type ? connection : { from: connection.from, to: connection.to }),
         }))
+
+        logger.debug('[SpecializationTreeImporter] Résumé du mapping', {
+          specializationId,
+          rawNodeCount: rawCount,
+          importedNodeCount: normalizedNodes.length,
+          connectionCount: connections.length,
+        })
+
+        if (detectedFormat === 'unknown') {
+          logger.warn('[SpecializationTreeImporter] Format non reconnu', { specializationId })
+        }
+
+        if (detectedFormat === 'talent-rows-unknown') {
+          logger.warn('[SpecializationTreeImporter] Format rows sans nœuds identifiables', {
+            specializationId,
+            rowCount: asArray(xmlSpecialization?.TalentRows?.TalentRow).length,
+          })
+        }
+
+        if (normalizedNodes.length === 0 && rawCount > 0) {
+          logger.warn('[SpecializationTreeImporter] Toutes les entrées brutes rejetées', { specializationId, rawCount })
+        }
 
         if (normalizedNodes.length === 0 || connections.length === 0) {
           incrementSpecializationTreeImportStat('incompleteTrees')

--- a/tests/importer/specialization-tree-ogg-dude.spec.mjs
+++ b/tests/importer/specialization-tree-ogg-dude.spec.mjs
@@ -9,6 +9,7 @@ vi.mock('../../module/utils/logger.mjs', () => ({
   },
 }))
 
+import { logger } from '../../module/utils/logger.mjs'
 import OggDudeDataElement from '../../module/settings/models/OggDudeDataElement.mjs'
 import { buildSpecializationTreeContext } from '../../module/importer/items/specialization-tree-ogg-dude.mjs'
 import { extractDirectionalConnections, specializationTreeMapper } from '../../module/importer/mappers/oggdude-specialization-tree-mapper.mjs'
@@ -165,6 +166,97 @@ describe('specializationTreeMapper', () => {
     expect(result[0].system.connections).toContainEqual({ from: 'r1c1', to: 'r1c2', type: 'horizontal' })
     expect(result[0].system.connections).toContainEqual({ from: 'r1c2', to: 'r1c3', type: 'horizontal' })
     expect(result[0].system.connections).toContainEqual({ from: 'r1c2', to: 'r2c2', type: 'vertical' })
+  })
+
+  it('logs debug with detected format for talent-rows-keys', () => {
+    const input = [
+      {
+        Key: 'ADVISOR',
+        Name: 'Advisor',
+        TalentRows: {
+          TalentRow: [
+            {
+              Cost: '5',
+              Talents: { Key: ['PLAUSDEN', 'KNOWSOM'] },
+            },
+          ],
+        },
+      },
+    ]
+
+    specializationTreeMapper(input)
+
+    expect(logger.debug).toHaveBeenCalledWith(
+      expect.stringContaining('Format détecté'),
+      expect.objectContaining({ specializationId: 'advisor', format: 'talent-rows-keys' }),
+    )
+  })
+
+  it('logs debug with mapping summary', () => {
+    const input = [
+      {
+        Key: 'ADVISOR',
+        Name: 'Advisor',
+        TalentRows: {
+          TalentRow: [
+            {
+              Cost: '5',
+              Talents: { Key: ['PLAUSDEN', 'KNOWSOM'] },
+            },
+          ],
+        },
+      },
+    ]
+
+    specializationTreeMapper(input)
+
+    expect(logger.debug).toHaveBeenCalledWith(
+      expect.stringContaining('Résumé du mapping'),
+      expect.objectContaining({
+        specializationId: 'advisor',
+        rawNodeCount: 2,
+        importedNodeCount: 2,
+        connectionCount: 0,
+      }),
+    )
+  })
+
+  it('logs warn for directional target missing', () => {
+    const input = [
+      {
+        Key: 'ADVISOR',
+        Name: 'Advisor',
+        TalentRows: {
+          TalentRow: [
+            {
+              Cost: '5',
+              Talents: { Key: ['PLAUSDEN'] },
+              Directions: {
+                Direction: [{ Right: 'true' }],
+              },
+            },
+          ],
+        },
+      },
+    ]
+
+    specializationTreeMapper(input)
+
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining('directional-target-missing'),
+      expect.objectContaining({ specializationId: 'advisor' }),
+    )
+  })
+
+  it('logs warn for unknown format', () => {
+    const input = [{ Key: 'UNKNOWN', Name: 'Unknown Format' }]
+
+    specializationTreeMapper(input)
+
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining('Format non reconnu'),
+      expect.objectContaining({ specializationId: 'unknown' }),
+    )
   })
 })
 


### PR DESCRIPTION
## Summary

Adds structured diagnostic logging to the OggDude specialization-tree mapper, making the XML format detected and mapping metrics visible in the Foundry console for easier debugging of import issues.

## Changes

- **`module/importer/mappers/oggdude-specialization-tree-mapper.mjs`**:
  - Added `detectInputFormat(xmlSpecialization)` — detects 5 formats: `talent-rows-keys`, `talent-rows-columns`, `talent-rows-unknown`, `flat-list`, `unknown`
  - `logger.debug` for format detected (`specializationId`, `format`)
  - `logger.debug` for mapping summary (`rawNodeCount`, `importedNodeCount`, `connectionCount`)
  - `logger.warn` for anomalies: unknown format, rows without identifiable nodes, all entries rejected, directional target missing

- **`tests/importer/specialization-tree-ogg-dude.spec.mjs`**:
  - 4 new tests verifying `logger.debug`/`logger.warn` calls with correct arguments
  - All 19 tests pass (15 existing + 4 new)

## Related

Closes #220