### PR TITLE
US12: refondre l'onglet Talents en vue consolidée

### DIFF
--- a/documentation/plan/character-sheet/talent/196-plan-refondre-onglet-talents-vue-consolidee.md
+++ b/documentation/plan/character-sheet/talent/196-plan-refondre-onglet-talents-vue-consolidee.md
@@ -1,0 +1,328 @@
+# Plan d'implementation - US12 : Refondre l'onglet Talents en vue consolidee
+
+**Issue** : [#196 - US12: Refondre l'onglet Talents en vue consolidee](https://github.com/herveDarritchon/foundryvtt-swerpg/issues/196)
+**Epic** : [#184 - EPIC: Refonte V1 des talents Edge](https://github.com/herveDarritchon/foundryvtt-swerpg/issues/184)
+**ADR** : `documentation/architecture/adr/adr-0001-foundry-applicationv2-adoption.md`, `documentation/architecture/adr/adr-0004-vitest-testing-strategy.md`, `documentation/architecture/adr/adr-0005-localization-strategy.md`, `documentation/architecture/adr/adr-0010-architecture-des-effets-mecaniques-des-talents.md`
+**Module(s) impacte(s)** : `module/applications/sheets/character-sheet.mjs` (modification), `templates/sheets/actor/talents.hbs` (modification), `styles/actor.less` (modification), `lang/fr.json` (modification potentielle), `lang/en.json` (modification potentielle), `tests/applications/sheets/character-sheet-talents.test.mjs` (modification)
+
+---
+
+## 1. Objectif
+
+Remplacer l'ancien onglet Talents de la fiche personnage par une vue de consultation consolidee, alimentee par la couche domaine deja introduite avec US7.
+
+Le resultat attendu est un onglet lisible en jeu, sans achat direct, sans persistance d'une vue derivee, et tolerant aux donnees incompletes.
+
+---
+
+## 2. Perimetre
+
+### Inclus dans cette US / ce ticket
+
+- Brancher l'onglet Talents sur la vue consolidee derivee de `actor.system.progression.talentPurchases`.
+- Afficher pour chaque talent :
+  - nom ;
+  - activation ;
+  - ranked / non-ranked ;
+  - rang consolide si applicable ;
+  - source(s) lisibles.
+- Garantir une seule entree pour un talent ranked, avec rang consolide.
+- Garantir une seule entree pour un talent non-ranked, meme multi-arbres.
+- Gerer les cas degrades sans bloquer l'onglet :
+  - talent introuvable ;
+  - source non resolue ;
+  - arbre incomplet ;
+  - noeud manquant.
+- Stabiliser un ordre d'affichage simple et previsible.
+- Ajouter ou ajuster les tests Vitest cibles sur la preparation de contexte de fiche.
+
+### Exclu de cette US / ce ticket
+
+- Achat depuis l'onglet Talents.
+- Drag & drop.
+- Suppression / remboursement.
+- Edition manuelle.
+- Automatisation des effets mecaniques / `ActiveEffect`.
+- Persistance de la vue consolidee dans `system` ou `flags`.
+- Refonte de la vue graphique des arbres de specialisation.
+- Ajout d'un acces depuis l'onglet Talents vers la vue graphique.
+- Refonte du legacy `actor-mixins/talents.mjs` au-dela de ce qui est strictement necessaire pour ne pas interferer.
+
+---
+
+## 3. Constat sur l'existant
+
+- La couche domaine existe deja :
+  - `module/lib/talent-node/owned-talent-summary.mjs`
+  - `module/lib/talent-node/talent-tree-resolver.mjs`
+- La dependance fonctionnelle principale `#191` est livree : la vue consolidee est calculee a partir de `talentPurchases` et non persistee.
+- `module/applications/sheets/character-sheet.mjs` appelle deja `buildOwnedTalentSummary()` via `#buildConsolidatedTalentList()`.
+- `templates/sheets/actor/talents.hbs` affiche deja une liste consolidee minimale.
+- `tests/applications/sheets/character-sheet-talents.test.mjs` couvrent deja une partie du mapping sheet -> template data.
+- `styles/actor.less` possede une section `.tab.talents`, mais pas de stylage explicite des nouvelles classes `talent-consolidated`, `talent-rank`, `talent-sources`.
+- Les cles i18n de base existent deja :
+  - `SWERPG.TALENT.ACTIVE`
+  - `SWERPG.TALENT.PASSIVE`
+  - `SWERPG.TALENT.RANKED`
+  - `SWERPG.TALENT.UNKNOWN`
+  - `SWERPG.TALENT.UNKNOWN_SOURCE`
+  - `SWERPG.TALENT.SOURCES`
+- L'onglet n'est pas encore completement aligne avec le cadrage :
+  - pas d'ordre d'affichage stabilise ;
+  - pas de strategie documentee pour les etats degrades fins ;
+  - pas de rendu explicite du caractere non-ranked ;
+  - pas de stylage dedie ;
+  - aucun point d'entree visible vers la vue graphique, bien qu'un handler `talentTree` existe cote `CharacterSheet`.
+
+---
+
+## 4. Decisions d'architecture
+
+### 4.1. L'onglet Talents consomme exclusivement la couche domaine consolidee
+
+**Decision** : l'onglet lit `buildOwnedTalentSummary()` et n'accede pas directement a `talentPurchases` pour reconstruire sa propre logique.
+
+Justification :
+
+- conforme a l'issue ;
+- conforme au cadrage `01-modele-domaine-talents.md` et `04-ui-onglet-talents.md` ;
+- evite de dupliquer la logique metier dans l'UI ;
+- reduit le risque de divergence entre US7 et US12.
+
+### 4.2. La vue consolidee reste derivee et non persistee
+
+**Decision** : aucune donnee supplementaire n'est ecrite dans `actor.system` ou `actor.flags`.
+
+Justification :
+
+- conforme a US7 et au cadrage ;
+- evite une deuxieme source de verite ;
+- garde le recalcul naturel apres achat ou import.
+
+### 4.3. Presentation minimale retenue : liste simple triee
+
+**Decision** : afficher une liste plate, lisible et stable, sans regroupement visuel par activation en V1.
+
+Justification :
+
+- choix valide ;
+- plus simple a implementer et a tester ;
+- suffisant pour satisfaire l'issue ;
+- evite d'introduire une structure de sections non demandee.
+
+### 4.4. Tri d'affichage deterministe au niveau feuille
+
+**Decision** : appliquer un tri UI stable sur les entrees consolidees avant rendu, sans modifier le contrat domaine de US7.
+
+Ordre recommande :
+
+- nom resolu croissant ;
+- a defaut, libelle degrade ;
+- en cas d'egalite, `talentId`.
+
+Justification :
+
+- ameliore la lisibilite en jeu ;
+- limite les variations d'ordre dues a l'historique d'achat ;
+- garde la logique metier independante des preferences d'affichage.
+
+### 4.5. Les sources sont deduites pour l'affichage
+
+**Decision** : l'UI deduplique les libelles de source affiches, meme si plusieurs achats d'un talent ranked proviennent d'une meme specialisation.
+
+Justification :
+
+- l'utilisateur attend des sources lisibles, pas une repetition de labels identiques ;
+- le rang reste porte par `entry.rank`, donc la perte d'information n'affecte pas la progression ;
+- la granularite achat-par-noeud reste disponible dans la couche domaine si necessaire ailleurs.
+
+### 4.6. Les etats degrages restent non bloquants et localises
+
+**Decision** : toute entree invalide ou partiellement resolue reste affichee avec fallback lisible.
+
+Regles minimales :
+
+- nom manquant -> `SWERPG.TALENT.UNKNOWN`
+- source non resolue -> `SWERPG.TALENT.UNKNOWN_SOURCE`
+- activation inconnue ou absente -> libelle neutre ou absence de tag, selon la cle disponible
+- aucun crash ni filtrage silencieux d'une entree achetee
+
+Justification :
+
+- conforme a l'issue ;
+- conforme au cadrage UI ;
+- utile pour les imports incomplets et le diagnostic.
+
+### 4.7. Aucun acces a la vue graphique dans cette US
+
+**Decision** : meme si `actor.toggleTalentTree()` existe deja, US12 ne cree pas de bouton ni d'action d'ouverture depuis l'onglet Talents.
+
+Justification :
+
+- choix valide ;
+- l'issue #196 est centree sur la vue consolidee ;
+- evite d'elargir la US a un couplage avec la vue graphique des arbres.
+
+### 4.8. Les effets mecaniques restent explicitement hors scope
+
+**Decision** : l'onglet n'interprete pas `system.effects`, n'applique aucun `ActiveEffect` et n'enrichit pas le rendu avec de la logique mecanique.
+
+Justification :
+
+- conforme a l'issue ;
+- conforme a ADR-0010 ;
+- evite de melanger vue de possession et automatisation metier.
+
+---
+
+## 5. Plan de travail detaille
+
+### Etape 1 - Auditer et stabiliser l'adaptateur UI de l'onglet Talents
+
+**Quoi faire** : revoir `#buildConsolidatedTalentList()` dans `module/applications/sheets/character-sheet.mjs` pour garantir un contrat template propre :
+
+- ordre stable ;
+- source labels dedupliques ;
+- libelles degrages coherents ;
+- exposition explicite des donnees utiles au template.
+
+**Fichiers** :
+
+- `module/applications/sheets/character-sheet.mjs`
+
+**Risques** :
+
+- casser les tests existants en modifiant le contrat de rendu ;
+- introduire un tri dependant de labels localises si le tri est applique trop tard.
+
+### Etape 2 - Refaire le template de l'onglet Talents autour de la vue consolidee
+
+**Quoi faire** : adapter `templates/sheets/actor/talents.hbs` pour afficher clairement :
+
+- nom ;
+- tags d'activation ;
+- statut ranked / non-ranked ;
+- rang si applicable ;
+- sources.
+
+Le template doit rester purement declaratif, sans action d'achat.
+
+**Fichiers** :
+
+- `templates/sheets/actor/talents.hbs`
+
+**Risques** :
+
+- afficher implicitement certaines infos sans les rendre lisibles ;
+- conserver des hypotheses de rendu legacy liees aux `Item` embarques.
+
+### Etape 3 - Ajouter le stylage dedie a l'onglet Talents consolide
+
+**Quoi faire** : completer `styles/actor.less` pour prendre en charge la structure reelle du template consolide :
+
+- espacement ;
+- lisibilite des tags ;
+- mise en valeur du rang ;
+- affichage compact et lisible des sources ;
+- comportement correct sur largeur reduite.
+
+**Fichiers** :
+
+- `styles/actor.less`
+
+**Risques** :
+
+- regression visuelle sur d'autres `.line-item` si les selecteurs sont trop larges ;
+- mauvais rendu mobile/etroit si la hierarchie n'est pas specifique a `.tab.talents`.
+
+### Etape 4 - Completer l'i18n si des libelles manquent
+
+**Quoi faire** : verifier si l'onglet a besoin de nouvelles cles pour :
+
+- non-ranked ;
+- rang ;
+- etat non specifie ;
+- eventuel message vide si aucun talent n'est possede.
+
+N'ajouter des cles que si les libelles existants ne suffisent pas.
+
+**Fichiers** :
+
+- `lang/fr.json`
+- `lang/en.json`
+
+**Risques** :
+
+- introduire des cles non utilisees ;
+- incoherence FR/EN.
+
+### Etape 5 - Etendre les tests de feuille personnage
+
+**Quoi faire** : completer `tests/applications/sheets/character-sheet-talents.test.mjs` pour couvrir :
+
+- tri stable ;
+- deduplication des sources affichees ;
+- rendu degrade non bloquant ;
+- absence d'achat direct ;
+- talents ranked et non-ranked ;
+- multi-spe.
+
+Ajouter des scenarios cibles seulement si le contrat feuille change reellement.
+
+**Fichiers** :
+
+- `tests/applications/sheets/character-sheet-talents.test.mjs`
+
+**Risques** :
+
+- tests trop couples a des details de presentation ;
+- oublier un scenario degrade alors qu'il est demande par l'issue.
+
+---
+
+## 6. Fichiers modifies
+
+| Fichier | Action | Description du changement |
+|---|---|---|
+| `module/applications/sheets/character-sheet.mjs` | modification | Stabiliser l'adaptation de `buildOwnedTalentSummary()` vers les donnees template-ready |
+| `templates/sheets/actor/talents.hbs` | modification | Remplacer le rendu implicite par un affichage consolide explicite et non interactif |
+| `styles/actor.less` | modification | Ajouter le stylage specifique de l'onglet Talents consolide |
+| `lang/fr.json` | modification potentielle | Ajouter les libelles manquants cote FR si besoin reel |
+| `lang/en.json` | modification potentielle | Ajouter les libelles manquants cote EN si besoin reel |
+| `tests/applications/sheets/character-sheet-talents.test.mjs` | modification | Couvrir le contrat final de preparation de contexte et les cas degrages |
+| `tests/lib/talent-node/owned-talent-summary.test.mjs` | modification optionnelle | Uniquement si un ecart domaine reel est decouvert pendant l'alignement UI |
+
+---
+
+## 7. Risques
+
+| Risque | Impact | Mitigation |
+|---|---|---|
+| L'UI re-duplique de la logique metier | Divergence entre US7 et US12 | Garder toute consolidation dans `owned-talent-summary` et limiter la fiche a l'adaptation d'affichage |
+| Ordre d'affichage instable | Mauvaise lisibilite et tests fragiles | Definir un tri explicite et le documenter dans les tests |
+| Sources repetees pour un talent ranked | Affichage confus | Dedupliquer les labels de sources cote presentation |
+| Etats degrages masques | Donnees achetees invisibles | Toujours afficher une entree avec fallback localise |
+| Selecteurs LESS trop generiques | Regression visuelle sur d'autres onglets | Scoper le CSS sous `.swerpg.sheet.actor .tab.talents` |
+| Ajout i18n incomplet | Libelles bruts ou cles visibles | Verifier FR/EN ensemble et ne creer que les cles necessaires |
+| Glissement de scope vers la vue graphique | US plus large que prevu | Exclure explicitement le bouton d'acces et tout achat depuis l'onglet |
+
+---
+
+## 8. Proposition d'ordre de commit
+
+1. `feat(character-sheet): adapt talents tab data to consolidated talent summary`
+2. `feat(character-sheet): refactor talents tab template for consolidated display`
+3. `style(character-sheet): polish consolidated talents tab layout`
+4. `test(character-sheet): cover consolidated talents tab states and fallbacks`
+
+Si de nouvelles cles i18n sont reellement necessaires :
+
+5. `i18n(talent): add missing labels for consolidated talents tab`
+
+---
+
+## 9. Dependances avec les autres US
+
+- **Bloquante** : `#191` / US7, deja identifiee par l'issue. US12 depend de `buildOwnedTalentSummary()` comme source UI.
+- **Amelioration mais non bloquante** : `#193` / US9, qui fiabilise le referentiel des definitions generiques de talents. US12 peut fonctionner avec des fallbacks tant que certaines definitions restent incompletes.
+- **Hors dependance directe dans cette US** : la vue graphique des arbres de specialisation. Le cadrage la mentionne, mais le choix retenu est de ne pas l'integrer a US12.

--- a/lang/en.json
+++ b/lang/en.json
@@ -1109,6 +1109,8 @@
     "PASSIVE": "Passive",
     "UNSPECIFIED": "Unspecified",
     "RANKED": "Ranked",
+    "NON_RANKED": "Non-ranked",
+    "RANK": "Rank",
     "UNKNOWN": "Unknown Talent",
     "UNKNOWN_SOURCE": "Unknown Source",
     "SOURCES": "Sources",

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -1101,6 +1101,8 @@
     "PASSIVE": "Passif",
     "UNSPECIFIED": "Non spécifié",
     "RANKED": "Ranked",
+    "NON_RANKED": "Non ranked",
+    "RANK": "Rang",
     "UNKNOWN": "Talent inconnu",
     "UNKNOWN_SOURCE": "Source inconnue",
     "SOURCES": "Sources",

--- a/module/applications/sheets/character-sheet.mjs
+++ b/module/applications/sheets/character-sheet.mjs
@@ -925,6 +925,9 @@ export default class CharacterSheet extends SwerpgBaseActorSheet {
   #buildConsolidatedTalentList() {
     const definitions = this.#buildTalentDefinitions()
     const summary = buildOwnedTalentSummary(this.actor, definitions)
+    const unknownTalentLabel = game.i18n.localize('SWERPG.TALENT.UNKNOWN')
+    const unknownSourceLabel = game.i18n.localize('SWERPG.TALENT.UNKNOWN_SOURCE')
+    const unspecifiedActivationLabel = game.i18n.localize('SWERPG.TALENT.UNSPECIFIED')
 
     return summary.map((entry) => {
       const tags = []
@@ -932,31 +935,42 @@ export default class CharacterSheet extends SwerpgBaseActorSheet {
         tags.push({ label: game.i18n.localize('SWERPG.TALENT.ACTIVE'), cssClass: 'tag-active' })
       } else if (entry.activation === 'passive') {
         tags.push({ label: game.i18n.localize('SWERPG.TALENT.PASSIVE'), cssClass: 'tag-passive' })
+      } else {
+        tags.push({ label: unspecifiedActivationLabel, cssClass: 'tag-neutral' })
       }
+
       if (entry.isRanked) {
-        tags.push({ label: game.i18n.localize('SWERPG.TALENT.RANKED') })
+        tags.push({ label: game.i18n.localize('SWERPG.TALENT.RANKED'), cssClass: 'tag-ranked' })
+      } else if (entry.isRanked === false) {
+        tags.push({ label: game.i18n.localize('SWERPG.TALENT.NON_RANKED'), cssClass: 'tag-neutral' })
       }
 
-      const sourceLabels = entry.sources.map((s) => {
+      const sourceLabels = Array.from(new Set(entry.sources.map((s) => {
         if (s.resolutionState === 'ok') {
-          return s.specializationName || s.treeName || game.i18n.localize('SWERPG.TALENT.UNKNOWN_SOURCE')
+          return s.specializationName || s.treeName || unknownSourceLabel
         }
-        return game.i18n.localize('SWERPG.TALENT.UNKNOWN_SOURCE')
-      })
+        return unknownSourceLabel
+      })))
 
-      let rankValue = '-'
-      if (entry.isRanked && entry.rank !== null) {
-        rankValue = entry.rank
-      }
+      const rankValue = entry.isRanked && entry.rank !== null ? entry.rank : null
+      const displayName = entry.name || unknownTalentLabel
 
       return {
         talentId: entry.talentId,
-        name: entry.name || game.i18n.localize('SWERPG.TALENT.UNKNOWN'),
+        name: displayName,
         tags,
         isRanked: entry.isRanked,
         rank: rankValue,
         sourceLabels,
       }
+    }).sort((left, right) => {
+      const leftName = left.name || unknownTalentLabel
+      const rightName = right.name || unknownTalentLabel
+
+      const nameCompare = leftName.localeCompare(rightName)
+      if (nameCompare !== 0) return nameCompare
+
+      return left.talentId.localeCompare(right.talentId)
     })
   }
 

--- a/styles/actor.less
+++ b/styles/actor.less
@@ -1704,6 +1704,91 @@
         justify-content: flex-end;
       }
     }
+
+    .talent-consolidated {
+      flex-direction: column;
+      align-items: stretch;
+      gap: 0.35rem;
+      padding: 0.4rem 0.55rem;
+
+      .talent-consolidated__header {
+        display: flex;
+        align-items: flex-start;
+        justify-content: space-between;
+        gap: 0.5rem;
+      }
+
+      .talent-consolidated__title-group {
+        display: flex;
+        align-items: center;
+        flex-wrap: wrap;
+        gap: 0.35rem;
+        min-width: 0;
+      }
+
+      .talent-consolidated__name {
+        margin: 0;
+      }
+
+      .talent-consolidated__tag {
+        white-space: nowrap;
+      }
+
+      .talent-consolidated__details {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        flex-wrap: wrap;
+        gap: 0.35rem 0.75rem;
+        color: #d0e6f6;
+      }
+
+      .tag-neutral {
+        background: rgba(122, 138, 156, 0.25);
+        border: 1px solid rgba(155, 176, 194, 0.4);
+        color: #c2d5e5;
+      }
+
+      .tag-ranked {
+        background: rgba(201, 179, 106, 0.18);
+        border: 1px solid rgba(201, 179, 106, 0.35);
+        color: #e4d29d;
+      }
+
+      .talent-rank {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.25rem;
+        font-size: var(--font-size-12);
+      }
+
+      .talent-rank__label,
+      .source-label {
+        color: #9bb0c2;
+        font-weight: 600;
+      }
+
+      .talent-rank__value {
+        color: #f0e0a0;
+        font-weight: 700;
+      }
+
+      .talent-sources {
+        display: inline-flex;
+        align-items: baseline;
+        flex-wrap: wrap;
+        gap: 0.25rem;
+        min-width: 0;
+      }
+
+      .source-values {
+        min-width: 0;
+      }
+
+      .source-name {
+        color: #d0e6f6;
+      }
+    }
   }
 
   /* ----------------------------------------- */

--- a/styles/swerpg.css
+++ b/styles/swerpg.css
@@ -2387,6 +2387,77 @@ input[type='range'] {
   flex: 0.5;
   justify-content: flex-end;
 }
+.swerpg.sheet.actor .tab.talents .talent-consolidated {
+  flex-direction: column;
+  align-items: stretch;
+  gap: 0.35rem;
+  padding: 0.4rem 0.55rem;
+}
+.swerpg.sheet.actor .tab.talents .talent-consolidated .talent-consolidated__header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 0.5rem;
+}
+.swerpg.sheet.actor .tab.talents .talent-consolidated .talent-consolidated__title-group {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 0.35rem;
+  min-width: 0;
+}
+.swerpg.sheet.actor .tab.talents .talent-consolidated .talent-consolidated__name {
+  margin: 0;
+}
+.swerpg.sheet.actor .tab.talents .talent-consolidated .talent-consolidated__tag {
+  white-space: nowrap;
+}
+.swerpg.sheet.actor .tab.talents .talent-consolidated .talent-consolidated__details {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: 0.35rem 0.75rem;
+  color: #d0e6f6;
+}
+.swerpg.sheet.actor .tab.talents .talent-consolidated .tag-neutral {
+  background: rgba(122, 138, 156, 0.25);
+  border: 1px solid rgba(155, 176, 194, 0.4);
+  color: #c2d5e5;
+}
+.swerpg.sheet.actor .tab.talents .talent-consolidated .tag-ranked {
+  background: rgba(201, 179, 106, 0.18);
+  border: 1px solid rgba(201, 179, 106, 0.35);
+  color: #e4d29d;
+}
+.swerpg.sheet.actor .tab.talents .talent-consolidated .talent-rank {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  font-size: var(--font-size-12);
+}
+.swerpg.sheet.actor .tab.talents .talent-consolidated .talent-rank__label,
+.swerpg.sheet.actor .tab.talents .talent-consolidated .source-label {
+  color: #9bb0c2;
+  font-weight: 600;
+}
+.swerpg.sheet.actor .tab.talents .talent-consolidated .talent-rank__value {
+  color: #f0e0a0;
+  font-weight: 700;
+}
+.swerpg.sheet.actor .tab.talents .talent-consolidated .talent-sources {
+  display: inline-flex;
+  align-items: baseline;
+  flex-wrap: wrap;
+  gap: 0.25rem;
+  min-width: 0;
+}
+.swerpg.sheet.actor .tab.talents .talent-consolidated .source-values {
+  min-width: 0;
+}
+.swerpg.sheet.actor .tab.talents .talent-consolidated .source-name {
+  color: #d0e6f6;
+}
 .swerpg.sheet.actor .tab.skills.skills.skills {
   /* ----------------------------------------- */
   /*  Legacy Skill Container                    */

--- a/templates/sheets/actor/talents.hbs
+++ b/templates/sheets/actor/talents.hbs
@@ -3,28 +3,34 @@
   data-tab="{{tabs.talents.id}}"
   data-group="{{tabs.talents.group}}"
 >
-
   {{#each talents as |talent|}}
-    <div class="line-item talent-consolidated" data-talent-id="{{talent.talentId}}">
-      <div class="title">
-        <h4 class="item-header">{{talent.name}}</h4>
-        <div class="tags">
+    <article class="line-item talent-consolidated" data-talent-id="{{talent.talentId}}">
+      <div class="talent-consolidated__header">
+        <div class="talent-consolidated__title-group">
+          <h4 class="item-header talent-consolidated__name">{{talent.name}}</h4>
           {{#each talent.tags as |tag|}}
-            <span class="tag {{tag.cssClass}}">{{tag.label}}</span>
+            <span class="tag {{tag.cssClass}} talent-consolidated__tag">{{tag.label}}</span>
           {{/each}}
         </div>
       </div>
-      <div class="talent-rank">
+
+      <div class="talent-consolidated__details">
         {{#if talent.isRanked}}
-          {{talent.rank}}
+          <div class="talent-rank">
+            <span class="talent-rank__label">{{localize 'SWERPG.TALENT.RANK'}}:</span>
+            <span class="talent-rank__value">{{talent.rank}}</span>
+          </div>
         {{/if}}
+
+        <div class="talent-sources">
+          <span class="source-label">{{localize 'SWERPG.TALENT.SOURCES'}}:</span>
+          <span class="source-values">
+            {{#each talent.sourceLabels as |source|}}
+              <span class="source-name">{{source}}{{#unless @last}}, {{/unless}}</span>
+            {{/each}}
+          </span>
+        </div>
       </div>
-      <div class="talent-sources">
-        <span class="source-label">{{localize 'SWERPG.TALENT.SOURCES'}}:</span>
-        {{#each talent.sourceLabels as |source i|}}
-          <span class="source-name">{{source}}{{#unless @last}}, {{/unless}}</span>
-        {{/each}}
-      </div>
-    </div>
+    </article>
   {{/each}}
 </section>

--- a/tests/applications/sheets/character-sheet-talents.test.mjs
+++ b/tests/applications/sheets/character-sheet-talents.test.mjs
@@ -19,7 +19,7 @@ vi.mock('../../../module/lib/talent-node/owned-talent-summary.mjs', () => ({
 
 import { buildOwnedTalentSummary } from '../../../module/lib/talent-node/owned-talent-summary.mjs'
 
-describe('CharacterSheet talent consolidation (US8)', () => {
+describe('CharacterSheet talent consolidation (US12)', () => {
   let CharacterSheet
   let SwerpgBaseActorSheet
 
@@ -126,7 +126,7 @@ describe('CharacterSheet talent consolidation (US8)', () => {
     expect(entry.sourceLabels).toEqual(['Bodyguard', 'Mercenary Soldier'])
     expect(entry.tags).toEqual([
       { label: 'SWERPG.TALENT.ACTIVE', cssClass: 'tag-active' },
-      { label: 'SWERPG.TALENT.RANKED' },
+      { label: 'SWERPG.TALENT.RANKED', cssClass: 'tag-ranked' },
     ])
   })
 
@@ -148,9 +148,10 @@ describe('CharacterSheet talent consolidation (US8)', () => {
 
     const entry = context.talents[0]
     expect(entry.isRanked).toBe(false)
-    expect(entry.rank).toBe('-')
+    expect(entry.rank).toBeNull()
     expect(entry.tags).toEqual([
       { label: 'SWERPG.TALENT.PASSIVE', cssClass: 'tag-passive' },
+      { label: 'SWERPG.TALENT.NON_RANKED', cssClass: 'tag-neutral' },
     ])
   })
 
@@ -172,8 +173,10 @@ describe('CharacterSheet talent consolidation (US8)', () => {
 
     const entry = context.talents[0]
     expect(entry.name).toBe('SWERPG.TALENT.UNKNOWN')
-    expect(entry.tags).toEqual([])
-    expect(entry.rank).toBe('-')
+    expect(entry.tags).toEqual([
+      { label: 'SWERPG.TALENT.UNSPECIFIED', cssClass: 'tag-neutral' },
+    ])
+    expect(entry.rank).toBeNull()
   })
 
   it('uses unknown source label when resolution state is not ok', async () => {
@@ -207,6 +210,7 @@ describe('CharacterSheet talent consolidation (US8)', () => {
         sources: [
           { specializationName: 'Bodyguard', resolutionState: 'ok' },
           { specializationName: 'Mercenary Soldier', resolutionState: 'ok' },
+          { specializationName: 'Bodyguard', resolutionState: 'ok' },
         ],
       },
     ])
@@ -217,5 +221,43 @@ describe('CharacterSheet talent consolidation (US8)', () => {
     const entry = context.talents[0]
     expect(entry.sourceLabels).toHaveLength(2)
     expect(entry.sourceLabels).toEqual(['Bodyguard', 'Mercenary Soldier'])
+  })
+
+  it('sorts consolidated entries by display name then talent id', async () => {
+    buildOwnedTalentSummary.mockReturnValue([
+      {
+        talentId: 'talent-zeta',
+        name: 'Zeta',
+        activation: 'passive',
+        isRanked: false,
+        rank: null,
+        sources: [{ specializationName: 'Bodyguard', resolutionState: 'ok' }],
+      },
+      {
+        talentId: 'talent-alpha-b',
+        name: 'Alpha',
+        activation: 'active',
+        isRanked: true,
+        rank: 1,
+        sources: [{ specializationName: 'Pilot', resolutionState: 'ok' }],
+      },
+      {
+        talentId: 'talent-alpha-a',
+        name: 'Alpha',
+        activation: 'passive',
+        isRanked: false,
+        rank: null,
+        sources: [{ specializationName: 'Explorer', resolutionState: 'ok' }],
+      },
+    ])
+
+    const actor = buildMockActor()
+    const context = await getContext(actor)
+
+    expect(context.talents.map((entry) => entry.talentId)).toEqual([
+      'talent-alpha-a',
+      'talent-alpha-b',
+      'talent-zeta',
+    ])
   })
 })


### PR DESCRIPTION
Closes #196

## Summary
- branche l'onglet Talents sur la vue consolidée et stabilise le tri ainsi que les fallbacks UI
- refond le template et le style pour afficher activation, ranked/non-ranked, rang et sources de façon lisible
- ajoute les clés i18n manquantes et étend les tests Vitest ciblés sur la fiche personnage

## Validation
- `pnpm vitest run tests/applications/sheets/character-sheet-talents.test.mjs`