### PR TITLE
feat(talent-tree): show node details and lock reasons in specialization tree graph view

### DIFF
--- a/documentation/plan/character-sheet/talent/235-plan-fix-afficher-detail-noeuds-raisons-blocage-vue-graphique.md
+++ b/documentation/plan/character-sheet/talent/235-plan-fix-afficher-detail-noeuds-raisons-blocage-vue-graphique.md
@@ -1,0 +1,288 @@
+# Plan d'implémentation — #235 : Afficher le détail des nœuds et les raisons de blocage (US16)
+
+**Issue** : [#235 — Afficher le détail des nœuds et les raisons de blocage (US16)](https://github.com/herveDarritchon/foundryvtt-swerpg/issues/235)  
+**Epic** : [#184 — EPIC: Refonte V1 des talents Edge — modèle, onglet talents et arbres de spécialisation](https://github.com/herveDarritchon/foundryvtt-swerpg/issues/184)  
+**Issue parente** : [#200 — US16: Afficher arbres, nœuds et connexions dans la vue graphique](https://github.com/herveDarritchon/foundryvtt-swerpg/issues/200)  
+**ADR** : `documentation/architecture/adr/adr-0001-foundry-applicationv2-adoption.md`, `documentation/architecture/adr/adr-0004-vitest-testing-strategy.md`, `documentation/architecture/adr/adr-0005-localization-strategy.md`, `documentation/architecture/adr/adr-0012-unit-tests-readable-diagnostics.md`  
+**Module(s) impacté(s)** : `module/applications/specialization-tree-app.mjs` (modification), `templates/applications/specialization-tree-app.hbs` (modification), `styles/applications.less` (modification), `lang/fr.json` (modification), `lang/en.json` (modification), `tests/applications/specialization-tree-app.test.mjs` (modification)
+
+---
+
+## 1. Objectif
+
+Compléter la vue graphique des arbres de spécialisation pour qu'un utilisateur puisse consulter, au clic sur un nœud, les informations minimales utiles sans déclencher d'achat ni introduire d'état applicatif persistant.
+
+Le résultat attendu est une consultation en lecture seule du nœud courant avec :
+- nom du talent ;
+- coût XP ;
+- indication ranked / non-ranked si disponible ;
+- état du nœud ;
+- raison localisée compréhensible si le nœud est `locked` ou `invalid`.
+
+---
+
+## 2. Périmètre
+
+### Inclus dans cette US / ce ticket
+
+- Ajouter au view-model de rendu les métadonnées de détail nécessaires à l'affichage du nœud consulté.
+- Introduire un mapping applicatif `reasonCode -> clé i18n`.
+- Afficher un tooltip DOM léger au clic sur un nœud du viewport.
+- Exposer un fallback compréhensible pour les cas invalides ou incomplets.
+- Ajouter les clés i18n FR/EN des raisons utilisateur.
+- Étendre les tests du contrat de rendu et du mapping des raisons.
+
+### Exclu de cette US / ce ticket
+
+- Achat de nœud depuis la vue -> US18.
+- Sélection persistée d'un nœud ou d'une spécialisation -> hors périmètre de `#235`.
+- Panneau latéral interactif ou état UI durable.
+- Recalcul des règles métier de verrouillage côté UI.
+- Modification de `actor.system`, `actor.flags` ou du data model.
+- Refonte du moteur PIXI ou du resolver d'arbres.
+
+---
+
+## 3. Constat sur l'existant
+
+- `module/applications/specialization-tree-app.mjs` calcule déjà :
+  - les spécialisations possédées ;
+  - le dernier arbre `available` affiché par défaut ;
+  - les `renderNodes` et `renderConnections` ;
+  - les variantes visuelles de nœud ;
+  - le label localisé de `nodeState`.
+- Le rendu PIXI dessine déjà les connexions, les cartes de nœud, le nom du talent et le coût XP.
+- Aucune interaction de consultation n'existe encore dans le viewport :
+  - pas de hit area explicite ;
+  - pas de tooltip ;
+  - pas de détail synchronisé au clic.
+- `module/lib/talent-node/talent-node-state.mjs` expose déjà les `reasonCode` métier utiles :
+  - `already-purchased`
+  - `specialization-not-owned`
+  - `tree-not-found`
+  - `tree-incomplete`
+  - `node-not-found`
+  - `node-invalid`
+  - `node-locked`
+  - `not-enough-xp`
+- La couche application n'exploite aujourd'hui ni `reasonCode` ni `details`.
+- Les fichiers `lang/fr.json` et `lang/en.json` contiennent déjà les clés de statut de l'application graphique, mais pas encore les libellés détaillés des raisons de blocage.
+- Les tests `tests/applications/specialization-tree-app.test.mjs` couvrent déjà :
+  - le contexte vide ;
+  - le choix du dernier arbre disponible ;
+  - la construction des nœuds et connexions ;
+  - les variantes d'état ;
+  - l'absence de comportement d'achat pendant le rendu.
+- L'issue `#234` bloquante est fermée : les variantes visuelles sont donc déjà livrées et `#235` peut se concentrer sur le détail consultatif.
+
+---
+
+## 4. Décisions d'architecture
+
+### 4.1. Détail minimal via tooltip DOM léger
+
+**Problème** : il faut afficher un détail compréhensible sans introduire de panneau complexe ni d'état applicatif persistant.
+
+**Options envisagées** :
+- panneau latéral interactif ;
+- libellé DOM adjacent permanent ;
+- tooltip DOM léger synchronisé au nœud.
+
+**Décision retenue** : utiliser un tooltip DOM léger affiché au clic sur un nœud.
+
+**Justification** :
+- respecte explicitement le cadrage de `#235` ;
+- reste léger dans une application `ApplicationV2` conforme à ADR-0001 ;
+- évite de transformer la consultation en navigation secondaire.
+
+### 4.2. Clic uniquement comme contrat principal
+
+**Problème** : l'issue mentionne "survol ou clic", mais il faut un contrat de test clair et stable.
+
+**Options envisagées** :
+- survol ;
+- survol + clic ;
+- clic uniquement.
+
+**Décision retenue** : considérer le clic comme contrat principal de l'US.
+
+**Justification** :
+- plus explicite pour un canvas PIXI ;
+- réduit l'ambiguïté de timing et d'accessibilité du survol ;
+- simplifie les tests applicatifs sans figer un comportement hover fragile.
+
+### 4.3. Mapping des raisons dans la couche application
+
+**Problème** : `reasonCode` est exploitable techniquement mais pas affichable tel quel à l'utilisateur.
+
+**Décision retenue** : faire le mapping `reasonCode -> clé i18n` dans `specialization-tree-app.mjs`.
+
+**Justification** :
+- conforme à ADR-0005 ;
+- préserve la pureté de la couche domaine ;
+- permet d'améliorer le wording sans toucher au moteur métier.
+
+### 4.4. Réutiliser `getTreeNodesStates()` comme source unique
+
+**Problème** : l'UI ne doit pas re-déduire localement les raisons ou les états.
+
+**Décision retenue** : enrichir le view-model à partir des résultats existants de `getTreeNodesStates()`.
+
+**Justification** :
+- une seule source de vérité ;
+- pas de divergence entre achat futur, affichage et tests ;
+- cohérent avec le découpage des responsabilités déjà en place.
+
+### 4.5. Pas d'état persistant dans l'application ni dans l'acteur
+
+**Décision** : le tooltip est purement consultatif et volatil.
+
+**Justification** :
+- conforme au périmètre de l'issue ;
+- évite tout débordement vers US17/US18 ;
+- ne nécessite ni `flags` ni extension du modèle système.
+
+---
+
+## 5. Plan de travail détaillé
+
+### Étape 1 — Enrichir le view-model de rendu des nœuds
+
+**Quoi faire** :
+- compléter `renderNodes` avec les données de détail consultatif :
+  - `nodeState`
+  - `nodeStateLabel`
+  - `reasonCode`
+  - `reasonLabel`
+  - indicateur ranked / non-ranked si résoluble
+  - identifiant stable exploitable pour le clic
+
+**Fichiers** :
+- `module/applications/specialization-tree-app.mjs`
+
+**Risques spécifiques** :
+- dupliquer la logique métier existante ;
+- ne pas prévoir de fallback clair pour un talent introuvable ou un nœud invalide.
+
+### Étape 2 — Introduire le mapping `reasonCode -> i18n`
+
+**Quoi faire** :
+- définir la table de mapping applicative des raisons métier ;
+- prévoir des fallbacks localisés pour les cas non attendus ;
+- reformuler les raisons techniques en texte utilisateur.
+
+**Fichiers** :
+- `module/applications/specialization-tree-app.mjs`
+- `lang/fr.json`
+- `lang/en.json`
+
+**Risques spécifiques** :
+- désynchronisation FR/EN ;
+- exposition d'un texte trop technique si une raison n'est pas mappée proprement.
+
+### Étape 3 — Ajouter la structure DOM du tooltip
+
+**Quoi faire** :
+- enrichir le template de l'application avec une zone DOM dédiée au tooltip ;
+- prévoir un conteneur compatible avec un affichage conditionnel, sans panneau latéral ;
+- garder la structure simple et découplée du canvas.
+
+**Fichiers** :
+- `templates/applications/specialization-tree-app.hbs`
+
+**Risques spécifiques** :
+- couplage trop fort entre structure DOM et géométrie PIXI ;
+- glissement vers une UI persistante plus lourde que nécessaire.
+
+### Étape 4 — Brancher l'interaction clic dans le rendu PIXI
+
+**Quoi faire** :
+- rendre les nœuds cliquables ;
+- associer chaque clic à l'ouverture ou mise à jour du tooltip ;
+- afficher les informations principales sans déclencher aucune action métier ;
+- fermer ou remplacer le détail lorsqu'un autre nœud est cliqué ou lors d'un rerender.
+
+**Fichiers** :
+- `module/applications/specialization-tree-app.mjs`
+
+**Risques spécifiques** :
+- logique d'interaction trop mêlée au dessin ;
+- comportement involontaire assimilable à une préparation d'achat.
+
+### Étape 5 — Styliser le tooltip et préserver la lisibilité
+
+**Quoi faire** :
+- ajouter le style du tooltip léger ;
+- garantir une lisibilité correcte sur desktop et mobile ;
+- veiller à la cohérence visuelle avec les variantes d'état déjà livrées par `#234`.
+
+**Fichiers** :
+- `styles/applications.less`
+
+**Risques spécifiques** :
+- contraste insuffisant ;
+- tooltip coupé ou mal positionné sur petits écrans.
+
+### Étape 6 — Étendre les tests du contrat applicatif
+
+**Quoi faire** :
+- couvrir la présence des métadonnées de détail dans le contexte ;
+- couvrir le mapping des `reasonCode` vers des labels localisés ;
+- vérifier l'absence de déclenchement métier ;
+- tester les cas principaux :
+  - `locked` par XP insuffisants ;
+  - `locked` par accessibilité ;
+  - `invalid` pour arbre incomplet ;
+  - `invalid` pour talent ou nœud introuvable ;
+  - fallback localisé.
+
+**Fichiers** :
+- `tests/applications/specialization-tree-app.test.mjs`
+
+**Risques spécifiques** :
+- tests trop couplés à PIXI au lieu du contrat ;
+- assertions trop larges, contraires à ADR-0012.
+
+---
+
+## 6. Fichiers modifiés
+
+| Fichier | Action | Description du changement |
+|---|---|---|
+| `module/applications/specialization-tree-app.mjs` | modification | Enrichir le view-model, mapper `reasonCode`, gérer le clic sur nœud et synchroniser le tooltip |
+| `templates/applications/specialization-tree-app.hbs` | modification | Ajouter la structure DOM légère du détail consultatif |
+| `styles/applications.less` | modification | Styliser le tooltip et ses variantes de lisibilité |
+| `lang/fr.json` | modification | Ajouter les labels FR des raisons de blocage et du détail de nœud |
+| `lang/en.json` | modification | Ajouter les labels EN correspondants |
+| `tests/applications/specialization-tree-app.test.mjs` | modification | Couvrir le contrat de détail, le mapping i18n et l'absence d'achat |
+
+---
+
+## 7. Risques
+
+| Risque | Impact | Mitigation |
+|---|---|---|
+| Le tooltip introduit une pseudo-sélection persistante | dérive fonctionnelle hors scope | limiter l'état à une consultation volatile réinitialisée au rerender |
+| Le mapping UI diverge des `reasonCode` domaine | incohérences visibles utilisateur | centraliser le mapping dans un seul objet applicatif et le couvrir par tests |
+| Le clic sur nœud prépare involontairement US18 | confusion fonctionnelle | séparer strictement consultation et achat, sans appel métier |
+| Les raisons invalides restent trop techniques | UX pauvre | reformuler en i18n utilisateur et prévoir un fallback lisible |
+| Le rendu/tests deviennent fragiles à cause de PIXI | maintenance coûteuse | tester le view-model et la logique de mapping plutôt que des détails graphiques |
+| Le tooltip est mal positionné ou peu lisible sur mobile | régression UX | prévoir un style responsive simple et des limites de largeur |
+
+---
+
+## 8. Proposition d'ordre de commit
+
+1. `feat(talent-tree): expose node detail metadata for graphical tree view`
+2. `feat(talent-tree): map node lock reasons to localized labels`
+3. `feat(talent-tree): show readonly node details on click`
+4. `test(talent-tree): cover localized node detail reasons`
+
+---
+
+## 9. Dépendances avec les autres US
+
+- Dépend de `#200` pour le périmètre global US16.
+- Dépend fonctionnellement du travail déjà livré par `#234`, désormais fermé, pour les variantes visuelles de nœud.
+- Repose sur `module/lib/talent-node/talent-node-state.mjs` pour les états et `reasonCode`.
+- Prépare US18 sans l'anticiper : les nœuds deviennent consultables mais pas achetables.

--- a/lang/en.json
+++ b/lang/en.json
@@ -1134,6 +1134,25 @@
           "LOCKED": "Locked",
           "INVALID": "Invalid"
         },
+        "REASON": {
+          "ALREADY_PURCHASED": "Already purchased",
+          "SPECIALIZATION_NOT_OWNED": "Specialization not owned",
+          "TREE_NOT_FOUND": "Reference tree not found",
+          "TREE_INCOMPLETE": "Reference tree is incomplete",
+          "NODE_NOT_FOUND": "Node not found in tree",
+          "NODE_INVALID": "Node data is invalid",
+          "NODE_LOCKED": "Prerequisites not met",
+          "NOT_ENOUGH_XP": "Not enough XP",
+          "UNKNOWN": "Unknown reason"
+        },
+        "TOOLTIP": {
+          "XP_COST": "Cost",
+          "TYPE": "Type",
+          "RANKED": "Ranked Talent",
+          "NON_RANKED": "Non-ranked Talent",
+          "STATE": "State",
+          "REASON": "Reason"
+        },
         "EMPTY": {
           "NO_ACTOR_TITLE": "No actor selected",
           "NO_ACTOR_DESCRIPTION": "Open this application from a character sheet to inspect the owned specialization trees.",

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -1126,6 +1126,25 @@
           "LOCKED": "Verrouillé",
           "INVALID": "Invalide"
         },
+        "REASON": {
+          "ALREADY_PURCHASED": "Déjà acheté",
+          "SPECIALIZATION_NOT_OWNED": "Spécialisation non possédée",
+          "TREE_NOT_FOUND": "Arbre de référence introuvable",
+          "TREE_INCOMPLETE": "Arbre de référence incomplet",
+          "NODE_NOT_FOUND": "Nœud introuvable dans l'arbre",
+          "NODE_INVALID": "Données du nœud invalides",
+          "NODE_LOCKED": "Prérequis non remplis",
+          "NOT_ENOUGH_XP": "XP insuffisants",
+          "UNKNOWN": "Raison inconnue"
+        },
+        "TOOLTIP": {
+          "XP_COST": "Coût",
+          "TYPE": "Type",
+          "RANKED": "Talent à rangs",
+          "NON_RANKED": "Talent sans rang",
+          "STATE": "État",
+          "REASON": "Raison"
+        },
         "EMPTY": {
           "NO_ACTOR_TITLE": "Aucun acteur sélectionné",
           "NO_ACTOR_DESCRIPTION": "Ouvrez cette application depuis une fiche personnage pour consulter les arbres de spécialisation possédés.",

--- a/module/applications/specialization-tree-app.mjs
+++ b/module/applications/specialization-tree-app.mjs
@@ -1,5 +1,5 @@
 import { resolveActorSpecializationTrees } from '../lib/talent-node/talent-tree-resolver.mjs'
-import { getTreeNodesStates, NODE_STATE } from '../lib/talent-node/talent-node-state.mjs'
+import { getTreeNodesStates, NODE_STATE, REASON_CODE } from '../lib/talent-node/talent-node-state.mjs'
 import { logger } from '../utils/logger.mjs'
 
 const { api } = foundry.applications
@@ -16,6 +16,19 @@ const NODE_STATE_LABEL_KEYS = Object.freeze({
   [NODE_STATE.LOCKED]: 'SWERPG.TALENT.SPECIALIZATION_TREE_APP.NODE_STATE.LOCKED',
   [NODE_STATE.INVALID]: 'SWERPG.TALENT.SPECIALIZATION_TREE_APP.NODE_STATE.INVALID',
 })
+
+const REASON_LABEL_KEYS = Object.freeze({
+  [REASON_CODE.ALREADY_PURCHASED]: 'SWERPG.TALENT.SPECIALIZATION_TREE_APP.REASON.ALREADY_PURCHASED',
+  [REASON_CODE.SPECIALIZATION_NOT_OWNED]: 'SWERPG.TALENT.SPECIALIZATION_TREE_APP.REASON.SPECIALIZATION_NOT_OWNED',
+  [REASON_CODE.TREE_NOT_FOUND]: 'SWERPG.TALENT.SPECIALIZATION_TREE_APP.REASON.TREE_NOT_FOUND',
+  [REASON_CODE.TREE_INCOMPLETE]: 'SWERPG.TALENT.SPECIALIZATION_TREE_APP.REASON.TREE_INCOMPLETE',
+  [REASON_CODE.NODE_NOT_FOUND]: 'SWERPG.TALENT.SPECIALIZATION_TREE_APP.REASON.NODE_NOT_FOUND',
+  [REASON_CODE.NODE_INVALID]: 'SWERPG.TALENT.SPECIALIZATION_TREE_APP.REASON.NODE_INVALID',
+  [REASON_CODE.NODE_LOCKED]: 'SWERPG.TALENT.SPECIALIZATION_TREE_APP.REASON.NODE_LOCKED',
+  [REASON_CODE.NOT_ENOUGH_XP]: 'SWERPG.TALENT.SPECIALIZATION_TREE_APP.REASON.NOT_ENOUGH_XP',
+})
+
+const REASON_LABEL_DEFAULT = 'SWERPG.TALENT.SPECIALIZATION_TREE_APP.REASON.UNKNOWN'
 
 const NODE_STATE_VARIANTS = Object.freeze({
   [NODE_STATE.PURCHASED]: Object.freeze({
@@ -85,6 +98,21 @@ export function resolveTalentItem(talentId) {
     return item?.name ?? game.i18n.localize('SWERPG.TALENT.UNKNOWN')
   } catch {
     return game.i18n.localize('SWERPG.TALENT.UNKNOWN')
+  }
+}
+
+export function resolveTalentDetail(talentId) {
+  try {
+    const item = fromUuidSync(talentId)
+    if (!item) {
+      return { name: game.i18n.localize('SWERPG.TALENT.UNKNOWN'), isRanked: false }
+    }
+    return {
+      name: item.name ?? game.i18n.localize('SWERPG.TALENT.UNKNOWN'),
+      isRanked: item.system?.isRanked ?? false,
+    }
+  } catch {
+    return { name: game.i18n.localize('SWERPG.TALENT.UNKNOWN'), isRanked: false }
   }
 }
 
@@ -169,9 +197,12 @@ export function buildSpecializationTreeContext(actor) {
 
     renderNodes = nodes.map((node) => {
       const pos = computeNodePosition(node.row, node.column)
+      const detail = resolveTalentDetail(node.talentId)
       return {
         nodeId: node.nodeId,
-        talentName: resolveTalentItem(node.talentId),
+        talentId: node.talentId,
+        talentName: detail.name,
+        isRanked: detail.isRanked,
         xpCost: node.cost ?? 0,
         row: node.row,
         column: node.column,
@@ -184,12 +215,17 @@ export function buildSpecializationTreeContext(actor) {
     renderNodes = renderNodes.map((node) => {
       const stateResult = nodeStates.get(node.nodeId) ?? { state: NODE_STATE.INVALID }
       const variant = NODE_STATE_VARIANTS[stateResult.state] ?? NODE_STATE_VARIANTS[NODE_STATE.INVALID]
+      const reasonCode = stateResult.reasonCode ?? null
       return {
         ...node,
         nodeState: stateResult.state,
         nodeStateLabel: game.i18n.localize(
           NODE_STATE_LABEL_KEYS[stateResult.state] ?? NODE_STATE_LABEL_KEYS[NODE_STATE.INVALID],
         ),
+        reasonCode,
+        reasonLabel: reasonCode
+          ? game.i18n.localize(REASON_LABEL_KEYS[reasonCode] ?? REASON_LABEL_DEFAULT)
+          : null,
         variant,
       }
     })
@@ -279,6 +315,10 @@ export default class SpecializationTreeApp extends api.HandlebarsApplicationMixi
   #treeContainer = null
 
   #isResizeBound = false
+
+  #renderNodesCache = null
+
+  #selectedNodeId = null
 
   get title() {
     return game.i18n.format('SWERPG.TALENT.SPECIALIZATION_TREE_APP.TITLE', {
@@ -394,11 +434,16 @@ export default class SpecializationTreeApp extends api.HandlebarsApplicationMixi
       this.#treeContainer = null
     }
 
+    this.#renderNodesCache = null
+    this.#hideNodeTooltip()
+
     const { renderNodes, renderConnections } = context ?? {}
     if (!renderNodes?.length && !renderConnections?.length) return
 
     this.#treeContainer = new PIXI.Container()
     this.pixiApp.stage.addChild(this.#treeContainer)
+
+    this.#renderNodesCache = renderNodes
 
     if (renderConnections.length > 0) {
       const gfx = new PIXI.Graphics()
@@ -442,8 +487,67 @@ export default class SpecializationTreeApp extends api.HandlebarsApplicationMixi
         costText.x = node.x + 4
         costText.y = node.y + NODE_HEIGHT - 16
         this.#treeContainer.addChild(costText)
+
+        const hitArea = new PIXI.Graphics()
+        hitArea.beginFill(0xffffff, 0.001)
+        hitArea.drawRect(node.x, node.y, NODE_WIDTH, NODE_HEIGHT)
+        hitArea.endFill()
+        hitArea.eventMode = 'static'
+        hitArea.cursor = 'pointer'
+        const capturedNode = node
+        hitArea.on('pointerdown', (event) => {
+          event.stopPropagation()
+          this.#showNodeTooltip(capturedNode)
+        })
+        this.#treeContainer.addChild(hitArea)
       }
+
+      this.pixiApp.stage.eventMode = 'static'
+      this.pixiApp.stage.on('pointerdown', () => this.#hideNodeTooltip())
     }
+  }
+
+  #showNodeTooltip(node) {
+    const root = typeof HTMLElement !== 'undefined' && this.element instanceof HTMLElement
+      ? this.element
+      : this.element?.[0] ?? this.element
+    const tooltip = root?.querySelector?.('[data-node-tooltip]')
+    if (!tooltip) return
+
+    const i18n = game.i18n.localize.bind(game.i18n)
+
+    const typeLabel = node.isRanked
+      ? i18n('SWERPG.TALENT.SPECIALIZATION_TREE_APP.TOOLTIP.RANKED')
+      : i18n('SWERPG.TALENT.SPECIALIZATION_TREE_APP.TOOLTIP.NON_RANKED')
+
+    const headerEl = tooltip.querySelector('[data-tooltip-header]')
+    const bodyEl = tooltip.querySelector('[data-tooltip-body]')
+    if (headerEl) {
+      headerEl.textContent = node.talentName
+    }
+    if (bodyEl) {
+      const parts = [
+        `${i18n('SWERPG.TALENT.SPECIALIZATION_TREE_APP.TOOLTIP.XP_COST')}: ${node.xpCost} XP`,
+        `${i18n('SWERPG.TALENT.SPECIALIZATION_TREE_APP.TOOLTIP.TYPE')}: ${typeLabel}`,
+        `${i18n('SWERPG.TALENT.SPECIALIZATION_TREE_APP.TOOLTIP.STATE')}: ${node.nodeStateLabel}`,
+      ]
+      if (node.reasonLabel) {
+        parts.push(`${i18n('SWERPG.TALENT.SPECIALIZATION_TREE_APP.TOOLTIP.REASON')}: ${node.reasonLabel}`)
+      }
+      bodyEl.innerHTML = parts.join('<br>')
+    }
+
+    tooltip.hidden = false
+    this.#selectedNodeId = node.nodeId
+  }
+
+  #hideNodeTooltip() {
+    const root = typeof HTMLElement !== 'undefined' && this.element instanceof HTMLElement
+      ? this.element
+      : this.element?.[0] ?? this.element
+    const tooltip = root?.querySelector?.('[data-node-tooltip]')
+    if (tooltip) tooltip.hidden = true
+    this.#selectedNodeId = null
   }
 
   #teardownViewport() {

--- a/styles/applications.less
+++ b/styles/applications.less
@@ -596,6 +596,7 @@
     flex: 1;
     min-height: 0;
     padding: 1rem;
+    position: relative;
   }
 
   .specialization-tree-app__viewport,
@@ -619,6 +620,41 @@
     display: block;
     width: 100%;
     height: 100%;
+  }
+
+  .specialization-tree-app__node-tooltip {
+    position: absolute;
+    bottom: 1.5rem;
+    right: 1.5rem;
+    min-width: 200px;
+    max-width: 280px;
+    padding: 0.75rem 1rem;
+    background: rgba(10, 17, 26, 0.95);
+    border: 1px solid rgba(120, 169, 194, 0.4);
+    border-radius: 8px;
+    color: #d5e4f1;
+    font-size: var(--font-size-12, 12px);
+    line-height: 1.6;
+    z-index: 10;
+    pointer-events: auto;
+    box-shadow: 0 4px 16px rgba(0, 0, 0, 0.5);
+
+    &[hidden] {
+      display: none;
+    }
+  }
+
+  .specialization-tree-app__node-tooltip-header {
+    color: #eef8ff;
+    font-weight: 600;
+    font-size: var(--font-size-14, 14px);
+    margin-bottom: 0.4rem;
+    padding-bottom: 0.4rem;
+    border-bottom: 1px solid rgba(120, 169, 194, 0.18);
+  }
+
+  .specialization-tree-app__node-tooltip-body {
+    color: #c8dcee;
   }
 
   .specialization-tree-app__empty,

--- a/styles/swerpg.css
+++ b/styles/swerpg.css
@@ -1050,6 +1050,7 @@ input[type='range'] {
   flex: 1;
   min-height: 0;
   padding: 1rem;
+  position: relative;
 }
 .swerpg.application.specialization-tree-app .specialization-tree-app__viewport,
 .swerpg.application.specialization-tree-app .specialization-tree-app__empty,
@@ -1070,6 +1071,37 @@ input[type='range'] {
   display: block;
   width: 100%;
   height: 100%;
+}
+.swerpg.application.specialization-tree-app .specialization-tree-app__node-tooltip {
+  position: absolute;
+  bottom: 1.5rem;
+  right: 1.5rem;
+  min-width: 200px;
+  max-width: 280px;
+  padding: 0.75rem 1rem;
+  background: rgba(10, 17, 26, 0.95);
+  border: 1px solid rgba(120, 169, 194, 0.4);
+  border-radius: 8px;
+  color: #d5e4f1;
+  font-size: var(--font-size-12, 12px);
+  line-height: 1.6;
+  z-index: 10;
+  pointer-events: auto;
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.5);
+}
+.swerpg.application.specialization-tree-app .specialization-tree-app__node-tooltip[hidden] {
+  display: none;
+}
+.swerpg.application.specialization-tree-app .specialization-tree-app__node-tooltip-header {
+  color: #eef8ff;
+  font-weight: 600;
+  font-size: var(--font-size-14, 14px);
+  margin-bottom: 0.4rem;
+  padding-bottom: 0.4rem;
+  border-bottom: 1px solid rgba(120, 169, 194, 0.18);
+}
+.swerpg.application.specialization-tree-app .specialization-tree-app__node-tooltip-body {
+  color: #c8dcee;
 }
 .swerpg.application.specialization-tree-app .specialization-tree-app__empty,
 .swerpg.application.specialization-tree-app .specialization-tree-app__sidebar-empty {

--- a/templates/applications/specialization-tree-app.hbs
+++ b/templates/applications/specialization-tree-app.hbs
@@ -39,6 +39,10 @@
             data-specialization-tree-viewport
             aria-label='{{viewportAriaLabel}}'
           ></div>
+          <div class='specialization-tree-app__node-tooltip' data-node-tooltip hidden>
+            <div class='specialization-tree-app__node-tooltip-header' data-tooltip-header></div>
+            <div class='specialization-tree-app__node-tooltip-body' data-tooltip-body></div>
+          </div>
         {{else}}
           <div class='specialization-tree-app__empty'>
             <h3>{{emptyStateTitle}}</h3>

--- a/tests/applications/specialization-tree-app.test.mjs
+++ b/tests/applications/specialization-tree-app.test.mjs
@@ -43,6 +43,7 @@ describe('specialization-tree application', () => {
   let getViewportDimensions
   let computeNodePosition
   let resolveTalentItem
+  let resolveTalentDetail
 
   beforeEach(async () => {
     setupFoundryMock({
@@ -65,6 +66,21 @@ describe('specialization-tree application', () => {
         'SWERPG.TALENT.SPECIALIZATION_TREE_APP.NODE_STATE.AVAILABLE': 'Available',
         'SWERPG.TALENT.SPECIALIZATION_TREE_APP.NODE_STATE.LOCKED': 'Locked',
         'SWERPG.TALENT.SPECIALIZATION_TREE_APP.NODE_STATE.INVALID': 'Invalid',
+        'SWERPG.TALENT.SPECIALIZATION_TREE_APP.REASON.ALREADY_PURCHASED': 'Already purchased',
+        'SWERPG.TALENT.SPECIALIZATION_TREE_APP.REASON.SPECIALIZATION_NOT_OWNED': 'Specialization not owned',
+        'SWERPG.TALENT.SPECIALIZATION_TREE_APP.REASON.TREE_NOT_FOUND': 'Reference tree not found',
+        'SWERPG.TALENT.SPECIALIZATION_TREE_APP.REASON.TREE_INCOMPLETE': 'Reference tree is incomplete',
+        'SWERPG.TALENT.SPECIALIZATION_TREE_APP.REASON.NODE_NOT_FOUND': 'Node not found in tree',
+        'SWERPG.TALENT.SPECIALIZATION_TREE_APP.REASON.NODE_INVALID': 'Node data is invalid',
+        'SWERPG.TALENT.SPECIALIZATION_TREE_APP.REASON.NODE_LOCKED': 'Prerequisites not met',
+        'SWERPG.TALENT.SPECIALIZATION_TREE_APP.REASON.NOT_ENOUGH_XP': 'Not enough XP',
+        'SWERPG.TALENT.SPECIALIZATION_TREE_APP.REASON.UNKNOWN': 'Unknown reason',
+        'SWERPG.TALENT.SPECIALIZATION_TREE_APP.TOOLTIP.XP_COST': 'Cost',
+        'SWERPG.TALENT.SPECIALIZATION_TREE_APP.TOOLTIP.TYPE': 'Type',
+        'SWERPG.TALENT.SPECIALIZATION_TREE_APP.TOOLTIP.RANKED': 'Ranked Talent',
+        'SWERPG.TALENT.SPECIALIZATION_TREE_APP.TOOLTIP.NON_RANKED': 'Non-ranked Talent',
+        'SWERPG.TALENT.SPECIALIZATION_TREE_APP.TOOLTIP.STATE': 'State',
+        'SWERPG.TALENT.SPECIALIZATION_TREE_APP.TOOLTIP.REASON': 'Reason',
         'SWERPG.TALENT.UNKNOWN': 'Unknown talent',
       },
     })
@@ -72,6 +88,7 @@ describe('specialization-tree application', () => {
     function createMockContainer() {
       return {
         children: [],
+        eventMode: 'none',
         addChild: vi.fn(function (child) {
           this.children.push(child)
           return child
@@ -83,6 +100,7 @@ describe('specialization-tree application', () => {
         destroy: vi.fn(function () {
           this.children = []
         }),
+        on: vi.fn(),
       }
     }
 
@@ -104,6 +122,9 @@ describe('specialization-tree application', () => {
       Graphics: class MockGraphics {
         constructor() {
           this.calls = []
+          this.eventMode = 'none'
+          this.cursor = 'default'
+          this._listeners = {}
         }
         lineStyle(...args) {
           this.calls.push(['lineStyle', ...args])
@@ -129,6 +150,14 @@ describe('specialization-tree application', () => {
           this.calls.push(['drawRoundedRect', ...args])
           return this
         }
+        drawRect(...args) {
+          this.calls.push(['drawRect', ...args])
+          return this
+        }
+        on(event, handler) {
+          this._listeners[event] = handler
+          return this
+        }
       },
       Text: class MockText {
         constructor(text, style) {
@@ -151,6 +180,7 @@ describe('specialization-tree application', () => {
       getViewportDimensions,
       computeNodePosition,
       resolveTalentItem,
+      resolveTalentDetail,
     } = await import('../../module/applications/specialization-tree-app.mjs'))
   })
 
@@ -709,5 +739,213 @@ describe('specialization-tree application', () => {
     expect(app.pixiApp).toBeNull()
     expect(app.actor).toBeNull()
     expect(app.document).toBeNull()
+  })
+
+  describe('resolveTalentDetail', () => {
+    it('returns talent name and isRanked when item is found', () => {
+      globalThis.fromUuidSync = vi.fn(() => ({
+        name: 'Dodge',
+        system: { isRanked: true },
+      }))
+      const detail = resolveTalentDetail('Item.talent-dodge')
+      expect(detail.name).toBe('Dodge')
+      expect(detail.isRanked).toBe(true)
+    })
+
+    it('returns talent name and isRanked=false when item is found but not ranked', () => {
+      globalThis.fromUuidSync = vi.fn(() => ({
+        name: 'Tough',
+        system: { isRanked: false },
+      }))
+      const detail = resolveTalentDetail('Item.talent-tough')
+      expect(detail.name).toBe('Tough')
+      expect(detail.isRanked).toBe(false)
+    })
+
+    it('returns unknown fallback when item is not found', () => {
+      globalThis.fromUuidSync = vi.fn(() => null)
+      const detail = resolveTalentDetail('Item.talent-nonexistent')
+      expect(detail.name).toBe('Unknown talent')
+      expect(detail.isRanked).toBe(false)
+    })
+
+    it('returns unknown fallback when fromUuidSync throws', () => {
+      globalThis.fromUuidSync = vi.fn(() => { throw new Error('not found') })
+      const detail = resolveTalentDetail('Item.talent-error')
+      expect(detail.name).toBe('Unknown talent')
+      expect(detail.isRanked).toBe(false)
+    })
+  })
+
+  it('includes talentId and isRanked in every render node', () => {
+    const actor = createActor({
+      system: {
+        details: {
+          specializations: [
+            { specializationId: 'spec-bodyguard', name: 'Bodyguard', treeUuid: 'Item.tree-bodyguard' },
+          ],
+        },
+        progression: {
+          talentPurchases: [],
+          experience: { available: 100 },
+        },
+      },
+    })
+
+    globalThis.fromUuidSync = vi.fn((uuid) => {
+      if (uuid === 'Item.tree-bodyguard') {
+        return {
+          type: 'specialization-tree',
+          name: 'Bodyguard Tree',
+          system: {
+            nodes: [
+              { nodeId: 'r1c1', talentId: 'Item.talent-tough', row: 1, column: 1, cost: 10 },
+              { nodeId: 'r2c1', talentId: 'Item.talent-protect', row: 2, column: 1, cost: 15 },
+            ],
+            connections: [{ from: 'r1c1', to: 'r2c1' }],
+          },
+        }
+      }
+      if (uuid === 'Item.talent-tough') return { name: 'Tough', system: { isRanked: true } }
+      if (uuid === 'Item.talent-protect') return { name: 'Protect', system: { isRanked: false } }
+      return null
+    })
+
+    const context = buildSpecializationTreeContext(actor)
+
+    expect(context.renderNodes, 'should have 2 render nodes').toHaveLength(2)
+
+    const tough = context.renderNodes.find((n) => n.nodeId === 'r1c1')
+    expect(tough).toBeDefined()
+    expect(tough.talentId).toBe('Item.talent-tough')
+    expect(tough.isRanked).toBe(true)
+
+    const protect = context.renderNodes.find((n) => n.nodeId === 'r2c1')
+    expect(protect).toBeDefined()
+    expect(protect.talentId).toBe('Item.talent-protect')
+    expect(protect.isRanked).toBe(false)
+  })
+
+  it('includes reasonCode and reasonLabel for locked nodes', () => {
+    const actor = createActor({
+      system: {
+        details: {
+          specializations: [
+            { specializationId: 'spec-bodyguard', name: 'Bodyguard', treeUuid: 'Item.tree-bodyguard' },
+          ],
+        },
+        progression: {
+          talentPurchases: [],
+          experience: { available: 0 },
+        },
+      },
+    })
+
+    globalThis.fromUuidSync = vi.fn((uuid) => {
+      if (uuid === 'Item.tree-bodyguard') {
+        return {
+          type: 'specialization-tree',
+          name: 'Bodyguard Tree',
+          system: {
+            nodes: [
+              { nodeId: 'r1c1', talentId: 'Item.talent-tough', row: 1, column: 1, cost: 10 },
+            ],
+            connections: [{ from: 'r1c1', to: 'r2c1' }],
+          },
+        }
+      }
+      if (uuid === 'Item.talent-tough') return { name: 'Tough', system: { isRanked: false } }
+      return null
+    })
+
+    const context = buildSpecializationTreeContext(actor)
+
+    expect(context.renderNodes).toHaveLength(1)
+    const node = context.renderNodes[0]
+    expect(node.nodeState).toBe('locked')
+    expect(node.reasonCode).toBe('not-enough-xp')
+    expect(node.reasonLabel).toBe('Not enough XP')
+  })
+
+  it('includes reasonCode and reasonLabel for nodes locked by accessibility', () => {
+    const actor = createActor({
+      system: {
+        details: {
+          specializations: [
+            { specializationId: 'spec-bodyguard', name: 'Bodyguard', treeUuid: 'Item.tree-bodyguard' },
+          ],
+        },
+        progression: {
+          talentPurchases: [],
+          experience: { available: 100 },
+        },
+      },
+    })
+
+    globalThis.fromUuidSync = vi.fn((uuid) => {
+      if (uuid === 'Item.tree-bodyguard') {
+        return {
+          type: 'specialization-tree',
+          name: 'Bodyguard Tree',
+          system: {
+            nodes: [
+              { nodeId: 'r1c1', talentId: 'Item.talent-tough', row: 1, column: 1, cost: 10 },
+              { nodeId: 'r2c1', talentId: 'Item.talent-protect', row: 2, column: 1, cost: 5 },
+            ],
+            connections: [{ from: 'r1c1', to: 'r2c1' }],
+          },
+        }
+      }
+      if (uuid === 'Item.talent-tough') return { name: 'Tough', system: { isRanked: false } }
+      if (uuid === 'Item.talent-protect') return { name: 'Protect', system: { isRanked: false } }
+      return null
+    })
+
+    const context = buildSpecializationTreeContext(actor)
+
+    const lockedNode = context.renderNodes.find((n) => n.nodeState === 'locked')
+    expect(lockedNode).toBeDefined()
+    expect(lockedNode.reasonCode).toBe('node-locked')
+    expect(lockedNode.reasonLabel).toBe('Prerequisites not met')
+  })
+
+  it('sets reasonLabel to null for available nodes', () => {
+    const actor = createActor({
+      system: {
+        details: {
+          specializations: [
+            { specializationId: 'spec-bodyguard', name: 'Bodyguard', treeUuid: 'Item.tree-bodyguard' },
+          ],
+        },
+        progression: {
+          talentPurchases: [],
+          experience: { available: 100 },
+        },
+      },
+    })
+
+    globalThis.fromUuidSync = vi.fn((uuid) => {
+      if (uuid === 'Item.tree-bodyguard') {
+        return {
+          type: 'specialization-tree',
+          name: 'Bodyguard Tree',
+          system: {
+            nodes: [
+              { nodeId: 'r1c1', talentId: 'Item.talent-tough', row: 1, column: 1, cost: 10 },
+            ],
+            connections: [{ from: 'r1c1', to: 'r2c1' }],
+          },
+        }
+      }
+      if (uuid === 'Item.talent-tough') return { name: 'Tough', system: { isRanked: false } }
+      return null
+    })
+
+    const context = buildSpecializationTreeContext(actor)
+
+    const available = context.renderNodes.find((n) => n.nodeState === 'available')
+    expect(available).toBeDefined()
+    expect(available.reasonCode).toBe('')
+    expect(available.reasonLabel).toBeNull()
   })
 })


### PR DESCRIPTION
## Summary

Complète la vue graphique des arbres de spécialisation (#235 / US16) avec l'affichage consultatif des détails de nœud et des raisons de blocage, sans déclencher d'achat ni introduire d'état persistant.

## Changes

### View-model enrichi (`specialization-tree-app.mjs`)
- `resolveTalentDetail()` : résout le nom et le flag `isRanked` depuis un UUID de talent
- `talentId`, `isRanked`, `reasonCode`, `reasonLabel` ajoutés à chaque `renderNode`
- Mapping `REASON_LABEL_KEYS` : toutes les `reasonCode` métier vers clés i18n, avec `REASON_LABEL_DEFAULT` en fallback

### Interaction clic et tooltip DOM
- Zones cliquables PIXI transparentes (`hitArea`) sur chaque nœud avec `eventMode = 'static'`
- Clic nœud → tooltip positionné en bas à droite du viewport avec :
  - Nom du talent, coût XP, type (ranked/non-ranked), état, raison de blocage (si locked/invalid)
- Clic fond du canvas → tooltip masqué
- Tooltip réinitialisé au re-rendu

### i18n
- 9 clés `REASON.*` (FR/EN) pour chaque raison de blocage
- 6 clés `TOOLTIP.*` (FR/EN) pour les libellés du tooltip

### Styles (`applications.less`)
- Tooltip en `position: absolute`, fond semi-transparent, bordure cohérente avec le thème existant
- `.specialization-tree-app__viewport-panel` passe en `position: relative`

### Tests
- `resolveTalentDetail` : item trouvé (ranked/non-ranked), introuvable, exception
- `talentId` + `isRanked` présents dans tous les `renderNodes`
- `reasonCode` + `reasonLabel` : locked par XP, locked par accessibilité, disponible

## Validation
```
pnpm vitest run  # 139 files, 1591 passed, 2 skipped
```

Closes #235
