### PR TITLE
docs(opencode): valider la doctrine cible et la matrice des usages frequents

### DIFF
--- a/documentation/cadrage/llm/cadrage-opencode-configuration.md
+++ b/documentation/cadrage/llm/cadrage-opencode-configuration.md
@@ -1184,8 +1184,61 @@ La stratégie recommandée est :
 
 C’est cette discipline qui permettra d’obtenir le meilleur compromis entre coût, qualité, contrôle et vélocité.
 
-La règle structurante à retenir est simple :
+---
 
-> Exécuter ≠ analyser ≠ corriger.
+## 17. Doctrine cible validée — Issue #267
 
-C’est elle qui doit guider en priorité la conception des agents, des commandes, des permissions et des choix de modèles.
+Cette section formalise la doctrine cible validée par l’issue [#267](https://github.com/herveDarritchon/foundryvtt-swerpg/issues/267). Elle extrait les principes normatifs du présent document et les complète par la matrice des usages fréquents, les niveaux de risque, d’autonomie et les types d’agent attendus.
+
+### 17.1. Principes doctrinaux
+
+1. **Orchestration assistée** — OpenCode assiste l’utilisateur, ne le remplace pas. Les décisions d’architecture, les modifications de code, les suppressions et les opérations Git critiques restent sous validation humaine.
+2. **Séparation des rôles** — Un agent de planification ne modifie pas le code. Un agent d’implémentation suit un plan. Un agent de revue ne valide pas son propre travail. Un agent de test diagnostique avant de corriger.
+3. **Permissions alignées sur le risque** — Les tâches à risque élevé (code, architecture, Git) exigent une validation humaine explicite. Les tâches à faible risque (lecture, recherche, documentation) peuvent être déléguées avec une autonomie plus large.
+4. **Commandes pour les routines, skills pour le savoir** — Les commandes standardisent les workflows récurrents. Les skills portent la connaissance durable du projet (conventions, architecture, patterns, pièges).
+5. **Modèle adapté au besoin** — Les modèles de raisonnement avancé sont réservés aux décisions d’architecture, plans complexes et revues critiques. Les modèles économiques ou locaux suffisent pour l’exploration, les tâches mécaniques et les reformulations.
+
+### 17.2. Matrice des usages fréquents
+
+| Activité | Risque | Autonomie | Type d’agent | Skill existant | Validation humaine |
+|---|---|---|---|---|---|
+| Créer des issues depuis un cadrage | Moyen | Assistée | Planification / Découpage | `to-issues` | Oui — contenu des issues |
+| Créer un plan depuis une issue | Moyen | Assistée | Planification | `plan-depuis-issue` | Oui — plan validé |
+| Écrire un plan dans `documentation/plan/` | Faible | Assistée | Documentation | `ecrire-plan-fichier` | Non |
+| Implémenter un plan | Élevé | Assistée | Implémentation | `implementer-depuis-plan` | Oui — code et tests |
+| Diagnostiquer / corriger un bug | Élevé | Assistée | Correction | Partiellement `implementer-depuis-plan` | Oui — fix et tests |
+| Exécuter et analyser des tests | Faible | Lecture seule ou assistée | Test | Aucun | Non — résultat suffit |
+| Relire un diff / revue de code | Élevé | Lecture seule | Revue | Aucun | Oui — approbation |
+| Préparer / créer une PR | Moyen | Assistée | Documentation | `my-pull-requests` (lister seulement) | Oui — PR à valider |
+| Mettre à jour une documentation projet | Faible | Assistée | Documentation | Aucun | Non |
+| Lancer des vérifications mécaniques | Faible | Automatique (script) | Script | Aucun | Non |
+
+### 17.3. Niveaux de risque — Définition
+
+| Niveau | Exemples | Exigence |
+|---|---|---|
+| **Faible** | Documentation, lint, tests automatisés, exploration | Autonomie large, contrôle minimal |
+| **Moyen** | Planification, issues, PR, refactor localisé | Autonomie assistée, validation humaine recommandée |
+| **Élevé** | Implémentation, architecture, Git destructeur, suppression | Validation humaine obligatoire avant action |
+
+### 17.4. Écarts identifiés par l’audit des skills
+
+L’audit des skills existants (cf. documentation/plan/llm/267-audit-skills-opencode.md) révèle les écarts suivants :
+
+1. **`my-pull-requests`** — Le skill liste les PR mais ne permet pas d’en créer. Or l’usage attendu “préparer/créer une PR” n’est pas couvert. **Action** : créer ou étendre un skill de création de PR.
+2. **`ecrire-plan-fichier`** — Ce skill est une opération mécanique d’écriture. Il correspond davantage au rôle d’une **commande** que d’un skill porteur de connaissance. **Action** : évaluer sa transformation en commande dans un ticket ultérieur.
+3. **Activités non couvertes** — Aucun skill dédié n’existe pour : test automatisé, revue de code, diagnostic de bug, vérifications mécaniques, documentation projet. **Action** : décider dans un ticket ultérieur si ces activités nécessitent un skill, une commande, ou un simple prompt réutilisable.
+
+### 17.5. Ordre de mise en oeuvre recommandé pour les tickets suivants
+
+1. Doctrine et cartographie (ce ticket) ✓
+2. Alignement des commandes — Formaliser les routines les plus fréquentes en commandes OpenCode
+3. Alignement des skills — Corriger les écarts (`my-pull-requests`), transformer les skills mécaniques en commandes
+4. Permissions — Définir les permissions par type d’agent et niveau de risque
+5. Plugins / hooks transverses — Ajouter des garde-fous si nécessaire (sécurité, coût, validation)
+6. Mesure et ajustements — Observer l’utilisation réelle et ajuster la configuration
+
+[1]: https://opencode.ai/docs/agents/?utm_source=chatgpt.com "Agents"
+[2]: https://opencode.ai/docs/tools/?utm_source=chatgpt.com "Tools"
+[3]: https://opencode.ai/docs/commands/?utm_source=chatgpt.com "Commands"
+[4]: https://opencode.ai/docs/plugins/?utm_source=chatgpt.com "Plugins"

--- a/documentation/plan/llm/267-audit-skills-opencode.md
+++ b/documentation/plan/llm/267-audit-skills-opencode.md
@@ -1,0 +1,221 @@
+# Audit de cohérence des skills OpenCode — Issue #267
+
+**Issue** : [#267 — OpenCode - Valider la doctrine cible et la liste des usages frequents](https://github.com/herveDarritchon/foundryvtt-swerpg/issues/267)
+**Doctrine de référence** : `documentation/cadrage/llm/cadrage-opencode-configuration.md` (section 17)
+**Périmètre** : Audit documentaire uniquement — aucune modification des skills n’est effectuée dans ce ticket.
+
+---
+
+## Contexte
+
+Cinq skills locaux sous `.agents/skills/` sont audités au regard de la doctrine cible validée (orchestration assistée, séparation des rôles, skills = savoir projet, commandes = routines). L’audit compare pour chaque skill l’**intention annoncée**, le **résultat attendu**, les **limites**, le **niveau d’autonomie implicite** et la **cohérence avec le rôle doctrinal attendu**.
+
+---
+
+## 1. `plan-depuis-issue`
+
+### Intention annoncée
+
+Générer un plan d’implémentation technique détaillé à partir d’une issue GitHub. Le skill produit un document structuré dans `documentation/plan/`.
+
+### Résultat attendu
+
+Plan validé, fichier `.md` créé, aucune modification de code.
+
+### Limites explicites
+
+- Ne jamais écrire une ligne de code d’implémentation.
+- Ne pas modifier le code existant.
+- Ne pas modifier les issues GitHub.
+
+### Niveau d’autonomie implicite
+
+**Assistée** — Le skill pose des questions à l’utilisateur avant de finaliser le plan (décisions d’architecture, périmètre). Il ne modifie pas le code.
+
+### Cohérence avec la doctrine
+
+| Critère | État |
+|---|---|
+| Rôle doctrinal attendu | Planification |
+| Séparation des responsabilités | ✅ Ne modifie pas le code |
+| Validation humaine | ✅ Décisions validées avant rédaction |
+| Skill ou commande | ✅ Skill (apporte méthode et structure de plan) |
+| Alignement risque | ✅ Risque moyen, validation humaine intégrée |
+
+### Écarts identifiés
+
+Aucun écart significatif. Le skill est bien aligné avec la doctrine.
+
+---
+
+## 2. `ecrire-plan-fichier`
+
+### Intention annoncée
+
+Prendre un plan déjà rédigé ou validé et le matérialiser dans `documentation/plan/` sans refaire le travail de planification.
+
+### Résultat attendu
+
+Fichier Markdown créé au bon emplacement, contenu préservé.
+
+### Limites explicites
+
+- Ne pas inventer de détails techniques.
+- Ne pas enrichir, redécouper ni re-spécifier.
+- Ne pas modifier le code source.
+- Ne pas lancer de tests.
+- Ne pas créer de commit ni de PR.
+
+### Niveau d’autonomie implicite
+
+**Assistée** — Opération mécanique avec vérifications (collision, arborescence, nommage).
+
+### Cohérence avec la doctrine
+
+| Critère | État |
+|---|---|
+| Rôle doctrinal attendu | Documentation |
+| Séparation des responsabilités | ✅ Opération d’écriture pure |
+| Validation humaine | ✅ Plan déjà validé avant |
+| Skill ou commande | ⚠️ **Pourrait être une commande** — Opération mécanique, pas de savoir projet |
+| Alignement risque | ✅ Faible |
+
+### Écarts identifiés
+
+**Écart structurel** : Ce skill est une opération mécanique d’écriture de fichier. Selon la doctrine (“les skills apportent le savoir projet, les commandes standardisent les routines”), il correspond davantage au rôle d’une **commande** que d’un skill porteur de connaissance. Il ne contient pas de règle projet, de convention d’architecture ou de connaissance durable — seulement un workflow d’écriture.
+
+**Recommandation** : Évaluer sa transformation en commande OpenCode dans un ticket ultérieur.
+
+---
+
+## 3. `implementer-depuis-plan`
+
+### Intention annoncée
+
+Transformer un plan en implémentation réelle, sans repartir de zéro, en exécutant le plan de manière disciplinée avec tests et validation.
+
+### Résultat attendu
+
+Code implémenté, tests ajoutés ou adaptés, validation effectuée, résumé livré.
+
+### Limites explicites
+
+- Ne pas réinventer l’architecture si le plan tranche.
+- Ne pas faire de refactor hors périmètre.
+- Ne pas modifier des zones non concernées.
+- Ne pas introduire de comportement opportuniste.
+
+### Niveau d’autonomie implicite
+
+**Assistée** — Autonomie élevée dans le cadre du plan, mais strictement bornée par les règles du skill (ne pas dévier, ne pas étendre, signaler les écarts).
+
+### Cohérence avec la doctrine
+
+| Critère | État |
+|---|---|
+| Rôle doctrinal attendu | Implémentation |
+| Séparation des responsabilités | ✅ Suit un plan, ne planifie pas |
+| Validation humaine | ✅ Écarts signalés, validation des choix ambigus |
+| Skill ou commande | ✅ Skill (contient savoir projet : conventions, architecture, tests) |
+| Alignement risque | ✅ Risque élevé, encadré par des règles strictes |
+
+### Écarts identifiés
+
+Aucun écart significatif. Le skill est le plus complet et le mieux aligné avec la doctrine.
+
+---
+
+## 4. `to-issues`
+
+### Intention annoncée
+
+Break a plan, spec, or PRD into independently-grabbable issues on the project issue tracker using tracer-bullet vertical slices.
+
+### Résultat attendu
+
+Issues créées sur le tracker GitHub, découpées en tranches verticales, avec critères d’acceptation et dépendances.
+
+### Limites explicites
+
+- Do NOT close or modify any parent issue.
+- Prefer AFK over HITL where possible.
+- Keep issue content in French.
+
+### Niveau d’autonomie implicite
+
+**Élevée** — Le skill peut créer des issues de manière autonome (AFK) après validation du découpage par l’utilisateur.
+
+### Cohérence avec la doctrine
+
+| Critère | État |
+|---|---|
+| Rôle doctrinal attendu | Planification / Découpage |
+| Séparation des responsabilités | ✅ Crée des issues, ne modifie pas le code |
+| Validation humaine | ✅ Découpage validé avant publication |
+| Skill ou commande | ✅ Skill (apporte méthode de découpage vertical) |
+| Alignement risque | ✅ Moyen, validation humaine sur le contenu |
+| Langue | ⚠️ Skill en anglais, mais produit du contenu français — acceptable |
+
+### Écarts identifiés
+
+**Écart mineur** : Le skill est entièrement en anglais alors que les autres skills du projet sont en français (ou bilingues). La doctrine ne tranche pas sur la langue des skills, mais l’incohérence peut surprendre.
+
+---
+
+## 5. `my-pull-requests`
+
+### Intention annoncée
+
+List my pull requests in the current repository.
+
+### Résultat attendu
+
+Affichage des PR assignées à l’utilisateur, avec description, statut de review et check failures.
+
+### Limites explicites
+
+- Read-only : liste et décrit, ne crée pas.
+- Utilise `#list_pull_requests` et `#request_copilot_review`.
+
+### Niveau d’autonomie implicite
+
+**Lecture seule** — Consultation uniquement.
+
+### Cohérence avec la doctrine
+
+| Critère | État |
+|---|---|
+| Rôle doctrinal attendu | Documentation / Consultation |
+| Séparation des responsabilités | ✅ Lecture seule |
+| Validation humaine | ✅ Pas d’action |
+| Skill ou commande | ⚠️ Usage très étroit, pourrait être une commande |
+| Alignement risque | ✅ Faible |
+
+### Écarts identifiés
+
+**Écart critique** : L’issue #267 liste comme activité fréquente “faire une pr avec le code développer” (préparer/créer une PR). Or `my-pull-requests` ne fait que **lister** les PR existantes. Il n’existe aucun skill ni commande pour **créer** ou **préparer** une PR.
+
+**Recommandation** : Créer un nouveau skill (ou étendre `my-pull-requests`) dédié à la préparation et création de PR, capable de :
+- Lire le diff, le plan initial et les résultats de tests
+- Générer un résumé factuel des changements
+- Créer la PR sur le tracker avec titre, corps et labels
+
+---
+
+## Synthèse des écarts
+
+| Skill | Alignement | Écart | Priorité |
+|---|---|---|---|
+| `plan-depuis-issue` | ✅ Bon | Aucun | — |
+| `ecrire-plan-fichier` | ⚠️ Partiel | Opération mécanique → commande plutôt que skill | Faible |
+| `implementer-depuis-plan` | ✅ Bon | Aucun | — |
+| `to-issues` | ✅ Bon | Langue anglaise (mineur) | Très faible |
+| `my-pull-requests` | ❌ Décalé | Liste les PR mais ne permet pas d’en créer | **Élevée** |
+
+## Recommandations générales
+
+1. **Créer un skill “préparer/créer une PR”** pour couvrir l’usage manquant le plus critique.
+2. **Évaluer `ecrire-plan-fichier` comme future commande OpenCode** plutôt que skill, dans un ticket d’alignement des commandes.
+3. **Ne pas créer de skills pour les activités mécaniques** (lint, tests automatisés, exploration simple) — privilégier des commandes ou scripts.
+4. **Maintenir la séparation des rôles** dans les nouveaux skills : ne pas mélanger planification, implémentation et review dans le même skill.
+5. **Documenter l’exigence de langue française** pour les skills destinés à produire du contenu destiné au projet.

--- a/documentation/plan/llm/267-plan-doctrine-opencode-usages-frequents.md
+++ b/documentation/plan/llm/267-plan-doctrine-opencode-usages-frequents.md
@@ -1,0 +1,349 @@
+# Plan d'implémentation — OpenCode : valider la doctrine cible et la liste des usages fréquents
+
+**Issue** : [#267 — OpenCode - Valider la doctrine cible et la liste des usages frequents](https://github.com/herveDarritchon/foundryvtt-swerpg/issues/267)
+**ADR** : `documentation/architecture/adr/adr-0010-llm-code-ready.md`, `documentation/architecture/adr/adr-0012-unit-tests-readable-diagnostics.md`
+**Module(s) impacté(s)** : `documentation/cadrage/llm/cadrage-opencode-configuration.md` (modification), `.agents/skills/*/SKILL.md` (audit documentaire uniquement dans ce ticket, modification potentielle hors périmètre)
+
+---
+
+## 1. Objectif
+
+Formaliser une doctrine cible exploitable pour l'usage d'OpenCode dans le projet SWERPG, en priorisant les activités récurrentes, en leur associant un niveau de risque, un niveau d'autonomie acceptable et un type d'agent attendu.
+
+Le résultat attendu n'est pas une configuration exécutable, mais un cadre de décision stable pour les tickets suivants portant sur les commandes, skills, agents, permissions et garde-fous. Le ticket doit aussi vérifier si les skills déjà présents sont cohérents avec cette doctrine cible, sans commencer à les refondre.
+
+---
+
+## 2. Périmètre
+
+### Inclus dans cette US / ce ticket
+
+- Définir explicitement la doctrine cible OpenCode pour le projet.
+- Confirmer que la cible est une **orchestration assistée** et non une automatisation complète.
+- Produire une liste priorisée de **6 à 10 activités fréquentes**.
+- Associer à chaque activité :
+  - un niveau de risque ;
+  - un niveau d'autonomie acceptable ;
+  - un type d'agent ou de profil attendu ;
+  - le rôle attendu des skills, commandes et permissions.
+- Auditer les skills existants suivants au regard de la doctrine :
+  - `plan-depuis-issue`
+  - `ecrire-plan-fichier`
+  - `implementer-depuis-plan`
+  - `to-issues`
+  - `my-pull-requests`
+- Identifier les écarts entre usages cibles et outillage existant.
+- Préparer des recommandations structurantes pour les tickets d'orchestration suivants.
+
+### Exclu de cette US / ce ticket
+
+- Implémentation de commandes OpenCode.
+- Création ou modification effective des agents.
+- Changement de permissions ou de plugins.
+- Refactor direct des skills existants.
+- Automatisation d'un workflow complet de bout en bout.
+- Toute modification du code applicatif SWERPG.
+- Toute mise à jour de l'issue GitHub elle-même.
+
+---
+
+## 3. Constat sur l'existant
+
+### 3.1. Un cadrage doctrinal existe déjà
+
+Le document `documentation/cadrage/llm/cadrage-opencode-configuration.md` contient déjà la matière principale :
+
+- principe directeur d'affectation par coût / risque / complexité ;
+- séparation forte des rôles ;
+- importance des permissions ;
+- rôle distinct des skills, commandes, agents et plugins ;
+- rejet explicite de l'automatisation excessive ;
+- recommandation d'une **orchestration assistée** ;
+- recommandation de partir de **6 à 10 activités fréquentes**.
+
+Ce document constitue la source principale pour ce ticket.
+
+### 3.2. Les skills projet existent déjà mais ne forment pas encore une doctrine validée
+
+Le repo contient plusieurs skills locaux sous `.agents/skills/`, dont les plus pertinents ici :
+
+- `plan-depuis-issue`
+- `ecrire-plan-fichier`
+- `implementer-depuis-plan`
+- `to-issues`
+- `my-pull-requests`
+
+Ils matérialisent déjà des usages réels, mais ils n'ont pas encore été reliés explicitement à une cartographie commune du risque, de l'autonomie et du type d'agent.
+
+### 3.3. Un écart explicite existe autour de la PR
+
+L'issue cite comme activité fréquente : "faire une pr avec le code développer".
+Or le skill existant `my-pull-requests` sert aujourd'hui à **lister** les PR assignées, pas à **préparer/créer** une PR.
+
+Cet écart doit être documenté comme un problème de cohérence entre besoin d'usage et outillage actuel.
+
+### 3.4. Le projet possède déjà des garde-fous architecturaux réutilisables
+
+Même si l'issue ne concerne pas le code SWERPG directement, deux ADRs apportent une discipline utile :
+
+- `adr-0010-llm-code-ready.md` : formalise des garde-fous destinés aux agents et rappelle qu'un brief opérationnel n'est pas l'architecture complète.
+- `adr-0012-unit-tests-readable-diagnostics.md` : impose une exigence de lisibilité et de diagnostic utile, pertinente pour caractériser l'activité "tests".
+
+### 3.5. Le besoin est documentaire, pas technique
+
+Le ticket est étiqueté `documentation`, `architecture`, `epic`.
+Le besoin est de produire une base de pilotage et d'arbitrage, pas une configuration prématurée. Cela est cohérent avec le cadrage existant : "la configuration ne doit pas chercher à créer un système complexe pour le plaisir".
+
+---
+
+## 4. Décisions d'architecture
+
+### 4.1. Doctrine d'orchestration assistée vs automatisation complète
+
+**Question** : quel niveau d'autonomie cible faut-il valider ?
+
+**Options envisagées** :
+- Automatisation complète des workflows fréquents.
+- Orchestration assistée avec validation humaine sur les zones à risque.
+
+**Décision** : retenir l'**orchestration assistée** comme doctrine cible.
+
+**Justification** :
+- Le cadrage existant l'énonce explicitement.
+- Les activités à risque du projet incluent code, architecture, suppression, refactor et Git.
+- Cela évite de transformer trop tôt OpenCode en "agent tout-puissant".
+- Le ticket demande une base de décision stable, pas une délégation totale.
+
+### 4.2. Prioriser une matrice d'usages fréquents élargie à 6-10 activités
+
+**Question** : faut-il se limiter aux 5 activités citées dans l'issue ?
+
+**Options envisagées** :
+- Rester strictement sur les 5 activités listées.
+- Produire une matrice élargie cohérente avec le cadrage OpenCode.
+
+**Décision** : produire une matrice **élargie à 6-10 activités**.
+
+**Justification** :
+- Le document de cadrage recommande explicitement ce volume.
+- Les activités "tests", "revue", "diagnostic de bug" et "préparation de PR" sont structurellement récurrentes.
+- Une doctrine partielle serait trop faible pour guider les tickets suivants.
+
+### 4.3. Séparer doctrine d'usage et audit des skills
+
+**Question** : faut-il modifier les skills actuels dans ce ticket ?
+
+**Options envisagées** :
+- Corriger immédiatement les skills incohérents.
+- Se limiter à un audit documentaire et préparer les tickets suivants.
+
+**Décision** : faire un **audit de cohérence sans modification**.
+
+**Justification** :
+- L'issue vise une doctrine, pas une implémentation.
+- Le cadrage insiste sur la séparation des responsabilités.
+- Cette approche évite un mélange entre conception et exécution.
+
+### 4.4. Utiliser les skills comme porteurs de savoir, pas comme workflows complets
+
+**Question** : quelle place donner aux skills dans la doctrine ?
+
+**Options envisagées** :
+- Faire des skills le conteneur principal des workflows.
+- Réserver les skills au savoir projet et laisser les commandes porter les routines.
+
+**Décision** : confirmer que **les skills apportent le savoir projet**, tandis que **les commandes standardisent les routines**.
+
+**Justification** :
+- C'est la règle explicitée dans `documentation/cadrage/llm/cadrage-opencode-configuration.md`.
+- Cela évite des skills trop longs et trop directifs.
+- Cela permet de mieux relier risque, permission et type d'agent.
+
+### 4.5. Auditer les usages réels à partir des écarts de langage entre besoin et skill
+
+**Question** : comment détecter les incohérences les plus utiles ?
+
+**Options envisagées** :
+- Lire uniquement les noms des skills.
+- Comparer l'intention métier de l'issue avec la capacité réelle de chaque skill.
+
+**Décision** : auditer par **écart intention / capacité réelle**.
+
+**Justification** :
+- Le cas `my-pull-requests` montre qu'un nom ou une présence de skill ne suffit pas.
+- La doctrine doit porter sur des usages opérationnels réels, pas sur un inventaire superficiel.
+
+---
+
+## 5. Plan de travail détaillé
+
+### Étape 1 — Consolider la doctrine cible à partir du cadrage existant
+
+**Quoi faire** :
+- Extraire du document de cadrage les principes réellement normatifs.
+- Reformuler une doctrine courte et stable :
+  - orchestration assistée ;
+  - séparation des rôles ;
+  - permissions alignées sur le risque ;
+  - commandes pour les routines ;
+  - skills pour la connaissance durable.
+
+**Fichiers concernés** :
+- `documentation/cadrage/llm/cadrage-opencode-configuration.md`
+- futur plan dans `documentation/plan/llm/`
+
+**Risques spécifiques** :
+- Produire une doctrine redondante par rapport au cadrage.
+- Rester trop abstrait pour être exploitable.
+
+### Étape 2 — Définir la liste prioritaire des activités fréquentes
+
+**Quoi faire** :
+- Établir une matrice priorisée de 6 à 10 usages.
+- Recommandation de base pour la matrice :
+  - créer des issues depuis un cadrage ;
+  - créer un plan depuis une issue ;
+  - écrire un plan dans `documentation/plan/` ;
+  - implémenter un plan ;
+  - diagnostiquer/corriger un bug ;
+  - exécuter et analyser des tests ;
+  - relire un diff ;
+  - préparer/créer une PR ;
+  - mettre à jour une documentation projet ;
+  - lancer des vérifications mécaniques.
+
+**Fichiers concernés** :
+- futur plan
+- `documentation/cadrage/llm/cadrage-opencode-configuration.md`
+
+**Risques spécifiques** :
+- Liste trop large pour être utile.
+- Liste trop courte pour guider les prochains tickets.
+
+### Étape 3 — Associer risque, autonomie et type d'agent à chaque activité
+
+**Quoi faire** :
+- Pour chaque activité, préciser :
+  - niveau de risque : faible / moyen / élevé ;
+  - autonomie : lecture seule / exécution assistée / exécution avec validation humaine ;
+  - type d'agent : exploration, planification, implémentation, test, review, documentation ;
+  - besoin éventuel de skill spécialisé ;
+  - nécessité ou non d'une validation explicite.
+
+**Fichiers concernés** :
+- futur plan
+
+**Risques spécifiques** :
+- Confondre activité métier et choix d'outil.
+- Sous-estimer le risque Git / architecture / code.
+
+### Étape 4 — Auditer la cohérence des skills existants avec la doctrine
+
+**Quoi faire** :
+- Vérifier pour chaque skill :
+  - intention annoncée ;
+  - résultat attendu ;
+  - limites ;
+  - niveau d'autonomie implicite ;
+  - cohérence avec le rôle doctrinal attendu.
+- Identifier les écarts notables, par exemple :
+  - skill manquant pour préparer/créer une PR ;
+  - skill trop étroit ou mal nommé ;
+  - usage qui devrait être une commande plutôt qu'un skill.
+
+**Fichiers concernés** :
+- `.agents/skills/plan-depuis-issue/SKILL.md`
+- `.agents/skills/ecrire-plan-fichier/SKILL.md`
+- `.agents/skills/implementer-depuis-plan/SKILL.md`
+- `.agents/skills/to-issues/SKILL.md`
+- `.agents/skills/my-pull-requests/SKILL.md`
+
+**Risques spécifiques** :
+- Basculer vers une refonte de skills hors scope.
+- Juger un skill sur son nom plutôt que sur son contrat réel.
+
+### Étape 5 — Formaliser les écarts et les suites recommandées
+
+**Quoi faire** :
+- Produire une section claire :
+  - usages déjà couverts ;
+  - usages partiellement couverts ;
+  - usages non couverts ;
+  - ambiguïtés de vocabulaire ;
+  - tickets d'orchestration à ouvrir ensuite.
+
+**Fichiers concernés** :
+- futur plan
+
+**Risques spécifiques** :
+- Recommandations trop vagues.
+- Absence de priorisation exploitable.
+
+### Étape 6 — Définir un ordre de mise en oeuvre pour les tickets suivants
+
+**Quoi faire** :
+- Recommander un enchaînement logique :
+  1. doctrine et cartographie ;
+  2. alignement des commandes ;
+  3. alignement des skills ;
+  4. permissions ;
+  5. plugins/hooks transverses si nécessaire ;
+  6. mesure et ajustements.
+
+**Fichiers concernés** :
+- futur plan
+
+**Risques spécifiques** :
+- Démarrer par la technique avant la doctrine.
+- Créer une sur-orchestration trop tôt.
+
+---
+
+## 6. Fichiers modifiés
+
+| Fichier | Action | Description du changement |
+|---|---|---|
+| `documentation/plan/llm/267-plan-doctrine-opencode-usages-frequents.md` | création | Plan canonique de l'issue |
+| `documentation/cadrage/llm/cadrage-opencode-configuration.md` | modification potentielle ultérieure | Alignement ou extraction éventuelle d'une synthèse doctrinale après validation |
+| `.agents/skills/plan-depuis-issue/SKILL.md` | audit uniquement dans ce ticket | Vérifier cohérence avec rôle de planification sans modification |
+| `.agents/skills/ecrire-plan-fichier/SKILL.md` | audit uniquement dans ce ticket | Vérifier séparation planification / matérialisation |
+| `.agents/skills/implementer-depuis-plan/SKILL.md` | audit uniquement dans ce ticket | Vérifier cohérence avec autonomie assistée |
+| `.agents/skills/to-issues/SKILL.md` | audit uniquement dans ce ticket | Vérifier cohérence avec découpage vertical des tickets |
+| `.agents/skills/my-pull-requests/SKILL.md` | audit uniquement dans ce ticket | Documenter l'écart avec l'usage cible "préparer/créer une PR" |
+
+---
+
+## 7. Risques
+
+| Risque | Impact | Mitigation |
+|---|---|---|
+| La doctrine répète le cadrage existant sans valeur ajoutée | Document peu utile pour la suite | Produire une synthèse orientée décision et matrice d'usages |
+| La matrice des usages est trop large | Priorisation floue | Limiter à 6-10 usages réellement fréquents |
+| La matrice des usages est trop étroite | Doctrine insuffisante pour les prochains tickets | Inclure au minimum plan, issues, implémentation, tests, review, PR |
+| Confusion entre skill, commande, agent et plugin | Mauvais design des tickets suivants | Réserver à chaque notion un rôle explicite dans le plan |
+| Tentation de corriger les skills tout de suite | Dérive de scope | Limiter ce ticket à l'audit et aux recommandations |
+| Sous-estimation du risque des tâches Git et code | Automatisation excessive | Imposer validation humaine sur PR, code, architecture et opérations critiques |
+| Mauvais alignement entre besoin métier et outillage actuel | Doctrine théorique, peu actionnable | Documenter explicitement les écarts comme `my-pull-requests` vs création de PR |
+
+---
+
+## 8. Proposition d'ordre de commit
+
+1. `docs(opencode): formaliser la doctrine cible d'orchestration assistee`
+2. `docs(opencode): cartographier les usages frequents avec risque et autonomie`
+3. `docs(opencode): auditer la coherence des skills existants avec la doctrine`
+
+---
+
+## 9. Dépendances avec les autres US
+
+- Ce ticket est **amont** pour les futurs tickets de configuration OpenCode.
+- Les tickets suivants devraient dépendre de sa validation :
+  - commande ou workflow "préparer une issue" ;
+  - commande ou workflow "créer un plan depuis une issue" ;
+  - commande ou workflow "écrire un plan dans `documentation/plan/`" ;
+  - commande ou workflow "implémenter un plan" ;
+  - commande ou workflow "préparer/créer une PR" ;
+  - tickets d'alignement des permissions et garde-fous.
+- Aucun blocage technique identifié dans le repo actuel.
+- Blocage principal : validation humaine de la doctrine.


### PR DESCRIPTION
## Summary

Issue #267 — Valider et formaliser la doctrine cible OpenCode du projet SWERPG :

- **Doctrine cible** : orchestration assistée, séparation des rôles, permissions alignées sur le risque, skills pour le savoir / commandes pour les routines
- **Matrice des 10 usages fréquents** : chaque activité documentée avec niveau de risque, autonomie, type d'agent, skill existant et besoin de validation humaine
- **Audit des 5 skills existants** : `plan-depuis-issue` et `implementer-depuis-plan` alignés, `ecrire-plan-fichier` candidat commande, `my-pull-requests` en écart critique (liste les PR mais ne permet pas d'en créer)
- **Recommandations de suite** : ordre de mise en oeuvre en 6 phases pour les tickets d'orchestration suivants

## Files changed

- `documentation/cadrage/llm/cadrage-opencode-configuration.md` — ajout section 17 (doctrine, matrice, écarts, roadmap)
- `documentation/plan/llm/267-plan-doctrine-opencode-usages-frequents.md` — plan canonique
- `documentation/plan/llm/267-audit-skills-opencode.md` — audit détaillé des 5 skills

Closes #267