### PR TITLE
Alignement ADR-0014 talents (clarification legacies, doc, tests, issue #22)

### DIFF
--- a/documentation/architecture/adr/adr-0014-talents-standalone-arbres-v1-et-source-de-verite-progression.md
+++ b/documentation/architecture/adr/adr-0014-talents-standalone-arbres-v1-et-source-de-verite-progression.md
@@ -1,0 +1,238 @@
+---
+title: 'ADR-0014: Talent standalone, arbres V1 et source de vérité de progression'
+status: 'Accepted'
+date: '2026-05-15'
+authors: 'Hervé Darritchon, Architecture Team'
+tags: ['talent', 'specialization-tree', 'oggdude', 'architecture', 'progression']
+supersedes: ''
+superseded_by: ''
+---
+
+## Status
+
+**Accepted** - Cette décision formalise le modèle d'architecture V1 des talents Edge, des arbres de spécialisation et de la progression acteur.
+
+## Context
+
+Le projet a historiquement porté plusieurs représentations concurrentes ou ambiguës autour des talents :
+
+1. des `Item` `talent` avec des champs comme `system.trees`, `system.node` et `system.row` ;
+2. une structure legacy héritée de Crucible autour de `SwerpgTalentNode` et d'un arbre global ;
+3. un import OggDude `Talent.xml` initialement trop riche et conceptuellement mélangé avec des notions d'arborescence ;
+4. une implémentation V1 plus récente fondée sur des `Item` `specialization-tree` et des achats de nœuds acteur dans `actor.system.progression.talentPurchases`.
+
+L'audit de l'issue #22 a montré que la codebase a déjà convergé dans les faits vers une architecture plus claire, mais que cette décision restait implicite, dispersée et partiellement brouillée par des reliquats legacy.
+
+Il faut donc acter officiellement :
+
+1. le rôle de `Talent.xml` ;
+2. le support canonique des arbres V1 ;
+3. la source de vérité de progression acteur ;
+4. le statut des champs `system.trees`, `system.node`, `system.row` sur `Item.talent`.
+
+## Decision
+
+Le projet adopte officiellement la séparation suivante :
+
+```txt
+Talent.xml
+= définition générique standalone d'un talent
+
+specialization-tree
+= support canonique des arbres V1
+
+actor.system.progression.talentPurchases
+= source de vérité de progression acteur
+
+Item.talent.system.trees / node / row
+= legacy résiduel, non canonique pour la V1
+```
+
+Cette décision est normative pour :
+
+1. les imports OggDude ;
+2. les évolutions du modèle de données ;
+3. les plans techniques ;
+4. les futures features UI et domaine autour des talents.
+
+## Detailed Decision
+
+### 1. `Talent.xml` décrit un talent générique standalone
+
+L'import `Talent.xml` sert à créer ou mettre à jour une définition générique de talent.
+
+Le contrat métier attendu pour ce flux concerne la fiche standalone :
+
+1. identité du talent ;
+2. description lisible ;
+3. activation ;
+4. caractère ranked ou non ;
+5. données d'import et de diagnostic dans `flags.swerpg.import`.
+
+`Talent.xml` ne constitue pas le support canonique :
+
+1. des positions dans un arbre ;
+2. des coûts XP de nœud ;
+3. des connexions entre nœuds ;
+4. des prérequis structurels d'achat dans un arbre donné ;
+5. de la progression possédée par un acteur.
+
+En conséquence, un mapper `Talent.xml` ne doit pas introduire de dépendance métier V1 à `system.trees`, `system.node` ou `system.row` pour représenter une arborescence.
+
+### 2. `specialization-tree` est le support canonique des arbres V1
+
+Les arbres de talents V1 sont portés par des `Item` de type `specialization-tree`.
+
+Ce type est la représentation canonique de :
+
+1. l'identité de l'arbre ;
+2. son rattachement à une spécialisation ;
+3. son rattachement éventuel à une carrière ;
+4. ses nœuds ;
+5. les positions `row` / `column` ;
+6. les coûts ;
+7. les connexions.
+
+Le contrat minimal canonique des nœuds est :
+
+```js
+{
+  nodeId: 'r1c1',
+  talentId: 'parry',
+  talentUuid: 'Item.xxxxx',
+  row: 1,
+  column: 1,
+  cost: 5,
+}
+```
+
+Le contrat minimal canonique des connexions est :
+
+```js
+{
+  from: 'r1c1',
+  to: 'r2c1',
+  type: 'vertical',
+}
+```
+
+Toute logique V1 de résolution, rendu, accessibilité, achat ou consolidation doit partir de `specialization-tree`, et non d'une tentative de reconstruction depuis des champs portés par `Item.talent`.
+
+### 3. `talentPurchases` est la source de vérité de progression acteur
+
+La possession effective d'un talent par un acteur ne se déduit pas d'un simple `Item.talent` embarqué ni d'un champ stocké sur la définition générique.
+
+La source de vérité V1 de progression acteur est :
+
+```txt
+actor.system.progression.talentPurchases
+```
+
+Chaque entrée représente un achat de nœud dans un arbre donné.
+
+Contrat minimal :
+
+```js
+{
+  treeId: 'bodyguard-tree',
+  nodeId: 'r1c1',
+  talentId: 'parry',
+  specializationId: 'bodyguard',
+}
+```
+
+Ce stockage doit permettre de recalculer :
+
+1. les nœuds achetés ;
+2. les nœuds accessibles ;
+3. les talents possédés ;
+4. les rangs consolidés des talents ranked ;
+5. les sources d'acquisition d'un talent ;
+6. les coûts XP associés aux achats.
+
+Les vues dérivées, y compris l'onglet Talents et les vues graphiques d'arbres, doivent être reconstruites à partir de :
+
+1. `talentPurchases` ;
+2. `specialization-tree` ;
+3. la définition générique des talents ;
+4. les spécialisations possédées.
+
+### 4. `system.trees`, `system.node`, `system.row` sur `Item.talent` sont legacy
+
+Les champs suivants sur `Item.talent` ne sont pas la modélisation canonique V1 des arbres ou de la progression :
+
+1. `system.trees`
+2. `system.node`
+3. `system.row`
+
+Ils doivent être traités comme du legacy résiduel.
+
+Cela signifie :
+
+1. aucun nouveau flux V1 ne doit les choisir comme source de vérité ;
+2. aucun nouveau plan ne doit les utiliser pour encoder une arborescence V1 ;
+3. leur présence actuelle n'implique pas qu'ils représentent un contrat stable à étendre ;
+4. tout nettoyage ou retrait doit être planifié de manière explicite pour éviter de casser les usages legacy encore présents.
+
+Tant qu'ils existent, leur statut doit être lu comme :
+
+```txt
+compatibilité interne ou reliquat historique
+!= contrat métier canonique V1
+```
+
+## Consequences
+
+### Positive
+
+1. **POS-001**: séparation claire entre définition de talent, structure d'arbre et progression acteur.
+2. **POS-002**: réduction des ambiguïtés autour de `Talent.xml` et du périmètre des bugfix d'import.
+3. **POS-003**: stabilité du contrat consommé par la couche domaine V1 (`specialization-tree` + `talentPurchases`).
+4. **POS-004**: base explicite pour les futures features de rendu, validation de prérequis et achat de talents.
+5. **POS-005**: meilleure lisibilité pour les plans techniques, revues et contributions LLM.
+
+### Negative
+
+1. **NEG-001**: coexistence temporaire entre architecture canonique V1 et reliquats legacy sur `Item.talent`.
+2. **NEG-002**: nécessité de maintenir une discipline documentaire pour éviter le retour de formulations ambiguës comme "full talent tree support" côté import talent.
+3. **NEG-003**: futurs nettoyages du data model `talent` devront être planifiés avec précaution pour éviter des régressions sur les usages historiques.
+
+## Alternatives Considered
+
+### Stocker l'arborescence directement sur `Item.talent`
+
+1. **ALT-001**: **Description**: utiliser `system.trees`, `system.node`, `system.row` comme base métier V1 et enrichir progressivement ces champs.
+2. **ALT-002**: **Rejection Reason**: mélange la définition générique du talent avec ses occurrences dans plusieurs arbres, complique le multi-arbre, et entre en conflit avec l'architecture V1 déjà en place sur `specialization-tree`.
+
+### Faire de `Talent.xml` la source primaire des arbres
+
+1. **ALT-003**: **Description**: enrichir `Talent.xml` pour porter les positions, dépendances et coûts des talents dans les arbres.
+2. **ALT-004**: **Rejection Reason**: ne correspond pas au découpage actuel du pipeline, mélange deux concepts différents, et rend l'import talent inutilement couplé à la structure des arbres.
+
+### Utiliser les `Item.talent` embarqués acteur comme source de vérité de progression
+
+1. **ALT-005**: **Description**: considérer qu'un acteur possède un talent dès qu'un `Item.talent` lui est attaché.
+2. **ALT-006**: **Rejection Reason**: ne permet pas de distinguer proprement les nœuds sources, les achats multi-arbres, les rangs consolidés et les données structurelles d'achat.
+
+## Implementation Notes
+
+1. **IMP-001**: tout bugfix `Talent.xml` doit rester centré sur la fiche standalone, sauf décision ultérieure explicite.
+2. **IMP-002**: tout travail sur les arbres V1 doit cibler `specialization-tree` comme contrat canonique.
+3. **IMP-003**: toute logique de possession, consolidation ou accessibilité doit partir de `actor.system.progression.talentPurchases`.
+4. **IMP-004**: les champs `system.trees`, `system.node`, `system.row` de `Item.talent` doivent être explicitement considérés comme legacy dans les plans et audits.
+5. **IMP-005**: la documentation d'import doit être corrigée lorsqu'elle laisse entendre que `Talent.xml` porte à lui seul le support complet des arbres.
+6. **IMP-006**: les nettoyages futurs du data model `talent` doivent être faits via une issue ou un plan dédié, et non de manière opportuniste.
+
+## References
+
+1. `documentation/audit/issue-22-audit-gestion-talents-arbres.md`
+2. `documentation/spec/oggdude-importer/bug-fix-talent-import-need1-1.0.md`
+3. `documentation/cadrage/character-sheet/talent/01-modele-domaine-talents.md`
+4. `documentation/cadrage/character-sheet/talent/03-import-oggdude-talents.md`
+5. `documentation/plan/character-sheet/talent/193-plan-importer-definitions-generiques-talents.md`
+6. `documentation/plan/character-sheet/talent/194-plan-importer-arbres-specialisation.md`
+7. `module/models/talent.mjs`
+8. `module/models/specialization-tree.mjs`
+9. `module/importer/mappers/oggdude-talent-mapper.mjs`
+10. `module/importer/mappers/oggdude-specialization-tree-mapper.mjs`
+11. `module/lib/talent-node/talent-node-state.mjs`

--- a/documentation/audit/issue-22-audit-gestion-talents-arbres.md
+++ b/documentation/audit/issue-22-audit-gestion-talents-arbres.md
@@ -1,0 +1,244 @@
+# Audit issue #22 — Gestion des Talents dans les arbres
+
+## Résumé
+
+L'issue [#22](https://github.com/herveDarritchon/foundryvtt-swerpg/issues/22) n'est **pas déjà implémentée telle quelle**.
+
+En revanche, la codebase a **largement convergé** vers une réponse produit/architecture implicite :
+
+- `Talent.xml` est traité comme une source de **définitions génériques de talents**, pas comme une source canonique d'arborescences.
+- les arbres V1 sont portés par des `Item` de type `specialization-tree` avec `nodes`, `connections`, `row`, `column`, `cost`.
+- la progression acteur est portée par `actor.system.progression.talentPurchases`, pas par `Item.talent.system.row/node/trees`.
+
+Le delta principal avec l'issue est donc le suivant :
+
+- la **décision d'architecture demandée par l'issue n'est pas formalisée dans un document unique** ;
+- des **reliquats legacy** existent encore sur `module/models/talent.mjs` (`system.node`, `system.trees`, `system.row`) et brouillent la sémantique cible ;
+- la documentation est **partiellement contradictoire** sur le support réel des talent trees.
+
+## Conclusion
+
+Conclusion courte : **la direction cible de l'issue est implémentée dans les faits, mais pas complètement stabilisée ni nettoyée**.
+
+Je ne considère donc pas l'issue comme "déjà faite" au sens strict. Je la considère comme **partiellement résolue par des travaux ultérieurs**, avec encore un besoin de :
+
+1. documenter explicitement la décision ;
+2. clarifier le statut legacy de `system.trees`, `system.node`, `system.row` sur les talents ;
+3. corriger la documentation contradictoire.
+
+## Ce que dit le code aujourd'hui
+
+### 1. `Talent.xml` est traité comme un import de talent générique
+
+Le mapper OggDude talent construit bien un `Item` `talent` centré sur la fiche de base :
+
+- `module/importer/mappers/oggdude-talent-mapper.mjs:264-292`
+- `system.id`
+- `system.activation`
+- `system.isRanked`
+- `system.description`
+- `flags.swerpg.import.*`
+
+Le mapper **n'écrit pas** `system.trees`, `system.node` ni `system.row` dans le résultat final.
+
+Cela aligne le comportement réel avec l'option :
+
+- `Talent.xml = fiche générique uniquement`
+
+Référence documentaire alignée :
+
+- `documentation/spec/oggdude-importer/bug-fix-talent-import-need1-1.0.md:101-107`
+- `documentation/plan/character-sheet/talent/193-plan-importer-definitions-generiques-talents.md:22-40`
+
+### 2. Les arbres V1 sont portés par `specialization-tree`
+
+Le modèle métier V1 des arbres est explicitement séparé des talents génériques :
+
+- `module/models/specialization-tree.mjs:7-35`
+- `module/importer/mappers/oggdude-specialization-tree-mapper.mjs:421-468`
+
+Les données structurelles de l'arbre vivent dans :
+
+- `system.specializationId`
+- `system.careerId`
+- `system.nodes[]`
+  - `nodeId`
+  - `talentId`
+  - `talentUuid`
+  - `row`
+  - `column`
+  - `cost`
+- `system.connections[]`
+
+La logique domaine et UI V1 consomme déjà ce contrat :
+
+- `module/lib/talent-node/talent-tree-resolver.mjs`
+- `module/lib/talent-node/talent-node-state.mjs`
+- `module/applications/specialization-tree-app.mjs`
+
+### 3. La progression acteur ne dépend plus des champs `row/node/trees` du talent
+
+La source de vérité de progression est désormais :
+
+- `actor.system.progression.talentPurchases`
+
+avec des entrées du type :
+
+- `treeId`
+- `nodeId`
+- `talentId`
+- `specializationId`
+
+Cette direction est visible dans :
+
+- `module/lib/talent-node/talent-node-state.mjs:40-45`
+- `documentation/cadrage/character-sheet/talent/01-modele-domaine-talents.md:323-374`
+
+### 4. Le code marque explicitement l'ancien arbre global comme legacy
+
+Le fichier legacy des nœuds Crucible indique lui-même qu'il ne faut plus l'utiliser pour la V1 Edge :
+
+- `module/config/talent-tree.mjs:9-15`
+
+Le message est clair :
+
+- ne plus ajouter de nouveaux arbres/nœuds ici ;
+- utiliser les `specialization-tree` pour la V1.
+
+## Delta précis entre l'issue et la codebase
+
+### 1. La décision demandée par l'issue est implicite, pas stabilisée
+
+L'issue demande un livrable explicite de type ADR/document de décision.
+
+Je n'ai pas trouvé dans la codebase un document unique qui dise clairement, en une seule place :
+
+- `Talent.xml` n'alimente que les talents génériques ;
+- les arborescences sont importées ailleurs ;
+- `system.trees`, `system.node`, `system.row` ne sont plus des champs V1 canoniques pour la progression.
+
+La réponse existe, mais elle est dispersée entre :
+
+- des plans (`US9`, `US10`) ;
+- des specs d'import ;
+- des commentaires de code ;
+- les implémentations elles-mêmes.
+
+### 2. `system.trees`, `system.node`, `system.row` existent encore sur `Item.talent`
+
+Le modèle `module/models/talent.mjs` déclare toujours :
+
+- `node` (`StringField` adossé au legacy `SwerpgTalentNode`) ;
+- `trees` (`SetField(DocumentUUIDField)`) ;
+- `row` (`NumberField`).
+
+Référence :
+
+- `module/models/talent.mjs:68-95`
+
+Problèmes observés :
+
+- `node` reste couplé au fichier legacy `module/config/talent-tree.mjs` ;
+- `trees` valide des UUID de `specialization` ou `career`, pas de `specialization-tree` (`module/models/talent.mjs:316-327`) ;
+- `row` existe encore pour des flux legacy de coût d'achat (`module/lib/talents/trained-talent.mjs:16-58`, `module/lib/talents/ranked-trained-talent.mjs:17-64`).
+
+Donc la sémantique demandée par l'issue n'est **pas vraiment stabilisée** sur ces champs : ils sont surtout des **reliquats legacy** encore présents pour compatibilité interne.
+
+### 3. Le mapper `Talent.xml` garde un reste de logique legacy dans son contexte
+
+Même si le résultat final n'écrit plus `system.node`, le contexte du mapper calcule encore :
+
+- `node: resolveTalentNode(...)`
+- `tier`
+- `rank`
+
+Référence :
+
+- `module/importer/mappers/oggdude-talent-mapper.mjs:103-137`
+
+Ce n'est pas bloquant fonctionnellement, mais cela montre que le nettoyage conceptuel n'est pas terminé.
+
+### 4. La documentation contient au moins une contradiction importante
+
+Le fichier :
+
+- `documentation/importer/README.md:33`
+
+annonce :
+
+- `Talent ... Full talent tree support`
+
+Cette phrase est trompeuse par rapport à l'état réel :
+
+- le support des arbres existe bien dans le système ;
+- mais il est porté par le domaine `specialization-tree`, pas par `Talent.xml` seul ;
+- et la doc `documentation/importer/talent-import-architecture.md` reste décrite selon un contrat plus ancien, centré sur `node`, `rank`, `actions`, `actorHooks`.
+
+## Réponse aux questions de l'issue, à partir de l'état actuel
+
+### 1. Rôle de `Talent.xml`
+
+Réponse implicite actuelle de la codebase :
+
+- `Talent.xml` doit rester **agnostique des arbres** au niveau du contrat persistant `Item.talent`.
+- Les arbres et leurs nœuds sont importés dans un flux séparé `specialization-tree`.
+
+### 2. Signification de `system.trees`, `system.node`, `system.row`
+
+Réponse implicite actuelle :
+
+- ces champs **ne sont pas la base canonique V1** pour la progression talents Edge ;
+- la base canonique V1 est :
+  - `specialization-tree.system.nodes[*]`
+  - `specialization-tree.system.connections[*]`
+  - `actor.system.progression.talentPurchases[*]`
+
+En l'état, `system.trees/node/row` sur `Item.talent` doivent être lus comme des **champs legacy résiduels**, pas comme le contrat architecturel recommandé.
+
+### 3. Workflow cible de gestion des Talent Trees
+
+Réponse implicite actuelle :
+
+- import des définitions génériques de talents ;
+- import séparé des arbres de spécialisation ;
+- résolution runtime arbre <-> spécialisation <-> talent ;
+- progression acteur via achat de nœuds.
+
+Donc le workflow réel est un **mix orienté référentiels importés + exploitation in-Foundry**, pas un stockage d'arborescence directement dans `Item.talent`.
+
+### 4. Priorité court terme
+
+Le code actuel montre que la priorité court terme a déjà été tranchée en pratique :
+
+- les bugfix `Talent.xml` ciblent la fiche standalone ;
+- les arbres ont leur propre chantier ;
+- la progression V1 s'appuie sur `specialization-tree` et `talentPurchases`.
+
+## Verdict
+
+### Ce qui est déjà fait
+
+- séparation effective entre talent générique et arbre de spécialisation ;
+- import dédié des arbres ;
+- logique métier V1 de nœuds et achats ;
+- documents de plan US9/US10 cohérents avec cette séparation.
+
+### Ce qui n'est pas complètement fait
+
+- un document de décision explicite répondant à l'issue #22 ;
+- une stabilisation claire du statut de `system.trees/node/row` ;
+- un nettoyage complet des reliquats legacy du mapper talent ;
+- une documentation import cohérente avec l'architecture actuelle.
+
+## Recommandation
+
+Je recommande de considérer l'issue #22 comme **partiellement satisfaite par l'architecture actuelle, mais non clôturable sans formalisation**.
+
+Action minimale recommandée :
+
+1. garder l'issue ouverte tant qu'une décision explicite n'est pas écrite ;
+2. référencer cet audit ;
+3. ouvrir ensuite un petit ticket de nettoyage documentaire/legacy pour :
+   - clarifier `module/models/talent.mjs` ;
+   - corriger `documentation/importer/README.md` ;
+   - archiver ou réécrire `documentation/importer/talent-import-architecture.md`.

--- a/documentation/cadrage/llm/cadrage-opencode-configuration.md
+++ b/documentation/cadrage/llm/cadrage-opencode-configuration.md
@@ -6,7 +6,7 @@ L’objectif de cette démarche est d’optimiser l’usage d’OpenCode en asso
 
 La configuration ne doit pas chercher à créer un système complexe pour le plaisir. Elle doit d’abord répondre à un besoin opérationnel simple : éviter d’utiliser des modèles coûteux ou puissants pour des tâches simples, tout en réservant les modèles les plus capables aux décisions, plans, arbitrages techniques, corrections sensibles et revues critiques.
 
-OpenCode dispose déjà de mécanismes structurants pour spécialiser les usages : agents, commandes, skills, modèles, permissions, outils et plugins. Les agents peuvent être configurés avec des rôles, modèles et accès spécifiques ; les commandes peuvent encapsuler des actions récurrentes ; les skills servent à charger des instructions réutilisables ; les plugins permettent d’étendre ou d’encadrer certains comportements. ([OpenCode][1])
+OpenCode dispose de mécanismes structurants pour spécialiser les usages : agents, commandes, skills, modèles, permissions, outils et plugins. Les agents peuvent être configurés avec des rôles, modèles et accès spécifiques ; les commandes peuvent encapsuler des actions récurrentes ; les skills servent à charger des instructions réutilisables ; les plugins permettent d’étendre ou d’encadrer certains comportements.
 
 Ce cadrage vise donc à définir **une doctrine d’usage**, pas une implémentation.
 
@@ -22,29 +22,34 @@ Cela implique de ne pas raisonner uniquement en termes de “meilleur modèle”
 
 Un modèle très puissant est pertinent pour analyser une architecture, préparer un plan de refactoring ou résoudre un bug complexe. Il est beaucoup moins pertinent pour lancer un linter, résumer une erreur triviale ou rédiger une PR simple.
 
+La configuration cible doit donc favoriser une logique de **sobriété raisonnée** : utiliser le niveau d’intelligence nécessaire, mais pas davantage.
+
 ---
 
 ## 3. Objectifs opérationnels
 
 La configuration cible doit permettre de :
 
-1. **Réduire la consommation inutile de tokens**
+1. **Réduire la consommation inutile de tokens**  
    Les modèles coûteux doivent être réservés aux tâches où leur valeur ajoutée est réelle.
 
-2. **Améliorer la qualité des résultats**
+2. **Améliorer la qualité des résultats**  
    Chaque tâche doit être confiée à un agent dont le rôle est clair, limité et cohérent.
 
-3. **Limiter les dérives de scope**
+3. **Limiter les dérives de scope**  
    Un agent chargé de planifier ne doit pas implémenter. Un agent chargé de tester ne doit pas réécrire l’architecture. Un agent chargé de relire ne doit pas modifier le code.
 
-4. **Standardiser les workflows récurrents**
+4. **Standardiser les workflows récurrents**  
    Les actions fréquentes — plan, implémentation, correction de bug, tests, lint, revue, PR — doivent devenir des routines explicites.
 
-5. **Préserver le contrôle humain**
+5. **Préserver le contrôle humain**  
    Les tâches à risque doivent rester sous validation humaine, notamment les modifications de code, les suppressions, les changements d’architecture ou les commandes destructrices.
 
-6. **Capitaliser le contexte projet**
+6. **Capitaliser le contexte projet**  
    Les règles propres au projet doivent être portées par des skills ou instructions réutilisables, afin d’éviter de répéter les mêmes consignes à chaque session.
+
+7. **Séparer les opérations mécaniques des opérations cognitives**  
+   Les actions réalisables par script, commande ou outil déterministe doivent être exécutées sans mobiliser inutilement de modèle coûteux. Le LLM doit intervenir prioritairement sur l’interprétation du résultat, l’analyse d’un échec, l’arbitrage ou la correction.
 
 ---
 
@@ -88,9 +93,11 @@ L’agent chargé des bugs doit être orienté vers la sobriété : corriger le 
 
 Les tests doivent être considérés comme une activité distincte.
 
-Un agent de test doit pouvoir exécuter ou analyser les résultats de tests, identifier les échecs, distinguer les problèmes de code, de test ou d’environnement, puis proposer une correction.
+Un agent de test peut contribuer à exécuter ou analyser les résultats de tests, identifier les échecs, distinguer les problèmes de code, de test ou d’environnement, puis proposer une correction.
 
 Mais il ne doit pas systématiquement modifier le code. Dans beaucoup de cas, son premier rôle est d’expliquer l’échec.
+
+L’exécution d’une suite complète de tests ne doit pas entraîner l’envoi systématique de l’intégralité des logs au modèle. Le résultat attendu d’une exécution complète est d’abord un verdict court : succès ou échec, nombre de fichiers concernés, nombre de tests en échec, chemins des fichiers de test pertinents.
 
 ### 4.6 Lint, format et vérifications mécaniques
 
@@ -100,7 +107,71 @@ Un linter, un formatter ou une commande de build doivent être prioritairement p
 
 Ces tâches sont de bons candidats pour des modèles locaux ou économiques.
 
-### 4.7 Revue de code
+### 4.7 Règle générale de ségrégation entre action mécanique, interprétation et correction
+
+La règle de ségrégation ne doit pas être limitée aux tests. Elle doit s’appliquer à toutes les actions qui peuvent être réalisées par script, commande, outil projet ou automatisation déterministe.
+
+Par principe, une action ne doit pas être confiée à un LLM si elle peut être exécutée de manière fiable par une commande existante.
+
+Cela concerne notamment :
+
+- tests ;
+- lint ;
+- format ;
+- build ;
+- génération de types ;
+- vérification de dépendances ;
+- extraction de diff ;
+- recherche de fichiers ;
+- calcul de couverture ;
+- génération de rapports techniques ;
+- création d’artefacts mécaniques ;
+- commandes Git simples ;
+- vérifications de structure ou de conventions déjà outillées.
+
+Ces actions doivent être exécutées prioritairement hors LLM, ou par un agent local ou économique disposant uniquement des permissions nécessaires à l’exécution de commandes.
+
+Le rôle du LLM ne doit pas être de remplacer l’outil déterministe, mais d’intervenir lorsque son apport est réellement utile :
+
+- interpréter un résultat ;
+- expliquer un échec ;
+- formuler une hypothèse ;
+- proposer une correction ;
+- arbitrer entre plusieurs solutions ;
+- relier l’erreur à l’architecture ou aux conventions du projet.
+
+L’exécution complète d’une commande ne doit pas entraîner l’envoi automatique de l’intégralité de sa sortie au contexte LLM. Les sorties longues doivent être filtrées, résumées ou réduites au périmètre utile.
+
+En cas d’échec, une deuxième étape distincte doit isoler le périmètre pertinent :
+
+- commande exécutée ;
+- statut de sortie ;
+- message d’erreur principal ;
+- fichiers ou modules concernés ;
+- extrait minimal de log ;
+- diff attendu/reçu lorsque disponible ;
+- contexte récent de modification si nécessaire ;
+- hypothèse de rattachement à une zone du code.
+
+L’analyse doit être déclenchée seulement après échec, sur un volume réduit et pertinent.
+
+La correction doit constituer une troisième étape séparée, avec un agent, un modèle et des permissions adaptés. Elle ne doit intervenir qu’après un diagnostic explicite et une proposition de correction minimale.
+
+La doctrine à respecter est la suivante :
+
+> Exécuter ne signifie pas analyser.  
+> Analyser ne signifie pas corriger.  
+> Corriger ne signifie pas élargir le scope.
+
+Formulé autrement :
+
+> Ce qui peut être fait par script doit être fait par script.  
+> Ce qui doit être compris, arbitré ou corrigé peut être confié au LLM.  
+> Le LLM doit travailler sur le résultat utile, pas sur le bruit produit par l’exécution.
+
+Cette règle est centrale pour limiter la consommation de tokens, éviter les corrections hasardeuses et empêcher qu’un agent chargé d’une simple vérification mécanique se transforme en agent de refactoring non contrôlé.
+
+### 4.8 Revue de code
 
 La revue est une activité critique.
 
@@ -110,7 +181,7 @@ La revue doit porter sur les risques réels : régression, dette technique, inco
 
 Elle ne doit pas se limiter à une reformulation positive du travail effectué.
 
-### 4.8 Rédaction de PR ou de changelog
+### 4.9 Rédaction de PR ou de changelog
 
 La rédaction de PR est une activité utile mais rarement critique.
 
@@ -128,26 +199,31 @@ Le choix du modèle doit suivre une logique d’arbitrage.
 
 Les modèles locaux doivent être privilégiés pour :
 
-* exploration simple ;
-* résumé de logs ;
-* analyse de sorties de tests ;
-* préparation de listes de fichiers ;
-* tâches répétitives ;
-* reformulations non critiques ;
-* vérifications à faible risque.
+- exploration simple ;
+- résumé de logs ;
+- analyse de sorties de tests ;
+- préparation de listes de fichiers ;
+- tâches répétitives ;
+- reformulations non critiques ;
+- vérifications à faible risque ;
+- pilotage ou synthèse d’opérations mécaniques ;
+- diagnostic simple sur logs courts.
 
 Ils sont intéressants quand la qualité attendue est correcte mais que le coût doit rester faible.
+
+Ils ne doivent pas être utilisés pour prendre seuls des décisions d’architecture majeures, modifier des zones sensibles ou arbitrer des refactorings complexes.
 
 ### 5.2 Modèles distants simples ou intermédiaires
 
 Les modèles distants simples ou intermédiaires doivent être utilisés pour :
 
-* rédaction de PR ;
-* synthèse de diff ;
-* petites corrections ;
-* diagnostic de tests lisibles ;
-* aide à la documentation ;
-* tâches standards avec peu d’ambiguïté.
+- rédaction de PR ;
+- synthèse de diff ;
+- petites corrections ;
+- diagnostic de tests lisibles ;
+- aide à la documentation ;
+- tâches standards avec peu d’ambiguïté ;
+- correction ciblée après diagnostic clair.
 
 Ils offrent un bon compromis entre fiabilité, rapidité et coût.
 
@@ -155,26 +231,29 @@ Ils offrent un bon compromis entre fiabilité, rapidité et coût.
 
 Les modèles de raisonnement avancé doivent être réservés à :
 
-* cadrage d’architecture ;
-* refactoring complexe ;
-* bug difficile à reproduire ;
-* arbitrage entre plusieurs solutions ;
-* conception de plan d’implémentation ;
-* revue critique avant merge ;
-* décisions qui engagent la maintenabilité long terme.
+- cadrage d’architecture ;
+- refactoring complexe ;
+- bug difficile à reproduire ;
+- arbitrage entre plusieurs solutions ;
+- conception de plan d’implémentation ;
+- revue critique avant merge ;
+- décisions qui engagent la maintenabilité long terme ;
+- analyse d’échecs persistants après plusieurs diagnostics simples.
 
 Ces modèles doivent être utilisés moins souvent, mais mieux.
+
+Ils ne doivent pas être mobilisés par défaut pour exécuter une suite de tests, lire des logs volumineux, lancer un linter ou rédiger une PR simple.
 
 ### 5.4 Modèles spécialisés code
 
 Les modèles spécialisés code doivent être privilégiés pour :
 
-* implémentation ;
-* refactoring localisé ;
-* écriture ou adaptation de tests ;
-* correction de bug confirmée ;
-* migration technique ;
-* compréhension fine d’une base existante.
+- implémentation ;
+- refactoring localisé ;
+- écriture ou adaptation de tests ;
+- correction de bug confirmée ;
+- migration technique ;
+- compréhension fine d’une base existante.
 
 Leur usage doit rester encadré par un plan ou une demande précise.
 
@@ -186,16 +265,28 @@ La configuration doit éviter les agents “tout-puissants”.
 
 Chaque agent doit avoir une responsabilité principale claire :
 
-* un agent de planification ne modifie pas ;
-* un agent d’implémentation suit un plan ;
-* un agent de test diagnostique avant de corriger ;
-* un agent de revue ne valide pas son propre travail ;
-* un agent documentaire ne change pas le comportement applicatif ;
-* un agent local économique ne prend pas de décision d’architecture majeure.
+- un agent de planification ne modifie pas ;
+- un agent d’implémentation suit un plan ;
+- un agent de test exécute ou diagnostique avant de corriger ;
+- un agent de vérification mécanique ne modifie pas le code ;
+- un agent d’analyse d’échec ne corrige pas sans validation ou commande dédiée ;
+- un agent de correction applique une correction minimale ;
+- un agent de revue ne valide pas son propre travail ;
+- un agent documentaire ne change pas le comportement applicatif ;
+- un agent local économique ne prend pas de décision d’architecture majeure.
 
 Cette séparation est plus importante que le choix exact du modèle.
 
 Un mauvais découpage des rôles fera gaspiller plus de tokens qu’un mauvais choix ponctuel de modèle.
+
+La séparation minimale à garantir est :
+
+1. **préparer ou planifier** ;
+2. **implémenter** ;
+3. **exécuter les vérifications** ;
+4. **analyser les échecs** ;
+5. **corriger de manière ciblée** ;
+6. **relire avant intégration**.
 
 ---
 
@@ -211,9 +302,13 @@ Une tâche d’implémentation peut modifier, mais dans un périmètre cadré.
 
 Une tâche de test peut exécuter des commandes, mais ne doit pas nécessairement pouvoir modifier.
 
+Une tâche de diagnostic peut lire les fichiers concernés et les logs ciblés, mais ne doit pas automatiquement écrire dans le code.
+
+Une tâche de correction peut modifier, mais seulement après diagnostic et dans un périmètre explicitement limité.
+
 Une tâche de revue doit pouvoir lire le diff, les fichiers concernés et les tests, mais ne doit pas écrire.
 
-OpenCode permet de contrôler l’accès aux outils comme la lecture, l’édition, le shell ou les outils externes via des permissions ; cette logique doit être utilisée comme un garde-fou, pas seulement comme une commodité. ([OpenCode][2])
+Cette logique doit être utilisée comme un garde-fou, pas seulement comme une commodité.
 
 ---
 
@@ -223,15 +318,17 @@ Les skills ne doivent pas être utilisés comme des workflows.
 
 Ils doivent plutôt contenir la connaissance durable du projet :
 
-* conventions d’architecture ;
-* règles de nommage ;
-* conventions de tests ;
-* stratégie i18n ;
-* règles de documentation ;
-* principes de découpage des issues ;
-* règles propres au framework utilisé ;
-* décisions d’architecture déjà prises ;
-* erreurs récurrentes à éviter.
+- conventions d’architecture ;
+- règles de nommage ;
+- conventions de tests ;
+- stratégie i18n ;
+- règles de documentation ;
+- principes de découpage des issues ;
+- règles propres au framework utilisé ;
+- décisions d’architecture déjà prises ;
+- erreurs récurrentes à éviter ;
+- règles de diagnostic des tests ;
+- règles de sobriété sur les logs et sorties de commandes.
 
 Un bon skill doit être court, ciblé, actionnable et maintenable.
 
@@ -239,9 +336,9 @@ Un mauvais skill devient un fourre-tout qui surcharge le contexte et affaiblit l
 
 La logique recommandée est donc :
 
-> Les agents exécutent des rôles.
-> Les commandes déclenchent des actions.
-> Les skills apportent le savoir projet.
+> Les agents exécutent des rôles.  
+> Les commandes déclenchent des actions.  
+> Les skills apportent le savoir projet.  
 > Les permissions encadrent le risque.
 
 ---
@@ -254,29 +351,40 @@ Elles servent à éviter de réécrire les mêmes prompts et à standardiser la 
 
 Chaque commande doit exprimer :
 
-* l’objectif ;
-* le résultat attendu ;
-* les limites ;
-* les critères de réussite ;
-* le niveau d’autonomie autorisé ;
-* le type d’agent ou de modèle adapté.
+- l’objectif ;
+- le résultat attendu ;
+- les limites ;
+- les critères de réussite ;
+- le niveau d’autonomie autorisé ;
+- le type d’agent ou de modèle adapté ;
+- le type de sortie attendue ;
+- la règle d’escalade éventuelle vers un autre agent ou modèle.
 
 Les commandes doivent rester orientées métier d’usage, pas technologie interne.
 
 Exemples de familles de commandes à prévoir :
 
-* préparer un plan ;
-* cadrer une issue ;
-* corriger un bug ;
-* implémenter un plan ;
-* exécuter les tests ;
-* analyser un échec de test ;
-* lancer le lint ;
-* relire un diff ;
-* préparer une PR ;
-* mettre à jour une documentation projet.
+- préparer un plan ;
+- cadrer une issue ;
+- corriger un bug ;
+- implémenter un plan ;
+- exécuter les tests ;
+- analyser un échec de test ;
+- lancer le lint ;
+- analyser un échec de lint ;
+- relire un diff ;
+- préparer une PR ;
+- mettre à jour une documentation projet.
 
-OpenCode permet de créer des commandes personnalisées sous forme de fichiers ou de configuration, avec des paramètres comme l’agent et le modèle associés. ([OpenCode][3])
+Les commandes de vérification doivent distinguer clairement :
+
+- l’exécution complète ;
+- l’isolation des échecs ;
+- l’analyse ciblée ;
+- la correction ;
+- la relance de validation.
+
+Cette distinction doit empêcher qu’une seule commande ou qu’un seul agent ne fasse tout le cycle sans contrôle.
 
 ---
 
@@ -286,19 +394,19 @@ Les hooks et plugins ne doivent pas devenir le cœur du système.
 
 Ils doivent être réservés à des usages transverses :
 
-* appliquer des règles de sécurité ;
-* empêcher l’accès à certains fichiers ;
-* journaliser les modèles utilisés ;
-* suivre les coûts ou durées ;
-* vérifier qu’une commande critique demande validation ;
-* déclencher une action mécanique après modification ;
-* intégrer un outil externe.
+- appliquer des règles de sécurité ;
+- empêcher l’accès à certains fichiers ;
+- journaliser les modèles utilisés ;
+- suivre les coûts ou durées ;
+- vérifier qu’une commande critique demande validation ;
+- déclencher une action mécanique après modification ;
+- intégrer un outil externe ;
+- limiter ou filtrer les sorties longues avant transmission au modèle ;
+- empêcher l’envoi automatique de logs volumineux au contexte LLM.
 
-La règle est simple :
-si la logique relève d’un **workflow humain**, elle doit plutôt être portée par des commandes et agents.
+La règle est simple :  
+si la logique relève d’un **workflow humain**, elle doit plutôt être portée par des commandes et agents.  
 Si la logique relève d’un **contrôle automatique transversal**, elle peut être portée par un hook ou plugin.
-
-OpenCode documente les plugins comme un mécanisme d’extension permettant de se brancher sur des événements et de personnaliser le comportement. ([OpenCode][4])
 
 ---
 
@@ -316,6 +424,11 @@ Avant de lancer une tâche, le système doit pouvoir répondre à ces questions 
 8. Faut-il un modèle spécialisé code ?
 9. Faut-il une validation humaine avant action ?
 10. Le contexte projet doit-il être chargé via un skill ?
+11. La tâche consiste-t-elle seulement à exécuter une commande ?
+12. Le modèle doit-il lire les logs complets ou seulement un extrait ciblé ?
+13. L’échec est-il simple, persistant, ambigu ou architectural ?
+14. L’agent doit-il diagnostiquer ou corriger ?
+15. La correction minimale est-elle suffisamment claire pour autoriser une modification ?
 
 Ces questions doivent guider la configuration, pas l’inverse.
 
@@ -325,18 +438,21 @@ Ces questions doivent guider la configuration, pas l’inverse.
 
 La configuration sera considérée comme efficace si elle permet de constater :
 
-* moins de prompts manuels répétés ;
-* moins d’usage des modèles coûteux sur des tâches simples ;
-* moins de dérives de scope ;
-* meilleure qualité des plans ;
-* meilleure lisibilité des PR ;
-* meilleure séparation entre diagnostic et correction ;
-* meilleure reproductibilité des workflows ;
-* moins de corrections humaines après passage du LLM ;
-* meilleure traçabilité des décisions ;
-* meilleur usage des skills projet.
+- moins de prompts manuels répétés ;
+- moins d’usage des modèles coûteux sur des tâches simples ;
+- moins de dérives de scope ;
+- meilleure qualité des plans ;
+- meilleure lisibilité des PR ;
+- meilleure séparation entre diagnostic et correction ;
+- meilleure reproductibilité des workflows ;
+- moins de corrections humaines après passage du LLM ;
+- meilleure traçabilité des décisions ;
+- meilleur usage des skills projet ;
+- moins de logs inutiles transmis au contexte ;
+- meilleure isolation des tests en échec ;
+- meilleure capacité à escalader vers un modèle plus fort uniquement lorsque c’est justifié.
 
-Le critère principal n’est pas la sophistication de la configuration.
+Le critère principal n’est pas la sophistication de la configuration.  
 Le critère principal est la **réduction du bruit opérationnel**.
 
 ---
@@ -373,6 +489,18 @@ Utiliser systématiquement le meilleur modèle est une mauvaise stratégie écon
 
 Le modèle fort doit être une exception justifiée, pas le mode normal.
 
+### 13.6 Transmission excessive de logs
+
+Les logs complets de tests, lint ou build peuvent consommer inutilement du contexte et détourner le modèle de l’information utile.
+
+Le système doit privilégier les sorties courtes, les erreurs ciblées et les relances limitées aux tests ou fichiers en échec.
+
+### 13.7 Confusion entre diagnostic et correction
+
+Un diagnostic ne doit pas déclencher automatiquement une modification.
+
+La correction doit être une étape distincte, explicitement autorisée, avec une attente de correction minimale.
+
 ---
 
 ## 14. Niveau d’ambition recommandé
@@ -381,13 +509,15 @@ La cible raisonnable n’est pas une orchestration autonome complète.
 
 La cible recommandée est une **orchestration assistée**, dans laquelle :
 
-* l’utilisateur choisit l’intention ;
-* OpenCode sélectionne ou applique le bon agent ;
-* les skills apportent le contexte projet ;
-* les permissions limitent les risques ;
-* les modèles coûteux sont réservés aux tâches à forte valeur ;
-* les commandes standardisent les routines ;
-* les revues restent explicites.
+- l’utilisateur choisit l’intention ;
+- OpenCode sélectionne ou applique le bon agent ;
+- les skills apportent le contexte projet ;
+- les permissions limitent les risques ;
+- les modèles coûteux sont réservés aux tâches à forte valeur ;
+- les commandes standardisent les routines ;
+- les revues restent explicites ;
+- les opérations mécaniques restent sobres ;
+- les analyses sont déclenchées seulement lorsque les résultats le justifient.
 
 L’autonomie doit augmenter seulement lorsque les routines sont stables et observées comme fiables.
 
@@ -407,23 +537,25 @@ Ne pas configurer des agents pour des cas rares.
 
 Créer une première cartographie des responsabilités :
 
-* lire ;
-* planifier ;
-* implémenter ;
-* tester ;
-* corriger ;
-* relire ;
-* documenter ;
-* préparer une PR.
+- lire ;
+- planifier ;
+- implémenter ;
+- exécuter ;
+- analyser ;
+- corriger ;
+- relire ;
+- documenter ;
+- préparer une PR.
 
 ### Phase 3 — Associer les niveaux de modèles
 
 Définir pour chaque activité le niveau de modèle attendu :
 
-* local ;
-* distant économique ;
-* distant spécialisé code ;
-* raisonnement fort.
+- aucun modèle lorsque l’action est purement mécanique ;
+- local ;
+- distant économique ;
+- distant spécialisé code ;
+- raisonnement fort.
 
 ### Phase 4 — Formaliser les commandes
 
@@ -431,11 +563,15 @@ Créer des commandes courtes, stables, réutilisables.
 
 Chaque commande doit exprimer ce qu’elle fait et ce qu’elle ne doit pas faire.
 
+Les commandes de test, lint et build doivent éviter de mélanger exécution, analyse et correction.
+
 ### Phase 5 — Structurer les skills
 
 Transformer les règles récurrentes du projet en skills spécialisés.
 
 Les skills doivent rester modulaires.
+
+Ils doivent inclure les conventions projet, mais aussi les règles de sobriété applicables aux sorties de commandes, tests et diagnostics.
 
 ### Phase 6 — Ajouter des garde-fous
 
@@ -443,16 +579,20 @@ Mettre en place les restrictions de permissions adaptées.
 
 Les permissions doivent refléter le niveau de risque.
 
+Les agents chargés d’exécuter des vérifications mécaniques doivent pouvoir exécuter les commandes nécessaires, mais ne doivent pas avoir par défaut le droit de modifier le code.
+
 ### Phase 7 — Mesurer et ajuster
 
 Observer les résultats :
 
-* quelle commande marche bien ;
-* quel agent dérive ;
-* quel modèle est surdimensionné ;
-* quelle tâche demande un modèle plus fort ;
-* quel skill est inutile ;
-* quelle règle manque.
+- quelle commande marche bien ;
+- quel agent dérive ;
+- quel modèle est surdimensionné ;
+- quelle tâche demande un modèle plus fort ;
+- quel skill est inutile ;
+- quelle règle manque ;
+- quels logs sont encore trop volumineux ;
+- quels échecs justifient réellement une escalade.
 
 ---
 
@@ -460,16 +600,592 @@ Observer les résultats :
 
 La configuration OpenCode doit être pensée comme une organisation du travail entre plusieurs profils d’assistants, et non comme un simple fichier de préférences de modèles.
 
-Le bon objectif n’est pas d’automatiser tout le développement.
+Le bon objectif n’est pas d’automatiser tout le développement.  
 Le bon objectif est de rendre chaque interaction plus précise, plus sobre et plus fiable.
 
 La stratégie recommandée est :
 
-> standardiser les actions fréquentes, spécialiser les agents, réserver les modèles puissants aux décisions importantes, utiliser les skills pour le contexte projet, et maintenir une validation humaine sur les actions à risque.
+> standardiser les actions fréquentes, spécialiser les agents, réserver les modèles puissants aux décisions importantes, utiliser les skills pour le contexte projet, maintenir une validation humaine sur les actions à risque, et séparer strictement l’exécution mécanique, l’analyse et la correction.
 
 C’est cette discipline qui permettra d’obtenir le meilleur compromis entre coût, qualité, contrôle et vélocité.
 
-[1]: https://opencode.ai/docs/agents/?utm_source=chatgpt.com "Agents"
-[2]: https://opencode.ai/docs/tools/?utm_source=chatgpt.com "Tools"
-[3]: https://opencode.ai/docs/commands/?utm_source=chatgpt.com "Commands"
-[4]: https://opencode.ai/docs/plugins/?utm_source=chatgpt.com "Plugins"
+La règle structurante à retenir est simple :
+
+> Exécuter ≠ analyser ≠ corriger.
+
+Elle peut être généralisée ainsi :
+
+> Script d’abord.  
+> LLM ensuite, uniquement si le résultat mérite interprétation, arbitrage ou correction.
+
+C’est cette règle qui doit guider en priorité la conception des agents, des commandes, des permissions et des choix de modèles.
+
+
+## 2. Principe directeur
+
+La configuration OpenCode doit être organisée autour d’une idée centrale :
+
+> Chaque activité doit être confiée à un profil d’agent adapté, avec le modèle le plus économique capable de produire un résultat fiable.
+
+Cela implique de ne pas raisonner uniquement en termes de “meilleur modèle”, mais en termes de **rapport coût / risque / complexité / valeur produite**.
+
+Un modèle très puissant est pertinent pour analyser une architecture, préparer un plan de refactoring ou résoudre un bug complexe. Il est beaucoup moins pertinent pour lancer un linter, résumer une erreur triviale ou rédiger une PR simple.
+
+La configuration cible doit donc favoriser une logique de **sobriété raisonnée** : utiliser le niveau d’intelligence nécessaire, mais pas davantage.
+
+---
+
+## 3. Objectifs opérationnels
+
+La configuration cible doit permettre de :
+
+1. **Réduire la consommation inutile de tokens**  
+   Les modèles coûteux doivent être réservés aux tâches où leur valeur ajoutée est réelle.
+
+2. **Améliorer la qualité des résultats**  
+   Chaque tâche doit être confiée à un agent dont le rôle est clair, limité et cohérent.
+
+3. **Limiter les dérives de scope**  
+   Un agent chargé de planifier ne doit pas implémenter. Un agent chargé de tester ne doit pas réécrire l’architecture. Un agent chargé de relire ne doit pas modifier le code.
+
+4. **Standardiser les workflows récurrents**  
+   Les actions fréquentes — plan, implémentation, correction de bug, tests, lint, revue, PR — doivent devenir des routines explicites.
+
+5. **Préserver le contrôle humain**  
+   Les tâches à risque doivent rester sous validation humaine, notamment les modifications de code, les suppressions, les changements d’architecture ou les commandes destructrices.
+
+6. **Capitaliser le contexte projet**  
+   Les règles propres au projet doivent être portées par des skills ou instructions réutilisables, afin d’éviter de répéter les mêmes consignes à chaque session.
+
+7. **Séparer les opérations mécaniques des opérations cognitives**  
+   L’exécution d’une commande, l’analyse de son résultat et la correction d’un problème doivent être considérées comme trois activités différentes.
+
+---
+
+## 4. Typologie des activités à distinguer
+
+La configuration doit distinguer clairement les familles d’activités suivantes.
+
+### 4.1 Exploration
+
+L’exploration consiste à comprendre le code, identifier les fichiers concernés, retrouver une convention, analyser une structure existante ou préparer le terrain avant une intervention.
+
+Cette activité doit privilégier des modèles économiques, éventuellement locaux, car elle demande surtout de la lecture, du repérage et de la synthèse.
+
+L’agent d’exploration doit être fortement limité : il lit, cherche, résume, mais ne modifie pas.
+
+### 4.2 Planification
+
+La planification est une activité à forte valeur. Elle sert à transformer une demande en stratégie d’intervention : périmètre, fichiers concernés, risques, dépendances, tests, ordre d’exécution.
+
+Cette activité mérite un modèle de raisonnement plus fort, car une mauvaise décision à ce stade coûte cher ensuite.
+
+L’agent de planification doit être interdit de modification. Son rôle est de produire une décision claire, pas de commencer à coder.
+
+### 4.3 Implémentation
+
+L’implémentation consiste à modifier le code selon un plan déjà défini.
+
+Cette activité doit être confiée à un modèle compétent en code, capable de respecter l’architecture existante et de produire des modifications minimales.
+
+L’agent d’implémentation doit être encadré par des règles strictes : ne pas élargir le scope, ne pas refactorer au-delà du besoin, ne pas modifier des zones non concernées, ne pas inventer de conventions.
+
+### 4.4 Correction de bug
+
+La correction de bug doit être séparée de l’implémentation générique.
+
+Un bug demande d’abord un diagnostic : reproduction, hypothèse, cause probable, preuve, correction minimale, test de non-régression.
+
+L’agent chargé des bugs doit être orienté vers la sobriété : corriger le défaut identifié, pas “améliorer” tout ce qu’il voit autour.
+
+### 4.5 Tests
+
+Les tests doivent être considérés comme une activité distincte.
+
+Un agent de test peut contribuer à exécuter ou analyser les résultats de tests, identifier les échecs, distinguer les problèmes de code, de test ou d’environnement, puis proposer une correction.
+
+Mais il ne doit pas systématiquement modifier le code. Dans beaucoup de cas, son premier rôle est d’expliquer l’échec.
+
+L’exécution d’une suite complète de tests ne doit pas entraîner l’envoi systématique de l’intégralité des logs au modèle. Le résultat attendu d’une exécution complète est d’abord un verdict court : succès ou échec, nombre de fichiers concernés, nombre de tests en échec, chemins des fichiers de test pertinents.
+
+### 4.6 Lint, format et vérifications mécaniques
+
+Les tâches mécaniques doivent être traitées avec le moins d’intelligence artificielle possible.
+
+Un linter, un formatter ou une commande de build doivent être prioritairement pilotés par scripts. Le modèle ne doit intervenir que pour analyser un échec, pas pour décider à la place de l’outil.
+
+Ces tâches sont de bons candidats pour des modèles locaux ou économiques.
+
+### 4.7 Règle de ségrégation entre exécution, analyse et correction
+
+Les commandes de test, lint, build, format et vérification doivent être considérées comme des opérations mécaniques.
+
+Elles doivent être exécutées prioritairement hors LLM, ou par un agent local ou économique disposant uniquement des permissions nécessaires à l’exécution de commandes.
+
+L’exécution complète d’une suite de tests, d’un lint ou d’un build ne doit pas entraîner l’envoi automatique de l’intégralité des logs au contexte LLM. Les sorties longues doivent être filtrées, résumées ou réduites au périmètre utile.
+
+En cas d’échec, une deuxième étape distincte doit isoler le périmètre pertinent :
+
+- fichier ou fichiers de test en échec ;
+- nom des tests concernés ;
+- erreur principale ;
+- diff attendu/reçu lorsque disponible ;
+- stack trace minimale ;
+- fichiers métier probablement liés ;
+- contexte récent de modification si nécessaire.
+
+L’analyse des logs doit être déclenchée seulement après échec, sur un volume réduit et pertinent.
+
+La correction doit constituer une troisième étape séparée, avec un agent, un modèle et des permissions adaptés. Elle ne doit intervenir qu’après un diagnostic explicite et une proposition de correction minimale.
+
+La doctrine à respecter est la suivante :
+
+> Exécuter ne signifie pas analyser.  
+> Analyser ne signifie pas corriger.  
+> Corriger ne signifie pas élargir le scope.
+
+Cette règle est centrale pour limiter la consommation de tokens, éviter les corrections hasardeuses et empêcher qu’un agent chargé d’une simple vérification mécanique se transforme en agent de refactoring non contrôlé.
+
+### 4.8 Revue de code
+
+La revue est une activité critique.
+
+Elle doit être confiée à un agent distinct de celui qui a implémenté, afin d’éviter l’auto-validation complaisante.
+
+La revue doit porter sur les risques réels : régression, dette technique, incohérence avec l’architecture, sécurité, maintenabilité, tests absents, dérive de scope.
+
+Elle ne doit pas se limiter à une reformulation positive du travail effectué.
+
+### 4.9 Rédaction de PR ou de changelog
+
+La rédaction de PR est une activité utile mais rarement critique.
+
+Elle peut être confiée à un modèle simple ou intermédiaire, à condition qu’il s’appuie sur le diff réel, le plan initial et les tests exécutés.
+
+Le texte de PR doit rester factuel : ce qui a été changé, pourquoi, comment tester, risques éventuels.
+
+---
+
+## 5. Doctrine de choix des modèles
+
+Le choix du modèle doit suivre une logique d’arbitrage.
+
+### 5.1 Modèles locaux
+
+Les modèles locaux doivent être privilégiés pour :
+
+- exploration simple ;
+- résumé de logs ;
+- analyse de sorties de tests ;
+- préparation de listes de fichiers ;
+- tâches répétitives ;
+- reformulations non critiques ;
+- vérifications à faible risque ;
+- pilotage ou synthèse d’opérations mécaniques ;
+- diagnostic simple sur logs courts.
+
+Ils sont intéressants quand la qualité attendue est correcte mais que le coût doit rester faible.
+
+Ils ne doivent pas être utilisés pour prendre seuls des décisions d’architecture majeures, modifier des zones sensibles ou arbitrer des refactorings complexes.
+
+### 5.2 Modèles distants simples ou intermédiaires
+
+Les modèles distants simples ou intermédiaires doivent être utilisés pour :
+
+- rédaction de PR ;
+- synthèse de diff ;
+- petites corrections ;
+- diagnostic de tests lisibles ;
+- aide à la documentation ;
+- tâches standards avec peu d’ambiguïté ;
+- correction ciblée après diagnostic clair.
+
+Ils offrent un bon compromis entre fiabilité, rapidité et coût.
+
+### 5.3 Modèles de raisonnement avancé
+
+Les modèles de raisonnement avancé doivent être réservés à :
+
+- cadrage d’architecture ;
+- refactoring complexe ;
+- bug difficile à reproduire ;
+- arbitrage entre plusieurs solutions ;
+- conception de plan d’implémentation ;
+- revue critique avant merge ;
+- décisions qui engagent la maintenabilité long terme ;
+- analyse d’échecs persistants après plusieurs diagnostics simples.
+
+Ces modèles doivent être utilisés moins souvent, mais mieux.
+
+Ils ne doivent pas être mobilisés par défaut pour exécuter une suite de tests, lire des logs volumineux, lancer un linter ou rédiger une PR simple.
+
+### 5.4 Modèles spécialisés code
+
+Les modèles spécialisés code doivent être privilégiés pour :
+
+- implémentation ;
+- refactoring localisé ;
+- écriture ou adaptation de tests ;
+- correction de bug confirmée ;
+- migration technique ;
+- compréhension fine d’une base existante.
+
+Leur usage doit rester encadré par un plan ou une demande précise.
+
+---
+
+## 6. Règles de séparation des responsabilités
+
+La configuration doit éviter les agents “tout-puissants”.
+
+Chaque agent doit avoir une responsabilité principale claire :
+
+- un agent de planification ne modifie pas ;
+- un agent d’implémentation suit un plan ;
+- un agent de test exécute ou diagnostique avant de corriger ;
+- un agent de vérification mécanique ne modifie pas le code ;
+- un agent d’analyse d’échec ne corrige pas sans validation ou commande dédiée ;
+- un agent de correction applique une correction minimale ;
+- un agent de revue ne valide pas son propre travail ;
+- un agent documentaire ne change pas le comportement applicatif ;
+- un agent local économique ne prend pas de décision d’architecture majeure.
+
+Cette séparation est plus importante que le choix exact du modèle.
+
+Un mauvais découpage des rôles fera gaspiller plus de tokens qu’un mauvais choix ponctuel de modèle.
+
+La séparation minimale à garantir est :
+
+1. **préparer ou planifier** ;
+2. **implémenter** ;
+3. **exécuter les vérifications** ;
+4. **analyser les échecs** ;
+5. **corriger de manière ciblée** ;
+6. **relire avant intégration**.
+
+---
+
+## 7. Gouvernance des permissions
+
+Les permissions doivent être pensées selon le risque de l’activité.
+
+Une tâche de lecture doit avoir un accès en lecture seule.
+
+Une tâche de planification ne doit pas pouvoir modifier le code.
+
+Une tâche d’implémentation peut modifier, mais dans un périmètre cadré.
+
+Une tâche de test peut exécuter des commandes, mais ne doit pas nécessairement pouvoir modifier.
+
+Une tâche de diagnostic peut lire les fichiers concernés et les logs ciblés, mais ne doit pas automatiquement écrire dans le code.
+
+Une tâche de correction peut modifier, mais seulement après diagnostic et dans un périmètre explicitement limité.
+
+Une tâche de revue doit pouvoir lire le diff, les fichiers concernés et les tests, mais ne doit pas écrire.
+
+Cette logique doit être utilisée comme un garde-fou, pas seulement comme une commodité.
+
+---
+
+## 8. Rôle des skills
+
+Les skills ne doivent pas être utilisés comme des workflows.
+
+Ils doivent plutôt contenir la connaissance durable du projet :
+
+- conventions d’architecture ;
+- règles de nommage ;
+- conventions de tests ;
+- stratégie i18n ;
+- règles de documentation ;
+- principes de découpage des issues ;
+- règles propres au framework utilisé ;
+- décisions d’architecture déjà prises ;
+- erreurs récurrentes à éviter ;
+- règles de diagnostic des tests ;
+- règles de sobriété sur les logs et sorties de commandes.
+
+Un bon skill doit être court, ciblé, actionnable et maintenable.
+
+Un mauvais skill devient un fourre-tout qui surcharge le contexte et affaiblit la qualité des réponses.
+
+La logique recommandée est donc :
+
+> Les agents exécutent des rôles.  
+> Les commandes déclenchent des actions.  
+> Les skills apportent le savoir projet.  
+> Les permissions encadrent le risque.
+
+---
+
+## 9. Rôle des commandes
+
+Les commandes doivent formaliser les activités récurrentes.
+
+Elles servent à éviter de réécrire les mêmes prompts et à standardiser la qualité attendue.
+
+Chaque commande doit exprimer :
+
+- l’objectif ;
+- le résultat attendu ;
+- les limites ;
+- les critères de réussite ;
+- le niveau d’autonomie autorisé ;
+- le type d’agent ou de modèle adapté ;
+- le type de sortie attendue ;
+- la règle d’escalade éventuelle vers un autre agent ou modèle.
+
+Les commandes doivent rester orientées métier d’usage, pas technologie interne.
+
+Exemples de familles de commandes à prévoir :
+
+- préparer un plan ;
+- cadrer une issue ;
+- corriger un bug ;
+- implémenter un plan ;
+- exécuter les tests ;
+- analyser un échec de test ;
+- lancer le lint ;
+- analyser un échec de lint ;
+- relire un diff ;
+- préparer une PR ;
+- mettre à jour une documentation projet.
+
+Les commandes de vérification doivent distinguer clairement :
+
+- l’exécution complète ;
+- l’isolation des échecs ;
+- l’analyse ciblée ;
+- la correction ;
+- la relance de validation.
+
+Cette distinction doit empêcher qu’une seule commande ou qu’un seul agent ne fasse tout le cycle sans contrôle.
+
+---
+
+## 10. Rôle des hooks et plugins
+
+Les hooks et plugins ne doivent pas devenir le cœur du système.
+
+Ils doivent être réservés à des usages transverses :
+
+- appliquer des règles de sécurité ;
+- empêcher l’accès à certains fichiers ;
+- journaliser les modèles utilisés ;
+- suivre les coûts ou durées ;
+- vérifier qu’une commande critique demande validation ;
+- déclencher une action mécanique après modification ;
+- intégrer un outil externe ;
+- limiter ou filtrer les sorties longues avant transmission au modèle ;
+- empêcher l’envoi automatique de logs volumineux au contexte LLM.
+
+La règle est simple :  
+si la logique relève d’un **workflow humain**, elle doit plutôt être portée par des commandes et agents.  
+Si la logique relève d’un **contrôle automatique transversal**, elle peut être portée par un hook ou plugin.
+
+---
+
+## 11. Critères d’arbitrage pour choisir le bon agent
+
+Avant de lancer une tâche, le système doit pouvoir répondre à ces questions :
+
+1. La tâche demande-t-elle de modifier le code ?
+2. La tâche engage-t-elle l’architecture ?
+3. Le résultat attendu est-il exploratoire ou exécutable ?
+4. Le coût d’une erreur est-il faible, moyen ou élevé ?
+5. La tâche est-elle répétitive ou exceptionnelle ?
+6. Peut-elle être traitée par un modèle local ?
+7. Faut-il un modèle de raisonnement ?
+8. Faut-il un modèle spécialisé code ?
+9. Faut-il une validation humaine avant action ?
+10. Le contexte projet doit-il être chargé via un skill ?
+11. La tâche consiste-t-elle seulement à exécuter une commande ?
+12. Le modèle doit-il lire les logs complets ou seulement un extrait ciblé ?
+13. L’échec est-il simple, persistant, ambigu ou architectural ?
+14. L’agent doit-il diagnostiquer ou corriger ?
+15. La correction minimale est-elle suffisamment claire pour autoriser une modification ?
+
+Ces questions doivent guider la configuration, pas l’inverse.
+
+---
+
+## 12. Critères d’évaluation de la configuration
+
+La configuration sera considérée comme efficace si elle permet de constater :
+
+- moins de prompts manuels répétés ;
+- moins d’usage des modèles coûteux sur des tâches simples ;
+- moins de dérives de scope ;
+- meilleure qualité des plans ;
+- meilleure lisibilité des PR ;
+- meilleure séparation entre diagnostic et correction ;
+- meilleure reproductibilité des workflows ;
+- moins de corrections humaines après passage du LLM ;
+- meilleure traçabilité des décisions ;
+- meilleur usage des skills projet ;
+- moins de logs inutiles transmis au contexte ;
+- meilleure isolation des tests en échec ;
+- meilleure capacité à escalader vers un modèle plus fort uniquement lorsque c’est justifié.
+
+Le critère principal n’est pas la sophistication de la configuration.  
+Le critère principal est la **réduction du bruit opérationnel**.
+
+---
+
+## 13. Risques à éviter
+
+### 13.1 Sur-orchestration
+
+Le risque principal est de construire trop tôt une usine à gaz.
+
+Il faut commencer par quelques agents et commandes bien conçus, puis enrichir progressivement.
+
+### 13.2 Agents trop larges
+
+Un agent qui sait tout faire finit par mal faire beaucoup de choses.
+
+Les agents doivent être spécialisés, mais pas proliférants.
+
+### 13.3 Skills trop longs
+
+Un skill trop complet peut devenir contre-productif.
+
+Il doit contenir les règles réellement utiles au moment de l’action.
+
+### 13.4 Automatisation excessive
+
+Tout ne doit pas être automatisé.
+
+Les décisions d’architecture, les changements de comportement, les suppressions et les refactorings importants doivent rester sous contrôle humain.
+
+### 13.5 Modèle puissant utilisé par défaut
+
+Utiliser systématiquement le meilleur modèle est une mauvaise stratégie économique.
+
+Le modèle fort doit être une exception justifiée, pas le mode normal.
+
+### 13.6 Transmission excessive de logs
+
+Les logs complets de tests, lint ou build peuvent consommer inutilement du contexte et détourner le modèle de l’information utile.
+
+Le système doit privilégier les sorties courtes, les erreurs ciblées et les relances limitées aux tests ou fichiers en échec.
+
+### 13.7 Confusion entre diagnostic et correction
+
+Un diagnostic ne doit pas déclencher automatiquement une modification.
+
+La correction doit être une étape distincte, explicitement autorisée, avec une attente de correction minimale.
+
+---
+
+## 14. Niveau d’ambition recommandé
+
+La cible raisonnable n’est pas une orchestration autonome complète.
+
+La cible recommandée est une **orchestration assistée**, dans laquelle :
+
+- l’utilisateur choisit l’intention ;
+- OpenCode sélectionne ou applique le bon agent ;
+- les skills apportent le contexte projet ;
+- les permissions limitent les risques ;
+- les modèles coûteux sont réservés aux tâches à forte valeur ;
+- les commandes standardisent les routines ;
+- les revues restent explicites ;
+- les opérations mécaniques restent sobres ;
+- les analyses sont déclenchées seulement lorsque les résultats le justifient.
+
+L’autonomie doit augmenter seulement lorsque les routines sont stables et observées comme fiables.
+
+---
+
+## 15. Recommandation de déploiement progressif
+
+La mise en place doit être progressive.
+
+### Phase 1 — Clarifier les usages
+
+Identifier les 6 à 10 activités réellement fréquentes.
+
+Ne pas configurer des agents pour des cas rares.
+
+### Phase 2 — Séparer les rôles
+
+Créer une première cartographie des responsabilités :
+
+- lire ;
+- planifier ;
+- implémenter ;
+- exécuter ;
+- analyser ;
+- corriger ;
+- relire ;
+- documenter ;
+- préparer une PR.
+
+### Phase 3 — Associer les niveaux de modèles
+
+Définir pour chaque activité le niveau de modèle attendu :
+
+- aucun modèle lorsque l’action est purement mécanique ;
+- local ;
+- distant économique ;
+- distant spécialisé code ;
+- raisonnement fort.
+
+### Phase 4 — Formaliser les commandes
+
+Créer des commandes courtes, stables, réutilisables.
+
+Chaque commande doit exprimer ce qu’elle fait et ce qu’elle ne doit pas faire.
+
+Les commandes de test, lint et build doivent éviter de mélanger exécution, analyse et correction.
+
+### Phase 5 — Structurer les skills
+
+Transformer les règles récurrentes du projet en skills spécialisés.
+
+Les skills doivent rester modulaires.
+
+Ils doivent inclure les conventions projet, mais aussi les règles de sobriété applicables aux sorties de commandes, tests et diagnostics.
+
+### Phase 6 — Ajouter des garde-fous
+
+Mettre en place les restrictions de permissions adaptées.
+
+Les permissions doivent refléter le niveau de risque.
+
+Les agents chargés d’exécuter des vérifications mécaniques doivent pouvoir exécuter les commandes nécessaires, mais ne doivent pas avoir par défaut le droit de modifier le code.
+
+### Phase 7 — Mesurer et ajuster
+
+Observer les résultats :
+
+- quelle commande marche bien ;
+- quel agent dérive ;
+- quel modèle est surdimensionné ;
+- quelle tâche demande un modèle plus fort ;
+- quel skill est inutile ;
+- quelle règle manque ;
+- quels logs sont encore trop volumineux ;
+- quels échecs justifient réellement une escalade.
+
+---
+
+## 16. Synthèse exécutive
+
+La configuration OpenCode doit être pensée comme une organisation du travail entre plusieurs profils d’assistants, et non comme un simple fichier de préférences de modèles.
+
+Le bon objectif n’est pas d’automatiser tout le développement.  
+Le bon objectif est de rendre chaque interaction plus précise, plus sobre et plus fiable.
+
+La stratégie recommandée est :
+
+> standardiser les actions fréquentes, spécialiser les agents, réserver les modèles puissants aux décisions importantes, utiliser les skills pour le contexte projet, maintenir une validation humaine sur les actions à risque, et séparer strictement l’exécution mécanique, l’analyse et la correction.
+
+C’est cette discipline qui permettra d’obtenir le meilleur compromis entre coût, qualité, contrôle et vélocité.
+
+La règle structurante à retenir est simple :
+
+> Exécuter ≠ analyser ≠ corriger.
+
+C’est elle qui doit guider en priorité la conception des agents, des commandes, des permissions et des choix de modèles.

--- a/documentation/importer/README.md
+++ b/documentation/importer/README.md
@@ -30,7 +30,7 @@ Le correctif 1.0 du mapper `Weapons.xml` fiabilise l'import des armes OggDude: p
 | Gear       | ✅ Active | [import-gear.md](./import-gear.md)                               | Categories, base mods, weapon profiles   |
 | Species    | ✅ Active | -                                                                | Characteristics, skills, talents         |
 | Career     | ✅ Active | [import-career.md](./import-career.md)                           | Skills, specializations                  |
-| Talent     | ✅ Active | [talent-import-architecture.md](./talent-import-architecture.md) | Full talent tree support                 |
+| Talent     | ✅ Active | [talent-import-architecture.md](./talent-import-architecture.md) | Générique uniquement (voir ADR-0014) ; arbre et progression = specialization-tree et talentPurchases |
 | Obligation | ✅ Active | [import-obligation.md](./import-obligation.md)                   | Narrative obligations with defaults      |
 
 ## Pipeline de mapping

--- a/documentation/importer/talent-import-architecture.md
+++ b/documentation/importer/talent-import-architecture.md
@@ -1,8 +1,31 @@
-# Import de Talents OggDude - Documentation Technique
+# Import de Talents OggDude — Documentation Technique
+
+## Note d'architecture (ADR-0014)
+
+Depuis [ADR-0014](../architecture/adr/adr-0014-talents-standalone-arbres-v1-et-source-de-verite-progression.md), le système SWERPG considère :
+
+- **`Talent.xml`** : simple définition générique du talent. Aucune arborescence, progression, coût ou connexion de nœud — ces données relèvent strictement des arbres `specialization-tree`.
+- **L'arborescence V1** : canonique uniquement portée par les Items de type `specialization-tree`.
+- **La progression acquise d'un acteur** : source de vérité unique `actor.system.progression.talentPurchases`.
+- **Les champs `system.trees`, `system.node`, `system.row` sur `Item.talent`** : considérés **legacy** et non canoniques V1 (à proscrire dans toute logique actuelle ou future).
+
+Ce document décrit le pipeline d'import OggDude pour les talents, en conformité avec cette architecture.
+
+---
 
 ## Vue d'ensemble
 
-Le système d'import de talents OggDude permet d'importer et de transformer les données de talents depuis les fichiers d'export OggDude Character Generator vers le système SwerpgTalent de Foundry VTT.
+L'import `Talent.xml` OggDude produit un **référentiel de définitions génériques de talents** — des `Item` `talent` exploitables par les arbres `specialization-tree` et la vue consolidée onglet Talents, sans stocker de coût XP, de position d'arbre, d'état acheté ou de mécanique d'acteur.
+
+Le pipeline :
+
+1. Extrait les données talents depuis `Talent.xml` (ZIP OggDude)
+2. Construit un **contexte de mapping** pour chaque talent (activation, classement, description, modificateurs, source)
+3. **Transforme** ce contexte en une définition générique de talent (contrat minimal `system.*`)
+4. Enregistre les données brutes et de diagnostic dans `flags.swerpg.import`
+5. Ne persiste **aucun** champ d'arborescence ou de progression dans `system.*`
+
+---
 
 ## Architecture
 
@@ -13,21 +36,22 @@ L'architecture suit les mêmes patterns que les autres domaines d'import (armor,
 ```
 OggDude.mjs (Orchestrateur)
 ├── buildTalentContext() (Context Builder)
-│   └── talentMapper() (Individual Item Mapper)
-│       └── OggDudeTalentMapper.transform() (Main Transformation)
+│   └── OggDudeTalentMapper.buildContextMap() (Strategy)
+│       └── buildSingleTalentContext()
 │           ├── Activation Mapping
-│           ├── Node Resolution
 │           ├── Prerequisite Transformation
 │           ├── Rank Processing
-│           └── Actions Creation
-└── Global Import Metrics
+│           ├── DieModifiers Extraction
+│           └── Description Assembly
+└── OggDudeTalentMapper.transform() (Template Method)
+    └── Production du contrat générique
 ```
 
 ### Modules Principaux
 
 #### 1. Context Builder (`talent-ogg-dude.mjs`)
 
-- **Rôle** : Adapter l'interface du mapper principal à l'architecture existante
+- **Rôle** : Adapter l'interface du mapper principal à l'architecture d'import existante
 - **Responsabilités** :
   - Construire le contexte d'import standard (jsonData, zip, image, folder, element)
   - Wrapper le mapper individuel pour compatibilité avec `OggDudeDataElement.processElements()`
@@ -39,7 +63,7 @@ OggDude.mjs (Orchestrateur)
 - **Responsabilités** :
   - Extraire les données talents depuis la structure OggDude
   - Construire le contexte de mapping pour chaque talent
-  - Transformer le contexte en données SwerpgTalent
+  - Transformer le contexte en définition générique `Item` `talent`
   - Valider la cohérence des données transformées
 
 #### 3. Modules de Mapping Spécialisés
@@ -47,32 +71,25 @@ OggDude.mjs (Orchestrateur)
 ##### `oggdude-talent-activation-map.mjs`
 
 - Mappe les codes d'activation OggDude vers `SYSTEM.TALENT_ACTIVATION`
-- Gère les variations de casse et les activations inconnues
+- Gère les variations de casse et les activations inconnues → valeur `unspecified`
 - Statistiques des activations non reconnues
-
-##### `oggdude-talent-node-map.mjs`
-
-- Résout les identifiants de nœuds OggDude vers les instances `SwerpgTalentNode`
-- Pattern matching pour les nœuds communs
-- Fallback gracieux pour les nœuds non trouvés
 
 ##### `oggdude-talent-prerequisite-map.mjs`
 
-- Transforme les prérequis XML OggDude en structure système
-- Mappe caractéristiques, compétences et talents requis
+- Transforme les prérequis XML OggDude (caractéristiques, compétences) en structure système
 - Validation des prérequis transformés
+- Stockage dans `flags.swerpg.import.prerequisites` à titre diagnostique uniquement
 
 ##### `oggdude-talent-rank-map.mjs`
 
-- Extrait tier, rang et coût depuis les données OggDude
+- Extrait `isRanked`, `tier` et `rank` depuis les données OggDude
 - Détecte si un talent est classé (ranked)
-- Calculs de coût avec validation des limites
+- **Ne persiste pas de coût XP** sur la définition générique — le coût relève exclusivement de `specialization-tree.system.nodes[].cost`
 
-##### `oggdude-talent-actions-map.mjs`
+##### `oggdude-talent-diemodifiers-map.mjs`
 
-- Transforme les actions OggDude en instances `SwerpgAction`
-- Crée des actions par défaut pour les talents sans actions
-- Support pour l'extension future des actions complexes
+- Extrait les `DieModifiers` OggDude pour enrichir la description et les flags d'import
+- Ne produit pas d'effet mécanique automatisé — les DieModifiers restent descriptifs
 
 #### 4. Utilitaires (`talent-import-utils.mjs`)
 
@@ -80,53 +97,59 @@ OggDude.mjs (Orchestrateur)
 - Fonctions de validation et de nettoyage des données
 - Intégration avec le système de métriques globales
 
-## Intégration avec l'Écosystème
+---
 
-### Métriques Globales
+## Contrat de transformation
 
-Le domaine talent est intégré dans `global-import-metrics.mjs` :
-
-```javascript
-// Statistiques agrégées incluent maintenant les talents
-const globalStats = getAllImportStats()
-console.log(globalStats.talent.processed) // Talents traités
-```
-
-### Registry Pattern
-
-Enregistrement dans l'orchestrateur `OggDude.mjs` :
-
-```javascript
-buildContextMap.set('talent', {
-  type: 'talent',
-  contextBuilder: buildTalentContext,
-})
-```
-
-### Compatibilité SwerpgTalent
-
-Les données transformées respectent le schéma `SwerpgTalent` :
+Le mapper `OggDudeTalentMapper.transform()` produit des données conformes à ce contrat :
 
 ```javascript
 {
-  name: string,
-  type: 'talent',
+  name: string,           // Nom du talent
+  type: 'talent',         // Type d'Item
   system: {
-    node: SwerpgTalentNode,
-    activation: TALENT_ACTIVATION,
-    isRanked: boolean,
-    rank: { idx: number, cost: number },
-    tier: number,
-    description: string,
-    requirements: object,
-    actions: SwerpgAction[],
-    actorHooks: object,
-    importMeta: object
-  }
+    id: string,           // Identifiant unique du talent
+    activation: string,   // Activation résolue (ou 'unspecified')
+    isRanked: boolean,    // Le talent est-il classé ?
+    description: string,  // Description enrichie (source, die modifiers)
+  },
+  flags: {
+    swerpg: {
+      oggdudeKey: string,           // Clé OggDude source
+      import: {
+        status: string,             // 'valid' ou 'incomplete'
+        warnings: string[],         // Avertissements (ex: activation inconnue)
+        source: string,             // Source éditeur
+        sourceText: string,         // Texte source formaté
+        dieModifiers: object[],     // Modificateurs de dés (descriptif)
+        prerequisites: object,      // Prérequis (diagnostic)
+        tier: number,               // Tier OggDude (diagnostic)
+        raw: {                      // Données brutes OggDude
+          key: string,
+          activation: string|undefined,
+          source: string|undefined,
+        },
+        importedAt: string,         // Timestamp ISO d'import
+      },
+    },
+  },
 }
 ```
 
-## Flux de Données
+⚠️ **Attention** : ce contrat **n'inclut pas** les champs suivants, qui sont legacy :
+
+| Champ legacy | Statut |
+|---|---|
+| `system.node` | Legacy — ne pas utiliser pour V1 |
+| `system.trees` | Legacy — ne pas utiliser pour V1 |
+| `system.row` | Legacy — ne pas utiliser pour V1 |
+| `system.rank.cost` | Non persistant — le coût XP relève de `specialization-tree` |
+| `system.actions` | Legacy — les actions ne sont pas importées depuis `Talent.xml` |
+| `system.actorHooks` | Legacy — non supporté dans le flux d'import V1 |
+
+---
+
+## Flux de données
 
 ### 1. Extraction
 
@@ -141,36 +164,41 @@ OggDude ZIP → buildTalentContext() →
 }
 ```
 
-### 2. Mapping Individuel
+### 2. Contexte individuel
 
 ```
 OggDude Talent Data → OggDudeTalentMapper.buildSingleTalentContext() →
 {
-  key: unique identifier,
-  name: talent name,
-  activation: resolved activation,
-  node: SwerpgTalentNode instance,
-  prerequisites: transformed requirements,
-  rank: { idx, cost },
-  actions: SwerpgAction[]
+  key: string,                    // Identifiant unique
+  name: string,                   // Nom du talent
+  activation: string,             // Activation résolue
+  isRanked: boolean,              // Classé ou non
+  description: string,            // Description nettoyée
+  sourceText: string,             // Texte source
+  dieModifiers: object[],         // Modificateurs de dés
+  prerequisites: object,          // Prérequis transformés
+  // Champs diagnostiques suivants (calculés mais non persistés dans system.*) :
+  node: SwerpgTalentNode|null,    // Résolution de nœud legacy (diagnostic)
+  tier: number,                   // Tier OggDude
+  rank: { idx, cost },            // Rang et coût OggDude
 }
 ```
 
-### 3. Transformation Finale
+### 3. Transformation finale
 
 ```
 Talent Context → OggDudeTalentMapper.transform() →
-SwerpgTalent Compatible Data → Foundry Item Creation
+Item talent générique (contrat system.* minimal + flags.swerpg.import)
 ```
+
+---
 
 ## Gestion d'Erreurs
 
 ### Stratégie de Fallback
 
-- **Activations inconnues** → 'passive'
-- **Nœuds non trouvés** → null (talent orphelin)
-- **Prérequis invalides** → {} (aucun prérequis)
-- **Actions manquantes** → action par défaut créée
+- **Activations inconnues** → `unspecified` (avec warning)
+- **Prérequis invalides** → `{}` (aucun prérequis)
 - **Données corrompues** → élément ignoré, statistique d'échec
 
 ### Logging et Observabilité
@@ -187,19 +215,20 @@ Métriques détaillées pour le monitoring :
 
 ```javascript
 {
-  processed: 0,      // Talents traités
-  created: 0,        // Talents créés avec succès
-  failed: 0,         // Échecs de traitement
-  validation_failed: 0,  // Échecs de validation
-  transform_failed: 0,   // Échecs de transformation
-  contextMaps: 0,        // Contextes construits
-  duplicates: 0,         // Doublons détectés
-  unknownActivations: 0, // Activations non reconnues
-  unresolvedNodes: 0,    // Nœuds non résolus
-  invalidPrerequisites: 0, // Prérequis invalides
-  transformed: 0         // Transformations réussies
+  processed: 0,               // Talents traités
+  created: 0,                 // Talents créés avec succès
+  failed: 0,                  // Échecs de traitement
+  validation_failed: 0,       // Échecs de validation
+  transform_failed: 0,        // Échecs de transformation
+  contextMaps: 0,             // Contextes construits
+  duplicates: 0,              // Doublons détectés
+  unknownActivations: 0,      // Activations non reconnues
+  invalidPrerequisites: 0,    // Prérequis invalides
+  transformed: 0,             // Transformations réussies
 }
 ```
+
+---
 
 ## Extension et Maintenance
 
@@ -212,9 +241,9 @@ Pour ajouter un nouveau type de mapping :
 3. Importer et utiliser dans `oggdude-talent-mapper.mjs`
 4. Ajouter les tests dans `tests/importer/`
 
-### Modification du Schéma SwerpgTalent
+### Modification du Contrat de Transformation
 
-Si le schéma `SwerpgTalent` évolue :
+Si le schéma `Item.talent` générique évolue :
 
 1. Mettre à jour `OggDudeTalentMapper.transform()`
 2. Adapter les modules de mapping concernés
@@ -225,8 +254,9 @@ Si le schéma `SwerpgTalent` évolue :
 
 - Les mappings utilisent des `Map` pour les lookups O(1)
 - Validation paresseuse des prérequis complexes
-- Cache des nœuds résolus dans `SwerpgTalentNode.nodes`
 - Streaming pour les gros volumes de talents
+
+---
 
 ## Tests
 
@@ -235,14 +265,16 @@ Si le schéma `SwerpgTalent` évolue :
 - **Utilitaires** : `tests/importer/talent-utils.spec.mjs`
 - **Mappings** : `tests/importer/talent-mappings.spec.mjs`
 - **Mapper Principal** : `tests/importer/talent-mapper.spec.mjs`
-- **Intégration** : Tests d'import bout-en-bout (à créer)
+- **Intégration** : `tests/importer/talent-import-real-test.spec.mjs`
 
 ### Stratégie de Test
 
 - Tests unitaires pour chaque fonction de mapping
-- Mocks des dépendances externes (SwerpgTalentNode, SYSTEM)
+- Mocks des dépendances externes
+- Vérification du contrat générique : pas de `system.node`, `system.row`, `system.trees` dans le résultat
 - Tests d'intégration avec données OggDude réelles
-- Tests de performance pour gros datasets
+
+---
 
 ## Sécurité
 
@@ -250,7 +282,7 @@ Si le schéma `SwerpgTalent` évolue :
 
 - Sanitisation des chaînes de caractères
 - Validation des types de données
-- Limites sur la longueur des descriptions
+- Limites sur la longueur des descriptions (2000 caractères)
 - Protection contre l'injection de code dans les noms
 
 ### Gestion des Ressources

--- a/documentation/plan/character-sheet/talent/245-plan-cloturer-issue-22-talents-arbres-legacy.md
+++ b/documentation/plan/character-sheet/talent/245-plan-cloturer-issue-22-talents-arbres-legacy.md
@@ -1,0 +1,252 @@
+# Plan d'implémentation — Clôturer l'issue #22 : talents, arbres et reliquats legacy
+
+**Issue** : [#22 — Gestion des Talents dans les arbres (`system.trees`, `system.node`, `system.row`)](https://github.com/herveDarritchon/foundryvtt-swerpg/issues/22)
+**Epic** : [#184 — EPIC: Refonte V1 des talents Edge](https://github.com/herveDarritchon/foundryvtt-swerpg/issues/184)
+**ADR** : `documentation/architecture/adr/adr-0014-talents-standalone-arbres-v1-et-source-de-verite-progression.md`, `documentation/architecture/adr/adr-0013-technical-key-and-business-key-separation.md`, `documentation/architecture/adr/adr-0012-unit-tests-readable-diagnostics.md`
+**Audit de référence** : `documentation/audit/issue-22-audit-gestion-talents-arbres.md`
+**Module(s) impacté(s)** : `documentation/importer/talent-import-architecture.md` (modification), `module/models/talent.mjs` (modification), `module/importer/mappers/oggdude-talent-mapper.mjs` (modification potentielle), `tests/importer/` (modification potentielle), issue `#22` (commentaire ou checklist finale)
+
+---
+
+## 1. Objectif
+
+Clôturer proprement l'issue `#22` en alignant définitivement la documentation et les points de contact techniques restants sur l'architecture désormais formalisée par ADR-0014 :
+
+- `Talent.xml` = définition générique standalone d'un talent ;
+- `specialization-tree` = support canonique des arbres V1 ;
+- `actor.system.progression.talentPurchases` = source de vérité de progression acteur ;
+- `Item.talent.system.trees`, `system.node`, `system.row` = reliquats legacy non canoniques pour la V1.
+
+Le résultat attendu n'est pas la suppression complète de tout le legacy talents, mais une **clôture saine de l'ambiguïté d'architecture** : plus aucune documentation active ni aucun point d'entrée courant ne doivent laisser entendre que `Talent.xml` ou `Item.talent` portent à eux seuls l'arborescence V1.
+
+---
+
+## 2. Périmètre
+
+### Inclus dans ce ticket
+
+- Réécrire la documentation d'import talent encore contradictoire avec ADR-0014
+- Expliciter dans le code le statut legacy de `system.trees`, `system.node`, `system.row` sur `Item.talent`
+- Vérifier si le mapper `Talent.xml` conserve des résidus conceptuels legacy non nécessaires au flux actuel
+- Réduire ou isoler les reliquats legacy du mapper talent si cela est faisable sans casser la compatibilité utile
+- Ajouter ou ajuster les tests qui verrouillent le contrat documentaire et technique minimal
+- Mettre à jour l'issue `#22` avec une checklist de sortie et la décision sur ce qui reste volontairement hors scope
+
+### Exclu de ce ticket
+
+- Suppression physique complète de `SwerpgTalentNode` et du canvas legacy Crucible
+- Suppression complète des flows legacy `trained-talent` / `ranked-trained-talent`
+- Migration des données existantes de personnages legacy
+- Refonte fonctionnelle des arbres V1 ou de l'UI de spécialisation
+- Réécriture complète de toute la documentation historique talents du projet
+
+---
+
+## 3. Constat sur l'existant
+
+### 3.1. La décision d'architecture existe désormais
+
+ADR-0014 formalise explicitement la séparation entre talent générique, arbre de spécialisation et progression acteur. L'audit de l'issue `#22` est donc désormais couvert sur le plan décisionnel.
+
+### 3.2. La documentation import talent reste partiellement contradictoire
+
+Le fichier `documentation/importer/talent-import-architecture.md` contient maintenant une note d'architecture correcte en tête, mais son corps continue de décrire un modèle ancien centré sur `SwerpgTalentNode`, `system.node`, `rank` et un contrat plus riche que le `transform()` réellement produit.
+
+Cela crée un risque immédiat :
+
+- un développeur peut lire l'en-tête ADR puis être recontaminé par le corps du document ;
+- la doc suggère encore une canonicité de `node` qui n'est plus vraie pour la V1 ;
+- le schéma documenté n'est plus celui réellement écrit par le mapper actuel.
+
+### 3.3. `module/models/talent.mjs` expose encore le legacy comme schéma normal
+
+Le data model `talent` déclare toujours :
+
+- `node` ;
+- `trees` ;
+- `row`.
+
+Ces champs sont aujourd'hui des reliquats de compatibilité, mais leur présence nue dans `defineSchema()` entretient une ambiguïté si elle n'est pas explicitement documentée dans le code.
+
+### 3.4. Le mapper `Talent.xml` ne persiste plus l'arbre, mais garde des traces de l'ancien modèle
+
+`module/importer/mappers/oggdude-talent-mapper.mjs` ne persiste plus `system.node`, `system.row` ou `system.trees` dans le résultat final. En revanche, le contexte calcule encore `node`, `tier` et `rank`.
+
+Ce n'est pas forcément un bug, mais cela doit être requalifié :
+
+- soit ces informations sont encore utiles comme diagnostics d'import ;
+- soit elles doivent sortir du chemin principal pour éviter de maintenir une dette conceptuelle inutile.
+
+### 3.5. Des chemins legacy runtime existent encore, mais ce n'est pas le vrai sujet de clôture de `#22`
+
+Les flows `trained-talent`, `ranked-trained-talent`, le global tree Crucible et certaines classes canvas legacy existent encore. Ils sont déjà identifiés comme dépréciés et suivis par d'autres travaux de neutralisation.
+
+La clôture de `#22` n'exige pas leur suppression immédiate, mais impose qu'ils soient clairement traités comme **hors contrat canonique V1**.
+
+---
+
+## 4. Décisions d'architecture appliquées par ce plan
+
+### 4.1. `#22` se clôt sur la clarification, pas sur l'éradication complète du legacy
+
+**Décision** : considérer l'issue `#22` comme une issue d'architecture et d'alignement documentaire/technique minimal, pas comme un ticket de suppression exhaustive du legacy talents.
+
+Justification :
+- cohérent avec le texte initial de l'issue ;
+- cohérent avec ADR-0014 ;
+- évite de bloquer indéfiniment la clôture sur des travaux plus larges déjà identifiés ailleurs.
+
+### 4.2. Toute documentation active doit refléter le contrat réellement canonique
+
+**Décision** : une documentation active qui décrit encore `SwerpgTalentNode` ou `system.node` comme contrat normal du flux `Talent.xml` doit être réécrite, pas seulement préfacée d'un avertissement.
+
+Justification :
+- une note en tête ne suffit pas si le contenu détaillé raconte encore l'ancien modèle ;
+- la doc doit aider un futur contributeur à prendre la bonne direction sans ambiguïté.
+
+### 4.3. Les champs legacy du modèle `talent` doivent être explicitement annotés comme tels
+
+**Décision** : tant que `node`, `trees` et `row` restent dans `module/models/talent.mjs`, ils doivent être signalés dans le code comme champs legacy non canoniques V1.
+
+Justification :
+- limite les réintroductions accidentelles dans de nouveaux développements ;
+- rend le contrat plus honnête pour les mainteneurs ;
+- aligne le code avec ADR-0014 sans forcer une suppression risquée immédiate.
+
+### 4.4. Le mapper talent peut conserver des diagnostics, pas une dépendance métier implicite
+
+**Décision** : si `node`, `tier` ou `rank` sont encore utiles dans le contexte d'import, ils doivent être conservés uniquement comme aide de diagnostic ou de compatibilité transitoire, jamais comme représentation métier canonique de l'arbre V1.
+
+Justification :
+- respecte ADR-0014 ;
+- évite une suppression trop agressive ;
+- permet un nettoyage progressif et testable.
+
+---
+
+## 5. Plan de travail détaillé
+
+### Étape 1 — Réécrire complètement `documentation/importer/talent-import-architecture.md`
+
+**Quoi faire** : remplacer les sections qui décrivent le flux comme centré sur `SwerpgTalentNode`, `system.node`, `rank` et un pseudo-contrat d'arbre par une documentation alignée sur le mapper réel : définition générique, activation, `isRanked`, description enrichie, données d'import dans `flags.swerpg.import`, et séparation stricte avec `specialization-tree`.
+
+**Fichiers** :
+- `documentation/importer/talent-import-architecture.md`
+
+**Risques** : réécrire trop vite et perdre quelques détails utiles sur les diagnostics d'import ; corriger la direction mais décrire un contrat qui ne correspond pas exactement au code actuel.
+
+### Étape 2 — Annoter clairement le legacy dans `module/models/talent.mjs`
+
+**Quoi faire** : ajouter une documentation de code explicite sur `node`, `trees` et `row` pour préciser qu'ils ne sont pas canoniques pour la V1 Talents Edge. Ajuster la JSDoc et, si utile, des commentaires ciblés dans `defineSchema()` et/ou les getters concernés.
+
+**Fichiers** :
+- `module/models/talent.mjs`
+
+**Risques** : commentaires trop vagues ou trop dispersés ; oubli d'un point de contact important qui continuerait de présenter ces champs comme normaux.
+
+### Étape 3 — Qualifier le reliquat legacy du mapper `Talent.xml`
+
+**Quoi faire** : relire `module/importer/mappers/oggdude-talent-mapper.mjs` et ses mappings satellites pour décider si `resolveTalentNode()`, `tier` et `rank` sont encore nécessaires.
+
+Sous-cas possibles :
+- s'ils ne servent plus au contrat ni aux tests utiles, les retirer du contexte principal ;
+- s'ils servent encore au diagnostic, les reléguer explicitement au statut de métadonnées non canoniques ;
+- s'ils servent à un test obsolète, corriger le test au lieu de sanctuariser le legacy.
+
+**Fichiers** :
+- `module/importer/mappers/oggdude-talent-mapper.mjs`
+- `module/importer/mappings/oggdude-talent-node-map.mjs`
+- `module/importer/mappings/oggdude-talent-rank-map.mjs`
+- `tests/importer/talent-mapper.spec.mjs`
+- `tests/importer/talent-mappings.spec.mjs`
+
+**Risques** : casser un diagnostic d'import légitime ; retirer une donnée encore utile sans couverture de test suffisante.
+
+### Étape 4 — Verrouiller le contrat par tests ciblés
+
+**Quoi faire** : ajouter ou mettre à jour des tests qui garantissent au minimum :
+
+- que le `transform()` talent n'écrit pas `system.node`, `system.row`, `system.trees` ;
+- que les métadonnées utiles restent dans `flags.swerpg.import` ;
+- que la documentation technique réécrite reflète bien le contrat réellement vérifié par le code ;
+- qu'aucun test ne dépend encore d'une hypothèse du type "Talent.xml = full tree support".
+
+**Fichiers** :
+- `tests/importer/talent-mapper.spec.mjs`
+- `tests/importer/talent-import-real-test.spec.mjs`
+- éventuellement un nouveau test ciblé si le contrat actuel n'est pas assez lisible
+
+**Risques** : tests trop couplés à l'implémentation actuelle des flags ; couverture insuffisante de la séparation talent générique / arbre.
+
+### Étape 5 — Clore `#22` avec une note de sortie explicite
+
+**Quoi faire** : une fois les points précédents livrés, ajouter sur l'issue `#22` un commentaire de clôture résumant :
+
+- ce qui est désormais couvert par ADR-0014 ;
+- les corrections documentaires réalisées ;
+- le fait que `system.trees/node/row` sont legacy ;
+- ce qui reste volontairement hors scope et suivi par des tickets/US de nettoyage legacy séparés.
+
+**Fichiers / supports** :
+- issue GitHub `#22`
+
+**Risques** : fermer l'issue sans mentionner clairement le reliquat legacy restant, ce qui pourrait recréer de l'ambiguïté plus tard.
+
+---
+
+## 6. Fichiers modifiés
+
+| Fichier | Action | Description du changement |
+|---|---|---|
+| `documentation/importer/talent-import-architecture.md` | modification | Réécrire le document pour refléter le vrai contrat `Talent.xml` générique et la séparation avec `specialization-tree` |
+| `module/models/talent.mjs` | modification | Annoter `node`, `trees`, `row` comme legacy non canoniques V1 |
+| `module/importer/mappers/oggdude-talent-mapper.mjs` | modification potentielle | Réduire ou requalifier les reliquats legacy du contexte d'import |
+| `module/importer/mappings/oggdude-talent-node-map.mjs` | modification potentielle | Ajuster ou isoler la logique de résolution legacy si elle reste nécessaire |
+| `module/importer/mappings/oggdude-talent-rank-map.mjs` | modification potentielle | Vérifier si la donnée reste utile comme diagnostic uniquement |
+| `tests/importer/talent-mapper.spec.mjs` | modification | Verrouiller le contrat final du mapper talent |
+| `tests/importer/talent-import-real-test.spec.mjs` | modification potentielle | Vérifier le pipeline réel sans support implicite des arbres via `Talent.xml` |
+
+---
+
+## 7. Stratégie de validation
+
+### Tests automatisés
+
+- `pnpm vitest run tests/importer/talent-mapper.spec.mjs`
+- `pnpm vitest run tests/importer/talent-mappings.spec.mjs`
+- `pnpm vitest run tests/importer/talent-import-real-test.spec.mjs`
+
+### Vérifications de revue
+
+- Relire `documentation/importer/talent-import-architecture.md` comme si l'ADR n'existait pas : le lecteur doit comprendre le bon contrat sans dépendre uniquement de la note en tête.
+- Vérifier que `module/models/talent.mjs` ne présente plus `node`, `trees`, `row` comme des champs V1 normaux sans qualification.
+- Vérifier qu'aucune spec ou test touché par cette US ne réintroduit l'idée de "full talent tree support" côté `Talent.xml`.
+
+---
+
+## 8. Critères d'acceptation
+
+- [ ] `documentation/importer/talent-import-architecture.md` est entièrement cohérent avec ADR-0014, pas seulement son en-tête
+- [ ] `module/models/talent.mjs` explicite le statut legacy non canonique V1 de `system.trees`, `system.node`, `system.row`
+- [ ] Le mapper talent n'introduit aucune dépendance métier V1 implicite à l'arborescence via `Talent.xml`
+- [ ] Les tests d'import talent verrouillent l'absence de persistance de `system.trees/node/row` dans le flux générique
+- [ ] L'issue `#22` peut être clôturée avec une note claire sur le périmètre réellement traité et le legacy restant hors scope
+
+---
+
+## 9. Risques et points d'attention
+
+- **Risque de faux alignement documentaire** : ajouter une note ADR sans réécrire le corps du document laisserait subsister l'ambiguïté.
+- **Risque de compatibilité legacy** : retirer trop tôt des reliquats du mapper ou du modèle `talent` pourrait casser des chemins encore tolérés.
+- **Risque de fermeture prématurée** : clôturer `#22` sans consigner le reliquat legacy restant ferait croire que tout le nettoyage Crucible est terminé.
+
+---
+
+## 10. Résultat attendu
+
+À l'issue de ce plan, `#22` devient clôturable pour de bonnes raisons :
+
+- la décision d'architecture est formalisée ;
+- la documentation active raconte le bon modèle ;
+- le code signale honnêtement ses reliquats legacy ;
+- les tests empêchent la réintroduction d'une confusion entre talent générique, arbre V1 et progression acteur.

--- a/module/importer/mappers/oggdude-talent-mapper.mjs
+++ b/module/importer/mappers/oggdude-talent-mapper.mjs
@@ -114,9 +114,13 @@ export class OggDudeTalentMapper {
         source: talentData.Source || talentData.SourceBook || 'OggDude Import',
         custom: talentData.Custom === 'true' || talentData.IsCustom === 'true',
 
-        // Données transformées
+        // Données transformées (contrat canonique : system.* générique uniquement)
         activation,
         hasUnknownActivation: activation === 'unspecified' && typeof rawActivation === 'string' && rawActivation.trim() !== '',
+        // Diagnostics legacy — calculés mais NON persistés dans system.*.
+        //   node : résolution de nœud OggDude / Crucible (legacy, diagnostic only)
+        //   tier : tier OggDude, stocké dans flags.swerpg.import.tier (diagnostic)
+        //   rank : rang et coût OggDude, NON persistés — le coût relève de specialization-tree
         node: resolveTalentNode(talentData.NodeId || talentData.TalentNode, { name }),
         tier: extractTalentTier(talentData),
         isRanked: extractIsRanked(talentData),

--- a/module/models/talent.mjs
+++ b/module/models/talent.mjs
@@ -19,12 +19,12 @@ const DEPR_TALENT_POINTS = () => SYSTEM.DEPRECATION.crucible.talentPoints
 
 /**
  * @typedef {Object} TalentData
- * @property {string} node
+ * @property {string} [node]         @deprecated V1 Edge legacy — do not use for V1. Canonical tree data is on specialization-tree nodes.
  * @property {string} description
  * @property {boolean} isRanked
  * @property {Rank} rank
  * @property {boolean} active
- * @property {SwerpgSpecialization[]} trees
+ * @property {SwerpgSpecialization[]} [trees]  @deprecated V1 Edge legacy — do not use for V1. Use specialization-tree items to access tree membership.
  * @property {SwerpgAction[]} actions   The actions which have been unlocked by this talent
  * @property {number} iconicSpells
  * @property {ActorHook[]} actorHooks
@@ -68,12 +68,18 @@ export default class SwerpgTalent extends foundry.abstract.TypeDataModel {
     return {
       id: new fields.StringField({ required: false, nullable: false, blank: false }),
       uuid: new fields.StringField({ required: false, nullable: false, blank: true, initial: '' }),
+      // @deprecated V1 Edge legacy — non-canonical for V1.
+      //   Tree membership is defined by specialization-tree entries, not by this field.
       node: new fields.StringField({ required: false, blank: true, choices: () => SwerpgTalentNode.getChoices() }),
+      // @deprecated V1 Edge legacy — non-canonical for V1.
+      //   Tree membership is defined by specialization-tree items, not by an Item.talent-level set.
       trees: new fields.SetField(new fields.DocumentUUIDField({ type: 'Item' }), {
         validate: SwerpgTalent.#validateTrees,
       }),
       description: new fields.HTMLField({ required: false, initial: undefined }),
       isRanked: new fields.BooleanField({ required: false, initial: false }),
+      // @deprecated V1 Edge legacy — non-canonical for V1.
+      //   Node row/position is defined by specialization-tree.system.nodes[].row.
       row: new fields.NumberField({ required: false, nullable: false, integer: true, initial: 1, min: 1, max: 5 }),
       rank: new fields.SchemaField({
         idx: new fields.NumberField({ required: true, blank: false, initial: 0 }),

--- a/tests/importer/talent-mapper.spec.mjs
+++ b/tests/importer/talent-mapper.spec.mjs
@@ -164,6 +164,8 @@ describe('OggDudeTalentMapper', () => {
       expect(result.system.importMeta).toBeUndefined()
       expect(result.system.node).toBeUndefined()
       expect(result.system.actions).toBeUndefined()
+      expect(result.system.trees).toBeUndefined()
+      expect(result.system.row).toBeUndefined()
     })
 
     it('devrait stocker dieModifiers dans flags.swerpg.import et enrichir la description', () => {


### PR DESCRIPTION
## Contexte/résumé
- Alignement complet de la doc, schéma, et pipeline import talents selon [ADR-0014](documentation/architecture/adr/adr-0014-talents-standalone-arbres-v1-et-source-de-verite-progression.md)
- Clôture de l’issue #22 (élimination confusion historique : arbre, rang, row non persistés sur Talent générique)
- Diagnostic, annotation et documentation de tous les champs legacy (node/trees/row/tier) : marqués explicitement legacy V1/à retirer ultérieurement
- Pipeline d’import nettoyé : plus aucun reliquat arbre, row ou coût ailleurs qu’en diagnostic (flags)
- Ajout et renforcement de tests Vitest garantissant le contrat strict (rien hors Talent canonique, audit des reliquats en flags uniquement)
- Documentation d’audit et plan conservée : voir dossiers documentation/audit et documentation/plan

### Scope
- Ne change rien à l’arbre Specialization ni à la progression acteur (issue distincte, hors scope)
- Ne supprime pas les legacy : annotation et verrouillage diagnostic uniquement (ticket à prévoir pour la suppression physique post-migration)
- Neutre pour les users, stable pour tous modules extérieurs

---
Tag: #ADR-0014 #Arbres #Legacy #ImportOggDude #Issue22 #Documentation
