### PR TITLE
feat(specialization-tree): drag-to-pan viewport from canvas background (Issue #252)

### DIFF
--- a/documentation/plan/character-sheet/specialization-tree/252-plan-pan-glisser-deposer-fond-canvas.md
+++ b/documentation/plan/character-sheet/specialization-tree/252-plan-pan-glisser-deposer-fond-canvas.md
@@ -1,0 +1,276 @@
+# Plan d'implémentation — #252 : Arbre de spécialisation — Pan par glisser-déposer sur le fond du canvas
+
+**Issue** : [#252 — Arbre de spécialisation — Pan par glisser-déposer sur le fond du canvas](https://github.com/herveDarritchon/foundryvtt-swerpg/issues/252)  
+**Dépendance** : [#250 — Vue initiale centrée et caméra runtime du canvas](https://github.com/herveDarritchon/foundryvtt-swerpg/issues/250)  
+**ADR principales** : `documentation/architecture/adr/adr-0001-foundry-applicationv2-adoption.md`, `documentation/architecture/adr/adr-0004-vitest-testing-strategy.md`, `documentation/architecture/adr/adr-0012-unit-tests-readable-diagnostics.md`  
+**Module(s) impacté(s)** : `module/applications/specialization-tree-app.mjs`, `tests/applications/specialization-tree-app.test.mjs`
+
+---
+
+## 1. Objectif
+
+Ajouter dans `SpecializationTreeApp` un déplacement de la vue par glisser-déposer sur le fond du canvas PIXI.
+
+Le résultat attendu est :
+- un `pointerdown` sur le fond du viewport qui démarre un pan runtime ;
+- un `pointermove` qui translate uniquement la caméra `#viewport`, jamais les coordonnées métier des nœuds ;
+- un `pointerup` / `pointerupoutside` qui termine proprement le pan ;
+- des interactions de nœud qui restent prioritaires et n'initient jamais le pan ;
+- des listeners PIXI centralisés, non dupliqués entre rendus et nettoyés au teardown.
+
+Cette tranche complète la navigation de base du viewport après l'introduction de la caméra runtime par `#250` et le recentrage manuel par `#251`.
+
+---
+
+## 2. Périmètre
+
+### Inclus
+
+- Ajout d'un état privé de pan runtime dans `SpecializationTreeApp`.
+- Centralisation des listeners `pointerdown` / `pointermove` / `pointerup` / `pointerupoutside` dans une méthode dédiée `#bindViewportInteractions()`.
+- Mise à jour de `#viewport.x` et `#viewport.y` pendant le drag.
+- Appel à `#applyViewportTransform()` après chaque déplacement.
+- Priorité conservée pour les interactions sur nœuds via `stopPropagation()`.
+- Prévention de la duplication des listeners entre deux rendus.
+- Nettoyage explicite des listeners lors du teardown.
+- Tests ciblés sur le contrat observable du pan.
+
+### Exclu
+
+- Zoom molette.
+- Boutons `zoomIn` / `zoomOut`.
+- Persistance du viewport.
+- Inertie, animation ou limites de déplacement.
+- Refonte du layout des nœuds.
+- Changement des coordonnées `renderNodes`.
+- Refonte template / styles / i18n.
+
+---
+
+## 3. Constat sur l'existant
+
+- `module/applications/specialization-tree-app.mjs` possède déjà une caméra runtime privée `#viewport = { scale: 1, x: 0, y: 0 }`.
+- `#applyViewportTransform()` applique déjà `position.set(x, y)` et `scale.set(scale)` au conteneur PIXI.
+- `#centerTree()` et `#resetView()` sont déjà en place suite à `#250` et `#251`.
+- `#drawTree()` recrée le `#treeContainer` à chaque redraw, mais la caméra reste portée par l'application.
+- Les nœuds utilisent déjà un `hitArea.on('pointerdown', ...)` avec `event.stopPropagation()`, ce qui prépare correctement la priorité des interactions nœud vs fond.
+- Le stage PIXI reçoit déjà un `pointerdown` pour masquer le tooltip, mais ce binding est aujourd'hui dispersé dans `#drawTree()` et ne couvre ni pan ni nettoyage dédié.
+- Il n'existe pas encore de méthode `#bindViewportInteractions()`.
+- Il n'existe pas encore d'état `#isPanning` / `#lastPointerPosition`.
+- Le teardown détruit `pixiApp`, mais ne formalise pas le détachement ciblé de listeners viewport.
+- Les tests couvrent déjà le viewport runtime, le centrage initial, le reset view et la non-mutation de `renderNodes`.
+- Les mocks PIXI du test enregistrent les listeners sur `Graphics`, mais pas encore sur le `stage` de façon exploitable pour simuler un drag complet.
+
+---
+
+## 4. Décisions d'architecture
+
+### 4.1. Pan porté par la caméra runtime, jamais par les nœuds
+
+**Décision** : modifier uniquement `#viewport.x` et `#viewport.y` pendant le drag.
+
+**Justification** :
+- conforme à l'issue ;
+- cohérent avec `#250` ;
+- évite de mélanger navigation UI et coordonnées métier.
+
+### 4.2. Listeners stage centralisés dans `#bindViewportInteractions()`
+
+**Décision** : extraire tout le wiring pointer du stage PIXI dans une méthode dédiée, appelée une fois par cycle de vie.
+
+**Justification** :
+- l'issue l'exige explicitement ;
+- évite les bindings dispersés dans `#drawTree() ` ;
+- simplifie la non-duplication et le teardown.
+
+### 4.3. Ajout d'un unbind explicite
+
+**Décision** : compléter `#bindViewportInteractions()` par un mécanisme de détachement ou de garde empêchant les doublons, et nettoyer au teardown.
+
+**Justification** :
+- l'acceptance criterion demande des listeners non dupliqués et nettoyés ;
+- `#drawTree()` est rappelée à chaque rendu ;
+- le simple `destroy()` final n'est pas un contrat de lisibilité suffisant pour les tests.
+
+### 4.4. Priorité aux interactions nœud
+
+**Décision** : conserver `event.stopPropagation()` sur les `hitArea` des nœuds et ne démarrer le pan que depuis le fond du stage.
+
+**Justification** :
+- conforme à l'issue ;
+- évite qu'un clic/drag sur un nœud ne bouge la caméra ;
+- préserve les interactions existantes de tooltip et futures actions de nœud.
+
+### 4.5. Stage rendu interactif sur tout le viewport
+
+**Décision** : s'assurer que le stage capte bien les événements sur le fond vide du canvas, y compris hors objet enfant, via `eventMode` et un `hitArea` couvrant le viewport si nécessaire.
+
+**Justification** :
+- en PIXI, le fond vide ne remonte pas toujours d'événement sans surface interactive explicite ;
+- c'est la condition pour que le pan sur fond fonctionne réellement ;
+- le plan doit couvrir ce point technique, sinon l'acceptance criterion peut être faux-positif en code.
+
+### 4.6. Tests centrés sur le contrat observable
+
+**Décision** : tester le démarrage/arrêt du pan, les appels à `position.set(...)`, et l'immuabilité des coordonnées de nœud, sans dépendre d'un rendu PIXI réel.
+
+**Justification** :
+- conforme ADR-0004 et ADR-0012 ;
+- évite les tests fragiles ;
+- rend les diagnostics clairs.
+
+---
+
+## 5. Plan de travail détaillé
+
+### Étape 1 — Introduire l'état runtime de pan
+
+**À faire**
+- Ajouter `#isPanning = false`.
+- Ajouter `#lastPointerPosition = null`.
+- Ajouter un état de binding viewport, par exemple `#isViewportInteractionsBound = false` ou une registry de handlers.
+- Définir clairement la structure attendue pour la dernière position pointeur `{ x, y }`.
+
+**Fichier**
+- `module/applications/specialization-tree-app.mjs`
+
+**Risque**
+- multiplier les états implicites si le pan se mélange au centrage/reset existants.
+
+### Étape 2 — Extraire `#bindViewportInteractions()`
+
+**À faire**
+- Créer une méthode dédiée qui branche les événements sur `this.pixiApp.stage`.
+- Y déplacer le `pointerdown` de fond aujourd'hui utilisé pour masquer le tooltip.
+- Y ajouter :
+  - `pointerdown` pour démarrer le pan sur fond ;
+  - `pointermove` pour translater `#viewport` ;
+  - `pointerup` pour terminer le pan ;
+  - `pointerupoutside` pour terminer le pan même si le relâchement sort du viewport.
+- Prévoir un garde pour que cette méthode n'ajoute pas deux fois les mêmes listeners.
+
+**Fichier**
+- `module/applications/specialization-tree-app.mjs`
+
+**Risque**
+- listeners dupliqués si le binding reste appelé à chaque render sans garde.
+
+### Étape 3 — Définir le contrat du drag
+
+**À faire**
+- Sur `pointerdown` fond :
+  - masquer le tooltip ;
+  - passer `#isPanning` à `true` ;
+  - mémoriser la position courante du pointeur.
+- Sur `pointermove` :
+  - ne rien faire si `#isPanning === false` ;
+  - calculer le delta depuis `#lastPointerPosition` ;
+  - incrémenter `#viewport.x` et `#viewport.y` avec ce delta ;
+  - mettre à jour `#lastPointerPosition` ;
+  - appeler `#applyViewportTransform()`.
+- Sur `pointerup` / `pointerupoutside` :
+  - remettre `#isPanning` à `false` ;
+  - vider `#lastPointerPosition`.
+
+**Fichier**
+- `module/applications/specialization-tree-app.mjs`
+
+**Risque**
+- mauvais accès aux coordonnées pointeur selon le mock/test et l'API PIXI.
+- Mitigation : encapsuler l'extraction `x/y` dans une lecture simple et testable du pointeur.
+
+### Étape 4 — Garantir la captation sur fond de stage
+
+**À faire**
+- Vérifier que `this.pixiApp.stage.eventMode = 'static'` est bien appliqué hors boucle de nœuds.
+- Si nécessaire, définir une `hitArea` de stage alignée sur les dimensions du viewport courant.
+- Revoir `#resizeViewport()` pour maintenir une surface interactive cohérente après resize.
+
+**Fichier**
+- `module/applications/specialization-tree-app.mjs`
+
+**Risque**
+- `pointerdown` sur fond qui ne se déclenche jamais en vrai runtime.
+- Mitigation : lier explicitement la surface interactive au viewport.
+
+### Étape 5 — Nettoyer le cycle de vie des listeners
+
+**À faire**
+- Ajouter `#unbindViewportInteractions()` ou un nettoyage équivalent dans `#teardownViewport()`.
+- Réinitialiser l'état de pan au teardown.
+- Faire en sorte que le redraw du tree container ne réenregistre pas les listeners stage.
+- Vérifier que fermer/réouvrir l'application repart d'un état propre.
+
+**Fichier**
+- `module/applications/specialization-tree-app.mjs`
+
+**Risque**
+- fuite d'état ou handlers morts après fermeture/réouverture.
+
+### Étape 6 — Étendre les tests
+
+**À faire**
+- Enrichir les mocks PIXI dans `tests/applications/specialization-tree-app.test.mjs` pour :
+  - enregistrer les handlers du `stage` ;
+  - pouvoir simuler `pointerdown`, `pointermove`, `pointerup`, `pointerupoutside`.
+- Ajouter un test qui prouve qu'un drag sur fond :
+  - démarre le pan ;
+  - appelle `position.set(...)` avec des coordonnées modifiées ;
+  - n'altère pas `renderNodes[x/y]`.
+- Ajouter un test qui prouve qu'un `pointerup` stoppe le pan.
+- Ajouter un test qui prouve qu'un `pointerupoutside` stoppe aussi le pan.
+- Ajouter un test qui prouve qu'un `pointerdown` nœud appelle `stopPropagation()` et n'initie pas le pan.
+- Ajouter un test de non-régression sur la non-duplication des listeners entre deux rendus si le mock le permet.
+
+**Fichier**
+- `tests/applications/specialization-tree-app.test.mjs`
+
+**Risque**
+- tests trop couplés à l'implémentation privée.
+- Mitigation : vérifier les effets observables sur `position.set`, l'arrêt du pan et l'immuabilité des nœuds.
+
+---
+
+## 6. Fichiers modifiés
+
+| Fichier | Action | Description |
+|---|---|---|
+| `module/applications/specialization-tree-app.mjs` | modification | Ajouter l'état de pan runtime, centraliser les bindings pointer du stage, gérer le drag de viewport et le cleanup |
+| `tests/applications/specialization-tree-app.test.mjs` | modification | Enrichir les mocks stage PIXI et couvrir le pan fond, l'arrêt du pan, la priorité des nœuds et la non-régression listeners |
+
+---
+
+## 7. Risques
+
+| Risque | Impact | Mitigation |
+|---|---|---|
+| Le stage ne capte pas les clics sur fond vide | le pan ne fonctionne pas en runtime | définir explicitement `eventMode` et `hitArea` du stage |
+| Listeners bindés à chaque render | déplacement accéléré, fuite mémoire, comportements incohérents | centraliser dans `#bindViewportInteractions()` avec garde et cleanup |
+| Drag sur nœud déclenche aussi le pan | UX cassée, conflit avec interactions nœud | conserver `stopPropagation()` sur les hit areas des nœuds |
+| `pointerupoutside` non géré | pan bloqué si le pointeur sort du viewport | terminer systématiquement le pan sur `pointerupoutside` |
+| Tests trop fragiles | faux négatifs et maintenance lourde | tester le contrat observable et enrichir légèrement le mock PIXI |
+| Mutation involontaire de `renderNodes` | régression métier et layout corrompu | conserver la translation au niveau caméra uniquement et tester l'immuabilité |
+
+---
+
+## 8. Proposition d'ordre de commit
+
+1. `feat(talent-tree): add runtime drag pan for specialization viewport`
+2. `refactor(talent-tree): centralize viewport pointer bindings and cleanup`
+3. `test(talent-tree): cover background drag pan and node interaction priority`
+
+---
+
+## 9. Dépendances avec les autres US
+
+- Dépend fonctionnellement de `#250`, déjà fermée et visible dans l'état actuel du code.
+- S'appuie aussi sur le recentrage runtime introduit par `#251`, déjà présent dans `SpecializationTreeApp`.
+- Prépare naturellement les tranches suivantes :
+  - zoom molette ;
+  - boutons de zoom ;
+  - éventuelle persistance de viewport ;
+  - bornage ou inertie de navigation.
+
+## 10. Validation prévue
+
+- `pnpm vitest tests/applications/specialization-tree-app.test.mjs`

--- a/module/applications/specialization-tree-app.mjs
+++ b/module/applications/specialization-tree-app.mjs
@@ -396,6 +396,12 @@ export default class SpecializationTreeApp extends api.HandlebarsApplicationMixi
 
   #zoomStep = 1.15
 
+  #isPanning = false
+
+  #lastPointerPosition = null
+
+  #isViewportInteractionsBound = false
+
   get title() {
     return game.i18n.format('SWERPG.TALENT.SPECIALIZATION_TREE_APP.TITLE', {
       actor: this.actor?.name ?? game.i18n.localize('SWERPG.TALENT.SPECIALIZATION_TREE_APP.UNKNOWN_ACTOR'),
@@ -455,6 +461,7 @@ export default class SpecializationTreeApp extends api.HandlebarsApplicationMixi
 
     this.#viewportHost = viewportHost
     this.#ensurePixiApp(viewportHost)
+    this.#bindViewportInteractions()
     this.#resizeViewport()
 
     if (!this.#isResizeBound) {
@@ -503,6 +510,9 @@ export default class SpecializationTreeApp extends api.HandlebarsApplicationMixi
     if (!this.pixiApp || !this.#viewportHost) return
     const { width, height } = getViewportDimensions(this.#viewportHost)
     this.pixiApp.renderer?.resize?.(width, height)
+    if (this.pixiApp.stage) {
+      this.pixiApp.stage.hitArea = new PIXI.Rectangle(0, 0, width, height)
+    }
   }
 
   #applyViewportTransform() {
@@ -540,6 +550,63 @@ export default class SpecializationTreeApp extends api.HandlebarsApplicationMixi
   #resetView() {
     this.#centerTree({ renderNodes: this.#renderNodesCache })
     this.#applyViewportTransform()
+  }
+
+  #bindViewportInteractions() {
+    if (this.#isViewportInteractionsBound || !this.pixiApp?.stage) return
+
+    this.#isViewportInteractionsBound = true
+    const stage = this.pixiApp.stage
+    stage.eventMode = 'static'
+
+    stage.on('pointerdown', (event) => {
+      this.#hideNodeTooltip()
+      this.#isPanning = true
+      this.#lastPointerPosition = this.#getPointerPosition(event)
+    })
+
+    stage.on('pointermove', (event) => {
+      if (!this.#isPanning || !this.#lastPointerPosition) return
+
+      const nextPosition = this.#getPointerPosition(event)
+      if (!nextPosition) return
+
+      this.#viewport.x += nextPosition.x - this.#lastPointerPosition.x
+      this.#viewport.y += nextPosition.y - this.#lastPointerPosition.y
+      this.#lastPointerPosition = nextPosition
+      this.#applyViewportTransform()
+    })
+
+    stage.on('pointerup', () => this.#stopPanning())
+    stage.on('pointerupoutside', () => this.#stopPanning())
+  }
+
+  #unbindViewportInteractions() {
+    if (!this.#isViewportInteractionsBound || !this.pixiApp?.stage) return
+
+    this.#isViewportInteractionsBound = false
+    this.pixiApp.stage.off?.('pointerdown')
+    this.pixiApp.stage.off?.('pointermove')
+    this.pixiApp.stage.off?.('pointerup')
+    this.pixiApp.stage.off?.('pointerupoutside')
+  }
+
+  #getPointerPosition(event) {
+    const point = event?.global ?? event?.data?.global
+    if (point?.x !== undefined && point?.y !== undefined) {
+      return { x: point.x, y: point.y }
+    }
+
+    if (event?.globalX !== undefined && event?.globalY !== undefined) {
+      return { x: event.globalX, y: event.globalY }
+    }
+
+    return null
+  }
+
+  #stopPanning() {
+    this.#isPanning = false
+    this.#lastPointerPosition = null
   }
 
   #drawTree(context) {
@@ -619,9 +686,6 @@ export default class SpecializationTreeApp extends api.HandlebarsApplicationMixi
         })
         this.#treeContainer.addChild(hitArea)
       }
-
-      this.pixiApp.stage.eventMode = 'static'
-      this.pixiApp.stage.on('pointerdown', () => this.#hideNodeTooltip())
     }
   }
 
@@ -669,6 +733,9 @@ export default class SpecializationTreeApp extends api.HandlebarsApplicationMixi
   }
 
   #teardownViewport() {
+    this.#unbindViewportInteractions()
+    this.#stopPanning()
+
     if (this.#isResizeBound) {
       window.removeEventListener('resize', this.#boundResize)
       this.#isResizeBound = false

--- a/tests/applications/specialization-tree-app.test.mjs
+++ b/tests/applications/specialization-tree-app.test.mjs
@@ -88,9 +88,11 @@ describe('specialization-tree application', () => {
     })
 
     function createMockContainer() {
+      const listeners = {}
       return {
         children: [],
         eventMode: 'none',
+        hitArea: null,
         position: { set: vi.fn() },
         scale: { set: vi.fn() },
         addChild: vi.fn(function (child) {
@@ -104,11 +106,27 @@ describe('specialization-tree application', () => {
         destroy: vi.fn(function () {
           this.children = []
         }),
-        on: vi.fn(),
+        on: vi.fn(function (event, handler) {
+          listeners[event] = handler
+          return this
+        }),
+        off: vi.fn(function (event) {
+          delete listeners[event]
+          return this
+        }),
+        _listeners: listeners,
       }
     }
 
     globalThis.PIXI = {
+      Rectangle: class MockRectangle {
+        constructor(x, y, width, height) {
+          this.x = x
+          this.y = y
+          this.width = width
+          this.height = height
+        }
+      },
       Application: class MockPixiApplication {
         constructor(options = {}) {
           this.options = options
@@ -1275,5 +1293,275 @@ describe('specialization-tree application', () => {
     const centerCall = container.position.set.mock.calls[0]
     expect(centerCall[0], 'centered x must differ from origin').not.toBe(0)
     expect(centerCall[1], 'centered y must differ from origin').not.toBe(0)
+  })
+
+  it('pans the viewport when dragging on the stage background', async () => {
+    const actor = createActor({
+      system: {
+        details: {
+          specializations: [{ specializationId: 'spec-bodyguard', name: 'Bodyguard', treeUuid: 'Item.tree-bodyguard' }],
+        },
+        progression: {
+          talentPurchases: [],
+          experience: { available: 100 },
+        },
+      },
+    })
+    globalThis.fromUuidSync = vi.fn((uuid) => {
+      if (uuid === 'Item.tree-bodyguard') {
+        return {
+          type: 'specialization-tree',
+          name: 'Bodyguard Tree',
+          system: {
+            nodes: [{ nodeId: 'r1c1', talentId: 'Item.talent-tough', row: 1, column: 1, cost: 10 }],
+            connections: [{ from: 'r1c1', to: 'r2c1' }],
+          },
+        }
+      }
+      if (uuid === 'Item.talent-tough') return { name: 'Tough' }
+      return null
+    })
+
+    const app = new SpecializationTreeApp()
+    app.actor = actor
+    app.document = actor
+    const host = createMockHost({ width: 640, height: 480 })
+    app.element = { querySelector: vi.fn(() => host) }
+
+    const context = buildSpecializationTreeContext(actor)
+    expect(context.renderNodes, 'drag test requires one render node').toHaveLength(1)
+    const originalNode = { x: context.renderNodes[0].x, y: context.renderNodes[0].y }
+
+    await app._onRender(context, { resetView: false })
+
+    const stage = app.pixiApp.stage
+    const container = stage.children.find((child) => child.position && child.scale)
+    expect(stage.hitArea, 'stage hitArea must cover the viewport').toEqual({ x: 0, y: 0, width: 640, height: 480 })
+
+    container.position.set.mockClear()
+
+    stage._listeners.pointerdown({ global: { x: 100, y: 120 } })
+    stage._listeners.pointermove({ global: { x: 140, y: 170 } })
+
+    expect(container.position.set, 'drag on background must move the viewport').toHaveBeenCalledWith(40, 50)
+    expect(context.renderNodes[0].x, 'drag must not mutate node x').toBe(originalNode.x)
+    expect(context.renderNodes[0].y, 'drag must not mutate node y').toBe(originalNode.y)
+  })
+
+  it('stops panning on pointerup', async () => {
+    const actor = createActor({
+      system: {
+        details: {
+          specializations: [{ specializationId: 'spec-bodyguard', name: 'Bodyguard', treeUuid: 'Item.tree-bodyguard' }],
+        },
+        progression: {
+          talentPurchases: [],
+          experience: { available: 100 },
+        },
+      },
+    })
+    globalThis.fromUuidSync = vi.fn((uuid) => {
+      if (uuid === 'Item.tree-bodyguard') {
+        return {
+          type: 'specialization-tree',
+          name: 'Bodyguard Tree',
+          system: {
+            nodes: [{ nodeId: 'r1c1', talentId: 'Item.talent-tough', row: 1, column: 1, cost: 10 }],
+            connections: [{ from: 'r1c1', to: 'r2c1' }],
+          },
+        }
+      }
+      if (uuid === 'Item.talent-tough') return { name: 'Tough' }
+      return null
+    })
+
+    const app = new SpecializationTreeApp()
+    app.actor = actor
+    app.document = actor
+    const host = createMockHost({ width: 640, height: 480 })
+    app.element = { querySelector: vi.fn(() => host) }
+
+    const context = buildSpecializationTreeContext(actor)
+    await app._onRender(context, { resetView: false })
+
+    const stage = app.pixiApp.stage
+    const container = stage.children.find((child) => child.position && child.scale)
+
+    stage._listeners.pointerdown({ global: { x: 10, y: 20 } })
+    stage._listeners.pointerup()
+    container.position.set.mockClear()
+    stage._listeners.pointermove({ global: { x: 30, y: 40 } })
+
+    expect(container.position.set, 'pointermove after pointerup must not pan').not.toHaveBeenCalled()
+  })
+
+  it('stops panning on pointerupoutside', async () => {
+    const actor = createActor({
+      system: {
+        details: {
+          specializations: [{ specializationId: 'spec-bodyguard', name: 'Bodyguard', treeUuid: 'Item.tree-bodyguard' }],
+        },
+        progression: {
+          talentPurchases: [],
+          experience: { available: 100 },
+        },
+      },
+    })
+    globalThis.fromUuidSync = vi.fn((uuid) => {
+      if (uuid === 'Item.tree-bodyguard') {
+        return {
+          type: 'specialization-tree',
+          name: 'Bodyguard Tree',
+          system: {
+            nodes: [{ nodeId: 'r1c1', talentId: 'Item.talent-tough', row: 1, column: 1, cost: 10 }],
+            connections: [{ from: 'r1c1', to: 'r2c1' }],
+          },
+        }
+      }
+      if (uuid === 'Item.talent-tough') return { name: 'Tough' }
+      return null
+    })
+
+    const app = new SpecializationTreeApp()
+    app.actor = actor
+    app.document = actor
+    const host = createMockHost({ width: 640, height: 480 })
+    app.element = { querySelector: vi.fn(() => host) }
+
+    const context = buildSpecializationTreeContext(actor)
+    await app._onRender(context, { resetView: false })
+
+    const stage = app.pixiApp.stage
+    const container = stage.children.find((child) => child.position && child.scale)
+
+    stage._listeners.pointerdown({ global: { x: 10, y: 20 } })
+    stage._listeners.pointerupoutside()
+    container.position.set.mockClear()
+    stage._listeners.pointermove({ global: { x: 30, y: 40 } })
+
+    expect(container.position.set, 'pointermove after pointerupoutside must not pan').not.toHaveBeenCalled()
+  })
+
+  it('stops propagation on node pointerdown so pan does not start from node interaction', async () => {
+    const actor = createActor({
+      system: {
+        details: {
+          specializations: [{ specializationId: 'spec-bodyguard', name: 'Bodyguard', treeUuid: 'Item.tree-bodyguard' }],
+        },
+        progression: {
+          talentPurchases: [],
+          experience: { available: 100 },
+        },
+      },
+    })
+    globalThis.fromUuidSync = vi.fn((uuid) => {
+      if (uuid === 'Item.tree-bodyguard') {
+        return {
+          type: 'specialization-tree',
+          name: 'Bodyguard Tree',
+          system: {
+            nodes: [{ nodeId: 'r1c1', talentId: 'Item.talent-tough', row: 1, column: 1, cost: 10 }],
+            connections: [{ from: 'r1c1', to: 'r2c1' }],
+          },
+        }
+      }
+      if (uuid === 'Item.talent-tough') return { name: 'Tough', system: { isRanked: false } }
+      return null
+    })
+
+    const tooltip = {
+      hidden: true,
+      querySelector: vi.fn((selector) => {
+        if (selector === '[data-tooltip-header]') return { textContent: '' }
+        if (selector === '[data-tooltip-body]') return { innerHTML: '' }
+        return null
+      }),
+    }
+
+    const app = new SpecializationTreeApp()
+    app.actor = actor
+    app.document = actor
+    const host = createMockHost({ width: 640, height: 480 })
+    app.element = {
+      querySelector: vi.fn((selector) => {
+        if (selector === '[data-specialization-tree-viewport]') return host
+        if (selector === '[data-node-tooltip]') return tooltip
+        return null
+      }),
+    }
+
+    const context = buildSpecializationTreeContext(actor)
+    await app._onRender(context, { resetView: false })
+
+    const stage = app.pixiApp.stage
+    const container = stage.children.find((child) => child.position && child.scale)
+    const nodeHitArea = container.children.find((child) => child._listeners?.pointerdown)
+    const stopPropagation = vi.fn()
+
+    nodeHitArea._listeners.pointerdown({ stopPropagation })
+    container.position.set.mockClear()
+    stage._listeners.pointermove({ global: { x: 30, y: 40 } })
+
+    expect(stopPropagation, 'node pointerdown must stop propagation').toHaveBeenCalled()
+    expect(container.position.set, 'node interaction alone must not start panning').not.toHaveBeenCalled()
+  })
+
+  it('does not duplicate stage listeners between renders and cleans them up on close', async () => {
+    const actor = createActor({
+      system: {
+        details: {
+          specializations: [{ specializationId: 'spec-bodyguard', name: 'Bodyguard', treeUuid: 'Item.tree-bodyguard' }],
+        },
+        progression: {
+          talentPurchases: [],
+          experience: { available: 100 },
+        },
+      },
+    })
+    globalThis.fromUuidSync = vi.fn((uuid) => {
+      if (uuid === 'Item.tree-bodyguard') {
+        return {
+          type: 'specialization-tree',
+          name: 'Bodyguard Tree',
+          system: {
+            nodes: [{ nodeId: 'r1c1', talentId: 'Item.talent-tough', row: 1, column: 1, cost: 10 }],
+            connections: [{ from: 'r1c1', to: 'r2c1' }],
+          },
+        }
+      }
+      if (uuid === 'Item.talent-tough') return { name: 'Tough' }
+      return null
+    })
+
+    const app = new SpecializationTreeApp()
+    app.actor = actor
+    app.document = actor
+    const host = createMockHost({ width: 640, height: 480 })
+    app.element = { querySelector: vi.fn(() => host) }
+
+    const context = buildSpecializationTreeContext(actor)
+    await app._onRender(context, { resetView: false })
+
+    const stage = app.pixiApp.stage
+    expect(stage.on.mock.calls.map(([eventName]) => eventName), 'stage listeners must be registered once').toEqual([
+      'pointerdown',
+      'pointermove',
+      'pointerup',
+      'pointerupoutside',
+    ])
+
+    stage.on.mockClear()
+    await app._onRender(context, { resetView: false })
+
+    expect(stage.on, 'rerender must not duplicate stage listeners').not.toHaveBeenCalled()
+
+    await app.close()
+
+    expect(stage.off.mock.calls.map(([eventName]) => eventName), 'close must clean viewport listeners').toEqual([
+      'pointerdown',
+      'pointermove',
+      'pointerup',
+      'pointerupoutside',
+    ])
   })
 })


### PR DESCRIPTION
Title: feat(specialization-tree): drag-to-pan viewport from canvas background (Issue #252)

Description

Résumé
- Ajoute le pan (déplacement) du viewport par glisser-déposer sur le fond du canvas de SpecializationTreeApp.
- Implémentation selon le plan #252 (documentation/plan/character-sheet/specialization-tree/252-plan-pan-glisser-deposer-fond-canvas.md).

Modifications principales
- Ajout d'un état privé pour le pan : #isPanning, #lastPointerPosition, #isViewportInteractionsBound.
- Centralisation des écouteurs pointer sur le stage :
  - #bindViewportInteractions() / #unbindViewportInteractions().
  - hitArea du stage défini dans #resizeViewport() via new PIXI.Rectangle(0,0,width,height).
  - #getPointerPosition(event) pour lire les coordonnées de façon fiable.
  - #stopPanning() pour terminer proprement le pan (pointerup / pointerupoutside).
- Suppression des bindings dispersés dans #drawTree().
- Nettoyage explicite des listeners dans #teardownViewport().
- Pan appliqué uniquement en modifiant #viewport.x/#viewport.y et en appelant #applyViewportTransform() (aucune mutation du modèle métier des nœuds).

Tests
- Nouveaux tests Vitest couvrant :
  - Démarrage du pan sur pointerdown du fond.
  - Mise à jour du viewport lors de pointermove.
  - Fin du pan sur pointerup et pointerupoutside.
  - stopPropagation() sur pointerdown d'un nœud empêche le pan.
  - Pas de duplication de listeners et cleanup au teardown.
- Mocks PIXI enrichis (stage listeners, PIXI.Rectangle).

Comment tester localement
1. Lancer les tests unitaires ciblés :
   pnpm vitest tests/applications/specialization-tree-app.test.mjs
2. Manuellement (Foundry) :
   - Ouvrir SpecializationTreeApp.
   - Cliquer/glisser sur le fond du canvas : le viewport doit se déplacer.
   - Cliquer sur un nœud : l'événement doit être stopPropagation() et ne doit pas initier le pan.
   - Relâcher la souris hors du canvas : le pan doit se terminer (pas d'état panning restant).

Checklist (avant merge)
- [x] Tous les tests Vitest passent en CI.
- [x] Aucun changement de modèle persistant (Foundry) n'est effectué.
- [x] Revues visuelles en runtime (optionnel mais recommandé) pour valider hitArea / comportement réel.

Liens
- Issue : https://github.com/herveDarritchon/foundryvtt-swerpg/issues/252
- Plan d'implémentation : documentation/plan/character-sheet/specialization-tree/252-plan-pan-glisser-deposer-fond-canvas.md

Commits recommandés (exemples)
- feat(talent-tree): add runtime drag pan for specialization viewport
- refactor(talent-tree): centralize viewport pointer bindings and cleanup
- test(talent-tree): cover background drag pan and node interaction priority
