### PR TITLE
feat(test): verify end-to-end talent resolution chain in world and compendium contexts

### DIFF
--- a/documentation/plan/character-sheet/specialization-tree/245-plan-verifier-chaine-complete-talents-arbres-world-compendium.md
+++ b/documentation/plan/character-sheet/specialization-tree/245-plan-verifier-chaine-complete-talents-arbres-world-compendium.md
@@ -1,0 +1,306 @@
+# Plan d'implémentation — #245 : Vérifier la chaîne complète talents et arbres en world et en compendium
+
+**Issue** : [#245 — Vérifier la chaîne complète talents et arbres en world et en compendium](https://github.com/herveDarritchon/foundryvtt-swerpg/issues/245)  
+**Bloqué par** : [#243](https://github.com/herveDarritchon/foundryvtt-swerpg/issues/243), [#244](https://github.com/herveDarritchon/foundryvtt-swerpg/issues/244)  
+**ADR principale** : `documentation/architecture/adr/adr-0013-technical-key-and-business-key-separation.md`  
+**ADRs complémentaires** : `documentation/architecture/adr/adr-0004-vitest-testing-strategy.md`, `documentation/architecture/adr/adr-0012-unit-tests-readable-diagnostics.md`  
+**Module(s) impacté(s)** : `tests/importer/specialization-tree-ogg-dude.integration.spec.mjs`, `tests/applications/specialization-tree-app.test.mjs`, potentiellement `tests/helpers/mock-foundry.mjs` et `tests/helpers/mock-foundry.test.mjs`
+
+---
+
+## 1. Objectif
+
+Valider de bout en bout que la chaîne :
+
+`talent référentiel` -> `talentUuid` importé dans les nœuds -> résolution du document Foundry -> affichage UI
+
+fonctionne correctement dans les deux contextes suivants :
+
+- **world items**
+- **compendium items**
+
+Le ticket porte sur une preuve d'intégration démontrable. Le besoin principal n'est plus d'introduire un nouveau contrat, mais de prouver que le contrat livré par #243 et consommé par #244 tient réellement en chaîne complète.
+
+---
+
+## 2. Périmètre
+
+### Inclus dans ce ticket
+
+- Ajouter un scénario automatisé complet pour world items.
+- Ajouter un scénario automatisé complet pour compendium items.
+- Vérifier la forme exacte de l'UUID Foundry réutilisé dans les nœuds.
+- Vérifier que l'UI affiche le talent attendu sans retomber sur `Unknown talent`.
+- Consolider les mocks de compendium si nécessaire pour refléter le vrai contrat utilisé par le code.
+
+### Exclu de ce ticket
+
+- Nouvelle évolution du contrat métier `talentId` / `talentUuid`.
+- Refonte de l'importer OggDude.
+- Refonte de l'application `specialization-tree-app`.
+- Migration de données historiques.
+- Ajout de tests Playwright sauf besoin explicite de validation navigateur réelle.
+
+---
+
+## 3. Constat sur l'existant
+
+### 3.1. Les tickets bloquants semblent déjà intégrés
+
+Le code lu montre que :
+
+- `module/importer/items/specialization-tree-ogg-dude.mjs` construit déjà un index de talents world + compendium.
+- `module/importer/mappers/oggdude-specialization-tree-mapper.mjs` persiste déjà `talentUuid` dans chaque nœud.
+- `module/applications/specialization-tree-app.mjs` résout déjà `talentUuid` en priorité et ne traite plus `talentId` comme UUID nominal.
+
+### 3.2. La couverture actuelle est fragmentée
+
+Les tests actuels couvrent des morceaux isolés :
+
+- enrichissement `talentUuid` dans le mapper ;
+- résolution UI via `resolveTalentDetail()` ;
+- rendu avec des nœuds déjà fournis.
+
+Mais ils ne démontrent pas une chaîne complète unique allant de l'import des talents/arbre jusqu'au rendu UI final.
+
+### 3.3. Le cas compendium n'est pas suffisamment prouvé en chaîne complète
+
+Aucun scénario de test ne vérifie explicitement :
+
+- la construction de `Compendium.<collection>.<id>` ;
+- sa persistance dans `node.talentUuid` ;
+- sa réutilisation effective dans le rendu UI.
+
+### 3.4. Les helpers de mock peuvent être trop faibles pour ce besoin
+
+Le helper `tests/helpers/mock-foundry.mjs` expose bien `game.packs`, mais sa forme actuelle ne reflète pas complètement ce que le code de prod parcourt :
+
+- `pack.documentName`
+- `pack.collection`
+- `pack.index.size`
+- `pack.index.values()`
+
+Pour un test compendium fiable, il faudra soit enrichir ce helper, soit créer localement un mock plus fidèle.
+
+---
+
+## 4. Décisions d'architecture
+
+### 4.1. Utiliser des tests d'intégration Vitest plutôt qu'une démo manuelle seule
+
+**Décision** : couvrir #245 principalement par des tests d'intégration Vitest.
+
+**Justification** :
+- conforme ADR-0004.
+- démonstration reproductible en CI.
+- plus robuste qu'une validation manuelle seule.
+
+### 4.2. Tester la chaîne complète dans un scénario unique par contexte
+
+**Décision** : écrire deux scénarios nominaux complets : world et compendium.
+
+**Justification** :
+- correspond exactement aux critères d'acceptation.
+- évite une couverture dispersée difficile à relire.
+
+### 4.3. Réutiliser les modules réels plutôt que sur-mocker la logique métier
+
+**Décision** : chaîner les vraies fonctions déjà en place :
+
+- `buildTalentIndex()`, `buildTalentByIdFromWorld()`, `buildTalentByIdFromCompendium()` de l'importer.
+- `specializationTreeMapper()`.
+- `buildSpecializationTreeContext()` de l'application UI.
+
+**Justification** :
+- meilleure preuve d'intégration.
+- limite les faux positifs dus à des mocks trop éloignés du runtime réel.
+
+### 4.4. Garder les assertions ciblées
+
+**Décision** : vérifier des valeurs métier simples :
+
+- `node.talentId`
+- `node.talentUuid`
+- `renderNode.talentName`
+- absence de `Unknown talent`
+
+**Justification** :
+- conforme ADR-0012.
+- diagnostics plus lisibles.
+
+### 4.5. Ne modifier le code métier que si le test révèle une vraie rupture
+
+**Décision** : ce ticket doit rester orienté validation. Toute modification de prod doit être justifiée par un échec réel découvert pendant la mise en place des scénarios.
+
+**Justification** :
+- le besoin exprimé est une vérification E2E, pas une nouvelle feature.
+- minimise le risque de régression.
+
+---
+
+## 5. Plan de travail détaillé
+
+### Étape 1 — Définir le scénario world nominal
+
+**À faire**
+
+- Préparer un talent world avec :
+  - `type: 'talent'`
+  - `system.id` renseigné
+  - `system.uuid` renseigné
+  - `uuid` renseigné
+- Importer ou mapper un arbre contenant un nœud pointant vers ce talent via `talentId`.
+- Vérifier que le mapper enrichit le nœud avec `talentUuid = Item.<id>`.
+- Construire ensuite un acteur et un arbre résolu côté UI.
+- Vérifier que `buildSpecializationTreeContext()` affiche le vrai nom du talent.
+
+**Fichiers**
+- `tests/importer/specialization-tree-ogg-dude.integration.spec.mjs`
+- potentiellement `tests/applications/specialization-tree-app.test.mjs`
+
+**Risques**
+- scénario trop artificiel s'il ne réutilise pas un flux déjà présent dans les tests de fixture.
+
+---
+
+### Étape 2 — Définir le scénario compendium nominal
+
+**À faire**
+
+- Préparer un pack compendium mocké avec :
+  - `documentName: 'Item'`
+  - `collection`
+  - `index` compatible `Map`
+  - entrée talent avec `_id`, `type`, `system.id`, `system.isRanked`, `flags.swerpg`
+- Vérifier que `buildTalentByIdFromCompendium()` génère un UUID de forme `Compendium.<collection>.<entryId>`.
+- Mapper un arbre et vérifier que `node.talentUuid` reprend exactement cette valeur.
+- Vérifier ensuite que l'UI résout ce `talentUuid` et affiche le bon talent.
+
+**Fichiers**
+- `tests/importer/specialization-tree-ogg-dude.integration.spec.mjs`
+- potentiellement `tests/helpers/mock-foundry.mjs`
+- potentiellement `tests/helpers/mock-foundry.test.mjs`
+
+**Risques**
+- mock compendium insuffisamment fidèle au runtime Foundry.
+- confusion entre format attendu par l'importer et format attendu par l'UI.
+
+---
+
+### Étape 3 — Consolider les helpers de mock si nécessaire
+
+**À faire**
+
+- Soit enrichir `addPacksMock()` pour produire des packs compatibles avec le code réel (`documentName`, `collection`, `index` en `Map`).
+- Soit garder un mock local dédié dans le test si l'évolution du helper n'apporte pas de valeur réutilisable.
+
+**Fichiers**
+- `tests/helpers/mock-foundry.mjs`
+- `tests/helpers/mock-foundry.test.mjs`
+
+**Risques**
+- introduire un helper trop générique pour un besoin très local.
+- casser des tests existants si le contrat du helper change.
+
+---
+
+### Étape 4 — Ajouter les assertions UI finales
+
+**À faire**
+
+Pour chaque contexte :
+
+- vérifier que `renderNodes` contient le nœud attendu.
+- vérifier que `renderNodes[i].talentName` correspond au vrai talent.
+- vérifier que `renderNodes[i].talentName !== 'Unknown talent'`.
+- vérifier que la résolution passe par la donnée enrichie attendue.
+
+**Fichiers**
+- `tests/applications/specialization-tree-app.test.mjs`
+- ou scénario transversal centralisé dans `tests/importer/specialization-tree-ogg-dude.integration.spec.mjs`
+
+**Risques**
+- dupliquer inutilement des cas déjà couverts.
+- disperser la lecture entre trop de fichiers.
+
+---
+
+### Étape 5 — Ajouter une preuve explicite de non-régression sur la séparation métier/technique
+
+**À faire**
+
+- vérifier que `talentId` reste la clé métier stable.
+- vérifier que `talentUuid` est la référence technique réutilisée telle quelle.
+- vérifier que la couche UI affiche le talent résolu sans réinterpréter `talentId` comme UUID nominal.
+
+**Fichiers**
+- `tests/importer/specialization-tree-ogg-dude.integration.spec.mjs`
+- `tests/applications/specialization-tree-app.test.mjs`
+
+**Risques**
+- assertions trop couplées à l'implémentation interne au lieu du contrat observable.
+
+---
+
+### Étape 6 — Validation finale
+
+**À faire**
+
+- exécuter les tests ciblés sur importer, application et helpers.
+- confirmer que les deux scénarios passent.
+- vérifier que les messages d'échec restent lisibles.
+
+**Commande cible**
+- `pnpm vitest tests/importer/specialization-tree-ogg-dude.integration.spec.mjs tests/applications/specialization-tree-app.test.mjs`
+
+**Risques**
+- besoin d'ajuster les mocks Foundry globaux.
+- flakiness si un test repose trop sur un état global partagé.
+
+---
+
+## 6. Fichiers modifiés
+
+| Fichier | Action | Description |
+|---|---|---|
+| `tests/importer/specialization-tree-ogg-dude.integration.spec.mjs` | modification | Ajouter les scénarios complets world et compendium |
+| `tests/applications/specialization-tree-app.test.mjs` | modification | Compléter la preuve d'affichage final côté UI si nécessaire |
+| `tests/helpers/mock-foundry.mjs` | modification potentielle | Rendre le mock compendium compatible avec `documentName`, `collection`, `index: Map` |
+| `tests/helpers/mock-foundry.test.mjs` | modification potentielle | Cadrer le nouveau contrat du helper si celui-ci évolue |
+
+---
+
+## 7. Risques
+
+| Risque | Impact | Mitigation |
+|---|---|---|
+| Le test compendium repose sur un mock irréaliste | faux positif | aligner le mock sur `pack.collection`, `pack.documentName`, `pack.index.values()` |
+| La couverture reste fragmentée entre importer et UI | preuve incomplète | ajouter au moins un scénario transversal lisible par contexte |
+| Les tests vérifient trop de structure | diagnostics médiocres | assertions ciblées sur UUID, nom affiché, absence de `Unknown talent` |
+| Le ticket dérive vers une refonte métier | scope creep | limiter les changements prod à une correction révélée par les tests |
+| État global Foundry partagé entre tests | intermittence | reset strict des mocks entre scénarios |
+| `buildTalentByIdFromWorld()` et `buildTalentByIdFromCompendium()` ne sont pas exportées dans les tests | blocage | les exporter depuis `specialization-tree-ogg-dude.mjs` (elles sont déjà dans le bloc `export { ... }`) |
+
+---
+
+## 8. Proposition d'ordre de commit
+
+1. `test(importer): add end-to-end world and compendium specialization tree talent resolution scenarios`
+2. `test(foundry): improve compendium pack mocks for specialization tree resolution`
+3. `test(ui): verify specialization tree renders resolved talents in both contexts`
+
+---
+
+## 9. Dépendances avec les autres US
+
+- `#243` doit rester la source de vérité pour l'enrichissement `talentUuid` à l'import.
+- `#244` doit rester la source de vérité pour la consommation UI de `talentUuid`.
+- `#245` vient valider l'intégration entre ces deux tickets, pas redéfinir leur responsabilité.
+
+## Recommandation
+
+Le chemin le plus propre est :
+
+1. étendre `tests/importer/specialization-tree-ogg-dude.integration.spec.mjs` avec deux vrais scénarios transversaux.
+2. n'ajuster `tests/applications/specialization-tree-app.test.mjs` que si une preuve UI complémentaire manque encore.
+3. ne toucher au code de production qu'en cas d'échec réel mis en évidence par ces scénarios.

--- a/tests/applications/specialization-tree-app.test.mjs
+++ b/tests/applications/specialization-tree-app.test.mjs
@@ -1063,4 +1063,58 @@ describe('specialization-tree application', () => {
     expect(available.reasonCode).toBe('')
     expect(available.reasonLabel).toBeNull()
   })
+
+  it('renders mapper-enriched nodes with talentUuid without falling back to Unknown talent', () => {
+    const actor = createActor({
+      system: {
+        details: {
+          specializations: [
+            { specializationId: 'spec-bodyguard', name: 'Bodyguard', treeUuid: 'Item.tree-bodyguard' },
+          ],
+        },
+        progression: {
+          talentPurchases: [],
+          experience: { available: 100 },
+        },
+      },
+    })
+
+    globalThis.fromUuidSync = vi.fn((uuid) => {
+      if (uuid === 'Item.tree-bodyguard') {
+        return {
+          type: 'specialization-tree',
+          name: 'Bodyguard Tree',
+          system: {
+            nodes: [
+              { nodeId: 'r1c1', talentId: 'grit', talentUuid: 'Item.talent-grit', row: 1, column: 1, cost: 10 },
+              { nodeId: 'r2c1', talentId: 'tough', talentUuid: 'Item.talent-tough', row: 2, column: 1, cost: 15 },
+            ],
+            connections: [{ from: 'r1c1', to: 'r2c1' }],
+          },
+        }
+      }
+      if (uuid === 'Item.talent-grit') return { name: 'Grit', system: { isRanked: true } }
+      if (uuid === 'Item.talent-tough') return { name: 'Tough', system: { isRanked: false } }
+      return null
+    })
+
+    const context = buildSpecializationTreeContext(actor)
+
+    expect(context.renderNodes, 'should have 2 render nodes').toHaveLength(2)
+
+    const grit = context.renderNodes.find((n) => n.nodeId === 'r1c1')
+    expect(grit).toBeDefined()
+    expect(grit.talentName, 'grit resolved by talentUuid').toBe('Grit')
+    expect(grit.talentId, 'grit keeps business key').toBe('grit')
+    expect(grit.isRanked, 'grit is ranked').toBe(true)
+
+    const tough = context.renderNodes.find((n) => n.nodeId === 'r2c1')
+    expect(tough).toBeDefined()
+    expect(tough.talentName, 'tough resolved by talentUuid').toBe('Tough')
+    expect(tough.talentId, 'tough keeps business key').toBe('tough')
+    expect(tough.isRanked, 'tough is not ranked').toBe(false)
+
+    const unknownNodes = context.renderNodes.filter((n) => n.talentName === 'Unknown talent')
+    expect(unknownNodes, 'no node falls back to Unknown talent').toHaveLength(0)
+  })
 })

--- a/tests/helpers/mock-foundry.mjs
+++ b/tests/helpers/mock-foundry.mjs
@@ -752,8 +752,8 @@ export function setCombatMock({ round = 1, combatants = [] } = {}) {
 
 /**
  * Add mock compendium packs to game.packs.
- * Each pack definition: { id, documents: Array<{id,name}> }
- * @param {Array<{id:string, documents?:Array<object>}>} packs
+ * Each pack definition: { id, documents: Array<{id,name,type?,system?,flags?}> }
+ * @param {object} packs - Object map of pack id → pack definition
  */
 export function addPacksMock(packs = {}) {
   if (!globalThis.game) {
@@ -762,15 +762,24 @@ export function addPacksMock(packs = {}) {
   if (!globalThis.game.packs) globalThis.game.packs = new Map()
   if (!packs || typeof packs !== 'object') return
 
-  // Support object map form: { 'id': { name, type, documents? } }
   for (const [id, def] of Object.entries(packs)) {
     if (!id || !def) continue
-    const { name = id, type = 'Item', documents = [] } = def
+    const { name = id, type = 'Item', documentName = 'Item', collection = id, documents = [] } = def
+    const index = new Map()
+    for (const doc of documents) {
+      const _id = doc.id ?? doc._id
+      const entry = { _id, name: doc.name ?? 'Unnamed', type: doc.type ?? type }
+      if (doc.system) entry.system = doc.system
+      if (doc.flags) entry.flags = doc.flags
+      index.set(_id, entry)
+    }
     const packObj = {
-      metadata: { id, name, type },
-      index: documents.map((d) => ({ _id: d.id, name: d.name })),
+      metadata: { id, name, type, documentName },
+      documentName,
+      collection,
+      index,
       contents: documents,
-      getDocument: vi.fn(async (docId) => documents.find((d) => d.id === docId) ?? undefined),
+      getDocument: vi.fn(async (docId) => documents.find((d) => (d.id ?? d._id) === docId) ?? undefined),
     }
     globalThis.game.packs.set(id, packObj)
   }

--- a/tests/helpers/mock-foundry.test.mjs
+++ b/tests/helpers/mock-foundry.test.mjs
@@ -276,6 +276,72 @@ describe('Mock Foundry Helpers', () => {
 
       expect(result).toBeUndefined()
     })
+
+    test('should set documentName default to Item', () => {
+      const packDefinitions = {
+        'swerpg.test': { name: 'Test' },
+      }
+
+      addPacksMock(packDefinitions)
+
+      const pack = globalThis.game.packs.get('swerpg.test')
+      expect(pack.documentName).toBe('Item')
+    })
+
+    test('should set collection default to pack id', () => {
+      const packDefinitions = {
+        'swerpg.test': { name: 'Test' },
+      }
+
+      addPacksMock(packDefinitions)
+
+      const pack = globalThis.game.packs.get('swerpg.test')
+      expect(pack.collection).toBe('swerpg.test')
+    })
+
+    test('should keep index as a Map with proper entries', () => {
+      const packDefinitions = {
+        'swerpg.talents': {
+          name: 'Talents',
+          type: 'Item',
+          documentName: 'Item',
+          collection: 'swerpg.talents',
+          documents: [
+            { id: 'talent-grit', name: 'Grit', type: 'talent', system: { id: 'grit', isRanked: true } },
+          ],
+        },
+      }
+
+      addPacksMock(packDefinitions)
+
+      const pack = globalThis.game.packs.get('swerpg.talents')
+      expect(pack.index).toBeInstanceOf(Map)
+      expect(pack.index.size).toBe(1)
+      expect(pack.index.has('talent-grit')).toBe(true)
+
+      const entry = pack.index.get('talent-grit')
+      expect(entry._id).toBe('talent-grit')
+      expect(entry.name).toBe('Grit')
+      expect(entry.type).toBe('talent')
+      expect(entry.system.id).toBe('grit')
+      expect(entry.system.isRanked).toBe(true)
+    })
+
+    test('should carry flags in index entries when provided', () => {
+      const packDefinitions = {
+        'swerpg.talents': {
+          documents: [
+            { id: 'talent-1', name: 'Talent 1', type: 'talent', flags: { swerpg: { oggdudeKey: 'TALENT_1' } } },
+          ],
+        },
+      }
+
+      addPacksMock(packDefinitions)
+
+      const pack = globalThis.game.packs.get('swerpg.talents')
+      const entry = pack.index.get('talent-1')
+      expect(entry.flags.swerpg.oggdudeKey).toBe('TALENT_1')
+    })
   })
 
   describe('foundry.utils methods', () => {

--- a/tests/importer/specialization-tree-ogg-dude.integration.spec.mjs
+++ b/tests/importer/specialization-tree-ogg-dude.integration.spec.mjs
@@ -1,10 +1,10 @@
-import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
 import fs from 'node:fs/promises'
 import path from 'node:path'
 import xml2jsModule from '../../vendors/xml2js.min.js'
 import { parseXmlToJson } from '../../module/utils/xml/parser.mjs'
 import { extractDirectionalConnections, specializationTreeMapper } from '../../module/importer/mappers/oggdude-specialization-tree-mapper.mjs'
-import { buildSpecializationTreeContext } from '../../module/importer/items/specialization-tree-ogg-dude.mjs'
+import { buildSpecializationTreeContext, buildTalentIndex, buildTalentByIdFromWorld, buildTalentByIdFromCompendium } from '../../module/importer/items/specialization-tree-ogg-dude.mjs'
 import OggDudeDataElement from '../../module/settings/models/OggDudeDataElement.mjs'
 import { resetSpecializationTreeImportStats } from '../../module/importer/utils/specialization-tree-import-utils.mjs'
 
@@ -280,5 +280,197 @@ describe('extractDirectionalConnections — contrat booléen OggDude', () => {
     const result = extractDirectionalConnections(nodes)
     expect(result.connections).toHaveLength(0)
     expect(result.warnings).toHaveLength(0)
+  })
+})
+
+describe('world items — end-to-end talent resolution chain', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    resetSpecializationTreeImportStats()
+    globalThis.game = {
+      items: [],
+      packs: new Map(),
+      i18n: { localize: (key) => key },
+    }
+  })
+
+  afterEach(() => {
+    delete globalThis.game
+  })
+
+  it('builds talent index from game.items and enriches node talentUuid via mapper', () => {
+    globalThis.game.items = [
+      {
+        type: 'talent',
+        name: 'Grit',
+        uuid: 'Item.grit001',
+        system: { id: 'grit', uuid: 'Item.grit001', isRanked: true },
+      },
+      {
+        type: 'talent',
+        name: 'Tough',
+        uuid: 'Item.tough001',
+        system: { id: 'tough', uuid: 'Item.tough001', isRanked: false },
+      },
+    ]
+
+    const worldIndex = buildTalentByIdFromWorld()
+
+    expect(worldIndex.has('grit'), 'world index contains grit').toBe(true)
+    expect(worldIndex.get('grit').uuid, 'grit uuid is Item.grit001').toBe('Item.grit001')
+    expect(worldIndex.has('tough'), 'world index contains tough').toBe(true)
+    expect(worldIndex.get('tough').uuid, 'tough uuid is Item.tough001').toBe('Item.tough001')
+
+    const input = [{
+      Key: 'BODYGUARD',
+      Name: 'Bodyguard',
+      TalentRows: {
+        TalentRow: [
+          { Index: '0', Cost: '5', Talents: { Key: ['GRIT'] } },
+          { Index: '1', Cost: '10', Talents: { Key: ['TOUGH'] } },
+        ],
+      },
+    }]
+
+    const result = specializationTreeMapper(input, { talentById: worldIndex })
+
+    expect(result[0].system.nodes[0].talentId, 'node 0 talentId is grit').toBe('grit')
+    expect(result[0].system.nodes[0].talentUuid, 'node 0 talentUuid resolved').toBe('Item.grit001')
+    expect(result[0].system.nodes[1].talentId, 'node 1 talentId is tough').toBe('tough')
+    expect(result[0].system.nodes[1].talentUuid, 'node 1 talentUuid resolved').toBe('Item.tough001')
+  })
+
+  it('buildTalentIndex combines world and compendium, preferring world', () => {
+    globalThis.game.items = [
+      {
+        type: 'talent',
+        name: 'Grit',
+        uuid: 'Item.grit-world',
+        system: { id: 'grit', uuid: 'Item.grit-world', isRanked: true },
+      },
+    ]
+
+    globalThis.game.packs.set('swerpg.talents', {
+      documentName: 'Item',
+      collection: 'swerpg.talents',
+      index: new Map([['talent-grit', {
+        _id: 'talent-grit',
+        name: 'Grit',
+        type: 'talent',
+        system: { id: 'grit', isRanked: true },
+      }]]),
+    })
+
+    const combined = buildTalentIndex()
+
+    expect(combined.has('grit'), 'combined index has grit').toBe(true)
+    expect(combined.get('grit').uuid, 'prefers world uuid').toBe('Item.grit-world')
+  })
+
+  it('buildTalentIndex returns empty map when no game', () => {
+    delete globalThis.game
+    const result = buildTalentIndex()
+    expect(result.size).toBe(0)
+  })
+})
+
+describe('compendium items — end-to-end talent resolution chain', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    resetSpecializationTreeImportStats()
+    globalThis.game = {
+      items: [],
+      packs: new Map(),
+      i18n: { localize: (key) => key },
+    }
+  })
+
+  afterEach(() => {
+    delete globalThis.game
+  })
+
+  it('builds talent index from compendium packs and enriches node talentUuid via mapper', () => {
+    globalThis.game.packs.set('swerpg.talents', {
+      documentName: 'Item',
+      collection: 'swerpg.talents',
+      index: new Map([['talent-grit', {
+        _id: 'talent-grit',
+        name: 'Grit',
+        type: 'talent',
+        system: { id: 'grit', isRanked: true },
+      }]]),
+    })
+
+    const compendiumIndex = buildTalentByIdFromCompendium()
+
+    expect(compendiumIndex.has('grit'), 'compendium index contains grit').toBe(true)
+    expect(compendiumIndex.get('grit').uuid, 'compendium uuid format').toBe('Compendium.swerpg.talents.talent-grit')
+
+    const input = [{
+      Key: 'BODYGUARD',
+      Name: 'Bodyguard',
+      TalentRows: {
+        TalentRow: [
+          { Index: '0', Cost: '5', Talents: { Key: ['GRIT'] } },
+        ],
+      },
+    }]
+
+    const result = specializationTreeMapper(input, { talentById: compendiumIndex })
+
+    expect(result[0].system.nodes[0].talentId, 'node talentId is grit').toBe('grit')
+    expect(result[0].system.nodes[0].talentUuid, 'node talentUuid is compendium uuid').toBe('Compendium.swerpg.talents.talent-grit')
+  })
+
+  it('skips packs with wrong documentName', () => {
+    globalThis.game.packs.set('swerpg.actors', {
+      documentName: 'Actor',
+      collection: 'swerpg.actors',
+      index: new Map([['actor-1', {
+        _id: 'actor-1',
+        name: 'Villain',
+        type: 'character',
+      }]]),
+    })
+
+    const compendiumIndex = buildTalentByIdFromCompendium()
+
+    expect(compendiumIndex.size, 'actor packs are skipped').toBe(0)
+  })
+
+  it('skips packs with empty index', () => {
+    globalThis.game.packs.set('swerpg.talents', {
+      documentName: 'Item',
+      collection: 'swerpg.talents',
+      index: new Map(),
+    })
+
+    const compendiumIndex = buildTalentByIdFromCompendium()
+
+    expect(compendiumIndex.size, 'empty pack index yields no results').toBe(0)
+  })
+
+  it('falls back to oggdudeKey flag when system.id is absent', () => {
+    globalThis.game.packs.set('swerpg.talents', {
+      documentName: 'Item',
+      collection: 'swerpg.talents',
+      index: new Map([['talent-legacy', {
+        _id: 'talent-legacy',
+        name: 'Legacy Talent',
+        type: 'talent',
+        flags: { swerpg: { oggdudeKey: 'LEGACY_TALENT' } },
+      }]]),
+    })
+
+    const compendiumIndex = buildTalentByIdFromCompendium()
+
+    expect(compendiumIndex.has('legacy_talent'), 'legacy fallback key is lowercased').toBe(true)
+    expect(compendiumIndex.get('legacy_talent').uuid, 'legacy uuid format').toBe('Compendium.swerpg.talents.talent-legacy')
+  })
+
+  it('returns empty map when no game.packs', () => {
+    delete globalThis.game.packs
+    const result = buildTalentByIdFromCompendium()
+    expect(result.size).toBe(0)
   })
 })


### PR DESCRIPTION
## Summary

Closes #245 — Valide de bout en bout la chaîne `talent référentiel -> talentUuid -> nœud -> UI` dans les contextes **world items** et **compendium items**, en s'appuyant sur le contrat ADR-0013 (séparation clé métier / clé technique).

## Changements

### Helper `addPacksMock` enrichi
- `documentName`, `collection` ajoutés aux packs mockés
- `index` passe d'un tableau à un `Map` (compatible avec le code de production qui utilise `.size` et `.values()`)
- Les entrées d'index transportent `type`, `system`, `flags`

### Tests E2E world (integration spec)
- `buildTalentByIdFromWorld()` indexe les talents de `game.items`
- `specializationTreeMapper()` enrichit les nœuds avec `talentUuid = Item.*`
- `buildTalentIndex()` combine world + compendium en préférant le monde

### Tests E2E compendium (integration spec)
- `buildTalentByIdFromCompendium()` indexe les packs avec UUID `Compendium.<collection>.<_id>`
- Vérifie le filtrage par `documentName`, le skip des index vides
- Fallback `oggdudeKey` quand `system.id` est absent

### Test UI (app test)
- Nœuds enrichis (type mapper) → `buildSpecializationTreeContext()` affiche `Grit` et `Tough`
- Vérification explicite : **aucun nœud n'affiche `Unknown talent`**

## Fichiers modifiés

| Fichier | Action |
|---|---|
| `tests/helpers/mock-foundry.mjs` | modification |
| `tests/helpers/mock-foundry.test.mjs` | modification |
| `tests/importer/specialization-tree-ogg-dude.integration.spec.mjs` | modification |
| `tests/applications/specialization-tree-app.test.mjs` | modification |
| `documentation/plan/character-sheet/specialization-tree/245-plan-verifier-chaine-complete-talents-arbres-world-compendium.md` | création |

## Validation

```
pnpm vitest run → 139 files, 1636 passed, 2 skipped, 0 failed
```