### PR TITLE
fix(talent-tree): resolve owned specialization trees when specializationId and treeUuid are missing

### DIFF
--- a/documentation/cadrage/character-sheet/specialization-tree/fix-owned-specialization-tree-resolution.md
+++ b/documentation/cadrage/character-sheet/specialization-tree/fix-owned-specialization-tree-resolution.md
@@ -1,0 +1,107 @@
+# Fix bug — Arbres de spécialisation non résolus
+
+## Problème
+
+Les arbres `specialization-tree` existent et sont valides, mais les spécialisations stockées sur l’acteur ne contiennent ni `specializationId`, ni `treeUuid`.
+
+Exemple actuel :
+
+```json
+{
+  "name": "Ambassador",
+  "img": "...",
+  "description": "...",
+  "specializationSkills": {},
+  "freeSkillRank": 4
+}
+````
+
+Le resolver ne peut donc pas relier la spécialisation possédée à son arbre.
+
+## Cause
+
+`actor.system.details.specializations` stocke une donnée incomplète.
+
+Le resolver attend :
+
+```js
+specializationId
+// ou
+treeUuid
+```
+
+Mais il ne reçoit que `name`.
+
+## Correction attendue
+
+### 1. Corriger l’ajout d’une spécialisation à l’acteur
+
+Quand une spécialisation est ajoutée à l’acteur, stocker aussi :
+
+```js
+specializationId
+treeUuid
+```
+
+Format cible :
+
+```json
+{
+  "name": "Ambassador",
+  "specializationId": "ambassador",
+  "treeUuid": "Item.UYiw0UBrUptRpxTk",
+  "img": "...",
+  "description": "...",
+  "specializationSkills": {},
+  "freeSkillRank": 4
+}
+```
+
+### 2. Ajouter une compatibilité legacy
+
+Pour les acteurs existants, résoudre temporairement par `name` si `specializationId` et `treeUuid` sont absents.
+
+Ordre de résolution :
+
+```txt
+1. treeUuid
+2. specializationId
+3. name fallback legacy
+4. unresolved
+```
+
+Le fallback par `name` doit logger un warning indiquant que les données acteur doivent être migrées.
+
+### 3. Ajouter une migration / normalisation
+
+Créer une fonction qui enrichit les anciennes spécialisations acteur :
+
+```js
+name -> specialization-tree.name -> specializationId + treeUuid
+```
+
+Ne pas supprimer les champs existants.
+
+## À ne pas faire
+
+* Ne pas corriger dans le renderer graphique.
+* Ne pas utiliser `name` comme clé métier principale.
+* Ne pas traiter l’i18n dans ce fix.
+* Ne pas élargir le scope aux compendiums.
+
+## Tests à ajouter
+
+* Résolution par `treeUuid`.
+* Résolution par `specializationId`.
+* Résolution legacy par `name`.
+* Retour `unresolved` si aucune correspondance.
+* Retour `incomplete` si l’arbre n’a pas de nodes/connections.
+* Migration sans perte des champs existants.
+
+## Critère d’acceptation
+
+L’acteur `Bo'Than Expl-Amb` affiche correctement les arbres `Ambassador` et `Advisor`, sans warning :
+
+```txt
+Owned specialization is missing specializationId and treeUuid
+```

--- a/module/documents/actor.mjs
+++ b/module/documents/actor.mjs
@@ -386,6 +386,18 @@ export default class SwerpgActor extends TalentsMixin(EquipmentMixin(ResourcesMi
     else {
       const itemData = item.toObject()
       const data = Object.assign(itemData.system, { name: itemData.name, img: itemData.img })
+      if (isCollection && item?.type === 'specialization' && globalThis.game?.items?.find) {
+        const nameSlug = data.name?.toLowerCase().replace(/\s+/g, '-') ?? ''
+        const tree = globalThis.game.items.find(
+          (i) =>
+            i?.type === 'specialization-tree' &&
+            (i?.system?.specializationId === nameSlug || i?.name === data.name),
+        )
+        if (tree) {
+          data.specializationId = tree.system.specializationId || nameSlug
+          data.treeUuid = tree.uuid
+        }
+      }
       if (isCollection) {
         this.system.details.specializations.add(data)
         updateData[key] = this.system.details.specializations

--- a/module/lib/talent-node/talent-tree-resolver.mjs
+++ b/module/lib/talent-node/talent-tree-resolver.mjs
@@ -1,5 +1,42 @@
 import { logger } from '../../utils/logger.mjs'
 
+export function findTreeForSpecialization(specData) {
+  const name = specData?.name
+  if (!name || !game?.items?.find) return null
+  const nameSlug = name.toLowerCase().replace(/\s+/g, '-')
+  return game.items.find(
+    (item) =>
+      item?.type === 'specialization-tree' &&
+      (item?.system?.specializationId === nameSlug || item?.name === name),
+  ) ?? null
+}
+
+/**
+ * Enrich an actor's owned specializations that are missing specializationId / treeUuid.
+ * Resolves them by name and persists the enrichment.
+ * @param {Actor|object} actor - The actor whose specializations should be normalized.
+ * @returns {Promise<Array<object>>} The enriched specializations array.
+ */
+export async function normalizeActorSpecializations(actor) {
+  const specializations = Array.from(actor?.system?.details?.specializations || [])
+  let hasChanges = false
+  const enriched = specializations.map((spec) => {
+    if (spec.specializationId || spec.treeUuid) return spec
+    hasChanges = true
+    const tree = findTreeForSpecialization(spec)
+    const nameSlug = spec.name?.toLowerCase().replace(/\s+/g, '-') ?? ''
+    return {
+      ...spec,
+      specializationId: tree?.system?.specializationId || nameSlug,
+      treeUuid: tree?.uuid ?? undefined,
+    }
+  })
+  if (hasChanges && typeof actor.update === 'function') {
+    await actor.update({ 'system.details.specializations': enriched })
+  }
+  return enriched
+}
+
 /**
  * Determine whether a specialization tree is structurally usable.
  * @param {Item|object|null} tree - The specialization-tree item to inspect.
@@ -59,6 +96,15 @@ export function resolveSpecializationTree(specializationData = {}) {
     logger.warn('[TalentTreeResolver] Owned specialization is missing specializationId and treeUuid', {
       specializationData,
     })
+
+    const nameTree = findTreeForSpecialization(specializationData)
+    if (nameTree) {
+      logger.warn('[TalentTreeResolver] Resolved legacy specialization by name fallback', {
+        name: specializationData?.name,
+        specializationId: nameTree.system.specializationId,
+      })
+      return { tree: nameTree, state: getSpecializationTreeResolutionState(nameTree) }
+    }
   }
 
   return { tree: null, state: 'unresolved' }

--- a/tests/lib/talent-node/talent-tree-resolver.test.mjs
+++ b/tests/lib/talent-node/talent-tree-resolver.test.mjs
@@ -11,7 +11,9 @@ vi.mock('../../../module/utils/logger.mjs', () => ({
 
 import { logger } from '../../../module/utils/logger.mjs'
 import {
+  findTreeForSpecialization,
   getSpecializationTreeResolutionState,
+  normalizeActorSpecializations,
   resolveActorSpecializationTrees,
   resolveSpecializationTree,
 } from '../../../module/lib/talent-node/talent-tree-resolver.mjs'
@@ -149,6 +151,170 @@ describe('talent-tree-resolver', () => {
         },
       }),
     ).toBe('incomplete')
+  })
+
+  describe('findTreeForSpecialization', () => {
+    it('finds a tree by matching name slug to specializationId', () => {
+      const tree = {
+        type: 'specialization-tree',
+        system: { specializationId: 'bodyguard', nodes: [], connections: [] },
+      }
+      globalThis.game.items = [tree]
+
+      const result = findTreeForSpecialization({ name: 'Bodyguard' })
+
+      expect(result).toBe(tree)
+    })
+
+    it('finds a tree by matching name exactly', () => {
+      const tree = {
+        type: 'specialization-tree',
+        name: 'Bodyguard Tree',
+        system: { specializationId: 'bodyguard', nodes: [], connections: [] },
+      }
+      globalThis.game.items = [tree]
+
+      const result = findTreeForSpecialization({ name: 'Bodyguard Tree' })
+
+      expect(result).toBe(tree)
+    })
+
+    it('returns null when no tree matches', () => {
+      globalThis.game.items = []
+
+      const result = findTreeForSpecialization({ name: 'Ambassador' })
+
+      expect(result).toBeNull()
+    })
+
+    it('returns null when specData has no name', () => {
+      const result = findTreeForSpecialization({})
+      expect(result).toBeNull()
+    })
+
+    it('returns null when game is not ready', () => {
+      globalThis.game = undefined
+      const result = findTreeForSpecialization({ name: 'Bodyguard' })
+      expect(result).toBeNull()
+    })
+  })
+
+  it('resolves legacy specialization by name fallback when specializationId and treeUuid are missing', () => {
+    const tree = {
+      type: 'specialization-tree',
+      system: { specializationId: 'bodyguard', nodes: [{ nodeId: 'r1c1' }], connections: [{ from: 'r1c1', to: 'r2c1' }] },
+    }
+    globalThis.game.items = [tree]
+
+    const result = resolveSpecializationTree({ name: 'Bodyguard' })
+
+    expect(result).toEqual({ tree, state: 'available' })
+    expect(logger.warn).toHaveBeenCalledTimes(2)
+  })
+
+  describe('normalizeActorSpecializations', () => {
+    it('enriches specializations missing specializationId and treeUuid', async () => {
+      const tree = {
+        uuid: 'Item.tree-bodyguard',
+        type: 'specialization-tree',
+        system: { specializationId: 'bodyguard', nodes: [], connections: [] },
+      }
+      globalThis.game.items = [tree]
+
+      const actor = {
+        system: {
+          details: {
+            specializations: new Set([
+              { name: 'Bodyguard', img: 'icons/bodyguard.png', freeSkillRank: 4, specializationSkills: [] },
+            ]),
+          },
+        },
+        update: vi.fn(),
+      }
+
+      const enriched = await normalizeActorSpecializations(actor)
+
+      expect(enriched).toHaveLength(1)
+      expect(enriched[0]).toMatchObject({
+        name: 'Bodyguard',
+        specializationId: 'bodyguard',
+        treeUuid: 'Item.tree-bodyguard',
+      })
+      expect(actor.update).toHaveBeenCalledOnce()
+    })
+
+    it('does not modify already-enriched specializations', async () => {
+      const actor = {
+        system: {
+          details: {
+            specializations: new Set([
+              { name: 'Bodyguard', specializationId: 'bodyguard', treeUuid: 'Item.tree-bodyguard' },
+            ]),
+          },
+        },
+        update: vi.fn(),
+      }
+
+      const enriched = await normalizeActorSpecializations(actor)
+
+      expect(actor.update).not.toHaveBeenCalled()
+      expect(enriched[0].specializationId).toBe('bodyguard')
+    })
+
+    it('falls back to slug when no tree is found', async () => {
+      globalThis.game.items = []
+
+      const actor = {
+        system: {
+          details: {
+            specializations: new Set([
+              { name: 'Ambassador', img: 'icons/ambassador.png', freeSkillRank: 3 },
+            ]),
+          },
+        },
+        update: vi.fn(),
+      }
+
+      const enriched = await normalizeActorSpecializations(actor)
+
+      expect(enriched).toHaveLength(1)
+      expect(enriched[0].specializationId).toBe('ambassador')
+      expect(enriched[0].treeUuid).toBeUndefined()
+      expect(actor.update).toHaveBeenCalledOnce()
+    })
+
+    it('preserves existing fields unchanged', async () => {
+      const tree = {
+        uuid: 'Item.tree-ambassador',
+        type: 'specialization-tree',
+        system: { specializationId: 'ambassador', nodes: [], connections: [] },
+      }
+      globalThis.game.items = [tree]
+
+      const actor = {
+        system: {
+          details: {
+            specializations: new Set([
+              {
+                name: 'Ambassador',
+                img: 'icons/ambassador.png',
+                freeSkillRank: 3,
+                specializationSkills: [{ id: 'charm' }, { id: 'leadership' }],
+                description: '<p>Some desc</p>',
+              },
+            ]),
+          },
+        },
+        update: vi.fn(),
+      }
+
+      const enriched = await normalizeActorSpecializations(actor)
+
+      expect(enriched[0].img).toBe('icons/ambassador.png')
+      expect(enriched[0].freeSkillRank).toBe(3)
+      expect(enriched[0].specializationSkills).toEqual([{ id: 'charm' }, { id: 'leadership' }])
+      expect(enriched[0].description).toBe('<p>Some desc</p>')
+    })
   })
 
   it('returns incomplete for trees flagged as unresolved by import diagnostics', () => {


### PR DESCRIPTION
## Summary

Corrige le bug où les arbres de spécialisation restent non résolus car les spécialisations stockées sur l'acteur (`actor.system.details.specializations`) ne contiennent ni `specializationId` ni `treeUuid`.

## Problème

Les données de spécialisation sur l'acteur ressemblent à :
```json
{ "name": "Ambassador", "img": "...", "freeSkillRank": 4 }
```

Le resolver (`resolveSpecializationTree`) ne peut pas relier cette entrée à son arbre de référence, retournant `unresolved`.

## Changements

### Fix 1 — Enrichissement à l'ajout (`actor.mjs`)
Lorsqu'une spécialisation est appliquée à l'acteur via `_applyDetailItem`, on recherche l'arbre correspondant et on stocke `specializationId` + `treeUuid` dans les données persistées.

### Fix 2 — Fallback legacy par `name` (`talent-tree-resolver.mjs`)
Dans `resolveSpecializationTree`, quand `treeUuid` et `specializationId` sont absents, on tente une résolution par `name` :
- Slugification du nom → correspondance avec `system.specializationId` des arbres
- Correspondance exacte avec `item.name`
- Warning logger pour signaler que les données devraient être migrées

Ordre de résolution : `treeUuid` → `specializationId` → `name` → `unresolved`

### Fix 3 — Migration (`normalizeActorSpecializations`)
Nouvelle fonction qui :
- Parcourt les spécialisations d'un acteur
- Enrichit celles qui manquent de `specializationId`/`treeUuid`
- Préserve tous les champs existants
- Persiste via `actor.update()`
- Utilise `findTreeForSpecialization()` (helper partagé)

## Tests
10 nouveaux tests :
- `findTreeForSpecialization` : match par slug, match par nom exact, aucun match, pas de name, game non prêt
- Résolution legacy par `name` dans `resolveSpecializationTree`
- `normalizeActorSpecializations` : enrichissement, pas de modification si déjà enrichi, fallback slug, préservation des champs

## Validation
```sh
pnpm vitest run  # 139 files, 1601 passed, 2 skipped
```

Closes #245
