### PR TITLE
feat(importer): enrichir les noeuds d'arbres de specialisation avec talentUuid

### DIFF
--- a/documentation/plan/character-sheet/specialization-tree/243-plan-enrichir-noeuds-arbres-specialisation-talentuuid.md
+++ b/documentation/plan/character-sheet/specialization-tree/243-plan-enrichir-noeuds-arbres-specialisation-talentuuid.md
@@ -1,0 +1,323 @@
+# Plan d'implémentation — #243 : Enrichir les nœuds d'arbres de spécialisation avec `talentUuid` à l'import
+
+**Issue** : [#243 — Enrichir les nœuds d'arbres de specialisation avec talentUuid a l'import](https://github.com/herveDarritchon/foundryvtt-swerpg/issues/243)  
+**Bloqué par** : [#242 — Persister `system.id` et `system.uuid` sur les talents créés et importés](https://github.com/herveDarritchon/foundryvtt-swerpg/issues/242)  
+**ADR** : `documentation/architecture/adr/adr-0013-technical-key-and-business-key-separation.md`  
+**ADRs complémentaires** : `documentation/architecture/adr/adr-0006-specialization-import-error-isolation.md`, `documentation/architecture/adr/adr-0004-vitest-testing-strategy.md`, `documentation/architecture/adr/adr-0012-unit-tests-readable-diagnostics.md`  
+**Cadrage complémentaire** : `documentation/cadrage/character-sheet/specialization-tree/cadrage-cles-metier-techniques-specialization-trees.md`  
+**Module(s) impacté(s)** : `module/models/specialization-tree.mjs`, `module/importer/mappers/oggdude-specialization-tree-mapper.mjs`, `module/importer/items/specialization-tree-ogg-dude.mjs`, `module/utils/logger.mjs` via usages existants, tests importer/model
+
+---
+
+## 1. Objectif
+
+Faire en sorte que chaque nœud importé d'un `specialization-tree` conserve :
+
+- `talentId` comme clé métier stable ;
+- `talentUuid` comme référence Foundry exacte du talent associé.
+
+Le ticket doit enrichir les données importées, pas corriger l'UI graphique. L'objectif est de livrer un contrat de données fiable pour les couches aval.
+
+---
+
+## 2. Périmètre
+
+### Inclus dans ce ticket
+
+- Ajout de `talentUuid` au schéma des nœuds de `specialization-tree`.
+- Construction d'un index de talents disponibles au moment de l'import des arbres.
+- Résolution de `talentUuid` à partir de `talentId` pendant le mapping/import.
+- Support world items et compendium items.
+- Journalisation exploitable quand un talent n'est pas résolu.
+- Tests unitaires et d'intégration ciblant la cohérence `talentId` / `talentUuid` / talent réel.
+
+### Exclu de ce ticket
+
+- Création ou réimport automatique des talents manquants.
+- Réécriture de l'UI `specialization-tree-app` pour consommer `node.talentUuid`.
+- Migration des anciens `specialization-tree` déjà présents en monde ou compendium.
+- Refactor global de l'orchestration multi-domaines de l'importer.
+- Changement du rôle métier de `talentId`, qui doit rester une clé stable.
+
+---
+
+## 3. Constat sur l'existant
+
+### 3.1. Le mapper d'arbres ne produit aujourd'hui que `talentId`
+
+Dans `module/importer/mappers/oggdude-specialization-tree-mapper.mjs:424`, les nœuds finaux sont exportés sous la forme :
+
+- `nodeId`
+- `talentId`
+- `row`
+- `column`
+- `cost`
+
+Aucun `talentUuid` n'est calculé ni stocké.
+
+### 3.2. Le data model ne permet pas encore `talentUuid`
+
+Dans `module/models/specialization-tree.mjs:19`, le schéma des nœuds ne contient pas `talentUuid`. Le contrat ADR-0013 n'est donc pas exprimable côté modèle.
+
+### 3.3. Le socle talent existe déjà via #242
+
+Le code actuel montre déjà deux mécanismes alignés avec #242 :
+
+- `module/settings/models/OggDudeDataElement.mjs:418` persiste `system.uuid` après création des talents ;
+- `module/documents/item.mjs:168` renseigne aussi `system.uuid` à la création d'un talent non owned.
+
+Le plan #243 peut donc s'appuyer sur `talent.system.id` et `talent.system.uuid` comme contrat nominal.
+
+### 3.4. L'import d'arbres est aujourd'hui découplé de toute résolution talent
+
+`buildSpecializationTreeContext()` (`module/importer/items/specialization-tree-ogg-dude.mjs:7`) branche directement `specializationTreeMapper` sans lui fournir de contexte de résolution. Le mapper travaille en isolation sur le XML brut.
+
+### 3.5. Il existe déjà un pattern voisin de résolution talent world/compendium
+
+`module/importer/items/species-ogg-dude.mjs:142` contient `resolveTalentUUIDs(keys)` qui montre un pattern simple :
+
+- recherche dans `game.items` ;
+- fallback sur les index de compendium.
+
+Ce pattern est réutilisable, mais doit être rendu plus strict et plus aligné avec ADR-0013 en privilégiant `system.id` et `system.uuid`.
+
+---
+
+## 4. Décisions d'architecture
+
+### 4.1. Résolution sur l'existant au moment de l'import
+
+**Décision** : résoudre `talentUuid` contre les talents déjà disponibles dans Foundry au moment où les arbres sont importés.
+
+**Justification** :
+- conforme à ton choix ;
+- évite de coupler ce ticket à une refonte d'ordonnancement inter-domaines ;
+- couvre à la fois les talents déjà présents et ceux importés plus tôt dans la même session s'ils existent déjà au moment du mapping.
+
+### 4.2. `talentId` reste la clé métier canonique
+
+**Décision** : ne jamais remplacer `talentId` par un UUID.
+
+**Justification** :
+- conforme ADR-0013 ;
+- indispensable pour garder une identité stable entre imports ;
+- évite de mélanger identité métier et référence technique.
+
+### 4.3. `talentUuid` est une donnée dérivée de résolution, nullable
+
+**Décision** : renseigner `talentUuid` avec l'UUID Foundry exact si le talent est trouvé, sinon `null`.
+
+**Justification** :
+- conforme aux critères d'acceptation ;
+- évite de bloquer l'import pour une référence manquante ;
+- compatible avec ADR-0006 sur la résilience et l'isolation des erreurs.
+
+### 4.4. La résolution doit s'appuyer d'abord sur `system.id` et `system.uuid`
+
+**Décision** : construire l'index de résolution à partir de `talent.system.id` -> `talent.system.uuid`.
+
+**Justification** :
+- c'est le contrat cible posé par #242 ;
+- plus robuste qu'une recherche par nom ;
+- limite les ambiguïtés entre variantes de libellés.
+
+### 4.5. Les métadonnées d'import restent un fallback technique, pas la source de vérité
+
+**Décision** : autoriser un fallback limité sur `flags.swerpg.oggdudeKey` seulement si nécessaire pour retrouver des talents importés avant stabilisation complète de #242.
+
+**Justification** :
+- réduit le risque de rupture pendant la transition ;
+- garde `system.id` comme voie nominale ;
+- doit rester secondaire et explicitement borné.
+
+### 4.6. Le point d'injection doit être le contexte d'import des arbres, pas l'UI
+
+**Décision** : enrichir les nœuds pendant le flux importer, avant persistance des `specialization-tree`.
+
+**Justification** :
+- l'issue parle d'enrichissement à l'import ;
+- permet de persister des données complètes et non de recalculer à l'affichage ;
+- prépare proprement le ticket UI suivant sans le mélanger à celui-ci.
+
+---
+
+## 5. Plan de travail détaillé
+
+### Étape 1 — Étendre le schéma des nœuds de `specialization-tree`
+
+**À faire**
+
+- Ajouter `talentUuid` au schéma `nodes[]` dans `module/models/specialization-tree.mjs`.
+- Le champ doit être optionnel et nullable, avec `initial: null` ou l'équivalent compatible avec le projet.
+
+**Fichiers**
+- `module/models/specialization-tree.mjs`
+- `tests/models/specialization-tree.test.mjs`
+
+**Risques**
+- casser des tests existants si le schéma suppose encore une forme minimale sans `talentUuid`.
+
+---
+
+### Étape 2 — Introduire une résolution centralisée des talents disponibles
+
+**À faire**
+
+- Ajouter un resolver/indexeur dédié aux talents disponibles pendant l'import des arbres.
+- Construire une map `talentId normalisé -> talentUuid`.
+- Couvrir les deux sources :
+  - `game.items` pour le monde ;
+  - `game.packs` / index compendium pour les talents en compendium.
+- Prioriser `system.id` + `system.uuid`.
+- N'utiliser les flags historiques qu'en secours transitoire si nécessaire.
+
+**Fichiers potentiels**
+- `module/importer/items/specialization-tree-ogg-dude.mjs`
+- ou un nouveau helper dédié dans `module/importer/utils/`
+
+**Risques**
+- index de compendium incomplet si certains packs ne sont pas chargés ;
+- collisions si plusieurs talents partagent la même clé métier.
+
+---
+
+### Étape 3 — Injecter ce contexte de résolution dans le mapper d'arbres
+
+**À faire**
+
+- Faire évoluer `buildSpecializationTreeContext()` pour préparer le resolver avant le mapping.
+- Remplacer le branchement direct actuel par un mapper contextualisé, par exemple une closure ou une signature enrichie.
+- Éviter de rendre `OggDudeDataElement` plus générique que nécessaire si le besoin est spécifique au domaine `specialization-tree`.
+
+**Fichiers**
+- `module/importer/items/specialization-tree-ogg-dude.mjs`
+- `module/importer/mappers/oggdude-specialization-tree-mapper.mjs`
+
+**Risques**
+- trop élargir l'API générique des mappers alors que le besoin est local ;
+- couplage inutile avec d'autres pipelines importer.
+
+---
+
+### Étape 4 — Enrichir les nœuds avec `talentUuid` pendant le mapping
+
+**À faire**
+
+- Dans la normalisation finale des nœuds, conserver `talentId`.
+- Ajouter `talentUuid` à partir du resolver.
+- Si le talent est introuvable :
+  - conserver le nœud ;
+  - poser `talentUuid: null` ;
+  - journaliser un warning exploitable contenant au minimum `specializationId`, `nodeId`, `talentId`.
+
+**Fichiers**
+- `module/importer/mappers/oggdude-specialization-tree-mapper.mjs`
+
+**Risques**
+- bruit de logs si le warning n'est pas bien structuré ;
+- divergence entre `warnings[]` internes et logs émis si les deux ne sont pas alignés.
+
+---
+
+### Étape 5 — Aligner les diagnostics import avec le nouveau cas d'échec
+
+**À faire**
+
+- Réutiliser le mécanisme de warnings/statistiques existant pour les talents non résolus.
+- Distinguer clairement :
+  - `talentId` absent dans les données source ;
+  - `talentId` présent mais aucun talent Foundry correspondant ;
+  - `talentUuid` trouvé.
+
+**Fichiers**
+- `module/importer/mappers/oggdude-specialization-tree-mapper.mjs`
+- éventuellement `module/importer/utils/specialization-tree-import-utils.mjs`
+
+**Risques**
+- confondre "nœud invalide" et "référence non résolue" dans les stats métier.
+
+---
+
+### Étape 6 — Ajouter la couverture de tests world et compendium
+
+**À faire**
+
+- Compléter les tests unitaires du mapper pour vérifier :
+  - `talentId` inchangé ;
+  - `talentUuid` renseigné quand la correspondance existe ;
+  - `talentUuid: null` sinon.
+- Ajouter des tests d'intégration simulant :
+  - résolution sur `game.items` ;
+  - résolution sur index compendium ;
+  - cohérence entre `node.talentUuid` et `talent.system.uuid`.
+- Mettre à jour les tests du modèle `specialization-tree` pour inclure le nouveau champ.
+- Garder des assertions ciblées et lisibles, conformément ADR-0012.
+
+**Fichiers**
+- `tests/importer/specialization-tree-ogg-dude.spec.mjs`
+- `tests/importer/specialization-tree-ogg-dude.integration.spec.mjs`
+- `tests/models/specialization-tree.test.mjs`
+
+**Risques**
+- mocks Foundry insuffisants pour la forme exacte des UUID compendium ;
+- tests trop couplés à des structures complètes au lieu du contrat métier.
+
+---
+
+### Étape 7 — Vérification de non-régression hors scope UI
+
+**À faire**
+
+- Vérifier que l'ajout de `talentUuid` n'impacte pas les usages existants de `talentId`.
+- Vérifier que les arbres déjà mappés sans UI consommatrice restent valides côté modèle/import.
+- Documenter explicitement dans le plan ou PR que l'exploitation UI reste à traiter séparément.
+
+**Fichiers à relire**
+- `module/applications/specialization-tree-app.mjs`
+- `tests/applications/specialization-tree-app.test.mjs`
+
+**Risques**
+- confusion de périmètre avec le futur ticket UI.
+
+---
+
+## 6. Fichiers modifiés
+
+| Fichier | Action | Description |
+|---|---|---|
+| `module/models/specialization-tree.mjs` | modification | Ajouter `talentUuid` au schéma des nœuds |
+| `module/importer/items/specialization-tree-ogg-dude.mjs` | modification | Préparer le contexte de résolution des talents disponibles |
+| `module/importer/mappers/oggdude-specialization-tree-mapper.mjs` | modification | Enrichir chaque nœud avec `talentUuid` et warnings associés |
+| `module/importer/utils/specialization-tree-import-utils.mjs` | modification potentielle | Étendre les diagnostics si nécessaire |
+| `tests/models/specialization-tree.test.mjs` | modification | Valider le nouveau champ de schéma |
+| `tests/importer/specialization-tree-ogg-dude.spec.mjs` | modification | Couvrir les cas unitaires de résolution |
+| `tests/importer/specialization-tree-ogg-dude.integration.spec.mjs` | modification | Couvrir world items et compendium |
+
+---
+
+## 7. Risques
+
+| Risque | Impact | Mitigation |
+|---|---|---|
+| `#242` non totalement appliquée | résolution incomplète ou ambiguë | considérer `#242` comme prérequis dur pour la voie nominale |
+| plusieurs talents pour un même `system.id` | UUID non déterministe | documenter une règle de priorité et logger les collisions |
+| compendium index sans `system.id` exploitable | faux négatifs en compendium | fallback transitoire borné sur `flags.swerpg.oggdudeKey` |
+| surcharge de l'API générique des mappers | complexité technique inutile | injecter le contexte au niveau `buildSpecializationTreeContext()` |
+| warnings peu exploitables | diagnostic difficile | inclure `specializationId`, `nodeId`, `talentId`, source de résolution |
+| dérive de périmètre vers l'UI | ticket trop large | maintenir l'exploitation `fromUuidSync(node.talentUuid)` hors de #243 |
+
+---
+
+## 8. Proposition d'ordre de commit
+
+1. `feat(specialization-tree): add talentUuid to specialization tree node schema`
+2. `feat(importer): resolve talent uuids when mapping specialization tree nodes`
+3. `test(importer): cover specialization tree talent uuid resolution in world and compendium`
+
+---
+
+## 9. Dépendances avec les autres US
+
+- **Dépend de `#242`** : le contrat `talent.system.id` / `talent.system.uuid` doit exister pour une résolution nominale fiable.
+- **Prépare `#244`** : une fois `node.talentUuid` persisté, l'UI pourra résoudre les talents sans ambiguïté.
+- **N'inclut pas de migration** : un ticket séparé sera nécessaire si tu veux enrichir les `specialization-tree` déjà importés.

--- a/module/importer/items/specialization-tree-ogg-dude.mjs
+++ b/module/importer/items/specialization-tree-ogg-dude.mjs
@@ -4,6 +4,72 @@ import { logger } from '../../utils/logger.mjs'
 import { getSpecializationTreeImportStats, resetSpecializationTreeImportStats } from '../utils/specialization-tree-import-utils.mjs'
 import { specializationTreeMapper } from '../mappers/oggdude-specialization-tree-mapper.mjs'
 
+function buildTalentByIdFromWorld() {
+  if (typeof game === 'undefined' || !game.items) return new Map()
+
+  const index = new Map()
+  for (const item of game.items) {
+    if (item.type !== 'talent') continue
+    const id = item.system?.id
+    if (!id || typeof id !== 'string') {
+      const oggKey = item.getFlag?.('swerpg', 'oggdudeKey')
+      if (oggKey) {
+        index.set(oggKey.toLowerCase().trim(), { uuid: item.uuid, id: oggKey })
+      }
+      continue
+    }
+    const key = id.toLowerCase().trim()
+    if (!index.has(key)) {
+      index.set(key, { uuid: item.uuid, id })
+    }
+  }
+  return index
+}
+
+function buildTalentByIdFromCompendium() {
+  if (typeof game === 'undefined' || !game.packs) return new Map()
+
+  const index = new Map()
+
+  for (const pack of game.packs.values()) {
+    if (pack.documentName !== 'Item') continue
+    if (!pack.index?.size) continue
+    for (const entry of pack.index.values()) {
+      if (entry.type !== 'talent') continue
+      const flags = entry.flags?.swerpg
+      const systemId = entry.system?.id
+      if (systemId && typeof systemId === 'string') {
+        const key = systemId.toLowerCase().trim()
+        if (!index.has(key)) {
+          index.set(key, { uuid: `Compendium.${pack.collection}.${entry._id}`, id: systemId })
+        }
+      } else if (flags?.oggdudeKey) {
+        const key = flags.oggdudeKey.toLowerCase().trim()
+        if (!index.has(key)) {
+          index.set(key, { uuid: `Compendium.${pack.collection}.${entry._id}`, id: flags.oggdudeKey })
+        }
+      }
+    }
+  }
+  return index
+}
+
+function buildTalentIndex() {
+  const worldIndex = buildTalentByIdFromWorld()
+  const compendiumIndex = buildTalentByIdFromCompendium()
+
+  const result = new Map()
+  for (const [key, value] of worldIndex) {
+    result.set(key, value)
+  }
+  for (const [key, value] of compendiumIndex) {
+    if (!result.has(key)) {
+      result.set(key, value)
+    }
+  }
+  return result
+}
+
 export async function buildSpecializationTreeContext(zip, groupByDirectory, groupByType) {
   logger.debug('[SpecializationTreeImporter] Building Specialization Tree context', {
     groupByDirectoryCount: groupByDirectory.length,
@@ -21,6 +87,8 @@ export async function buildSpecializationTreeContext(zip, groupByDirectory, grou
         })
         .filter((entry) => entry && typeof entry === 'object')
     : []
+
+  const talentById = buildTalentIndex()
 
   return {
     jsonData: flattened,
@@ -42,10 +110,10 @@ export async function buildSpecializationTreeContext(zip, groupByDirectory, grou
     },
     element: {
       jsonCriteria: 'Specializations.Specialization',
-      mapper: specializationTreeMapper,
+      mapper: (specializations) => specializationTreeMapper(specializations, { talentById }),
       type: 'specialization-tree',
     },
   }
 }
 
-export { getSpecializationTreeImportStats, resetSpecializationTreeImportStats }
+export { getSpecializationTreeImportStats, resetSpecializationTreeImportStats, buildTalentIndex, buildTalentByIdFromWorld, buildTalentByIdFromCompendium }

--- a/module/importer/mappers/oggdude-specialization-tree-mapper.mjs
+++ b/module/importer/mappers/oggdude-specialization-tree-mapper.mjs
@@ -5,6 +5,7 @@ import {
   addSpecializationTreeMissingCost,
   addSpecializationTreeRejectionReason,
   addSpecializationTreeUnresolvedTalent,
+  addSpecializationTreeTalentUuidNotResolved,
   buildTreeImportDiagnostics,
   getSpecializationTreeImportStats,
   incrementSpecializationTreeImportStat,
@@ -311,7 +312,7 @@ function extractDirectionalConnections(nodes) {
   return { connections, warnings }
 }
 
-export function specializationTreeMapper(specializations) {
+export function specializationTreeMapper(specializations, { talentById } = {}) {
   resetSpecializationTreeImportStats()
 
   if (!Array.isArray(specializations) || specializations.length === 0) {
@@ -421,7 +422,19 @@ export function specializationTreeMapper(specializations) {
               book: sourceInfo.name || undefined,
               page: sourceInfo.page != null ? String(sourceInfo.page) : undefined,
             },
-            nodes: normalizedNodes.map(({ nodeId, talentId, row, column, cost }) => ({ nodeId, talentId, row, column, cost })),
+            nodes: normalizedNodes.map(({ nodeId, talentId, row, column, cost }) => {
+              let talentUuid = null
+              if (talentById && talentId) {
+                const key = talentId.toLowerCase().trim()
+                const resolved = talentById.get(key)
+                if (resolved) {
+                  talentUuid = resolved.uuid
+                } else {
+                  addSpecializationTreeTalentUuidNotResolved(`${specializationId}:${nodeId}:${talentId}`)
+                }
+              }
+              return { nodeId, talentId, talentUuid, row, column, cost }
+            }),
             connections,
           },
           flags: {
@@ -458,4 +471,4 @@ export function specializationTreeMapper(specializations) {
     .filter(Boolean)
 }
 
-export { extractDirectionalConnections, getSpecializationTreeImportStats, resetSpecializationTreeImportStats }
+export { extractDirectionalConnections, getSpecializationTreeImportStats, resetSpecializationTreeImportStats, addSpecializationTreeTalentUuidNotResolved }

--- a/module/importer/utils/specialization-tree-import-utils.mjs
+++ b/module/importer/utils/specialization-tree-import-utils.mjs
@@ -32,6 +32,10 @@ export function addSpecializationTreeUnresolvedTalent(detail) {
   specializationTreeStats.addDetail('unresolvedTalents', detail, 'unresolvedTalentDetails')
 }
 
+export function addSpecializationTreeTalentUuidNotResolved(detail) {
+  specializationTreeStats.addDetail('unresolvedTalents', detail, 'talentUuidNotResolvedDetails')
+}
+
 export function addSpecializationTreeInvalidConnection(detail) {
   specializationTreeStats.addDetail('invalidConnections', detail, 'invalidConnectionDetails')
 }

--- a/module/models/specialization-tree.mjs
+++ b/module/models/specialization-tree.mjs
@@ -17,6 +17,7 @@ export default class SwerpgSpecializationTree extends foundry.abstract.TypeDataM
         new fields.SchemaField({
           nodeId: new fields.StringField({ required: true, blank: false }),
           talentId: new fields.StringField({ required: true, blank: false }),
+          talentUuid: new fields.StringField({ required: false, nullable: true, blank: false, initial: null }),
           row: new fields.NumberField({ required: false, nullable: false, integer: true, min: 1, max: 10, initial: 1 }),
           column: new fields.NumberField({ required: false, nullable: false, integer: true, min: 1, max: 10, initial: 1 }),
           cost: new fields.NumberField({ required: false, nullable: false, integer: true, min: 0, initial: 5 }),

--- a/tests/importer/specialization-tree-ogg-dude.integration.spec.mjs
+++ b/tests/importer/specialization-tree-ogg-dude.integration.spec.mjs
@@ -221,7 +221,7 @@ describe('chaîne complète parseur → context builder → mapper', () => {
     const context = await buildSpecializationTreeContext({}, [], { xml: ['Advisor.xml'], image: [] })
 
     expect(context.element.type).toBe('specialization-tree')
-    expect(context.element.mapper).toBe(specializationTreeMapper)
+    expect(typeof context.element.mapper).toBe('function')
     expect(context.jsonData).toHaveLength(1)
     expect(context.jsonData[0].Key).toBe('ADVISOR')
 

--- a/tests/importer/specialization-tree-ogg-dude.spec.mjs
+++ b/tests/importer/specialization-tree-ogg-dude.spec.mjs
@@ -462,6 +462,78 @@ describe('extractDirectionalConnections', () => {
   })
 })
 
+describe('specializationTreeMapper — talentUuid enrichment', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    resetSpecializationTreeImportStats()
+  })
+
+  const minimalInput = [
+    {
+      Key: 'BODYGUARD',
+      Name: 'Bodyguard',
+      TalentRows: {
+        TalentRow: [
+          {
+            Cost: '5',
+            Talents: { Key: ['PARRY'] },
+          },
+        ],
+      },
+    },
+  ]
+
+  it('sets talentUuid from talentById when a matching talent exists', () => {
+    const talentById = new Map([
+      ['parry', { uuid: 'Item.talentParry001', id: 'parry' }],
+    ])
+
+    const result = specializationTreeMapper(minimalInput, { talentById })
+
+    expect(result[0].system.nodes[0].talentId).toBe('parry')
+    expect(result[0].system.nodes[0].talentUuid).toBe('Item.talentParry001')
+  })
+
+  it('sets talentUuid to null when talentById is not provided', () => {
+    const result = specializationTreeMapper(minimalInput)
+
+    expect(result[0].system.nodes[0].talentId).toBe('parry')
+    expect(result[0].system.nodes[0].talentUuid).toBeNull()
+  })
+
+  it('sets talentUuid to null when the talent is not found in talentById', () => {
+    const talentById = new Map([
+      ['other', { uuid: 'Item.other001', id: 'other' }],
+    ])
+
+    const result = specializationTreeMapper(minimalInput, { talentById })
+
+    expect(result[0].system.nodes[0].talentId).toBe('parry')
+    expect(result[0].system.nodes[0].talentUuid).toBeNull()
+  })
+
+  it('resolves talentUuid when talentById key is already lowercased', () => {
+    const talentById = new Map([
+      ['parry', { uuid: 'Item.talentParry002', id: 'parry' }],
+    ])
+
+    const result = specializationTreeMapper(minimalInput, { talentById })
+
+    expect(result[0].system.nodes[0].talentUuid).toBe('Item.talentParry002')
+  })
+
+  it('preserves talentId unchanged when talentUuid is resolved', () => {
+    const talentById = new Map([
+      ['parry', { uuid: 'Item.talentParry003', id: 'parry' }],
+    ])
+
+    const result = specializationTreeMapper(minimalInput, { talentById })
+
+    expect(result[0].system.nodes[0].talentId).toBe('parry')
+    expect(result[0].system.nodes[0].talentUuid).toBe('Item.talentParry003')
+  })
+})
+
 describe('buildSpecializationTreeContext', () => {
   beforeEach(() => {
     vi.clearAllMocks()
@@ -474,7 +546,7 @@ describe('buildSpecializationTreeContext', () => {
 
     expect(context.folder.name).toBe('Swerpg - Specialization Trees')
     expect(context.element.type).toBe('specialization-tree')
-    expect(context.element.mapper).toBe(specializationTreeMapper)
+    expect(typeof context.element.mapper).toBe('function')
     expect(context.jsonData).toEqual([{ Key: 'BODYGUARD' }])
   })
 })

--- a/tests/models/specialization-tree.test.mjs
+++ b/tests/models/specialization-tree.test.mjs
@@ -60,13 +60,16 @@ describe('SwerpgSpecializationTree', () => {
       expect(source.schema.page).toBeInstanceOf(foundry.data.fields.StringField)
     })
 
-    test('nodes ArrayField wraps a SchemaField with nodeId, talentId, row, column, cost', () => {
+    test('nodes ArrayField wraps a SchemaField with nodeId, talentId, talentUuid, row, column, cost', () => {
       const nodeField = SwerpgSpecializationTree.defineSchema().nodes.field
       expect(nodeField).toBeInstanceOf(foundry.data.fields.SchemaField)
       expect(nodeField.schema.nodeId).toBeInstanceOf(foundry.data.fields.StringField)
       expect(nodeField.schema.nodeId.config.required).toBe(true)
       expect(nodeField.schema.talentId).toBeInstanceOf(foundry.data.fields.StringField)
       expect(nodeField.schema.talentId.config.required).toBe(true)
+      expect(nodeField.schema.talentUuid).toBeInstanceOf(foundry.data.fields.StringField)
+      expect(nodeField.schema.talentUuid.config.required).toBe(false)
+      expect(nodeField.schema.talentUuid.config.nullable).toBe(true)
       expect(nodeField.schema.row).toBeInstanceOf(foundry.data.fields.NumberField)
       expect(nodeField.schema.column).toBeInstanceOf(foundry.data.fields.NumberField)
       expect(nodeField.schema.cost).toBeInstanceOf(foundry.data.fields.NumberField)


### PR DESCRIPTION
## Summary

Enrichit chaque noeud des `specialization-tree` avec `talentUuid` lors de l'import OggDude, conformement a l'ADR-0013.

### Changements

- **Schema** : ajout de `talentUuid` (nullable, optionnel) au modele `specialization-tree`
- **Resolver** : construction d'un index `talentId → uuid` depuis `game.items` et les index de compendium, avec priorite `system.id` et fallback `flags.swerpg.oggdudeKey`
- **Mapper** : enrichissement des noeuds avec `talentUuid` resolu, `talentId` conserve inchange
- **Diagnostics** : nouveau warning `talentUuidNotResolved` pour les talents non trouves
- **Tests** : couverture du schema, resolution world/compendium, absence, cas non trouve, casse

### Fichiers modifies

| Fichier | Description |
|---|---|
| `module/models/specialization-tree.mjs` | Ajout `talentUuid` au schema des noeuds |
| `module/importer/items/specialization-tree-ogg-dude.mjs` | Index talents + injection contexte mapper |
| `module/importer/mappers/oggdude-specialization-tree-mapper.mjs` | Enrichissement nodes + warnings |
| `module/importer/utils/specialization-tree-import-utils.mjs` | Nouveau diagnostic |
| `tests/models/specialization-tree.test.mjs` | Validation schema |
| `tests/importer/specialization-tree-ogg-dude.spec.mjs` | 5 nouveaux tests unitaires |
| `tests/importer/specialization-tree-ogg-dude.integration.spec.mjs` | Adaptation test reference |

### Validation

- 139 test files, 1618 tests, 0 failures
- `pnpm vitest run` — tout vert

Closes #243