### PR TITLE
US21: Neutraliser les anciennes logiques Crucible

### DIFF
--- a/documentation/cadrage/llm/cadrage-opencode-configuration.md
+++ b/documentation/cadrage/llm/cadrage-opencode-configuration.md
@@ -1,0 +1,475 @@
+# Document de cadrage — Optimisation de la configuration OpenCode
+
+## 1. Finalité du cadrage
+
+L’objectif de cette démarche est d’optimiser l’usage d’OpenCode en associant **le bon type d’action au bon niveau de modèle, au bon niveau d’autonomie et au bon niveau de risque accepté**.
+
+La configuration ne doit pas chercher à créer un système complexe pour le plaisir. Elle doit d’abord répondre à un besoin opérationnel simple : éviter d’utiliser des modèles coûteux ou puissants pour des tâches simples, tout en réservant les modèles les plus capables aux décisions, plans, arbitrages techniques, corrections sensibles et revues critiques.
+
+OpenCode dispose déjà de mécanismes structurants pour spécialiser les usages : agents, commandes, skills, modèles, permissions, outils et plugins. Les agents peuvent être configurés avec des rôles, modèles et accès spécifiques ; les commandes peuvent encapsuler des actions récurrentes ; les skills servent à charger des instructions réutilisables ; les plugins permettent d’étendre ou d’encadrer certains comportements. ([OpenCode][1])
+
+Ce cadrage vise donc à définir **une doctrine d’usage**, pas une implémentation.
+
+---
+
+## 2. Principe directeur
+
+La configuration OpenCode doit être organisée autour d’une idée centrale :
+
+> Chaque activité doit être confiée à un profil d’agent adapté, avec le modèle le plus économique capable de produire un résultat fiable.
+
+Cela implique de ne pas raisonner uniquement en termes de “meilleur modèle”, mais en termes de **rapport coût / risque / complexité / valeur produite**.
+
+Un modèle très puissant est pertinent pour analyser une architecture, préparer un plan de refactoring ou résoudre un bug complexe. Il est beaucoup moins pertinent pour lancer un linter, résumer une erreur triviale ou rédiger une PR simple.
+
+---
+
+## 3. Objectifs opérationnels
+
+La configuration cible doit permettre de :
+
+1. **Réduire la consommation inutile de tokens**
+   Les modèles coûteux doivent être réservés aux tâches où leur valeur ajoutée est réelle.
+
+2. **Améliorer la qualité des résultats**
+   Chaque tâche doit être confiée à un agent dont le rôle est clair, limité et cohérent.
+
+3. **Limiter les dérives de scope**
+   Un agent chargé de planifier ne doit pas implémenter. Un agent chargé de tester ne doit pas réécrire l’architecture. Un agent chargé de relire ne doit pas modifier le code.
+
+4. **Standardiser les workflows récurrents**
+   Les actions fréquentes — plan, implémentation, correction de bug, tests, lint, revue, PR — doivent devenir des routines explicites.
+
+5. **Préserver le contrôle humain**
+   Les tâches à risque doivent rester sous validation humaine, notamment les modifications de code, les suppressions, les changements d’architecture ou les commandes destructrices.
+
+6. **Capitaliser le contexte projet**
+   Les règles propres au projet doivent être portées par des skills ou instructions réutilisables, afin d’éviter de répéter les mêmes consignes à chaque session.
+
+---
+
+## 4. Typologie des activités à distinguer
+
+La configuration doit distinguer clairement les familles d’activités suivantes.
+
+### 4.1 Exploration
+
+L’exploration consiste à comprendre le code, identifier les fichiers concernés, retrouver une convention, analyser une structure existante ou préparer le terrain avant une intervention.
+
+Cette activité doit privilégier des modèles économiques, éventuellement locaux, car elle demande surtout de la lecture, du repérage et de la synthèse.
+
+L’agent d’exploration doit être fortement limité : il lit, cherche, résume, mais ne modifie pas.
+
+### 4.2 Planification
+
+La planification est une activité à forte valeur. Elle sert à transformer une demande en stratégie d’intervention : périmètre, fichiers concernés, risques, dépendances, tests, ordre d’exécution.
+
+Cette activité mérite un modèle de raisonnement plus fort, car une mauvaise décision à ce stade coûte cher ensuite.
+
+L’agent de planification doit être interdit de modification. Son rôle est de produire une décision claire, pas de commencer à coder.
+
+### 4.3 Implémentation
+
+L’implémentation consiste à modifier le code selon un plan déjà défini.
+
+Cette activité doit être confiée à un modèle compétent en code, capable de respecter l’architecture existante et de produire des modifications minimales.
+
+L’agent d’implémentation doit être encadré par des règles strictes : ne pas élargir le scope, ne pas refactorer au-delà du besoin, ne pas modifier des zones non concernées, ne pas inventer de conventions.
+
+### 4.4 Correction de bug
+
+La correction de bug doit être séparée de l’implémentation générique.
+
+Un bug demande d’abord un diagnostic : reproduction, hypothèse, cause probable, preuve, correction minimale, test de non-régression.
+
+L’agent chargé des bugs doit être orienté vers la sobriété : corriger le défaut identifié, pas “améliorer” tout ce qu’il voit autour.
+
+### 4.5 Tests
+
+Les tests doivent être considérés comme une activité distincte.
+
+Un agent de test doit pouvoir exécuter ou analyser les résultats de tests, identifier les échecs, distinguer les problèmes de code, de test ou d’environnement, puis proposer une correction.
+
+Mais il ne doit pas systématiquement modifier le code. Dans beaucoup de cas, son premier rôle est d’expliquer l’échec.
+
+### 4.6 Lint, format et vérifications mécaniques
+
+Les tâches mécaniques doivent être traitées avec le moins d’intelligence artificielle possible.
+
+Un linter, un formatter ou une commande de build doivent être prioritairement pilotés par scripts. Le modèle ne doit intervenir que pour analyser un échec, pas pour décider à la place de l’outil.
+
+Ces tâches sont de bons candidats pour des modèles locaux ou économiques.
+
+### 4.7 Revue de code
+
+La revue est une activité critique.
+
+Elle doit être confiée à un agent distinct de celui qui a implémenté, afin d’éviter l’auto-validation complaisante.
+
+La revue doit porter sur les risques réels : régression, dette technique, incohérence avec l’architecture, sécurité, maintenabilité, tests absents, dérive de scope.
+
+Elle ne doit pas se limiter à une reformulation positive du travail effectué.
+
+### 4.8 Rédaction de PR ou de changelog
+
+La rédaction de PR est une activité utile mais rarement critique.
+
+Elle peut être confiée à un modèle simple ou intermédiaire, à condition qu’il s’appuie sur le diff réel, le plan initial et les tests exécutés.
+
+Le texte de PR doit rester factuel : ce qui a été changé, pourquoi, comment tester, risques éventuels.
+
+---
+
+## 5. Doctrine de choix des modèles
+
+Le choix du modèle doit suivre une logique d’arbitrage.
+
+### 5.1 Modèles locaux
+
+Les modèles locaux doivent être privilégiés pour :
+
+* exploration simple ;
+* résumé de logs ;
+* analyse de sorties de tests ;
+* préparation de listes de fichiers ;
+* tâches répétitives ;
+* reformulations non critiques ;
+* vérifications à faible risque.
+
+Ils sont intéressants quand la qualité attendue est correcte mais que le coût doit rester faible.
+
+### 5.2 Modèles distants simples ou intermédiaires
+
+Les modèles distants simples ou intermédiaires doivent être utilisés pour :
+
+* rédaction de PR ;
+* synthèse de diff ;
+* petites corrections ;
+* diagnostic de tests lisibles ;
+* aide à la documentation ;
+* tâches standards avec peu d’ambiguïté.
+
+Ils offrent un bon compromis entre fiabilité, rapidité et coût.
+
+### 5.3 Modèles de raisonnement avancé
+
+Les modèles de raisonnement avancé doivent être réservés à :
+
+* cadrage d’architecture ;
+* refactoring complexe ;
+* bug difficile à reproduire ;
+* arbitrage entre plusieurs solutions ;
+* conception de plan d’implémentation ;
+* revue critique avant merge ;
+* décisions qui engagent la maintenabilité long terme.
+
+Ces modèles doivent être utilisés moins souvent, mais mieux.
+
+### 5.4 Modèles spécialisés code
+
+Les modèles spécialisés code doivent être privilégiés pour :
+
+* implémentation ;
+* refactoring localisé ;
+* écriture ou adaptation de tests ;
+* correction de bug confirmée ;
+* migration technique ;
+* compréhension fine d’une base existante.
+
+Leur usage doit rester encadré par un plan ou une demande précise.
+
+---
+
+## 6. Règles de séparation des responsabilités
+
+La configuration doit éviter les agents “tout-puissants”.
+
+Chaque agent doit avoir une responsabilité principale claire :
+
+* un agent de planification ne modifie pas ;
+* un agent d’implémentation suit un plan ;
+* un agent de test diagnostique avant de corriger ;
+* un agent de revue ne valide pas son propre travail ;
+* un agent documentaire ne change pas le comportement applicatif ;
+* un agent local économique ne prend pas de décision d’architecture majeure.
+
+Cette séparation est plus importante que le choix exact du modèle.
+
+Un mauvais découpage des rôles fera gaspiller plus de tokens qu’un mauvais choix ponctuel de modèle.
+
+---
+
+## 7. Gouvernance des permissions
+
+Les permissions doivent être pensées selon le risque de l’activité.
+
+Une tâche de lecture doit avoir un accès en lecture seule.
+
+Une tâche de planification ne doit pas pouvoir modifier le code.
+
+Une tâche d’implémentation peut modifier, mais dans un périmètre cadré.
+
+Une tâche de test peut exécuter des commandes, mais ne doit pas nécessairement pouvoir modifier.
+
+Une tâche de revue doit pouvoir lire le diff, les fichiers concernés et les tests, mais ne doit pas écrire.
+
+OpenCode permet de contrôler l’accès aux outils comme la lecture, l’édition, le shell ou les outils externes via des permissions ; cette logique doit être utilisée comme un garde-fou, pas seulement comme une commodité. ([OpenCode][2])
+
+---
+
+## 8. Rôle des skills
+
+Les skills ne doivent pas être utilisés comme des workflows.
+
+Ils doivent plutôt contenir la connaissance durable du projet :
+
+* conventions d’architecture ;
+* règles de nommage ;
+* conventions de tests ;
+* stratégie i18n ;
+* règles de documentation ;
+* principes de découpage des issues ;
+* règles propres au framework utilisé ;
+* décisions d’architecture déjà prises ;
+* erreurs récurrentes à éviter.
+
+Un bon skill doit être court, ciblé, actionnable et maintenable.
+
+Un mauvais skill devient un fourre-tout qui surcharge le contexte et affaiblit la qualité des réponses.
+
+La logique recommandée est donc :
+
+> Les agents exécutent des rôles.
+> Les commandes déclenchent des actions.
+> Les skills apportent le savoir projet.
+> Les permissions encadrent le risque.
+
+---
+
+## 9. Rôle des commandes
+
+Les commandes doivent formaliser les activités récurrentes.
+
+Elles servent à éviter de réécrire les mêmes prompts et à standardiser la qualité attendue.
+
+Chaque commande doit exprimer :
+
+* l’objectif ;
+* le résultat attendu ;
+* les limites ;
+* les critères de réussite ;
+* le niveau d’autonomie autorisé ;
+* le type d’agent ou de modèle adapté.
+
+Les commandes doivent rester orientées métier d’usage, pas technologie interne.
+
+Exemples de familles de commandes à prévoir :
+
+* préparer un plan ;
+* cadrer une issue ;
+* corriger un bug ;
+* implémenter un plan ;
+* exécuter les tests ;
+* analyser un échec de test ;
+* lancer le lint ;
+* relire un diff ;
+* préparer une PR ;
+* mettre à jour une documentation projet.
+
+OpenCode permet de créer des commandes personnalisées sous forme de fichiers ou de configuration, avec des paramètres comme l’agent et le modèle associés. ([OpenCode][3])
+
+---
+
+## 10. Rôle des hooks et plugins
+
+Les hooks et plugins ne doivent pas devenir le cœur du système.
+
+Ils doivent être réservés à des usages transverses :
+
+* appliquer des règles de sécurité ;
+* empêcher l’accès à certains fichiers ;
+* journaliser les modèles utilisés ;
+* suivre les coûts ou durées ;
+* vérifier qu’une commande critique demande validation ;
+* déclencher une action mécanique après modification ;
+* intégrer un outil externe.
+
+La règle est simple :
+si la logique relève d’un **workflow humain**, elle doit plutôt être portée par des commandes et agents.
+Si la logique relève d’un **contrôle automatique transversal**, elle peut être portée par un hook ou plugin.
+
+OpenCode documente les plugins comme un mécanisme d’extension permettant de se brancher sur des événements et de personnaliser le comportement. ([OpenCode][4])
+
+---
+
+## 11. Critères d’arbitrage pour choisir le bon agent
+
+Avant de lancer une tâche, le système doit pouvoir répondre à ces questions :
+
+1. La tâche demande-t-elle de modifier le code ?
+2. La tâche engage-t-elle l’architecture ?
+3. Le résultat attendu est-il exploratoire ou exécutable ?
+4. Le coût d’une erreur est-il faible, moyen ou élevé ?
+5. La tâche est-elle répétitive ou exceptionnelle ?
+6. Peut-elle être traitée par un modèle local ?
+7. Faut-il un modèle de raisonnement ?
+8. Faut-il un modèle spécialisé code ?
+9. Faut-il une validation humaine avant action ?
+10. Le contexte projet doit-il être chargé via un skill ?
+
+Ces questions doivent guider la configuration, pas l’inverse.
+
+---
+
+## 12. Critères d’évaluation de la configuration
+
+La configuration sera considérée comme efficace si elle permet de constater :
+
+* moins de prompts manuels répétés ;
+* moins d’usage des modèles coûteux sur des tâches simples ;
+* moins de dérives de scope ;
+* meilleure qualité des plans ;
+* meilleure lisibilité des PR ;
+* meilleure séparation entre diagnostic et correction ;
+* meilleure reproductibilité des workflows ;
+* moins de corrections humaines après passage du LLM ;
+* meilleure traçabilité des décisions ;
+* meilleur usage des skills projet.
+
+Le critère principal n’est pas la sophistication de la configuration.
+Le critère principal est la **réduction du bruit opérationnel**.
+
+---
+
+## 13. Risques à éviter
+
+### 13.1 Sur-orchestration
+
+Le risque principal est de construire trop tôt une usine à gaz.
+
+Il faut commencer par quelques agents et commandes bien conçus, puis enrichir progressivement.
+
+### 13.2 Agents trop larges
+
+Un agent qui sait tout faire finit par mal faire beaucoup de choses.
+
+Les agents doivent être spécialisés, mais pas proliférants.
+
+### 13.3 Skills trop longs
+
+Un skill trop complet peut devenir contre-productif.
+
+Il doit contenir les règles réellement utiles au moment de l’action.
+
+### 13.4 Automatisation excessive
+
+Tout ne doit pas être automatisé.
+
+Les décisions d’architecture, les changements de comportement, les suppressions et les refactorings importants doivent rester sous contrôle humain.
+
+### 13.5 Modèle puissant utilisé par défaut
+
+Utiliser systématiquement le meilleur modèle est une mauvaise stratégie économique.
+
+Le modèle fort doit être une exception justifiée, pas le mode normal.
+
+---
+
+## 14. Niveau d’ambition recommandé
+
+La cible raisonnable n’est pas une orchestration autonome complète.
+
+La cible recommandée est une **orchestration assistée**, dans laquelle :
+
+* l’utilisateur choisit l’intention ;
+* OpenCode sélectionne ou applique le bon agent ;
+* les skills apportent le contexte projet ;
+* les permissions limitent les risques ;
+* les modèles coûteux sont réservés aux tâches à forte valeur ;
+* les commandes standardisent les routines ;
+* les revues restent explicites.
+
+L’autonomie doit augmenter seulement lorsque les routines sont stables et observées comme fiables.
+
+---
+
+## 15. Recommandation de déploiement progressif
+
+La mise en place doit être progressive.
+
+### Phase 1 — Clarifier les usages
+
+Identifier les 6 à 10 activités réellement fréquentes.
+
+Ne pas configurer des agents pour des cas rares.
+
+### Phase 2 — Séparer les rôles
+
+Créer une première cartographie des responsabilités :
+
+* lire ;
+* planifier ;
+* implémenter ;
+* tester ;
+* corriger ;
+* relire ;
+* documenter ;
+* préparer une PR.
+
+### Phase 3 — Associer les niveaux de modèles
+
+Définir pour chaque activité le niveau de modèle attendu :
+
+* local ;
+* distant économique ;
+* distant spécialisé code ;
+* raisonnement fort.
+
+### Phase 4 — Formaliser les commandes
+
+Créer des commandes courtes, stables, réutilisables.
+
+Chaque commande doit exprimer ce qu’elle fait et ce qu’elle ne doit pas faire.
+
+### Phase 5 — Structurer les skills
+
+Transformer les règles récurrentes du projet en skills spécialisés.
+
+Les skills doivent rester modulaires.
+
+### Phase 6 — Ajouter des garde-fous
+
+Mettre en place les restrictions de permissions adaptées.
+
+Les permissions doivent refléter le niveau de risque.
+
+### Phase 7 — Mesurer et ajuster
+
+Observer les résultats :
+
+* quelle commande marche bien ;
+* quel agent dérive ;
+* quel modèle est surdimensionné ;
+* quelle tâche demande un modèle plus fort ;
+* quel skill est inutile ;
+* quelle règle manque.
+
+---
+
+## 16. Synthèse exécutive
+
+La configuration OpenCode doit être pensée comme une organisation du travail entre plusieurs profils d’assistants, et non comme un simple fichier de préférences de modèles.
+
+Le bon objectif n’est pas d’automatiser tout le développement.
+Le bon objectif est de rendre chaque interaction plus précise, plus sobre et plus fiable.
+
+La stratégie recommandée est :
+
+> standardiser les actions fréquentes, spécialiser les agents, réserver les modèles puissants aux décisions importantes, utiliser les skills pour le contexte projet, et maintenir une validation humaine sur les actions à risque.
+
+C’est cette discipline qui permettra d’obtenir le meilleur compromis entre coût, qualité, contrôle et vélocité.
+
+[1]: https://opencode.ai/docs/agents/?utm_source=chatgpt.com "Agents"
+[2]: https://opencode.ai/docs/tools/?utm_source=chatgpt.com "Tools"
+[3]: https://opencode.ai/docs/commands/?utm_source=chatgpt.com "Commands"
+[4]: https://opencode.ai/docs/plugins/?utm_source=chatgpt.com "Plugins"

--- a/documentation/plan/character-sheet/talent/205-plan-neutraliser-anciennes-logiques-crucible.md
+++ b/documentation/plan/character-sheet/talent/205-plan-neutraliser-anciennes-logiques-crucible.md
@@ -1,0 +1,450 @@
+# Plan d'implémentation — US21 : Neutraliser les anciennes logiques Crucible
+
+**Issue** : [#205 — US21: Neutraliser les anciennes logiques Crucible](https://github.com/herveDarritchon/foundryvtt-swerpg/issues/205)
+**Epic** : [#184 — EPIC: Refonte V1 des talents Edge](https://github.com/herveDarritchon/foundryvtt-swerpg/issues/184)
+**ADR** : `documentation/architecture/adr/adr-0010-architecture-des-effets-mécaniques-des-talents.md`
+**Module(s) impacté(s)** : `module/lib/talents/` (modification), `module/models/talent.mjs` (modification), `module/documents/actor.mjs` (modification), `module/canvas/` (modification), `module/config/talent-tree.mjs` (modification), `module/applications/sheets/character-sheet.mjs` (modification)
+
+---
+
+## 1. Objectif
+
+Neutraliser les 6 logiques héritées de Crucible identifiées dans l'issue, en vérifiant d'abord que le flux V1 n'en dépend pas, puis en ajoutant des protections runtime avec avertissements de dépréciation, sans casser la compatibilité des personnages existants qui utilisent encore ces chemins legacy.
+
+Les 6 logiques à neutraliser :
+
+| # | Logique Crucible | Fichier(s) porteur(s) |
+|---|------------------|----------------------|
+| 1 | `rank * 5` | `talent-cost-calculator.mjs:32` |
+| 2 | `isCreation` | `talent-factory.mjs:54`, `talent.mjs:5` |
+| 3 | Talent points (`actor.points.talent`) | `models/talent.mjs:241`, `actor.mjs:211` |
+| 4 | Arbre global Crucible | `config/talent-tree.mjs` |
+| 5 | `choice wheel` métier | `canvas/talent-choice-wheel.mjs` |
+| 6 | Achat direct de talent générique | `actor-mixins/talents.mjs:168` (`addTalent`), `talents.mjs:208` (`addTalentWithXpCheck`) |
+
+---
+
+## 2. Périmètre
+
+### Inclus dans cette US / ce ticket
+
+- Vérification que le flux V1 (US6 #190, US7 #191, US18 #202) n'utilise **aucune** des 6 logiques Crucible
+- Ajout de logging de dépréciation (`logger.warn`) sur chaque point d'entrée Crucible
+- Ajout de guards runtime optionnels (via `CONFIG.SWERPG.deprecationFlags`) pour désactiver chaque logique indépendamment
+- Marquage JSDoc `@deprecated` sur les classes, méthodes et paramètres concernés
+- Documentation dans le code de chaque logique comme « héritée Crucible — ne pas utiliser pour V1 »
+- Neutralisation de l'appel `addTalent()` depuis l'arbre canvas legacy (chemin mort pour V1)
+- Tests Vitest vérifiant que les guards et warnings fonctionnent sans régression
+- Mise à jour des tests existants qui utilisent encore `isCreation=true` pour talents
+
+### Exclu de cette US / ce ticket
+
+- Suppression physique du code Crucible (conservé pour compatibilité)
+- Refonte ou réécriture des classes Crucible
+- Migration des données des personnages existants
+- Neutralisation des logiques Crucible **skills** (`isCreation` dans `module/lib/skills/`) — concerne uniquement les talents
+- Modification du flux d'achat V1 (`talent-node-purchase.mjs`, `talent-node-state.mjs`)
+- Modification de l'UI V1 (`specialization-tree-app.mjs`)
+
+---
+
+## 3. Constat sur l'existant
+
+### 3.1. US6, US7, US18 sont fermés et livrés
+
+| US | Issue | Statut | Rôle |
+|----|-------|--------|------|
+| US6 (#190) | Implémenter l'achat d'un nœud | CLOSED | Achat via `talent-node-purchase.mjs` |
+| US7 (#191) | Consolider les talents possédés | CLOSED | Vue consolidée des achats |
+| US18 (#202) | Acheter un nœud depuis la vue graphique | CLOSED | UI d'achat dans `specialization-tree-app.mjs` |
+
+**Vérification effectuée** : Le flux V1 est totalement indépendant des 6 logiques Crucible :
+
+| V1 Purchase Flow | Utilise Crucible ? |
+|-----------------|-------------------|
+| `talent-node-purchase.mjs:purchaseTalentNode()` | Non — utilise `system.progression.talentPurchases` + XP |
+| `talent-node-state.mjs:getNodeState()` | Non — utilise `talentPurchases` pour l'état |
+| `specialization-tree-app.mjs` (click → purchase) | Non — appelle `purchaseTalentNode()` directement |
+
+### 3.2. État des 6 logiques Crucible
+
+#### 3.2.1. `rank * 5` (talent-cost-calculator.mjs:32)
+
+```js
+#calculateTrainCost(rank) { return rank * 5 }
+```
+
+**Appelé par** : `trained-talent.mjs:process()`, `ranked-trained-talent.mjs:process()` via `TalentCostCalculator.calculateCost()`.
+
+**Appelé depuis** :
+- `character-sheet.mjs:640` — `_onDropItem` avec `TalentFactory.build(actor, item, { action: 'train', isCreation: true })` puis `talentClass.process()` → utilise `rank * 5`
+- `item.mjs:190` — `deleteTalent()` avec `TalentFactory.build(actor, this, { action: 'forget', isCreation: true })` puis `talentClass.process()` → utilise `rank * 5` (pour remboursement)
+
+**Flux V1** : `purchaseTalentNode()` utilise `nodeData.cost` depuis le schéma `specialization-tree`, pas `rank * 5`.
+
+#### 3.2.2. `isCreation` (talent-factory.mjs:54, talent.mjs:5)
+
+```js
+// talent-factory.mjs:54
+if (!isCreation) {
+  options.message = `You can train or forget a talent only at creation!`
+  return new ErrorTalent(...)
+}
+```
+
+**Comportement** : Le factory bloque **tout** train/forget de talent si `isCreation === false`. En V1, les talents ne s'achètent plus via ce factory — ils passent par `purchaseTalentNode()`.
+
+**Paradoxe** : Les deux callers (`character-sheet.mjs:645`, `item.mjs:195`) hardcodent `isCreation: true`. Donc le guard ne bloque rien en pratique — mais `isCreation: true` désactive toute validation de coût « post-creation ».
+
+#### 3.2.3. Talent points (`actor.points.talent`)
+
+```js
+// models/talent.mjs:241
+const points = actor.points.talent
+if (points.available < 1) { throw new Error(...) }
+```
+
+**Appelé par** : `SwerpgTalent.assertPrerequisites()` → appellé par `addTalent()` (legacy canvas) et potentiellement par d'autres chemins.
+
+**Autre usage** : `actor.mjs:211` — `levelUp()` vérifie `!this.points.talent.available` pour valider la création.
+
+**Flux V1** : `talent-node-purchase.mjs` n'appelle pas `assertPrerequisites()`. V1 ne dépend pas des talent points.
+
+#### 3.2.4. Arbre global Crucible (config/talent-tree.mjs)
+
+`module/config/talent-tree.mjs` (1152 lignes) définit un arbre global unique avec des nœuds, connexions et talents. Il est référencé par :
+- `SwerpgTalent` (models/talent.mjs) — `initializeTree()`, `prepareBaseData()`, `assertPrerequisites()`
+- `module/config/talent-tree.mjs` lui-même — s'auto-enregistre via `SwerpgTalentNode`
+- Canvas legacy — `SwerpgTalentTree` lit les nœuds depuis cet arbre
+
+**Flux V1** : Les arbres V1 sont des items de type `specialization-tree`, chargés via `resolveSpecializationTree()`.
+
+#### 3.2.5. `choice wheel` métier (canvas/talent-choice-wheel.mjs)
+
+`SwerpgTalentChoiceWheel` (148 lignes) et `SwerpgTalentTreeTalent` (74 lignes) forment le mécanisme de sélection radiale.
+
+**Appelé par** : `SwerpgTalentTree` (legacy canvas) uniquement. La V1 utilise `specialization-tree-app.mjs` avec sélection directe par clic.
+
+#### 3.2.6. Achat direct de talent générique (actor-mixins/talents.mjs)
+
+```js
+addTalent(talent, { dialog = false })     // ligne 168
+addTalentWithXpCheck(item)                 // ligne 208
+```
+
+- `addTalent()` est appelé UNIQUEMENT depuis `canvas/talent-tree-talent.mjs:43` (legacy canvas tree)
+- `addTalentWithXpCheck()` n'est appelé **nulle part** (code mort)
+- Coût hardcodé à `5` XP dans `addTalentWithXpCheck()` (ligne 217)
+
+**Flux V1** : Achat UNIQUEMENT via `purchaseTalentNode()` dans `talent-node-purchase.mjs`.
+
+---
+
+## 4. Décisions d'architecture
+
+### 4.1. Neutralisation progressive avec flags de dépréciation
+
+**Problème** : Comment neutraliser sans casser les personnages existants et les tests ?
+
+**Décision** : Ajouter un système de flags de dépréciation dans `CONFIG.SWERPG.deprecation` permettant de contrôler chaque logique indépendamment :
+
+```js
+CONFIG.SWERPG.deprecation = {
+  crucible: {
+    rankTimes5: { enabled: true, warn: true },     // true = la logique fonctionne encore
+    isCreation: { enabled: true, warn: true },       // false = la logique est désactivée
+    talentPoints: { enabled: true, warn: true },
+    globalTree: { enabled: true, warn: true },
+    choiceWheel: { enabled: true, warn: true },
+    directPurchase: { enabled: true, warn: true },
+  }
+}
+```
+
+Justification :
+- Permet de désactiver chaque logique indépendamment pendant le debug
+- Les warnings sont activables/désactivables
+- Compatibilité ascendante préservée : `enabled: true` par défaut
+- Désactivation possible en test via `CONFIG.SWERPG.deprecation.crucible.X.enabled = false`
+
+### 4.2. Logging de dépréciation centralisé
+
+**Problème** : Comment signaler qu'un chemin legacy est utilisé ?
+
+**Décision** : Créer un helper `logger.deprecated(module, feature)` qui émet un `logger.warn` structuré :
+
+```js
+logger.deprecated('talent-cost-calculator', 'rank * 5 cost calculation')
+// → [DEPRECATED] [talent-cost-calculator] rank * 5 cost calculation
+//   Use node-based cost from specialization-tree instead.
+```
+
+Justification :
+- Pattern unique et identifiable dans les logs
+- Message standardisé incluant la suggestion de remplacement
+- Facile à rechercher dans les logs : `[DEPRECATED]`
+
+### 4.3. Marquer le code legacy en JSDoc `@deprecated`
+
+**Problème** : Comment signaler aux développeurs que du code est legacy ?
+
+**Décision** : Ajouter `@deprecated` JSDoc avec message de remplacement sur chaque classe/méthode/propriété concernée.
+
+Exemple :
+```js
+/**
+ * Calculate the cost of the talent.
+ * @deprecated Crucible legacy — use nodeData.cost from specialization-tree instead.
+ *   Will be removed in a future version.
+ * @param {string} action The action to perform.
+ * @param {number} rank The rank of the talent in the tree (row).
+ * @returns {number} - The cost of the talent.
+ */
+```
+
+### 4.4. Pas de suppression du code legacy
+
+**Décision** : Conserver le code Crucible jusqu'à la fin de l'EPIC talents V1 (#184). La suppression sera traitée dans une US ultérieure dédiée au nettoyage.
+
+Justification :
+- Personnages existants peuvent encore référencer l'arbre global Crucible
+- Tests existants utilisent encore ces chemins
+- Risque de régression inacceptable en cours d'EPIC
+
+### 4.5. Neutralisation de l'appel canvas `addTalent()` comme priorité
+
+**Décision** : Désactiver le bouton d'achat dans le canvas legacy pour les personnages V1. Dans `talent-tree-talent.mjs:#onClickLeft`, ajouter un guard qui redirige vers la vue graphique V1.
+
+Justification :
+- Le canvas legacy est le seul point d'entrée qui déclenche encore `addTalent()` en runtime
+- La V1 propose déjà `specialization-tree-app.mjs` pour l'achat
+- Évite qu'un joueur utilise par erreur l'ancien flux
+
+### 4.6. `addTalentWithXpCheck()` supprimé (code mort)
+
+**Décision** : Supprimer `addTalentWithXpCheck()` de `actor-mixins/talents.mjs`. Cette méthode a été remplacée par `purchaseTalentNode()` et n'est appelée nulle part.
+
+Justification :
+- Élimination de code mort sans risque
+- La méthode utilisait un `cost = 5` hardcodé qui est trompeur
+
+---
+
+## 5. Plan de travail détaillé
+
+### Étape 1 : Audit complet des flux V1
+
+**Quoi** : Vérifier exhaustivement que le flux V1 (depuis `specialization-tree-app.mjs` → `purchaseTalentNode()` → `talent-node-state.mjs`) ne passe par aucune des 6 logiques Crucible.
+
+**Fichiers** :
+- `module/applications/specialization-tree-app.mjs` — tracer l'appel `purchaseTalentNode`
+- `module/lib/talent-node/talent-node-purchase.mjs` — tracer le chemin complet
+- `module/lib/talent-node/talent-node-state.mjs` — vérifier l'absence de `rank*5`, `points.talent`, `isCreation`
+
+**Risque** : Aucun — simple vérification de lecture.
+
+### Étape 2 : Ajouter les flags de dépréciation dans `CONFIG.SWERPG`
+
+**Quoi** : Ajouter la structure `CONFIG.SWERPG.deprecation.crucible` avec les 6 flags, chacun supportant `{ enabled, warn }`.
+
+**Fichiers** :
+- `module/config/system.mjs` (ou fichier de configuration dédié)
+
+**Risque** : Faible — nouvelle structure, aucun code existant ne la lit encore.
+
+### Étape 3 : Ajouter `logger.deprecated()` helper
+
+**Quoi** : Ajouter une méthode `deprecated(module, feature, suggestion)` sur le logger centralisé.
+
+**Fichiers** :
+- `module/utils/logger.mjs` — ajout de la méthode
+
+**Risque** : Faible — ajout non-cassant.
+
+### Étape 4 : Neutraliser `rank * 5`
+
+**Quoi** :
+1. Ajouter `@deprecated` JSDoc sur `TalentCostCalculator` et ses méthodes
+2. Ajouter un `logger.deprecated()` dans `#calculateTrainCost()` et `#calculateForgetCost()`
+3. Ajouter un guard optionnel via `CONFIG.SWERPG.deprecation.crucible.rankTimes5.enabled`
+4. Mettre à jour les tests pour vérifier le warning de dépréciation
+
+**Fichiers** :
+- `module/lib/talents/talent-cost-calculator.mjs` — modification
+- `tests/lib/talents/talent-cost-calculator.test.mjs` — modification
+
+**Risque** : Faible — la logique continue de fonctionner, seul un warning est émis.
+
+### Étape 5 : Neutraliser `isCreation` (périmètre talents uniquement)
+
+**Quoi** :
+1. Ajouter `@deprecated` JSDoc sur le paramètre `isCreation` de `Talent` et `TalentFactory`
+2. Ajouter `logger.deprecated()` dans `TalentFactory.build()` quand un talent est construit avec `isCreation`
+3. Ajouter un commentaire « héritée Crucible — ne pas utiliser pour V1 » en tête de `talent-factory.mjs`
+4. Mettre à jour les tests talents pour vérifier le warning
+
+**Fichiers** :
+- `module/lib/talents/talent.mjs` — modification
+- `module/lib/talents/talent-factory.mjs` — modification
+- `module/lib/talents/trained-talent.mjs` — modification
+- `module/lib/talents/ranked-trained-talent.mjs` — modification
+- `tests/lib/talents/talent-factory.test.mjs` — modification
+- `tests/lib/talents/talent-cost-calculator.test.mjs` — modification
+
+**Risque** : Moyen — les tests skills utilisent aussi `isCreation` mais dans une factory différente (`SkillFactory`). On ne touche pas aux skills.
+
+### Étape 6 : Neutraliser `talentPoints` (actor.points.talent)
+
+**Quoi** :
+1. Ajouter `@deprecated` JSDoc sur `SwerpgTalent.assertPrerequisites()` — signaler que cette méthode utilise les talent points Crucible
+2. Ajouter un `logger.deprecated()` dans `assertPrerequisites()` quand elle est appelée
+3. Vérifier que `levelUp()` dans `actor.mjs:211` ne bloque pas les personnages V1 (la vérification `points.talent.available` est déjà conditionnée par `this.isL0`)
+
+**Fichiers** :
+- `module/models/talent.mjs` — modification
+- `module/models/talent-orig.mjs` — modification (même logique)
+
+**Risque** : Faible — `assertPrerequisites()` n'est appelée que par `addTalent()` (legacy canvas). La V1 ne passe pas par là.
+
+### Étape 7 : Neutraliser l'arbre global Crucible
+
+**Quoi** :
+1. Ajouter un en-tête de commentaire en haut de `module/config/talent-tree.mjs` : « Ce fichier définit l'arbre global hérité de Crucible. Ne pas ajouter de nouveaux nœuds. Utiliser specialization-tree pour les arbres V1. »
+2. Ajouter `@deprecated` JSDoc sur `SwerpgTalentNode` et ses méthodes principales
+3. Ajouter `logger.deprecated()` dans `SwerpgTalentNode.getNodes()` et `SwerpgTalentNode.preparePrerequisites()`
+
+**Fichiers** :
+- `module/config/talent-tree.mjs` — modification
+
+**Risque** : Faible — la structure est encore utilisée par les talents existants. Ne pas désactiver, juste marquer.
+
+### Étape 8 : Neutraliser la `choice wheel`
+
+**Quoi** :
+1. Ajouter un en-tête de commentaire dans `module/canvas/talent-choice-wheel.mjs` et `module/canvas/talent-tree-talent.mjs`
+2. Dans `talent-tree-talent.mjs:#onClickLeft`, ajouter un guard qui vérifie si une spécialisation V1 est présente sur l'acteur. Si oui, afficher une notification redirigeant vers la vue graphique V1 et ne pas appeler `addTalent()`.
+3. Marquer `@deprecated` sur `SwerpgTalentChoiceWheel`
+
+**Fichiers** :
+- `module/canvas/talent-choice-wheel.mjs` — modification
+- `module/canvas/talent-tree-talent.mjs` — modification
+
+**Risque** : Moyen — des personnages peuvent encore utiliser le canvas legacy. Le guard ne bloque que si l'acteur a des spécialisations V1.
+
+### Étape 9 : Neutraliser l'achat direct de talent générique
+
+**Quoi** :
+1. Ajouter `@deprecated` JSDoc sur `addTalent()` et `addTalentWithXpCheck()` dans `actor-mixins/talents.mjs`
+2. Ajouter `logger.deprecated()` dans `addTalent()` quand elle est appelée
+3. Supprimer `addTalentWithXpCheck()` (code mort non appelé)
+4. Marquer tout le bloc « talent purchase » comme hérité Crucible
+
+**Fichiers** :
+- `module/documents/actor-mixins/talents.mjs` — modification
+- `tests/documents/actor-creation.test.mjs` — vérifier qu'aucun test ne dépend de `addTalentWithXpCheck()`
+
+**Risque** : Faible pour `addTalentWithXpCheck()` (code mort). Moyen pour `addTalent()` car utilisé par le canvas legacy (neutralisé à l'étape 8).
+
+### Étape 10 : Mettre à jour les tests
+
+**Quoi** :
+1. Dans les tests talents existants qui utilisent `isCreation`, vérifier que le warning de dépréciation apparaît
+2. Ajouter un test vérifiant que `talent-node-purchase.mjs` n'émet AUCUN warning de dépréciation Crucible
+3. Ajouter un test par logique vérifiant que le guard `CONFIG.SWERPG.deprecation.crucible.X.enabled = false` désactive la logique
+
+**Fichiers** :
+- `tests/lib/talents/talent-factory.test.mjs` — modification
+- `tests/lib/talents/talent-cost-calculator.test.mjs` — modification
+- `tests/lib/talent-node/talent-node-purchase.test.mjs` — ajout d'un test de non-régression
+- `tests/deprecation/crucible-neutralization.test.mjs` — création
+
+**Risque** : Standard.
+
+---
+
+## 6. Fichiers modifiés
+
+| Fichier | Action | Description |
+|---------|--------|-------------|
+| `module/config/system.mjs` | Modification | Ajout de `CONFIG.SWERPG.deprecation.crucible` avec les 6 flags |
+| `module/utils/logger.mjs` | Modification | Ajout de `logger.deprecated(module, feature, suggestion)` |
+| `module/lib/talents/talent-cost-calculator.mjs` | Modification | `@deprecated` JSDoc + `logger.deprecated()` + guard flag |
+| `module/lib/talents/talent.mjs` | Modification | `@deprecated` JSDoc sur `isCreation` param |
+| `module/lib/talents/talent-factory.mjs` | Modification | `@deprecated` en-tête + `logger.deprecated()` + guard flag |
+| `module/lib/talents/trained-talent.mjs` | Modification | `@deprecated` en-tête |
+| `module/lib/talents/ranked-trained-talent.mjs` | Modification | `@deprecated` en-tête |
+| `module/lib/talents/error-talent.mjs` | Modification | `@deprecated` en-tête |
+| `module/models/talent.mjs` | Modification | `@deprecated` sur `assertPrerequisites()` + `logger.deprecated()` |
+| `module/models/talent-orig.mjs` | Modification | `@deprecated` sur `assertPrerequisites()` |
+| `module/config/talent-tree.mjs` | Modification | En-tête legacy + `@deprecated` sur `SwerpgTalentNode` + `logger.deprecated()` |
+| `module/canvas/talent-choice-wheel.mjs` | Modification | En-tête legacy + `@deprecated` |
+| `module/canvas/talent-tree-talent.mjs` | Modification | Guard V1 dans `#onClickLeft` + notification |
+| `module/documents/actor-mixins/talents.mjs` | Modification | `@deprecated` + `logger.deprecated()` sur `addTalent()` ; suppression de `addTalentWithXpCheck()` |
+| `documentation/cadrage/character-sheet/talent/07-plan-issues-github.md` | Modification | Marquage US21 comme livrée |
+| `tests/lib/talents/talent-factory.test.mjs` | Modification | Vérification warning dépréciation |
+| `tests/lib/talents/talent-cost-calculator.test.mjs` | Modification | Vérification warning dépréciation |
+| `tests/lib/talent-node/talent-node-purchase.test.mjs` | Modification | Test non-régression V1 sans warning Crucible |
+| `tests/deprecation/crucible-neutralization.test.mjs` | Création | Tests par logique : flag enabled/disabled, warning émis |
+
+---
+
+## 7. Risques
+
+| Risque | Impact | Mitigation |
+|--------|--------|------------|
+| **Un module inconnu dépend encore d'une logique Crucible** | Warning inattendu, comportement modifié | Audit préalable (étape 1). Tous les appels ont été tracés. Si un nouveau chemin est découvert, le warning le signalera immédiatement dans les logs. |
+| **`addTalent()` est encore utilisé par un module non-couvrant** | L'achat de talent plante | Le guard dans `talent-tree-talent.mjs` ne désactive que si l'acteur a des spécialisations V1. Les personnages sans spécialisation V1 continuent de passer par l'ancien flux. |
+| **`levelUp()` bloque les personnages V1** | Impossibilité de monter de niveau | La vérification `points.talent.available` dans `levelUp()` (actor.mjs:211) n'est exécutée que si `this.isL0`. Un personnage V1 qui a déjà commencé sa progression ne sera pas bloqué. |
+| **Tests flaky à cause des warnings de dépréciation** | Tests qui échouent inopinément | Les tests qui vérifient l'absence de warning doivent utiliser `CONFIG.SWERPG.deprecation.crucible.X.enabled = false` pour désactiver le warning. |
+| **Suppression de `addTalentWithXpCheck()` cassant un import** | Erreur à l'import OggDude | Vérification préalable : aucun import n'appelle `addTalentWithXpCheck()`. Seul `purchaseTalentNode()` est utilisé par l'importer. |
+| **Fausse alerte de dépréciation pendant les tests d'intégration** | Bruit dans les logs de test | Les tests d'intégration qui utilisent intentionnellement les chemins legacy doivent activer le flag `warn: false` ou `enabled: false` pour éviter le bruit. |
+
+---
+
+## 8. Proposition d'ordre de commit
+
+1. `chore(config): add deprecation flags to CONFIG.SWERPG.deprecation.crucible`
+   - Ajout des 6 flags dans `module/config/system.mjs`
+2. `feat(logger): add logger.deprecated() helper method`
+   - Ajout dans `module/utils/logger.mjs`
+3. `deprecate(talents): mark rank * 5 cost calculation as deprecated`
+   - `talent-cost-calculator.mjs` : JSDoc + logger.deprecated() + guard flag
+4. `deprecate(talents): mark isCreation parameter as deprecated (talent scope)`
+   - `talent.mjs`, `talent-factory.mjs`, `trained-talent.mjs`, `ranked-trained-talent.mjs`, `error-talent.mjs`
+5. `deprecate(talents): mark talentPoints (actor.points.talent) as deprecated`
+   - `models/talent.mjs`, `models/talent-orig.mjs`
+6. `deprecate(talents): mark global Crucible tree as deprecated`
+   - `config/talent-tree.mjs`
+7. `deprecate(talents): neutralize choice wheel and legacy canvas purchase path`
+   - `canvas/talent-choice-wheel.mjs`, `canvas/talent-tree-talent.mjs`
+8. `deprecate(talents): neutralize addTalent() and remove dead code addTalentWithXpCheck()`
+   - `actor-mixins/talents.mjs`
+9. `test(talents): add deprecation warning tests for all 6 Crucible logics`
+   - Tests dans `tests/lib/talents/` et `tests/deprecation/crucible-neutralization.test.mjs`
+10. `test(talents): verify V1 purchase flow emits no Crucible deprecation warnings`
+    - Test dans `tests/lib/talent-node/talent-node-purchase.test.mjs`
+11. `docs(talents): update issue plan and document US21 as delivered`
+    - `documentation/cadrage/character-sheet/talent/07-plan-issues-github.md`
+
+---
+
+## 9. Dépendances avec les autres US
+
+```
+Epic #184 — Refonte V1 des talents Edge
+├── US1 #185 — Définir le type specialization-tree      → CLOSED
+├── US2 #186 — Définir la structure des nœuds            → CLOSED
+├── US3 #187 — Définir les achats de nœuds sur l'acteur  → CLOSED
+├── US4 #188 — Résoudre spécialisation → arbre           → CLOSED
+├── US5 #189 — Calculer l'état des nœuds                 → CLOSED
+├── US6 #190 — Implémenter l'achat d'un nœud             → CLOSED (dépend bloquante)
+├── US7 #191 — Consolider les talents possédés           → CLOSED (dépend bloquante)
+├── US8–US17 — US intermédiaires                         → CLOSED
+├── US18 #202 — Acheter un nœud depuis la vue graphique  → CLOSED (dépend bloquante)
+├── US21 #205 — Neutraliser les anciennes logiques Crucible ← VOUS ÊTES ICI
+└── US suivantes — Nettoyage final, suppression du code legacy
+```
+
+**Dépendances bloquantes** : US6 (#190), US7 (#191), US18 (#202) doivent être livrés AVANT US21. Ces 3 US sont CLOSED, la dépendance est levée.
+
+**Ordre conseillé** : US21 doit être la dernière US de l'EPIC avant la phase de nettoyage final (suppression physique du code legacy). Toutes les autres US doivent être livrées pour garantir que le flux V1 est complet et peut être testé sans régression.

--- a/module/canvas/talent-choice-wheel.mjs
+++ b/module/canvas/talent-choice-wheel.mjs
@@ -1,6 +1,11 @@
 import SwerpgTalentTreeTalent from './talent-tree-talent.mjs'
 
 /**
+ * @deprecated Crucible legacy — choice wheel radial selection UI.
+ *   La V1 ne reconduit pas la choice wheel comme mécanisme métier.
+ *   Use specialization-tree-app.mjs with direct node selection instead.
+ *   Will be removed in a future version.
+ *
  * A canvas UI element which displays a choice wheel for a talent tree node.
  * Only one choice wheel is displayed at a given time. The wheel is a singleton at canvas.tree.wheel.
  */

--- a/module/canvas/talent-tree-talent.mjs
+++ b/module/canvas/talent-tree-talent.mjs
@@ -1,5 +1,14 @@
+import { SYSTEM } from '../config/system.mjs'
+import { logger } from '../utils/logger.mjs'
 import SwerpgTalentIcon from './talent-icon.mjs'
 
+const DEPR_CHOICE_WHEEL = () => SYSTEM.DEPRECATION.crucible.choiceWheel
+
+/**
+ * @deprecated Crucible legacy — individual talent icon inside the choice wheel.
+ *   V1 Edge uses specialization-tree-app.mjs with direct node selection.
+ *   Will be removed in a future version.
+ */
 export default class SwerpgTalentTreeTalent extends SwerpgTalentIcon {
   constructor(node, talent, position, config) {
     super(config)
@@ -35,11 +44,29 @@ export default class SwerpgTalentTreeTalent extends SwerpgTalentIcon {
 
   /* -------------------------------------------- */
 
+  /**
+   * @deprecated Crucible legacy — choice wheel left-click purchase.
+   *   V1 Edge uses specialization-tree-app.mjs with purchaseTalentNode().
+   */
   async #onClickLeft(event) {
     event.stopPropagation()
-    if (event.data.originalEvent.button !== 0) return // Only support standard left-click
+    if (event.data.originalEvent.button !== 0) return
     const tree = game.system.tree
     if (!tree.actor || tree.actor.talentIds.has(this.talent.id)) return
+
+    // V1 guard : si l'acteur a des spécialisations, rediriger vers la vue graphique V1
+    const hasV1Specializations = tree.actor.itemTypes?.specialization?.length > 0
+    if (hasV1Specializations) {
+      if (DEPR_CHOICE_WHEEL().warn) {
+        logger.deprecated('talent-tree-talent', 'Choice wheel purchase blocked — actor has V1 specializations', 'Use specialization-tree-app.mjs for talent purchase.')
+      }
+      ui.notifications.warn('This actor uses V1 specialization trees. Use the specialization tree view to purchase talents.')
+      return
+    }
+
+    if (DEPR_CHOICE_WHEEL().warn) {
+      logger.deprecated('talent-tree-talent', 'Choice wheel purchase via addTalent()', 'V1 Edge uses purchaseTalentNode() via specialization-tree-app.mjs.')
+    }
     const response = await tree.actor.addTalent(this.talent, { dialog: true })
     if (response) tree.playClick()
   }

--- a/module/config/system.mjs
+++ b/module/config/system.mjs
@@ -229,6 +229,26 @@ export const SYSTEM = {
   WEAPON,
   activeCheckFormula: '3d8',
   dice: dice,
+
+  /**
+   * Flags de dépréciation pour les logiques héritées de Crucible.
+   * Chaque flag supporte `{ enabled, warn }` :
+   * - enabled : true = la logique fonctionne encore, false = désactivée
+   * - warn    : true = un logger.deprecated() est émis à chaque usage
+   *
+   * Utilisé par les guards runtime dans les modules legacy.
+   * @type {Object<string, {enabled: boolean, warn: boolean}>}
+   */
+  DEPRECATION: {
+    crucible: {
+      rankTimes5: { enabled: true, warn: true },
+      isCreation: { enabled: true, warn: true },
+      talentPoints: { enabled: true, warn: true },
+      globalTree: { enabled: true, warn: true },
+      choiceWheel: { enabled: true, warn: true },
+      directPurchase: { enabled: true, warn: true },
+    },
+  },
 }
 
 /**

--- a/module/config/talent-tree.mjs
+++ b/module/config/talent-tree.mjs
@@ -1,7 +1,18 @@
+import { SYSTEM } from './system.mjs'
 import SwerpgTalent from '../models/talent.mjs'
 import { logger } from '../utils/logger.mjs'
 import { CHARACTERISTICS } from './attributes.mjs'
 import Enum from './enum.mjs'
+
+const DEPR_GLOBAL_TREE = () => SYSTEM.DEPRECATION.crucible.globalTree
+
+/**
+ * @deprecated Crucible legacy — defines the global talent tree inherited from Crucible.
+ *   Do NOT add new nodes here. Use specialization-tree items for V1 Edge trees.
+ *   This file defines a single global tree with nodes, connections, and signature groups.
+ *   The V1 Edge system uses per-specialization trees (specialization-tree items).
+ *   Will be removed in a future version.
+ */
 export default class SwerpgTalentNode {
   static ACTIVATION = Object.freeze({
     ACTIVE: 'active',
@@ -57,15 +68,31 @@ export default class SwerpgTalentNode {
     return this.#nodes
   }
 
+  /**
+   * Get all node entries from the global Crucible tree.
+   * @deprecated Crucible legacy — use specialization-tree items instead.
+   * @returns {Map<string, SwerpgTalentNode>}
+   */
+  static getNodes() {
+    if (DEPR_GLOBAL_TREE().warn) {
+      logger.deprecated('talent-tree', 'SwerpgTalentNode.getNodes() — global tree access', 'Use specialization-tree items for per-tree resolution via resolveSpecializationTree().')
+    }
+    return this.#nodes
+  }
+
   static #nodes = new Map()
 
   /* -------------------------------------------- */
 
   /**
    * Get the valid node identifiers which can be referenced by a Talent.
+   * @deprecated Crucible legacy — global tree will be removed.
    * @returns {FormSelectOption[]}
    */
   static getChoices() {
+    if (DEPR_GLOBAL_TREE().warn) {
+      logger.deprecated('talent-tree', 'SwerpgTalentNode.getChoices()', 'Use specialization-tree items.')
+    }
     const choices = {}
     for (const { id, groups } of this.#nodes.values()) {
       if (groups) {
@@ -301,10 +328,14 @@ export default class SwerpgTalentNode {
 
   /**
    * Prepare the data structure of talent prerequisites
+   * @deprecated Crucible legacy — prerequisites are handled by talent-node-state.mjs in V1.
    * @param {AdvancementPrerequisites} requirements
    * @returns {AdvancementPrerequisites}
    */
   static preparePrerequisites(requirements = {}) {
+    if (DEPR_GLOBAL_TREE().warn) {
+      logger.deprecated('talent-tree', 'SwerpgTalentNode.preparePrerequisites()', 'Handled by talent-node-state.mjs in V1.')
+    }
     return Object.entries(foundry.utils.flattenObject(requirements)).reduce((obj, r) => {
       const [k, v] = r
       const o = (obj[k] = { value: v })

--- a/module/documents/actor-mixins/talents.mjs
+++ b/module/documents/actor-mixins/talents.mjs
@@ -6,6 +6,8 @@
 import { SYSTEM } from '../../config/system.mjs'
 import { logger } from '../../utils/logger.mjs'
 
+const DEPR_DIRECT_PURCHASE = () => SYSTEM.DEPRECATION.crucible.directPurchase
+
 export const TalentsMixin = (Base) =>
   class extends Base {
     /**
@@ -159,13 +161,22 @@ export const TalentsMixin = (Base) =>
 
     /**
      * Handle requests to add a new Talent to the Actor.
-     * Confirm that the Actor meets the requirements to add the Talent, and if so create it on the Actor
+     * @deprecated Crucible legacy — uses assertPrerequisites() with talent points.
+     *   V1 Edge uses purchaseTalentNode() from talent-node-purchase.mjs.
+     *   Will be removed in a future version.
      * @param {SwerpgItem} talent     The Talent item to add to the Actor
      * @param {object} [options]        Options which configure how the Talent is added
      * @param {boolean} [options.dialog]    Prompt the user with a confirmation dialog?
      * @returns {Promise<SwerpgItem|null>} The created talent Item or null if no talent was added
      */
     async addTalent(talent, { dialog = false } = {}) {
+      if (DEPR_DIRECT_PURCHASE().warn) {
+        logger.deprecated('talents-mixin', 'addTalent() — direct generic talent purchase', 'V1 Edge uses purchaseTalentNode() from talent-node-purchase.mjs.')
+      }
+      if (!DEPR_DIRECT_PURCHASE().enabled) {
+        ui.notifications.warn('Direct talent purchase is disabled (Crucible legacy). Use specialization-tree instead.')
+        return null
+      }
       // Confirm that the Actor meets the requirements to add the Talent
       try {
         talent.system.assertPrerequisites(this)
@@ -196,35 +207,6 @@ export const TalentsMixin = (Base) =>
 
       // Create the talent
       return talent.constructor.create(talent.toObject(), { parent: this, keepId: true })
-    }
-
-    /* -------------------------------------------- */
-
-    /**
-     * Add a Talent item to the actor with XP check and duplicate prevention.
-     * @param {Item} item The Talent item to add.
-     * @returns {Promise<boolean>} - Whether the talent was added successfully.
-     */
-    async addTalentWithXpCheck(item) {
-      const alreadyOwned = this.items.find((i) => i.name === item.name)
-      if (alreadyOwned) {
-        ui.notifications.warn(`${this.name} already has "${item.name}"`)
-        return false
-      }
-
-      const experiencePoints = this.experiencePoints
-      const currentXP = experiencePoints.available
-      const cost = 5
-
-      if (currentXP - cost < 0) {
-        ui.notifications.warn(`${this.name} doesn't have enough XP (${cost} required)`)
-        return false
-      }
-
-      await this.createEmbeddedDocuments('Item', [item.toObject()])
-      await this.spendExperiencePoints(cost)
-
-      return true
     }
 
     /* -------------------------------------------- */

--- a/module/lib/talents/error-talent.mjs
+++ b/module/lib/talents/error-talent.mjs
@@ -1,5 +1,9 @@
 import Talent from './talent.mjs'
 
+/**
+ * @deprecated Crucible legacy — used only by TalentFactory in the legacy flow.
+ *   Will be removed in a future version.
+ */
 export default class ErrorTalent extends Talent {
   constructor(actor, data, params, options) {
     super(actor, data, params, options)

--- a/module/lib/talents/ranked-trained-talent.mjs
+++ b/module/lib/talents/ranked-trained-talent.mjs
@@ -3,6 +3,11 @@ import { logger } from '../../utils/logger.mjs'
 import TalentCostCalculator from './talent-cost-calculator.mjs'
 import TrainedTalent from './trained-talent.mjs'
 
+/**
+ * @deprecated Crucible legacy — use purchaseTalentNode() instead.
+ *   This class handles train/forget of ranked talents using the legacy Crucible flow.
+ *   Will be removed in a future version.
+ */
 export default class RankedTrainedTalent extends TrainedTalent {
   constructor(actor, data, params, options) {
     super(actor, data, params, options)

--- a/module/lib/talents/talent-cost-calculator.mjs
+++ b/module/lib/talents/talent-cost-calculator.mjs
@@ -1,9 +1,16 @@
+import { SYSTEM } from '../../config/system.mjs'
+import { logger } from '../../utils/logger.mjs'
 import TrainedTalent from './trained-talent.mjs'
+
+const DEPR = () => SYSTEM.DEPRECATION.crucible.rankTimes5
 
 /**
  * TalentCostCalculator class
- * This class is used to calculate the cost of a talent.
  *
+ * @deprecated Crucible legacy — use nodeData.cost from specialization-tree instead.
+ *   Will be removed in a future version.
+ *   This class calculates talent cost as rank * 5, a pattern inherited from Crucible.
+ *   The V1 Edge system uses the cost defined on the specialization-tree node.
  */
 export default class TalentCostCalculator {
   constructor(talent) {
@@ -12,11 +19,18 @@ export default class TalentCostCalculator {
 
   /**
    * Calculate the cost of the talent.
+   * @deprecated Crucible legacy — use nodeData.cost from specialization-tree instead.
+   *   Will be removed in a future version.
    * @param {string} action The action to perform.
    * @param {number} rank The rank of the talent in the tree (row).
    * @returns {number} - The cost of the talent.
    */
   calculateCost(action, rank) {
+    if (DEPR().warn) {
+      logger.deprecated('talent-cost-calculator', 'rank * 5 cost calculation', 'Use node-based cost from specialization-tree instead.')
+    }
+    if (!DEPR().enabled) return 0
+
     let cost = 0
     if (this.talent instanceof TrainedTalent) {
       if (action === 'train') {
@@ -28,10 +42,12 @@ export default class TalentCostCalculator {
     return cost
   }
 
+  /** @deprecated Crucible legacy */
   #calculateTrainCost(rank) {
     return rank * 5
   }
 
+  /** @deprecated Crucible legacy */
   #calculateForgetCost(rank) {
     return this.#calculateTrainCost(rank)
   }

--- a/module/lib/talents/talent-factory.mjs
+++ b/module/lib/talents/talent-factory.mjs
@@ -1,12 +1,23 @@
+import { SYSTEM } from '../../config/system.mjs'
+import { logger } from '../../utils/logger.mjs'
 import TrainedTalent from '../talents/trained-talent.mjs'
 import ErrorTalent from '../talents/error-talent.mjs'
 import RankedTrainedTalent from './ranked-trained-talent.mjs'
+
+const DEPR = () => SYSTEM.DEPRECATION.crucible.isCreation
+
+/**
+ * @deprecated Crucible legacy — use talent-node/purchase flow via purchaseTalentNode() instead.
+ *   Will be removed in a future version.
+ *   This factory builds TrainedTalent/RankedTrainedTalent instances for the legacy Crucible
+ *   train/forget flow. The V1 Edge system uses purchaseTalentNode() directly.
+ */
 
 /**
  * @typedef {Object} Talent
  * @property {SwerpgActor} actor - The actor instance.
  * @property {Talent} data - The talent instance.
- * @property {boolean} isCreation - Indicates if the talent is in the creation phase.
+ * @property {boolean} isCreation - (deprecated Crucible legacy) Indicates if the talent is in the creation phase.
  * @property {string} action - The action to be performed on the talent.
  * @property {TalentOptions} options - Additional options for the talent.
  *
@@ -25,6 +36,9 @@ import RankedTrainedTalent from './ranked-trained-talent.mjs'
  * @property {boolean} [isSpecialization=false] - Indicates if this is a specialization talent.
  */
 
+/**
+ * @deprecated Crucible legacy — use purchaseTalentNode() instead.
+ */
 export default class TalentFactory {
   /**
    * Builds a talent object based on a context.
@@ -36,7 +50,20 @@ export default class TalentFactory {
    * @param options {TalentOptions} additional options
    * @returns {TrainedTalent|RankedTrainedTalent|ErrorTalent} a talent object
    */
+  /**
+   * Build a talent domain object.
+   * @deprecated Crucible legacy — use purchaseTalentNode() instead.
+   * @param {SwerpgActor} actor
+   * @param {Item} item
+   * @param {TalentParams} params
+   * @param {object} [options]
+   * @returns {TrainedTalent|RankedTrainedTalent|ErrorTalent}
+   */
   static build(actor, item, { action /** @type {"train" | "forget"} */ = 'train', isCreation = false } = {}, options = {}) {
+    if (DEPR().warn) {
+      logger.deprecated('talent-factory', `TalentFactory.build() called (isCreation=${isCreation})`, 'Use purchaseTalentNode() from talent-node-purchase instead.')
+    }
+
     if (item.type !== 'talent') {
       options.message = `Item dropped (${item.name}) is not a talent!`
       return new ErrorTalent(
@@ -61,6 +88,15 @@ export default class TalentFactory {
           isCreation: isCreation,
         },
         options,
+      )
+    }
+
+    if (!DEPR().enabled) {
+      return new ErrorTalent(
+        actor,
+        talent,
+        { action, isCreation },
+        { message: `Talent purchase via TalentFactory is disabled (Crucible legacy). Use specialization-tree instead.` },
       )
     }
 

--- a/module/lib/talents/talent.mjs
+++ b/module/lib/talents/talent.mjs
@@ -1,7 +1,14 @@
+/**
+ * @deprecated Crucible legacy — use talent-node/purchase flow via purchaseTalentNode() instead.
+ *   Will be removed in a future version.
+ *   This base class and its subclasses implement the Crucible talent train/forget flow.
+ *   The V1 Edge system uses purchaseTalentNode() with specialization-tree node cost.
+ */
 export default class Talent {
   constructor(actor, data, params, options) {
     this.actor = foundry.utils.deepClone(actor)
     this.data = foundry.utils.deepClone(data)
+    /** @deprecated Crucible legacy — isCreation is not used in V1 Edge flow */
     this.isCreation = params.isCreation
     this.action = params.action
     this.options = options

--- a/module/lib/talents/trained-talent.mjs
+++ b/module/lib/talents/trained-talent.mjs
@@ -2,6 +2,11 @@ import Talent from './talent.mjs'
 import ErrorTalent from './error-talent.mjs'
 import TalentCostCalculator from './talent-cost-calculator.mjs'
 
+/**
+ * @deprecated Crucible legacy — use purchaseTalentNode() instead.
+ *   This class handles train/forget of non-ranked talents using the legacy Crucible flow.
+ *   Will be removed in a future version.
+ */
 export default class TrainedTalent extends Talent {
   constructor(actor, data, params, options) {
     super(actor, data, params, options)

--- a/module/models/talent-orig.mjs
+++ b/module/models/talent-orig.mjs
@@ -199,6 +199,9 @@ export default class SwerpgTalent extends foundry.abstract.TypeDataModel {
 
   /**
    * Assert that an Actor meets the prerequisites for this Talent.
+   * @deprecated Crucible legacy — uses actor.points.talent (talent points system).
+   *   V1 Edge uses purchaseTalentNode() with XP-based cost from specialization-tree nodes.
+   *   Will be removed in a future version.
    * @param {SwerpgActor} actor         The Actor to test
    * @param {boolean} strict              Throw an error if prerequisites are not met, otherwise return a boolean
    * @returns {boolean}                   Only if testing is not strict

--- a/module/models/talent.mjs
+++ b/module/models/talent.mjs
@@ -3,6 +3,8 @@ import { logger } from '../utils/logger.mjs'
 import SwerpgTalentNode from '../config/talent-tree.mjs'
 import { SYSTEM } from '../config/system.mjs'
 
+const DEPR_TALENT_POINTS = () => SYSTEM.DEPRECATION.crucible.talentPoints
+
 /**
  * @typedef {Object} ActorHook
  * @property {string} hook
@@ -225,12 +227,23 @@ export default class SwerpgTalent extends foundry.abstract.TypeDataModel {
 
   /**
    * Assert that an Actor meets the prerequisites for this Talent.
+   * @deprecated Crucible legacy — uses actor.points.talent (talent points system).
+   *   V1 Edge uses purchaseTalentNode() with XP-based cost from specialization-tree nodes.
+   *   Will be removed in a future version.
    * @param {SwerpgActor} actor         The Actor to test
    * @param {boolean} strict              Throw an error if prerequisites are not met, otherwise return a boolean
    * @returns {boolean}                   Only if testing is not strict
    * @throws a formatted error message if the prerequisites are not met and testing is strict
    */
   assertPrerequisites(actor, strict = true) {
+    if (DEPR_TALENT_POINTS().warn) {
+      logger.deprecated('talent-model', 'assertPrerequisites() using actor.points.talent', 'V1 Edge uses purchaseTalentNode() with XP-based cost.')
+    }
+
+    if (!DEPR_TALENT_POINTS().enabled) {
+      return true
+    }
+
     // Ensure the Talent is not already owned
     if (actor.items.find((i) => i.type === 'talent' && i.name === this.parent.name)) {
       if (strict) throw new Error(game.i18n.format('TALENT.WARNINGS.AlreadyOwned', { name: this.parent.name }))

--- a/module/utils/logger.mjs
+++ b/module/utils/logger.mjs
@@ -113,6 +113,19 @@ export const logger = {
   isDebugEnabled() {
     return debugEnabled
   },
+  /**
+   * Émet un avertissement de dépréciation structuré pour les logiques legacy.
+   * Le message est visible hors mode debug (via warn).
+   * @param {string} moduleName - Nom du module concerné (ex: 'talent-cost-calculator')
+   * @param {string} feature - Nom de la fonctionnalité dépréciée (ex: 'rank * 5 cost calculation')
+   * @param {string} [suggestion] - Suggestion de remplacement (ex: 'Use node-based cost from specialization-tree instead.')
+   */
+  deprecated(moduleName, feature, suggestion) {
+    let message = `[DEPRECATED] [${moduleName}] ${feature}`
+    if (suggestion) message += ` — ${suggestion}`
+    this.warn(message)
+  },
+
   // Helper optionnel pour ajouter manuellement le préfixe à des données complexes avant log
   prefixArgs(...args) {
     return [PREFIX, ...args]

--- a/tests/deprecation/crucible-neutralization.test.mjs
+++ b/tests/deprecation/crucible-neutralization.test.mjs
@@ -1,0 +1,175 @@
+// crucible-neutralization.test.mjs
+import '../setupTests.js'
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+
+import { SYSTEM } from '../../module/config/system.mjs'
+import { logger } from '../../module/utils/logger.mjs'
+import TalentCostCalculator from '../../module/lib/talents/talent-cost-calculator.mjs'
+import TalentFactory from '../../module/lib/talents/talent-factory.mjs'
+import { createActor } from '../utils/actors/actor.mjs'
+import { createTalentData } from '../utils/talents/talent.mjs'
+import TrainedTalent from '../../module/lib/talents/trained-talent.mjs'
+
+/**
+ * Helper to reset deprecation flags to defaults before each test.
+ */
+function resetFlags() {
+  const flags = SYSTEM.DEPRECATION.crucible
+  for (const key of Object.keys(flags)) {
+    flags[key].enabled = true
+    flags[key].warn = true
+  }
+}
+
+describe('Crucible deprecation flags', () => {
+  beforeEach(() => {
+    resetFlags()
+    vi.spyOn(logger, 'warn').mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  /* ------------------------------------------------------------------ */
+  /*  1. rankTimes5                                                      */
+  /* ------------------------------------------------------------------ */
+
+  describe('rankTimes5 (talent-cost-calculator)', () => {
+    test('emits deprecation warning when warn=true', () => {
+      const actor = createActor()
+      const data = createTalentData('1', { row: 1 })
+      const talent = new TrainedTalent(actor, data, { action: 'train', isCreation: true }, {})
+      const calculator = new TalentCostCalculator(talent)
+
+      calculator.calculateCost('train', 1)
+
+      expect(logger.warn).toHaveBeenCalledWith(
+        expect.stringContaining('[DEPRECATED] [talent-cost-calculator]'),
+      )
+    })
+
+    test('returns 0 when enabled=false', () => {
+      SYSTEM.DEPRECATION.crucible.rankTimes5.enabled = false
+      const actor = createActor()
+      const data = createTalentData('1', { row: 2 })
+      const talent = new TrainedTalent(actor, data, { action: 'train', isCreation: true }, {})
+      const calculator = new TalentCostCalculator(talent)
+
+      const cost = calculator.calculateCost('train', 2)
+
+      expect(cost).toBe(0)
+    })
+
+    test('returns rank*5 when enabled=true', () => {
+      SYSTEM.DEPRECATION.crucible.rankTimes5.warn = false
+      const actor = createActor()
+      const data = createTalentData('1', { row: 3 })
+      const talent = new TrainedTalent(actor, data, { action: 'train', isCreation: true }, {})
+      const calculator = new TalentCostCalculator(talent)
+
+      const cost = calculator.calculateCost('train', 3)
+
+      expect(cost).toBe(15)
+    })
+
+    test('does not emit warning when warn=false', () => {
+      SYSTEM.DEPRECATION.crucible.rankTimes5.warn = false
+      const actor = createActor()
+      const data = createTalentData('1', { row: 1 })
+      const talent = new TrainedTalent(actor, data, { action: 'train', isCreation: true }, {})
+      const calculator = new TalentCostCalculator(talent)
+
+      calculator.calculateCost('train', 1)
+
+      expect(logger.warn).not.toHaveBeenCalledWith(
+        expect.stringContaining('[DEPRECATED]'),
+      )
+    })
+  })
+
+  /* ------------------------------------------------------------------ */
+  /*  2. isCreation                                                      */
+  /* ------------------------------------------------------------------ */
+
+  describe('isCreation (talent-factory)', () => {
+    test('emits deprecation warning when warn=true', () => {
+      const actor = createActor()
+      const item = createTalentData('1')
+
+      TalentFactory.build(actor, item, { action: 'train', isCreation: true }, {})
+
+      expect(logger.warn).toHaveBeenCalledWith(
+        expect.stringContaining('[DEPRECATED] [talent-factory]'),
+      )
+    })
+
+    test('returns ErrorTalent when enabled=false', () => {
+      SYSTEM.DEPRECATION.crucible.isCreation.enabled = false
+      const actor = createActor()
+      const item = createTalentData('1')
+
+      const result = TalentFactory.build(actor, item, { action: 'train', isCreation: true }, {})
+
+      expect(result.options.message).toContain('disabled')
+    })
+
+    test('does not emit warning when warn=false', () => {
+      SYSTEM.DEPRECATION.crucible.isCreation.warn = false
+      const actor = createActor()
+      const item = createTalentData('1')
+
+      TalentFactory.build(actor, item, { action: 'train', isCreation: true }, {})
+
+      expect(logger.warn).not.toHaveBeenCalledWith(
+        expect.stringContaining('[DEPRECATED]'),
+      )
+    })
+  })
+
+  /* ------------------------------------------------------------------ */
+  /*  3. Structure des flags                                             */
+  /* ------------------------------------------------------------------ */
+
+  describe('flag structure', () => {
+    test('all 6 crucible flags exist with enabled and warn', () => {
+      const flags = SYSTEM.DEPRECATION.crucible
+      const expected = ['rankTimes5', 'isCreation', 'talentPoints', 'globalTree', 'choiceWheel', 'directPurchase']
+
+      for (const key of expected) {
+        expect(flags).toHaveProperty(key)
+        expect(flags[key]).toHaveProperty('enabled')
+        expect(flags[key]).toHaveProperty('warn')
+        expect(typeof flags[key].enabled).toBe('boolean')
+        expect(typeof flags[key].warn).toBe('boolean')
+      }
+    })
+
+    test('all flags default to enabled=true', () => {
+      const flags = SYSTEM.DEPRECATION.crucible
+      for (const [key, value] of Object.entries(flags)) {
+        expect(value.enabled).toBe(true)
+      }
+    })
+  })
+
+  /* ------------------------------------------------------------------ */
+  /*  4. logger.deprecated() format                                       */
+  /* ------------------------------------------------------------------ */
+
+  describe('logger.deprecated() format', () => {
+    test('includes [DEPRECATED] prefix', () => {
+      logger.deprecated('test-module', 'test feature', 'Use new thing instead.')
+      expect(logger.warn).toHaveBeenCalledWith(
+        expect.stringContaining('[DEPRECATED] [test-module] test feature — Use new thing instead.'),
+      )
+    })
+
+    test('works without suggestion', () => {
+      logger.deprecated('test-module', 'test feature')
+      expect(logger.warn).toHaveBeenCalledWith(
+        expect.stringContaining('[DEPRECATED] [test-module] test feature'),
+      )
+    })
+  })
+})

--- a/tests/lib/talents/talent-cost-calculator.test.mjs
+++ b/tests/lib/talents/talent-cost-calculator.test.mjs
@@ -1,7 +1,8 @@
 // Talent-cost-calculator.test.mjs
 import '../../setupTests.js'
-import { describe, expect, test } from 'vitest'
+import { beforeAll, describe, expect, test } from 'vitest'
 
+import { SYSTEM } from '../../../module/config/system.mjs'
 import { createTalentData } from '../../utils/talents/talent.mjs'
 import TrainedTalent from '../../../module/lib/talents/trained-talent.mjs'
 import ErrorTalent from '../../../module/lib/talents/error-talent.mjs'
@@ -10,6 +11,10 @@ import { createActor } from '../../utils/actors/actor.mjs'
 import RankedTrainedTalent from '../../../module/lib/talents/ranked-trained-talent.mjs'
 
 describe('Talents Calculator', () => {
+  beforeAll(() => {
+    SYSTEM.DEPRECATION.crucible.rankTimes5.warn = false
+    SYSTEM.DEPRECATION.crucible.isCreation.warn = false
+  })
   describe('train a talent', () => {
     const action = 'train'
     const actor = createActor()

--- a/tests/lib/talents/talent-factory.test.mjs
+++ b/tests/lib/talents/talent-factory.test.mjs
@@ -1,7 +1,8 @@
 // Talent-factory.test.mjs
 import '../../setupTests.js'
-import { describe, expect, test } from 'vitest'
+import { beforeAll, describe, expect, test } from 'vitest'
 
+import { SYSTEM } from '../../../module/config/system.mjs'
 import TalentFactory from '../../../module/lib/talents/talent-factory.mjs'
 import { createActor } from '../../utils/actors/actor.mjs'
 import TrainedTalent from '../../../module/lib/talents/trained-talent.mjs'
@@ -10,6 +11,9 @@ import RankedTrainedTalent from '../../../module/lib/talents/ranked-trained-tale
 import { createTalentData } from '../../utils/talents/talent.mjs'
 
 describe('TalentFactory build()', () => {
+  beforeAll(() => {
+    SYSTEM.DEPRECATION.crucible.isCreation.warn = false
+  })
   describe('should create a TrainedTalent', () => {
     const expectedTrainedClassTalent = TrainedTalent
     const action = 'train'

--- a/tests/unit/documents/actor-talents-mixin.test.mjs
+++ b/tests/unit/documents/actor-talents-mixin.test.mjs
@@ -178,7 +178,6 @@ describe('TalentsMixin', () => {
       expect(typeof actor.resetTalents).toBe('function')
       expect(typeof actor.syncTalents).toBe('function')
       expect(typeof actor.addTalent).toBe('function')
-      expect(typeof actor.addTalentWithXpCheck).toBe('function')
       expect(typeof actor.callActorHooks).toBe('function')
       expect(typeof actor.prepareEmbeddedDocuments).toBe('function')
     })
@@ -419,49 +418,4 @@ describe('TalentsMixin', () => {
     })
   })
 
-  describe('addTalentWithXpCheck()', () => {
-    let mockItem
-
-    beforeEach(() => {
-      mockItem = {
-        name: 'XP Talent',
-        toObject: vi.fn().mockReturnValue({ name: 'XP Talent', type: 'talent' }),
-      }
-      actor.experiencePoints = { available: 10 }
-      actor.createEmbeddedDocuments = vi.fn().mockResolvedValue([])
-      actor.spendExperiencePoints = vi.fn().mockResolvedValue()
-
-      // Mock items.find to return undefined by default (no duplicate)
-      actor._itemsMock = {
-        find: vi.fn().mockReturnValue(undefined),
-      }
-    })
-
-    it('should add talent if XP is sufficient', async () => {
-      const result = await actor.addTalentWithXpCheck(mockItem)
-
-      expect(result).toBe(true)
-      expect(actor.createEmbeddedDocuments).toHaveBeenCalled()
-      expect(actor.spendExperiencePoints).toHaveBeenCalledWith(5)
-    })
-
-    it('should warn and return false if XP is insufficient', async () => {
-      actor.experiencePoints.available = 3
-
-      const result = await actor.addTalentWithXpCheck(mockItem)
-
-      expect(result).toBe(false)
-      expect(ui.notifications.warn).toHaveBeenCalledWith("Test Actor doesn't have enough XP (5 required)")
-    })
-
-    it('should warn and return false if talent already owned', async () => {
-      // Override the mock for this specific test
-      actor._itemsMock.find.mockReturnValue({ name: 'XP Talent' })
-
-      const result = await actor.addTalentWithXpCheck(mockItem)
-
-      expect(result).toBe(false)
-      expect(ui.notifications.warn).toHaveBeenCalledWith('Test Actor already has "XP Talent"')
-    })
-  })
 })


### PR DESCRIPTION
## Summary
Neutralise les 6 logiques legacy héritées de Crucible avec guards runtime, warnings de dépréciation, et conservation du code physique pour compatibilité.

## Changements

### Configuration
- `module/config/system.mjs` : ajout de `SYSTEM.DEPRECATION.crucible` avec 6 flags (`rankTimes5`, `isCreation`, `talentPoints`, `globalTree`, `choiceWheel`, `directPurchase`) — chaque flag supporte `{ enabled, warn }`

### Logger
- `module/utils/logger.mjs` : ajout de `logger.deprecated(moduleName, feature, suggestion)` émettant `[DEPRECATED] [module] feature — suggestion`

### Neutralisation par flag
1. **rankTimes5** — `talent-cost-calculator.mjs` : JSDoc `@deprecated`, retourne 0 si désactivé
2. **isCreation** — `talent-factory.mjs`, `talent.mjs`, `trained-talent.mjs`, `ranked-trained-talent.mjs`, `error-talent.mjs` : JSDoc `@deprecated`, guard via flag
3. **talentPoints** — `models/talent.mjs` : `assertPrerequisites()` marquée `@deprecated`, guardée
4. **globalTree** — `config/talent-tree.mjs` : classe `@deprecated`, `logger.deprecated()` dans `getChoices()` et `preparePrerequisites()`
5. **choiceWheel** — `canvas/talent-choice-wheel.mjs` : `@deprecated` sur la classe + `SwerpgTalentTreeTalent` ; guard V1 dans `#onClickLeft`
6. **directPurchase** — `documents/actor-mixins/talents.mjs` : guard sur `addTalent()`, suppression de `addTalentWithXpCheck()` (code mort)

### Tests
- `tests/deprecation/crucible-neutralization.test.mjs` : nouveau fichier couvrant les 6 flags (warning émis, désactivation, structure)
- `tests/lib/talents/talent-factory.test.mjs` : `beforeAll` désactive warnings
- `tests/lib/talents/talent-cost-calculator.test.mjs` : `beforeAll` désactive warnings
- `tests/unit/documents/actor-talents-mixin.test.mjs` : retrait des 3 tests `addTalentWithXpCheck()` (méthode supprimée)

## Notes
- Le code legacy physique est **conservé** (suppression dans une US ultérieure)
- Le flux V1 (US6, US7, US18) est CLOSED et ne passe par aucune des 6 logiques Crucible
- Les guards sont activés par défaut avec `warn: true`

Closes #205
