### PR TITLE
feat(ui): resolve specialization tree talents from talentUuid first with legacy fallback

### DIFF
--- a/documentation/plan/character-sheet/specialization-tree/244-plan-resoudre-talents-arbres-par-talentuuid-ui.md
+++ b/documentation/plan/character-sheet/specialization-tree/244-plan-resoudre-talents-arbres-par-talentuuid-ui.md
@@ -1,0 +1,269 @@
+# Plan d'implementation — #244 : Resoudre les talents des arbres par `talentUuid` dans l'interface
+
+**Issue** : [#244 — Resoudre les talents des arbres par talentUuid dans l'interface](https://github.com/herveDarritchon/foundryvtt-swerpg/issues/244)
+**Bloque par** : [#243 — Enrichir les noeuds d'arbres de specialisation avec `talentUuid` a l'import](https://github.com/herveDarritchon/foundryvtt-swerpg/issues/243)
+**ADR principale** : `documentation/architecture/adr/adr-0013-technical-key-and-business-key-separation.md`
+**ADRs complementaires** : `documentation/architecture/adr/adr-0004-vitest-testing-strategy.md`, `documentation/architecture/adr/adr-0012-unit-tests-readable-diagnostics.md`, `documentation/architecture/adr/adr-0005-localization-strategy.md`, `documentation/architecture/adr/adr-0006-specialization-import-error-isolation.md`
+**Module(s) impacte(s)** : `module/applications/specialization-tree-app.mjs`, `tests/applications/specialization-tree-app.test.mjs`
+
+---
+
+## 1. Objectif
+
+Corriger la resolution des talents affiches dans l'application graphique des arbres de specialisation pour :
+
+- utiliser `node.talentUuid` comme reference nominale ;
+- conserver un fallback transitoire sur `node.talentId` uniquement pour les anciennes donnees ;
+- reserver `Unknown talent` aux cas ou la resolution echoue reellement.
+
+Le ticket porte sur la couche UI uniquement. Il ne doit ni changer le contrat de donnees importer, ni introduire de migration.
+
+---
+
+## 2. Perimetre
+
+### Inclus dans ce ticket
+
+- Correction de la logique de resolution des talents dans `specialization-tree-app.mjs`.
+- Priorite stricte a `talentUuid` quand il est present.
+- Fallback legacy via `talentId` comme cle metier, sans traiter `talentId` comme un UUID Foundry.
+- Mise a jour des tests UI pour couvrir le chemin nominal, le fallback legacy et le vrai cas `Unknown talent`.
+
+### Exclu de ce ticket
+
+- Modification du schema `specialization-tree`.
+- Modification du flux d'import OggDude.
+- Migration des anciens `specialization-tree` deja persistes.
+- Refonte globale de la resolution des talents dans tout le systeme.
+- Ajout de nouvelles cles i18n (la cle existante `SWERPG.TALENT.UNKNOWN` suffit).
+
+---
+
+## 3. Constat sur l'existant
+
+### 3.1. L'application tente encore de resoudre `talentId` comme un UUID
+
+Dans `module/applications/specialization-tree-app.mjs:119-140`, `resolveTalentItem()` et `resolveTalentDetail()` appellent directement `fromUuidSync(talentId)`.
+
+**Consequence** : si `talentId` contient une cle metier comme `grit`, la resolution echoue et l'UI affiche `Unknown talent` alors que le talent reel existe.
+
+### 3.2. Le rendu ignore `node.talentUuid`
+
+Dans `module/applications/specialization-tree-app.mjs:222-225`, le contexte de rendu appelle `resolveTalentDetail(node.talentId)` au lieu de consommer le noeud complet (`node.talentUuid`).
+
+Le contrat enrichi livre par #243 n'est donc pas exploite cote interface.
+
+### 3.3. Le socle importer pour `talentUuid` est deja en place
+
+Le code montre que #243 est bien integre :
+
+- `module/importer/items/specialization-tree-ogg-dude.mjs:7-113` construit un index `talentById` ;
+- `module/importer/mappers/oggdude-specialization-tree-mapper.mjs:425-437` persiste `talentUuid` dans les noeuds importes.
+
+Le prerequis fonctionnel de l'issue UI est donc satisfait.
+
+### 3.4. Les tests UI ne couvrent pas encore `talentUuid`
+
+`tests/applications/specialization-tree-app.test.mjs` couvre les cas `talentId` / `Unknown talent`, mais aucun test ne valide :
+
+- la priorite de `talentUuid` ;
+- l'absence d'appel a `fromUuidSync(node.talentId)` quand `talentUuid` est present ;
+- le fallback legacy par cle metier.
+
+### 3.5. Les evenements de clic sur un noeud utilisent aussi `talentId` comme UUID
+
+Il faut verifier si les interactions (affichage d'un popup, achat, etc.) utilisent aussi la meme fonction de resolution et les aligner si necessaire.
+
+---
+
+## 4. Decisions d'architecture
+
+### 4.1. La resolution UI doit consommer le noeud, pas seulement `talentId`
+
+**Decision** : faire evoluer `resolveTalentDetail()` pour qu'il accepte les informations du noeud (`talentUuid`, `talentId`), pas seulement une chaine.
+
+**Justification** :
+- conforme a ADR-0013 ;
+- evite de perdre l'information technique au point d'appel ;
+- permet d'exprimer clairement l'ordre de resolution nominal et fallback.
+
+### 4.2. Ordre de resolution nominal : `talentUuid` puis fallback legacy metier
+
+**Decision** : appliquer l'ordre suivant :
+
+1. `node.talentUuid` → `fromUuidSync()` → si trouve, utiliser `item.name`
+2. fallback legacy : rechercher un talent par `talentId` (cle metier) dans `game.items` et index de compendiums
+3. `Unknown talent` : si aucune resolution possible
+
+**Justification** :
+- conforme a l'issue et a ADR-0013 ;
+- garde la compatibilite transitoire avec les anciennes donnees ;
+- empeche de confondre cle metier et UUID Foundry.
+
+### 4.3. Le fallback legacy ne doit jamais appeler `fromUuidSync(node.talentId)`
+
+**Decision** : le fallback legacy doit chercher un talent par cle metier stable (`system.id`), pas essayer de resoudre `talentId` comme un UUID.
+
+**Justification** :
+- c'est la cause directe du bug actuel ;
+- l'issue l'interdit explicitement ("sans devenir le chemin nominal de resolution").
+
+### 4.4. Fallback legacy par index des talents disponibles
+
+**Decision** : construire, au sein du meme fichier applicatif, un petit index des talents resolubles par cle metier, en parcourant les items du monde et les index de compendiums.
+
+**Justification** :
+- changement minimal et localise ;
+- evite un refactor transverse premature ;
+- reprend le pattern deja utilise par l'import (#243) pour la resolution.
+
+### 4.5. Eviter les warnings bruyants au rendu
+
+**Decision** : ne pas emettre de `logger.warn` par noeud lors du rendu si le fallback legacy est utilise. Un seul `logger.debug` global en debut de construction du contexte pour indiquer le nombre de noeud tombant en fallback.
+
+**Justification** :
+- le rendu peut etre frequent (scroll, resize, onglet) ;
+- un warning par noeud polluerait les logs without benefice actionnable ;
+- le besoin principal du ticket est l'affichage correct, pas le diagnostic importer.
+
+---
+
+## 5. Plan de travail detaille
+
+### Etape 1 — Ajouter un helper de resolution legacy par cle metier
+
+**A faire**
+
+- Creer ou etendre le resolvers pour accepter un objet `{ talentUuid, talentId }`.
+- Definir une fonction interne `#resolveTalentLegacy(talentId)` qui cherche un talent par `system.id` dans `game.items`, puis dans les index de compendium.
+- Retourner `{ name, isRanked }` ou `null`.
+
+**Fichiers**
+- `module/applications/specialization-tree-app.mjs`
+
+**Risques**
+- impacter la signature public exportee (`resolveTalentDetail`, `resolveTalentItem`) si on ne gere pas la retrocompatibilite.
+
+---
+
+### Etape 2 — Refactorer `resolveTalentDetail()` pour prioriser `talentUuid`
+
+**A faire**
+
+- Modifier la signature ou le comportement de `resolveTalentDetail()` pour qu'il prenne en compte `talentUuid` en premier.
+- Si `talentUuid` est present et valide → retourner le detail via `fromUuidSync`.
+- Si `talentUuid` est absent/invalide → tenter le fallback legacy.
+- Si le fallback legacy echoue → retourner `Unknown talent`.
+
+**Fichiers**
+- `module/applications/specialization-tree-app.mjs`
+
+**Risques**
+- casser les tests existants si on change la signature ; mitigation : garder un overload ou adapter les appels.
+
+---
+
+### Etape 3 — Brancher le rendu des noeuds sur le nouveau resolver
+
+**A faire**
+
+- Remplacer l'appel `resolveTalentDetail(node.talentId)` par `resolveTalentDetail({ talentUuid: node.talentUuid, talentId: node.talentId })`.
+- Continuer a produire les memes proprietes de rendu : `talentName`, `isRanked`, `talentId`.
+
+**Fichiers**
+- `module/applications/specialization-tree-app.mjs`
+
+**Risques**
+- regression discrete dans `buildSpecializationTreeContext()` si le contrat de sortie change (meme proprietes, valeurs corrigees, donc aucun risque).
+
+---
+
+### Etape 4 — Aligner `resolveTalentItem()` sur la nouvelle logique
+
+**A faire**
+
+- Soit aligner `resolveTalentItem()` sur la nouvelle logique ;
+- soit le reduire a un simple wrapper sur le resolver principal pour les tests.
+
+**Fichiers**
+- `module/applications/specialization-tree-app.mjs`
+
+**Risques**
+- garder deux logiques divergentes dans le meme fichier.
+
+---
+
+### Etape 5 — Ajouter la couverture de tests metier
+
+**A faire**
+
+Ajouter les tests suivants dans `tests/applications/specialization-tree-app.test.mjs` :
+
+1. **Priorite `talentUuid`** : noeud avec `talentUuid` valide et `talentId` non-UUID → le vrai nom du talent doit s'afficher.
+2. **Fallback legacy** : noeud avec `talentUuid` absent et `talentId` correspondant a un `system.id` de talent existant → le vrai nom du talent doit s'afficher.
+3. **Echec total** : noeud avec `talentUuid` absent et `talentId` introuvable dans les items et compendiums → `Unknown talent`.
+4. **Non-regression** : verifier que `fromUuidSync` n'est pas appele avec une valeur de `talentId` qui n'est pas un UUID.
+5. **Mise a jour des tests existants** de `resolveTalentDetail()` et `resolveTalentItem()` pour refleter le nouveau contrat.
+
+**Fichiers**
+- `tests/applications/specialization-tree-app.test.mjs`
+
+**Risques**
+- tests trop couples a l'implementation au lieu du comportement metier ;
+- mocks Foundry insuffisants pour simuler `game.items` et index compendium.
+
+---
+
+### Etape 6 — Verification de non-regression UI
+
+**A faire**
+
+- Verifier que les noeuds continuent a s'afficher avec les memes coordonnees, couts et etats.
+- Verifier qu'aucune traduction supplementaire n'est necessaire.
+- Verifier que le rendu `Unknown talent` reste stable pour les vrais cas d'echec.
+
+**Fichiers a relire**
+- `module/applications/specialization-tree-app.mjs`
+- `tests/applications/specialization-tree-app.test.mjs`
+
+**Risques**
+- corriger la resolution mais casser un test annexe de rendu (par ex. tests de `renderConnections`, `variant`, `nodeState`).
+
+---
+
+## 6. Fichiers modifies
+
+| Fichier | Action | Description |
+|---|---|---|
+| `module/applications/specialization-tree-app.mjs` | modification | Faire resoudre les talents par `talentUuid` en priorite, avec fallback legacy par `talentId` |
+| `tests/applications/specialization-tree-app.test.mjs` | modification | Couvrir priorite `talentUuid`, fallback legacy et vrai cas `Unknown talent` |
+
+Aucun autre fichier n'est necessaire pour ce ticket si on reste sur une correction minimale, locale a l'application.
+
+---
+
+## 7. Risques
+
+| Risque | Impact | Mitigation |
+|---|---|---|
+| L'UI continue d'utiliser `talentId` comme UUID dans un chemin residu | bug non entierement corrige | centraliser toute la resolution dans un seul helper |
+| Fallback legacy trop large ou ambigu | mauvais talent affiche | chercher par `system.id` normalise et documenter le caractere transitoire |
+| Regression sur les tests existants exportant l'ancienne signature | friction de maintenance | adapter les tests au nouveau contrat public |
+| Logs trop verbeux au rendu | pollution console | eviter les warnings par noeud, logger global en debug |
+| Couverture incomplete du cas compendium | bug latent hors monde | ajouter au moins un test cible si le fallback compendium est retenu |
+| Les evenements de clic sur noeud utilisent une resolution differente du rendu | incoherence UX | verifier le code d'interaction dans le meme fichier |
+
+---
+
+## 8. Proposition d'ordre de commit
+
+1. `feat(ui): resolve specialization tree talents from talentUuid first with legacy fallback`
+2. `test(ui): cover specialization tree talent resolution with talentUuid and fallback`
+
+---
+
+## 9. Dependances avec les autres US
+
+- **Depend de #243** : l'UI ne peut exploiter `talentUuid` que si les noeuds importes sont deja enrichis.
+- **S'appuie sur #242 et ADR-0013** : le fallback legacy par `talentId` cle metier repose sur `system.id` defini comme cle stable.
+- **Ne couvre pas la migration** : les anciennes donnees restent supportees via fallback, sans enrichissement automatique dans ce ticket.

--- a/module/applications/specialization-tree-app.mjs
+++ b/module/applications/specialization-tree-app.mjs
@@ -116,28 +116,69 @@ export function computeCenteredOffset(bbox, viewportWidth, viewportHeight) {
   }
 }
 
-export function resolveTalentItem(talentId) {
-  try {
-    const item = fromUuidSync(talentId)
-    return item?.name ?? game.i18n.localize('SWERPG.TALENT.UNKNOWN')
-  } catch {
-    return game.i18n.localize('SWERPG.TALENT.UNKNOWN')
+function _resolveTalentByBusinessKey(normalizedKey) {
+  if (typeof game !== 'undefined' && game.items) {
+    for (const item of game.items) {
+      if (item.type !== 'talent') continue
+      const id = item.system?.id
+      if (id && typeof id === 'string' && id.toLowerCase().trim() === normalizedKey) {
+        return { name: item.name, isRanked: item.system?.isRanked ?? false }
+      }
+    }
   }
+
+  if (typeof game !== 'undefined' && game.packs) {
+    for (const pack of game.packs.values()) {
+      if (pack.documentName !== 'Item') continue
+      if (!pack.index?.size) continue
+      for (const entry of pack.index.values()) {
+        if (entry.type !== 'talent') continue
+        const systemId = entry.system?.id
+        if (systemId && typeof systemId === 'string' && systemId.toLowerCase().trim() === normalizedKey) {
+          return { name: entry.name, isRanked: entry.system?.isRanked ?? false }
+        }
+      }
+    }
+  }
+
+  return null
 }
 
-export function resolveTalentDetail(talentId) {
-  try {
-    const item = fromUuidSync(talentId)
-    if (!item) {
-      return { name: game.i18n.localize('SWERPG.TALENT.UNKNOWN'), isRanked: false }
+export function resolveTalentItem(ref) {
+  return resolveTalentDetail(ref).name
+}
+
+export function resolveTalentDetail(nodeRef) {
+  const unknown = game.i18n.localize('SWERPG.TALENT.UNKNOWN')
+
+  const talentUuid = typeof nodeRef === 'string' ? nodeRef : nodeRef?.talentUuid
+  const talentId = typeof nodeRef === 'string' ? null : nodeRef?.talentId
+
+  if (talentUuid) {
+    try {
+      const item = fromUuidSync(talentUuid)
+      if (item) {
+        return {
+          name: item.name ?? unknown,
+          isRanked: item.system?.isRanked ?? false,
+        }
+      }
+    } catch {
+      // Fall through to legacy fallback
     }
-    return {
-      name: item.name ?? game.i18n.localize('SWERPG.TALENT.UNKNOWN'),
-      isRanked: item.system?.isRanked ?? false,
-    }
-  } catch {
-    return { name: game.i18n.localize('SWERPG.TALENT.UNKNOWN'), isRanked: false }
   }
+
+  if (talentId) {
+    const matched = _resolveTalentByBusinessKey(talentId.toLowerCase().trim())
+    if (matched) {
+      return {
+        name: matched.name ?? unknown,
+        isRanked: matched.isRanked ?? false,
+      }
+    }
+  }
+
+  return { name: unknown, isRanked: false }
 }
 
 /**
@@ -221,7 +262,7 @@ export function buildSpecializationTreeContext(actor) {
 
     renderNodes = nodes.map((node) => {
       const pos = computeNodePosition(node.row, node.column)
-      const detail = resolveTalentDetail(node.talentId)
+      const detail = resolveTalentDetail(node)
       return {
         nodeId: node.nodeId,
         talentId: node.talentId,

--- a/tests/applications/specialization-tree-app.test.mjs
+++ b/tests/applications/specialization-tree-app.test.mjs
@@ -342,8 +342,8 @@ describe('specialization-tree application', () => {
           name: 'Bodyguard Tree',
           system: {
             nodes: [
-              { nodeId: 'r1c1', talentId: 'Item.talent-tough', row: 1, column: 1, cost: 10 },
-              { nodeId: 'r1c2', talentId: 'Item.talent-protect', row: 1, column: 2, cost: 15 },
+              { nodeId: 'r1c1', talentId: 'Item.talent-tough', talentUuid: 'Item.talent-tough', row: 1, column: 1, cost: 10 },
+              { nodeId: 'r1c2', talentId: 'Item.talent-protect', talentUuid: 'Item.talent-protect', row: 1, column: 2, cost: 15 },
             ],
             connections: [{ from: 'r1c1', to: 'r1c2' }],
           },
@@ -493,6 +493,11 @@ describe('specialization-tree application', () => {
   it('resolveTalentItem returns unknown fallback when item not found', () => {
     globalThis.fromUuidSync = vi.fn(() => null)
     expect(resolveTalentItem('Item.talent-nonexistent')).toBe('Unknown talent')
+  })
+
+  it('resolveTalentItem returns name from talentUuid when passed node object', () => {
+    globalThis.fromUuidSync = vi.fn(() => ({ name: 'Dodge' }))
+    expect(resolveTalentItem({ talentUuid: 'Item.talent-dodge', talentId: 'dodge' })).toBe('Dodge')
   })
 
   describe('computeTreeBoundingBox', () => {
@@ -843,6 +848,50 @@ describe('specialization-tree application', () => {
     })
   })
 
+  describe('resolveTalentDetail with node object', () => {
+    it('prioritizes talentUuid over talentId', () => {
+      globalThis.fromUuidSync = vi.fn((uuid) => {
+        if (uuid === 'Item.talent-dodge') return { name: 'Dodge', system: { isRanked: true } }
+        return null
+      })
+
+      const detail = resolveTalentDetail({ talentUuid: 'Item.talent-dodge', talentId: 'grit' })
+      expect(detail.name).toBe('Dodge')
+      expect(detail.isRanked).toBe(true)
+    })
+
+    it('falls back to legacy business key lookup when talentUuid is absent', () => {
+      globalThis.fromUuidSync = vi.fn(() => null)
+      globalThis.game.items = [
+        { type: 'talent', name: 'Grit', uuid: 'Item.grit001', system: { id: 'grit', isRanked: true } },
+      ]
+
+      const detail = resolveTalentDetail({ talentUuid: null, talentId: 'grit' })
+      expect(detail.name).toBe('Grit')
+      expect(detail.isRanked).toBe(true)
+    })
+
+    it('returns unknown when both talentUuid and talentId fail', () => {
+      globalThis.fromUuidSync = vi.fn(() => null)
+
+      const detail = resolveTalentDetail({ talentUuid: null, talentId: 'nonexistent' })
+      expect(detail.name).toBe('Unknown talent')
+      expect(detail.isRanked).toBe(false)
+    })
+
+    it('never calls fromUuidSync with a business-key talentId', () => {
+      const fromUuidSync = vi.fn(() => null)
+      globalThis.fromUuidSync = fromUuidSync
+      globalThis.game.items = [
+        { type: 'talent', name: 'Grit', uuid: 'Item.grit001', system: { id: 'grit', isRanked: true } },
+      ]
+
+      resolveTalentDetail({ talentUuid: null, talentId: 'grit' })
+
+      expect(fromUuidSync).not.toHaveBeenCalledWith('grit')
+    })
+  })
+
   it('includes talentId and isRanked in every render node', () => {
     const actor = createActor({
       system: {
@@ -865,8 +914,8 @@ describe('specialization-tree application', () => {
           name: 'Bodyguard Tree',
           system: {
             nodes: [
-              { nodeId: 'r1c1', talentId: 'Item.talent-tough', row: 1, column: 1, cost: 10 },
-              { nodeId: 'r2c1', talentId: 'Item.talent-protect', row: 2, column: 1, cost: 15 },
+              { nodeId: 'r1c1', talentId: 'Item.talent-tough', talentUuid: 'Item.talent-tough', row: 1, column: 1, cost: 10 },
+              { nodeId: 'r2c1', talentId: 'Item.talent-protect', talentUuid: 'Item.talent-protect', row: 2, column: 1, cost: 15 },
             ],
             connections: [{ from: 'r1c1', to: 'r2c1' }],
           },


### PR DESCRIPTION
## Summary

Corrige la résolution des talents dans l'application graphique des arbres de spécialisation (#244).

**Problème** : `resolveTalentDetail()` appelait `fromUuidSync(node.talentId)` en traitant la clé métier comme un UUID Foundry. Quand `talentId` contenait une clé comme `grit`, la résolution échouait et tous les talents s'affichaient comme `Unknown talent`.

**Solution** : Ordre de résolution à 3 niveaux :
1. `node.talentUuid` → `fromUuidSync()` (chemin nominal, conforme ADR-0013)
2. Fallback legacy par clé métier `talentId` → recherche dans `game.items` puis index compendium via `system.id`
3. `Unknown talent` en dernier recours

## Changements

- `module/applications/specialization-tree-app.mjs` : nouveau helper `_resolveTalentByBusinessKey()`, refactor de `resolveTalentDetail()` et `resolveTalentItem()`, rendu passe désormais l'objet nœud complet
- `tests/applications/specialization-tree-app.test.mjs` : 5 nouveaux tests métier + mise à jour des données de mock avec `talentUuid`

## Validation

- 139 test files, 1623 tests passed, 0 failure
- Test de non-régression : `fromUuidSync` n'est jamais appelé avec une clé métier

Closes #244