### PR TITLE
fix(importer): harden incomplete OggDude talent imports

### DIFF
--- a/module/importer/mappers/oggdude-specialization-tree-mapper.mjs
+++ b/module/importer/mappers/oggdude-specialization-tree-mapper.mjs
@@ -5,6 +5,7 @@ import {
   addSpecializationTreeMissingCost,
   addSpecializationTreeRejectionReason,
   addSpecializationTreeUnresolvedTalent,
+  buildTreeImportDiagnostics,
   getSpecializationTreeImportStats,
   incrementSpecializationTreeImportStat,
   isResolvedNodeReference,
@@ -77,6 +78,7 @@ function resolveConnectionEndpoint(rawReference, maps) {
 
 function extractNodeConnectionEntries(rawNode, currentNodeId, maps) {
   const connections = []
+  const warnings = []
   const candidates = asArray(rawNode?.Connections?.Connection)
 
   for (const connection of candidates) {
@@ -84,6 +86,7 @@ function extractNodeConnectionEntries(rawNode, currentNodeId, maps) {
     const resolvedTo = resolveConnectionEndpoint(targetRef, maps)
     if (!resolvedTo) {
       addSpecializationTreeInvalidConnection(`${currentNodeId}->${targetRef || 'unknown'}`)
+      warnings.push(`invalid-connection:${currentNodeId}->${targetRef || 'unknown'}`)
       continue
     }
 
@@ -94,12 +97,13 @@ function extractNodeConnectionEntries(rawNode, currentNodeId, maps) {
     })
   }
 
-  return connections
+  return { connections, warnings }
 }
 
 function extractGlobalConnectionEntries(xmlSpecialization, maps) {
   const candidates = asArray(xmlSpecialization?.Connections?.Connection)
   const connections = []
+  const warnings = []
 
   for (const connection of candidates) {
     const fromRef = readFirstString(connection?.From, connection?.Source, connection?.FromNodeKey)
@@ -109,6 +113,7 @@ function extractGlobalConnectionEntries(xmlSpecialization, maps) {
 
     if (!from || !to) {
       addSpecializationTreeInvalidConnection(`${fromRef || 'unknown'}->${toRef || 'unknown'}`)
+      warnings.push(`invalid-connection:${fromRef || 'unknown'}->${toRef || 'unknown'}`)
       continue
     }
 
@@ -119,7 +124,7 @@ function extractGlobalConnectionEntries(xmlSpecialization, maps) {
     })
   }
 
-  return connections
+  return { connections, warnings }
 }
 
 function extractNodesFromRows(xmlSpecialization) {
@@ -351,9 +356,15 @@ export function specializationTreeMapper(specializations) {
           logger.warn(`[SpecializationTreeImporter] ${warning}`, { specializationId })
         }
 
-        const nodeConnections = normalizedNodes.flatMap((node) => extractNodeConnectionEntries(node.rawNode, node.nodeId, nodeMaps))
-        const globalConnections = extractGlobalConnectionEntries(xmlSpecialization, nodeMaps)
-        const connections = dedupeConnections([...nodeConnections, ...globalConnections, ...directionalConnections]).map((connection) => ({
+        const nodeConnectionResults = normalizedNodes.map((node) => extractNodeConnectionEntries(node.rawNode, node.nodeId, nodeMaps))
+        const globalConnectionResults = extractGlobalConnectionEntries(xmlSpecialization, nodeMaps)
+        const nodeConnections = nodeConnectionResults.flatMap((result) => result.connections)
+        const connectionWarnings = [
+          ...nodeConnectionResults.flatMap((result) => result.warnings),
+          ...globalConnectionResults.warnings,
+        ]
+        warnings.push(...connectionWarnings)
+        const connections = dedupeConnections([...nodeConnections, ...globalConnectionResults.connections, ...directionalConnections]).map((connection) => ({
           ...(connection.type ? connection : { from: connection.from, to: connection.to }),
         }))
 
@@ -384,6 +395,12 @@ export function specializationTreeMapper(specializations) {
           warnings.push('tree-incomplete')
         }
 
+        const unresolved = warnings.some((warning) => warning.startsWith('unresolved-talent'))
+        const diagnostics = buildTreeImportDiagnostics(warnings, unresolved, {
+          hasNodes: normalizedNodes.length > 0,
+          hasConnections: connections.length > 0,
+        })
+
         const rawCareerKey = readFirstString(
           xmlSpecialization?.CareerKey,
           xmlSpecialization?.CareerId,
@@ -411,13 +428,18 @@ export function specializationTreeMapper(specializations) {
             swerpg: {
               oggdudeKey: rawKey,
               import: {
+                ...diagnostics,
                 domain: 'specialization-tree',
                 source: sourceInfo.name || 'OggDude Import',
-                warnings,
+                raw: {
+                  key: rawKey,
+                  careerKey: rawCareerKey || undefined,
+                  inputFormat: detectedFormat,
+                  nodeCount: rawCount,
+                },
                 rawNodeCount: rawCount,
                 importedNodeCount: normalizedNodes.length,
                 importedConnectionCount: connections.length,
-                unresolved: warnings.some((warning) => warning.startsWith('unresolved-talent')),
               },
             },
           },

--- a/module/importer/mappers/oggdude-talent-mapper.mjs
+++ b/module/importer/mappers/oggdude-talent-mapper.mjs
@@ -4,7 +4,7 @@
  */
 
 import { logger } from '../../utils/logger.mjs'
-import { incrementTalentImportStat } from '../utils/talent-import-utils.mjs'
+import { buildTalentImportDiagnostics, incrementTalentImportStat } from '../utils/talent-import-utils.mjs'
 
 // Mappings spécialisés
 import { resolveTalentActivation } from '../mappings/oggdude-talent-activation-map.mjs'
@@ -101,6 +101,8 @@ export class OggDudeTalentMapper {
       // Clé unique du talent
       const key = this.generateTalentKey(talentData)
       const name = talentData.Name || talentData.TalentName || key
+      const rawActivation = talentData.Activation || talentData.ActivationType
+      const activation = resolveTalentActivation(rawActivation)
 
       // Construction du contexte avec toutes les transformations
       const context = {
@@ -113,7 +115,8 @@ export class OggDudeTalentMapper {
         custom: talentData.Custom === 'true' || talentData.IsCustom === 'true',
 
         // Données transformées
-        activation: resolveTalentActivation(talentData.Activation || talentData.ActivationType),
+        activation,
+        hasUnknownActivation: activation === 'unspecified' && typeof rawActivation === 'string' && rawActivation.trim() !== '',
         node: resolveTalentNode(talentData.NodeId || talentData.TalentNode, { name }),
         tier: extractTalentTier(talentData),
         isRanked: extractIsRanked(talentData),
@@ -251,6 +254,13 @@ export class OggDudeTalentMapper {
         incrementTalentImportStat('dieModifiers')
       }
 
+      const warnings = []
+      if (context.hasUnknownActivation) {
+        warnings.push('unknown-activation')
+      }
+
+      const diagnostics = buildTalentImportDiagnostics(warnings)
+
       const talentData = {
         name: context.name,
         type: 'talent',
@@ -263,11 +273,17 @@ export class OggDudeTalentMapper {
           swerpg: {
             oggdudeKey: context.key,
             import: {
+              ...diagnostics,
               source: context.source || 'OggDude Import',
               sourceText: context.sourceText || '',
               dieModifiers: context.dieModifiers || [],
               prerequisites: context.prerequisites || {},
               tier: context.tier || 1,
+              raw: {
+                key: context.key,
+                activation: context.originalData?.Activation || context.originalData?.ActivationType || undefined,
+                source: context.originalData?.Source || context.originalData?.SourceBook || undefined,
+              },
               importedAt: new Date().toISOString(),
             },
           },

--- a/module/importer/utils/specialization-tree-import-utils.mjs
+++ b/module/importer/utils/specialization-tree-import-utils.mjs
@@ -90,3 +90,16 @@ export function normalizeConnectionType(rawValue) {
 export function isResolvedNodeReference(nodeId) {
   return typeof nodeId === 'string' && /^r\d+c\d+$/i.test(nodeId)
 }
+
+export function buildTreeImportDiagnostics(warnings = [], unresolved = false, options = {}) {
+  const w = Array.isArray(warnings) ? [...warnings] : []
+  const u = Boolean(unresolved)
+  const hasNodes = options.hasNodes !== false
+  const hasConnections = options.hasConnections !== false
+
+  let status = 'valid'
+  if (!hasNodes) status = 'invalid'
+  else if (!hasConnections || w.length > 0 || u) status = 'incomplete'
+
+  return { status, warnings: w, unresolved: u }
+}

--- a/module/importer/utils/talent-import-utils.mjs
+++ b/module/importer/utils/talent-import-utils.mjs
@@ -124,3 +124,10 @@ export function generateTalentKey(name) {
     .replace(/_+/g, '_')
     .replace(/^_|_$/g, '')
 }
+
+export function buildTalentImportDiagnostics(warnings = [], unresolved = false) {
+  const w = Array.isArray(warnings) ? [...warnings] : []
+  const u = Boolean(unresolved)
+  const status = u || w.length > 0 ? 'incomplete' : 'valid'
+  return { status, warnings: w, unresolved: u }
+}

--- a/module/lib/talent-node/talent-node-state.mjs
+++ b/module/lib/talent-node/talent-node-state.mjs
@@ -51,6 +51,7 @@ function hasPurchase(actor, treeId, nodeId, talentId, specializationId) {
 function hasValidFields(node) {
   if (!node.nodeId || !node.talentId) return false
   if (node.row == null || node.cost == null) return false
+  if (typeof node.talentId === 'string' && node.talentId.startsWith('unknown:')) return false
   return true
 }
 
@@ -66,6 +67,12 @@ function missingFields(node) {
 function isCompleteTree(tree) {
   const nodes = tree?.system?.nodes
   const connections = tree?.system?.connections
+  const importFlags = tree?.flags?.swerpg?.import
+
+  if (importFlags?.unresolved || importFlags?.status === 'incomplete' || importFlags?.status === 'invalid') {
+    return false
+  }
+
   return Array.isArray(nodes) && nodes.length > 0
     && Array.isArray(connections) && connections.length > 0
 }

--- a/module/lib/talent-node/talent-tree-resolver.mjs
+++ b/module/lib/talent-node/talent-tree-resolver.mjs
@@ -6,6 +6,11 @@ import { logger } from '../../utils/logger.mjs'
  * @returns {'available'|'incomplete'}
  */
 export function getSpecializationTreeResolutionState(tree) {
+  const importFlags = tree?.flags?.swerpg?.import
+  if (importFlags?.unresolved || importFlags?.status === 'incomplete' || importFlags?.status === 'invalid') {
+    return 'incomplete'
+  }
+
   const nodes = Array.isArray(tree?.system?.nodes) ? tree.system.nodes : []
   const connections = Array.isArray(tree?.system?.connections) ? tree.system.connections : []
 

--- a/tests/importer/specialization-tree-ogg-dude.spec.mjs
+++ b/tests/importer/specialization-tree-ogg-dude.spec.mjs
@@ -73,6 +73,13 @@ describe('specializationTreeMapper', () => {
     expect(result[0].system.connections).toEqual([{ from: 'r1c1', to: 'r2c1', type: 'vertical' }])
     expect(result[0].flags.swerpg.import.importedNodeCount).toBe(3)
     expect(result[0].flags.swerpg.import.importedConnectionCount).toBe(1)
+    expect(result[0].flags.swerpg.import.status).toBe('valid')
+    expect(result[0].flags.swerpg.import.raw).toEqual({
+      key: 'BODYGUARD',
+      careerKey: 'HIRED_GUN',
+      inputFormat: 'talent-rows-columns',
+      nodeCount: 3,
+    })
     expect(result[0].system.description).toContain('Source:')
     expect(stats.total).toBe(1)
     expect(stats.imported).toBe(1)
@@ -94,8 +101,14 @@ describe('specializationTreeMapper', () => {
     const stats = getSpecializationTreeImportStats()
 
     expect(item.system.nodes[0].talentId).toBe('unknown:bodyguard:r1c1')
+    expect(item.flags.swerpg.import.status).toBe('incomplete')
     expect(item.flags.swerpg.import.unresolved).toBe(true)
     expect(item.flags.swerpg.import.warnings).toContain('unresolved-talent:r1c1')
+    expect(item.flags.swerpg.import.raw).toMatchObject({
+      key: 'BODYGUARD',
+      inputFormat: 'talent-rows-columns',
+      nodeCount: 1,
+    })
     expect(stats.unresolvedTalents).toBe(1)
     expect(stats.imported).toBe(1)
   })
@@ -115,6 +128,7 @@ describe('specializationTreeMapper', () => {
     const stats = getSpecializationTreeImportStats()
 
     expect(item.system.nodes).toEqual([])
+    expect(item.flags.swerpg.import.status).toBe('invalid')
     expect(item.flags.swerpg.import.warnings).toEqual(expect.arrayContaining(['missing-cost:r1c1', 'tree-incomplete']))
     expect(stats.missingCosts).toBe(1)
     expect(stats.incompleteTrees).toBe(1)
@@ -166,6 +180,46 @@ describe('specializationTreeMapper', () => {
     expect(result[0].system.connections).toContainEqual({ from: 'r1c1', to: 'r1c2', type: 'horizontal' })
     expect(result[0].system.connections).toContainEqual({ from: 'r1c2', to: 'r1c3', type: 'horizontal' })
     expect(result[0].system.connections).toContainEqual({ from: 'r1c2', to: 'r2c2', type: 'vertical' })
+  })
+
+  it('marks trees with partially invalid connections as incomplete', () => {
+    const result = specializationTreeMapper([
+      {
+        Key: 'BODYGUARD',
+        Name: 'Bodyguard',
+        TalentRows: {
+          TalentRow: [
+            {
+              Index: '1',
+              TalentColumns: {
+                TalentColumn: [
+                  {
+                    Index: '1',
+                    TalentKey: 'PARRY',
+                    Cost: '5',
+                    Connections: {
+                      Connection: [
+                        { To: 'r2c1', Type: 'Vertical' },
+                        { To: 'missing-node', Type: 'Vertical' },
+                      ],
+                    },
+                  },
+                ],
+              },
+            },
+            {
+              Index: '2',
+              TalentColumns: {
+                TalentColumn: [{ Index: '1', TalentKey: 'TOUGHENED', Cost: '10' }],
+              },
+            },
+          ],
+        },
+      },
+    ])
+
+    expect(result[0].flags.swerpg.import.status).toBe('incomplete')
+    expect(result[0].flags.swerpg.import.warnings).toEqual(expect.arrayContaining(['invalid-connection:r1c1->missing-node']))
   })
 
   it('logs debug with detected format for talent-rows-keys', () => {

--- a/tests/importer/talent-mapper.spec.mjs
+++ b/tests/importer/talent-mapper.spec.mjs
@@ -15,6 +15,11 @@ vi.mock('../../module/utils/logger.mjs', () => ({
 }))
 
 vi.mock('../../module/importer/utils/talent-import-utils.mjs', () => ({
+  buildTalentImportDiagnostics: (warnings = [], unresolved = false) => ({
+    status: unresolved || warnings.length > 0 ? 'incomplete' : 'valid',
+    warnings,
+    unresolved,
+  }),
   incrementTalentImportStat: vi.fn(),
 }))
 
@@ -145,6 +150,13 @@ describe('OggDudeTalentMapper', () => {
       expect(result.flags.swerpg.import).toBeDefined()
       expect(result.flags.swerpg.import.source).toBe('Test Source')
       expect(result.flags.swerpg.import.sourceText).toBe('Source: Core Rulebook p.100')
+      expect(result.flags.swerpg.import.status).toBe('valid')
+      expect(result.flags.swerpg.import.warnings).toEqual([])
+      expect(result.flags.swerpg.import.raw).toEqual({
+        key: 'force_sensitive',
+        activation: undefined,
+        source: undefined,
+      })
 
       // Vérifier l'absence de champs legacy
       expect(result.system.rank).toBeUndefined()
@@ -181,6 +193,7 @@ describe('OggDudeTalentMapper', () => {
       expect(result.flags.swerpg.import.dieModifiers).toHaveLength(1)
       expect(result.flags.swerpg.import.dieModifiers[0].skillKey).toBe('LORE')
       expect(result.flags.swerpg.import.dieModifiers[0].setbackCount).toBe(1)
+      expect(result.flags.swerpg.import.status).toBe('valid')
 
       expect(result.system.isRanked).toBe(true)
 
@@ -230,6 +243,37 @@ describe('OggDudeTalentMapper', () => {
 
       const result = OggDudeTalentMapper.transform(context)
       expect(result.system.activation).toBe('unspecified')
+      expect(result.flags.swerpg.import.status).toBe('valid')
+      expect(result.flags.swerpg.import.warnings).toEqual([])
+    })
+
+    it('devrait exposer un warning quand l activation source est inconnue', () => {
+      const context = {
+        key: 'odd_talent',
+        name: 'Odd Talent',
+        description: 'Test description',
+        dieModifiers: [],
+        source: 'Test',
+        activation: 'unspecified',
+        hasUnknownActivation: true,
+        isRanked: false,
+        tier: 1,
+        prerequisites: {},
+        originalData: {
+          Activation: 'WeirdAction',
+          Source: 'Edge of the Empire',
+        },
+      }
+
+      const result = OggDudeTalentMapper.transform(context)
+
+      expect(result.flags.swerpg.import.status).toBe('incomplete')
+      expect(result.flags.swerpg.import.warnings).toEqual(['unknown-activation'])
+      expect(result.flags.swerpg.import.raw).toEqual({
+        key: 'odd_talent',
+        activation: 'WeirdAction',
+        source: 'Edge of the Empire',
+      })
     })
   })
 

--- a/tests/lib/talent-node/talent-node-state.test.mjs
+++ b/tests/lib/talent-node/talent-node-state.test.mjs
@@ -256,6 +256,44 @@ describe('TalentNodeState', () => {
       expect(result.reasonCode).toBe(REASON_CODE.NODE_INVALID)
     })
 
+    it('returns invalid when node uses an unresolved unknown placeholder talent id', () => {
+      const actor = buildActor({ specializations: [{ specializationId: 'spec-1' }] })
+      const tree = buildTree({
+        specializationId: 'spec-1',
+        nodes: [{ nodeId: 'r1c1', talentId: 'unknown:spec-1:r1c1', row: 1, cost: 5 }],
+        connections: [{ from: 'r1c1', to: 'r2c1' }],
+      })
+
+      const result = getNodeState(actor, 'spec-1', tree, 'r1c1')
+
+      expect(result.state).toBe(NODE_STATE.INVALID)
+      expect(result.reasonCode).toBe(REASON_CODE.NODE_INVALID)
+    })
+
+    it('returns invalid when tree import flags mark the tree as incomplete', () => {
+      const actor = buildActor({ specializations: [{ specializationId: 'spec-1' }] })
+      const tree = {
+        ...buildTree({
+          specializationId: 'spec-1',
+          nodes: [buildNode()],
+          connections: [{ from: 'r1c1', to: 'r2c1' }],
+        }),
+        flags: {
+          swerpg: {
+            import: {
+              status: 'incomplete',
+              unresolved: true,
+            },
+          },
+        },
+      }
+
+      const result = getNodeState(actor, 'spec-1', tree, 'r1c1')
+
+      expect(result.state).toBe(NODE_STATE.INVALID)
+      expect(result.reasonCode).toBe(REASON_CODE.TREE_INCOMPLETE)
+    })
+
     it('handles actor without talentPurchases gracefully', () => {
       const actor = {
         system: {

--- a/tests/lib/talent-node/talent-tree-resolver.test.mjs
+++ b/tests/lib/talent-node/talent-tree-resolver.test.mjs
@@ -150,4 +150,23 @@ describe('talent-tree-resolver', () => {
       }),
     ).toBe('incomplete')
   })
+
+  it('returns incomplete for trees flagged as unresolved by import diagnostics', () => {
+    expect(
+      getSpecializationTreeResolutionState({
+        flags: {
+          swerpg: {
+            import: {
+              status: 'incomplete',
+              unresolved: true,
+            },
+          },
+        },
+        system: {
+          nodes: [{ nodeId: 'r1c1' }],
+          connections: [{ from: 'r1c1', to: 'r2c1' }],
+        },
+      }),
+    ).toBe('incomplete')
+  })
 })


### PR DESCRIPTION
## Summary
- standardize `flags.swerpg.import` diagnostics for OggDude talents and specialization trees with `status`, `warnings`, `unresolved`, and `raw`
- propagate incomplete import diagnostics into specialization-tree and talent mapping, including unknown activation and invalid connection warnings
- block unreliable talent tree purchases in domain resolution when imported nodes or trees remain unresolved

## Testing
- pnpm vitest run tests/importer/specialization-tree-ogg-dude.spec.mjs tests/importer/talent-mapper.spec.mjs tests/lib/talent-node/talent-tree-resolver.test.mjs tests/lib/talent-node/talent-node-state.test.mjs
- pnpm vitest run tests/importer tests/lib/talent-node

Closes #195