### PR TITLE
docs(opencode): cadrer le workflow d'exploration en lecture seule de bout en bout (issue #268)

### DIFF
--- a/documentation/cadrage/llm/cadrage-opencode-configuration.md
+++ b/documentation/cadrage/llm/cadrage-opencode-configuration.md
@@ -1242,3 +1242,88 @@ L’audit des skills existants (cf. documentation/plan/llm/267-audit-skills-open
 [2]: https://opencode.ai/docs/tools/?utm_source=chatgpt.com "Tools"
 [3]: https://opencode.ai/docs/commands/?utm_source=chatgpt.com "Commands"
 [4]: https://opencode.ai/docs/plugins/?utm_source=chatgpt.com "Plugins"
+
+---
+
+## 18. Workflow d'exploration en lecture seule — Issue #268
+
+Cette section formalise le workflow cible pour les demandes d'exploration en lecture seule, conformément à l'issue [#268](https://github.com/herveDarritchon/foundryvtt-swerpg/issues/268).
+
+### 18.1. Principe
+
+L'exploration en lecture seule est un workflow standardisé qui prend une intention utilisateur (comprendre, trouver, cartographier, vérifier) et produit une synthèse courte et sourcée, sans jamais modifier le code ni la documentation du projet.
+
+Elle est conçue pour être exécutée par un sous-agent `explore` avec un modèle économique ou local, sans capacité d'écriture.
+
+### 18.2. Intentions déclenchantes
+
+Le workflow d'exploration est adapté aux demandes suivantes :
+
+- comprendre une convention, une règle ou un pattern existant ;
+- trouver où se trouve un fichier, une classe, une fonction, une clé i18n ou un test ;
+- cartographier un module, un flux d'exécution ou une dépendance ;
+- préparer le terrain avant une planification ou une implémentation ;
+- vérifier un fait, une règle ou une décision documentée ;
+- comparer des approches existantes dans le code.
+
+### 18.3. Exclusions explicites
+
+Ne pas utiliser ce workflow pour :
+
+- planifier ou concevoir une solution ;
+- implémenter ou modifier du code ;
+- corriger un bug ;
+- relire un diff ou valider une PR ;
+- modifier de la documentation ;
+- lancer ou analyser des tests automatisés en continu.
+
+### 18.4. Agent et permissions
+
+| Propriété | Valeur |
+|---|---|
+| Type d'agent | `explore` |
+| Modèle cible | Économique ou local |
+| Autonomie | Lecture seule stricte |
+| Outils autorisés | Recherche fichiers, recherche textuelle, lecture fichiers, consultation web si explicitement demandée |
+| Interdits | Édition, écriture, tests non nécessaires, Git modifiant l'état, commandes destructrices |
+
+### 18.5. Contrat de sortie
+
+Toute restitution d'exploration doit contenir :
+
+1. **Résumé** de la demande comprise et du périmètre exploré.
+2. **Constatations principales** avec références de fichiers et lignes.
+3. **Points non résolus** ou zones d'incertitude, s'il y en a.
+4. **Recommandation d'étape suivante** : planification, implémentation, revue, documentation, ou fin.
+
+Règles de sobriété :
+
+- pas de longs logs bruts ;
+- pas de citations massives de code ;
+- pas de pseudo-plan d'implémentation ;
+- pas d'action non demandée ;
+- pas d'escalade vers un autre workflow sans mention explicite.
+
+### 18.6. Escalade
+
+Si la demande utilisateur dépasse le périmètre d'exploration, le workflow s'arrête et oriente vers :
+
+| Si la demande nécessite... | Orienter vers |
+|---|---|
+| Un plan d'implémentation | `plan-depuis-issue` |
+| De l'implémentation | `implementer-depuis-plan` |
+| Une revue de diff | Revue de code |
+| Un diagnostic de bug | Diagnostic / Correction |
+| Une mise à jour de documentation | Documentation |
+
+L'exploration ne doit pas franchir ces frontières de rôle sans instruction explicite.
+
+### 18.7. Variantes de profondeur
+
+| Profondeur | Périmètre typique | Temps estimé |
+|---|---|---|
+| Rapide | Un fichier, une convention, une référence | 1-2 min |
+| Moyenne | Un module, un flux, 3-5 fichiers | 3-5 min |
+| Approfondie | Architecture transverse, dépendances, 5-15 fichiers | 5-10 min |
+
+La profondeur est choisie par l'utilisateur ou inférée depuis l'intention exprimée.

--- a/documentation/plan/llm/268-plan-workflow-exploration-readonly.md
+++ b/documentation/plan/llm/268-plan-workflow-exploration-readonly.md
@@ -1,0 +1,342 @@
+# Plan d'implémentation — OpenCode : cadrer un workflow d'exploration en lecture seule de bout en bout
+
+**Issue** : [#268 — OpenCode - Cadrer un workflow d'exploration en lecture seule de bout en bout](https://github.com/herveDarritchon/foundryvtt-swerpg/issues/268)
+**ADR** : `documentation/architecture/adr/adr-0010-llm-code-ready.md`, `documentation/architecture/adr/adr-0012-unit-tests-readable-diagnostics.md`
+**Module(s) impacté(s)** : `documentation/cadrage/llm/cadrage-opencode-configuration.md` (modification), `documentation/spec/llm/opencode-exploration-readonly-command.md` (création), `documentation/spec/llm/opencode-exploration-readonly-scenarios.md` (création)
+
+---
+
+## 1. Objectif
+
+Définir un workflow complet pour les demandes d'exploration OpenCode, depuis l'intention utilisateur jusqu'au résultat restitué, avec un agent limité à la lecture, à la recherche et à la synthèse.
+
+Le résultat attendu est un cadre opérable et sobre qui :
+- traite de bout en bout une demande de compréhension sans aucune capacité d'écriture ;
+- explicite les limites de l'agent, le type de résultat attendu et le niveau de modèle visé ;
+- réduit le coût des tâches de lecture et de préparation sans dégrader la fiabilité ;
+- prépare une future commande OpenCode cohérente avec la doctrine validée en `#267`.
+
+---
+
+## 2. Périmètre
+
+### Inclus dans cette US / ce ticket
+
+- Formaliser le workflow cible d'exploration en lecture seule.
+- Définir les intentions utilisateur qui doivent router vers ce workflow.
+- Définir les permissions et limites du profil d'exploration.
+- Définir le contrat de sortie attendu :
+  - synthèse courte ;
+  - preuves et références de fichiers ;
+  - questions ouvertes ;
+  - critères d'escalade.
+- Définir le niveau de modèle cible :
+  - modèle économique ou local par défaut ;
+  - pas de modèle de raisonnement fort pour la simple exploration.
+- Définir la place du sous-agent `explore` dans ce workflow.
+- Définir une matrice de scénarios de validation manuelle.
+- Produire la spécification documentaire d'une future commande OpenCode d'exploration.
+
+### Exclu de cette US / ce ticket
+
+- Implémentation effective d'une commande OpenCode exécutable.
+- Création ou modification d'un skill dédié à l'exploration simple.
+- Création ou modification d'un agent d'implémentation.
+- Toute écriture de code applicatif SWERPG.
+- Toute modification de permissions runtime réelles hors documentation.
+- Toute automatisation d'escalade vers planification ou implémentation.
+- Toute mise à jour de l'issue GitHub elle-même.
+
+---
+
+## 3. Constat sur l'existant
+
+### 3.1. La doctrine cible existe déjà
+
+`documentation/cadrage/llm/cadrage-opencode-configuration.md` formalise déjà les règles structurantes utiles ici :
+- exploration = lecture, recherche, synthèse ;
+- une tâche de lecture doit avoir un accès en lecture seule ;
+- les commandes portent les routines ;
+- les skills portent le savoir projet ;
+- les modèles économiques suffisent pour l'exploration ;
+- la cible recommandée est une orchestration assistée.
+
+### 3.2. L'issue #267 a déjà tranché le positionnement doctrinal
+
+La section 17 du cadrage, issue de `#267`, classe explicitement l'exploration parmi les activités à faible risque et rappelle qu'il ne faut pas créer de skill pour les activités mécaniques ou l'exploration simple.
+
+Cela oriente fortement `#268` vers une **commande documentée**, et non vers un nouveau skill.
+
+### 3.3. Aucun artefact OpenCode local n'existe encore pour les commandes
+
+Le dépôt ne contient pas aujourd'hui :
+- de répertoire `.opencode/` ;
+- de répertoire `docs/agents/` ;
+- de fichier `AGENTS.md` projet ;
+- de convention locale déjà matérialisée pour stocker des commandes OpenCode.
+
+Le ticket doit donc d'abord cadrer le workflow et la spécification, sans présumer d'une implémentation technique déjà installée.
+
+### 3.4. Le dépôt possède déjà des patterns documentaires réutilisables
+
+Les zones existantes les plus cohérentes pour porter ce travail sont :
+- `documentation/cadrage/llm/` pour la doctrine ;
+- `documentation/spec/` pour une spécification opérable ;
+- `.github/prompts/` et `.github/chatmodes/` comme références de structuration d'artefacts assistants, sans les cibler directement dans ce ticket.
+
+### 3.5. Le niveau de modèle recommandé est déjà documenté
+
+Le cadrage OpenCode et le prompt `model-recommendation` convergent :
+- outils lecture seule => modèles économiques ou locaux ;
+- pas de modèle avancé pour une simple tâche de repérage ;
+- raisonnement fort réservé aux plans, arbitrages et revues critiques.
+
+### 3.6. Le ticket a une dépendance GitHub ambiguë
+
+L'issue mentionne un blocage par `#256`, mais la référence GitHub actuelle pointe vers une PR `talent-tree` sans lien apparent avec OpenCode ou le workflow d'exploration.
+
+Cette dépendance doit être clarifiée dans le plan comme risque documentaire, pas comme dépendance technique fiable.
+
+---
+
+## 4. Décisions d'architecture
+
+### 4.1. Commande documentée plutôt que skill dédié
+
+**Décision** : cadrer le workflow comme une future **commande OpenCode**, documentée dans le dépôt, et non comme un nouveau skill.
+
+**Options envisagées** :
+- créer un skill d'exploration ;
+- décrire une commande/routine d'exploration ;
+- rester purement théorique sans artefact cible.
+
+**Justification** :
+- la doctrine validée dit : commandes pour les routines, skills pour le savoir ;
+- l'audit `#267` recommande explicitement de ne pas créer de skill pour l'exploration simple ;
+- une commande est mieux adaptée à un flux standardisé entrée -> recherche -> synthèse.
+
+### 4.2. Sous-agent `explore` seul pour l'exécution
+
+**Décision** : retenir le sous-agent `explore` comme moteur exclusif du workflow d'exploration.
+
+**Options envisagées** :
+- agent général bridé ;
+- mix `general` / `explore` ;
+- `explore` seul.
+
+**Justification** :
+- l'objectif du ticket est précisément une activité bornée à la lecture ;
+- cela limite le risque de dérive de scope ;
+- cela rend le choix du modèle plus économique et plus prévisible ;
+- cela aligne mieux autonomie, coût et fiabilité.
+
+### 4.3. Sortie courte, sourcée, non verbeuse
+
+**Décision** : imposer une restitution courte avec preuves minimales :
+- réponse synthétique ;
+- références de fichiers et lignes pertinentes ;
+- éventuelles zones d'incertitude ;
+- proposition d'escalade seulement si nécessaire.
+
+**Justification** :
+- le cadrage OpenCode impose de ne pas noyer le contexte avec des sorties longues ;
+- ADR-0012 valorise des diagnostics lisibles et ciblés ;
+- l'exploration doit aider à décider, pas produire un dump brut.
+
+### 4.4. Escalade explicite vers planification ou implémentation
+
+**Décision** : le workflow d'exploration s'arrête dès que la demande nécessite :
+- arbitrage d'architecture ;
+- plan d'implémentation ;
+- modification de code ;
+- validation fonctionnelle large.
+
+**Justification** :
+- séparation stricte des rôles ;
+- prévention des dérives ;
+- conformité avec l'orchestration assistée validée par `#267`.
+
+### 4.5. Spécification documentaire avant matérialisation technique
+
+**Décision** : dans ce ticket, créer une spécification documentaire de la future commande et de ses scénarios de validation, sans figer encore un répertoire runtime OpenCode inexistant dans le repo.
+
+**Justification** :
+- le dépôt n'a pas encore de convention locale pour les commandes OpenCode ;
+- cela permet de livrer une décision exploitable sans inventer une intégration prématurée ;
+- la matérialisation technique pourra suivre dans un ticket d'alignement des commandes.
+
+---
+
+## 5. Plan de travail détaillé
+
+### Étape 1 — Consolider la doctrine d'exploration en lecture seule
+
+**Quoi faire** :
+- Extraire du cadrage OpenCode les règles normatives applicables à l'exploration.
+- Ajouter une section dédiée au workflow d'exploration :
+  - intention utilisateur ;
+  - permissions ;
+  - type d'agent ;
+  - niveau de modèle ;
+  - forme du résultat ;
+  - conditions d'escalade.
+
+**Fichiers à modifier** :
+- `documentation/cadrage/llm/cadrage-opencode-configuration.md`
+
+**Risques spécifiques** :
+- répéter la doctrine existante sans valeur ajoutée ;
+- rester trop abstrait pour être exécutable.
+
+### Étape 2 — Définir le contrat d'entrée du workflow
+
+**Quoi faire** :
+- Décrire précisément quels types de demandes doivent déclencher l'exploration.
+- Décrire les exclusions :
+  - demandes de plan ;
+  - demandes d'implémentation ;
+  - demandes de correction ;
+  - demandes de revue de diff.
+- Définir les variantes de profondeur attendues :
+  - rapide ;
+  - moyenne ;
+  - approfondie.
+
+**Fichiers à modifier** :
+- `documentation/spec/llm/opencode-exploration-readonly-command.md`
+
+**Risques spécifiques** :
+- frontière floue entre exploration et planification ;
+- sur-déclenchement du workflow pour des demandes non adaptées.
+
+### Étape 3 — Définir le contrat d'exécution du sous-agent
+
+**Quoi faire** :
+- Formaliser l'usage du sous-agent `explore`.
+- Décrire les outils autorisés en lecture :
+  - recherche de fichiers ;
+  - recherche textuelle ;
+  - lecture de fichiers ;
+  - consultation web si explicitement utile.
+- Décrire les interdits :
+  - édition de fichiers ;
+  - écriture de documentation ;
+  - commandes destructrices ;
+  - tests non nécessaires ;
+  - Git modifiant l'état du dépôt.
+
+**Fichiers à modifier** :
+- `documentation/spec/llm/opencode-exploration-readonly-command.md`
+
+**Risques spécifiques** :
+- oublier un garde-fou important ;
+- décrire un profil trop large, proche d'un agent général.
+
+### Étape 4 — Définir le contrat de sortie
+
+**Quoi faire** :
+- Définir le format minimal de restitution :
+  - résumé de la demande comprise ;
+  - constats principaux ;
+  - références factuelles ;
+  - points non résolus ;
+  - recommandation d'étape suivante.
+- Définir les règles de sobriété :
+  - pas de longs logs ;
+  - pas de citations massives ;
+  - pas de pseudo-plan caché ;
+  - pas d'action non demandée.
+
+**Fichiers à modifier** :
+- `documentation/spec/llm/opencode-exploration-readonly-command.md`
+
+**Risques spécifiques** :
+- sortie trop bavarde ;
+- sortie trop pauvre pour être utile ;
+- confusion entre synthèse et plan d'action.
+
+### Étape 5 — Définir la matrice d'escalade
+
+**Quoi faire** :
+- Décrire quand l'exploration doit s'arrêter et orienter vers :
+  - planification ;
+  - implémentation ;
+  - revue ;
+  - test ;
+  - documentation.
+- Donner des exemples concrets de routage.
+
+**Fichiers à modifier** :
+- `documentation/spec/llm/opencode-exploration-readonly-command.md`
+- `documentation/spec/llm/opencode-exploration-readonly-scenarios.md`
+
+**Risques spécifiques** :
+- laisser l'agent franchir trop facilement la frontière de rôle ;
+- escalade trop tardive.
+
+### Étape 6 — Définir les scénarios de validation manuelle
+
+**Quoi faire** :
+- Rédiger 6 à 10 scénarios représentatifs couvrant :
+  - compréhension de convention ;
+  - cartographie d'un module ;
+  - identification de fichiers concernés ;
+  - préparation d'un futur plan ;
+  - refus correct d'une demande d'écriture ;
+  - escalade correcte vers un autre workflow.
+- Associer à chaque scénario :
+  - entrée ;
+  - comportement attendu ;
+  - format de sortie attendu ;
+  - critère d'acceptation.
+
+**Fichiers à modifier** :
+- `documentation/spec/llm/opencode-exploration-readonly-scenarios.md`
+
+**Risques spécifiques** :
+- validation trop théorique ;
+- scénarios non représentatifs des usages réels.
+
+---
+
+## 6. Fichiers modifiés
+
+| Fichier | Action | Description du changement |
+|---|---|---|
+| `documentation/plan/llm/268-plan-workflow-exploration-readonly.md` | création | Plan canonique de l'issue |
+| `documentation/cadrage/llm/cadrage-opencode-configuration.md` | modification | Ajout d'une section normative dédiée au workflow d'exploration en lecture seule |
+| `documentation/spec/llm/opencode-exploration-readonly-command.md` | création | Spécification opérable de la future commande OpenCode d'exploration |
+| `documentation/spec/llm/opencode-exploration-readonly-scenarios.md` | création | Scénarios de validation manuelle et matrice d'escalade |
+
+---
+
+## 7. Risques
+
+| Risque | Impact | Mitigation |
+|---|---|---|
+| Confondre exploration et planification | L'agent commence à proposer ou imposer une solution | Définir des critères d'entrée/sortie et une matrice d'escalade explicite |
+| Créer un skill au lieu d'une commande | Désalignement avec la doctrine `#267` | Rappeler explicitement la règle "commandes pour les routines" |
+| Décrire un agent trop puissant | Dérive de scope et coût excessif | Imposer `explore` seul, lecture seule stricte, modèle économique |
+| Sortie trop verbeuse | Coût élevé et faible lisibilité | Fixer un contrat de restitution court et sourcé |
+| Sortie insuffisamment étayée | Baisse de fiabilité | Exiger références de fichiers et éléments vérifiés |
+| Absence de convention locale pour stocker les commandes OpenCode | Blocage d'implémentation ultérieure | Livrer d'abord une spécification documentaire indépendante du runtime |
+| Dépendance `#256` incohérente | Mauvaise lecture des prérequis | Documenter la dépendance comme ambiguë et demander clarification avant implémentation runtime |
+| Validation trop théorique | Workflow non fiable en pratique | Prévoir une batterie de scénarios manuels représentatifs |
+
+---
+
+## 8. Proposition d'ordre de commit
+
+1. `docs(opencode): formaliser le workflow d'exploration en lecture seule`
+2. `docs(opencode): specifier la commande d'exploration et son contrat de sortie`
+3. `docs(opencode): ajouter les scenarios de validation du workflow d'exploration`
+
+---
+
+## 9. Dépendances avec les autres US
+
+- Ce ticket dépend conceptuellement de la doctrine validée par `#267`.
+- Ce ticket est amont pour un futur ticket d'alignement des commandes OpenCode.
+- Ce ticket est amont pour un futur ticket de définition des permissions runtime par type d'agent.
+- Ce ticket est amont pour tout workflow "préparer un plan", "diagnostiquer", "review" ou "préparer une PR" nécessitant un routage depuis une phase d'exploration.
+- La référence "Blocked by #256" doit être clarifiée, car l'objet actuellement résolu par GitHub ne semble pas lié au périmètre OpenCode.

--- a/documentation/spec/llm/opencode-exploration-readonly-command.md
+++ b/documentation/spec/llm/opencode-exploration-readonly-command.md
@@ -1,0 +1,132 @@
+# Spécification — Commande OpenCode d'exploration en lecture seule
+
+**Issue** : [#268 — OpenCode - Cadrer un workflow d'exploration en lecture seule de bout en bout](https://github.com/herveDarritchon/foundryvtt-swerpg/issues/268)
+**Doctrine de référence** : `documentation/cadrage/llm/cadrage-opencode-configuration.md` (section 18)
+
+---
+
+## 1. Objectif
+
+Cette spécification décrit la future commande OpenCode d'exploration en lecture seule. Elle formalise le contrat d'entrée, le contrat d'exécution, le contrat de sortie et la matrice d'escalade, sans présumer de l'emplacement exact de stockage des commandes dans le dépôt (`.opencode/`, `docs/agents/`, ou autre — à définir dans un ticket d'alignement technique).
+
+---
+
+## 2. Contrat d'entrée
+
+### 2.1. Types de demandes éligibles
+
+La commande est déclenchée pour les intentions suivantes :
+
+- **Comprendre** : « Où est définie la fonction X ? », « Comment fonctionne le flux Y ? »
+- **Trouver** : « Quel fichier contient la config des armes ? », « Où est la clé i18n pour Z ? »
+- **Cartographier** : « Quels sont les fichiers du module d'import OggDude ? », « Quelle est la structure du dossier `module/models/` ? »
+- **Vérifier** : « Est-ce que la règle X est appliquée dans le code ? », « Y a-t-il un test pour Y ? »
+- **Préparer** : « Avant de planifier, j'aimerais comprendre comment sont organisés les talents. »
+
+### 2.2. Types de demandes exclues
+
+La commande refuse ou redirige les demandes suivantes :
+
+- **Planifier** : « Fais un plan pour implémenter X » → escalade vers `plan-depuis-issue`
+- **Implémenter** : « Ajoute la fonction X dans le fichier Y » → escalade vers `implementer-depuis-plan`
+- **Corriger** : « Corrige le bug dans Z » → escalade vers diagnostic / correction
+- **Revue** : « Relis ce diff » → escalade vers revue de code
+- **Écrire** : « Ajoute cette section dans la doc » → escalade vers documentation
+
+### 2.3. Variantes de profondeur
+
+| Profondeur | Usage typique | Sortie attendue |
+|---|---|---|
+| `explore --quick` | Question ponctuelle (une convention, un fichier) | 1-3 phrases + référence fichier:ligne |
+| `explore` (moyen, défaut) | Cartographie d'un module, compréhension d'un flux | 3-8 constats + fichier:ligne + résumé |
+| `explore --deep` | Architecture transverse, dépendances, historique | Synthèse structurée avec sections |
+
+---
+
+## 3. Contrat d'exécution
+
+### 3.1. Sous-agent
+
+La commande utilise exclusivement le sous-agent `explore`. Aucun autre type d'agent (general, planification, implémentation) n'est autorisé dans ce workflow.
+
+### 3.2. Outils autorisés
+
+- Recherche de fichiers (glob)
+- Recherche textuelle (grep, regex)
+- Lecture de fichiers (read, avec offset/limit)
+- Consultation web (fetch, search) — seulement si explicitement utile à la demande
+
+### 3.3. Interdits
+
+- Édition ou écriture de fichiers (write, edit)
+- Création ou suppression de fichiers ou dossiers
+- Exécution de tests non nécessaires à l'exploration
+- Commandes Git modifiant l'état du dépôt (commit, push, branch, merge, rebase)
+- Commandes destructrices (rm, mv, chmod, etc.)
+- Skills de planification ou d'implémentation (plan-depuis-issue, implementer-depuis-plan)
+- Écriture de documentation
+
+### 3.4. Modèle cible
+
+Modèle économique ou local. Pas de modèle de raisonnement avancé pour la simple exploration.
+
+---
+
+## 4. Contrat de sortie
+
+### 4.1. Format minimal
+
+```markdown
+## Résumé
+
+<2-3 phrases décrivant la demande comprise et le périmètre exploré>
+
+## Constats
+
+- **Constat 1** : description courte — `fichier.mjs:42`
+- **Constat 2** : description courte — `fichier.mjs:85-92`
+- ...
+
+## Points non résolus
+
+- <question ouverte s'il y en a>
+
+## Suite recommandée
+
+- <planification | implémentation | revue | documentation | fin>
+```
+
+### 4.2. Règles de sobriété
+
+- Pas de logs bruts ou de sorties de commande non filtrées.
+- Pas de citations massives de code (max 5 lignes par citation, sauf nécessité justifiée).
+- Pas de plan d'implémentation déguisé en synthèse.
+- Pas d'action non demandée (exemple : ne pas commencer à implémenter sous prétexte d'exploration).
+- Si la demande dépasse le périmètre d'exploration, le signaler dans « Suite recommandée » sans franchir la frontière.
+
+---
+
+## 5. Matrice d'escalade
+
+| Condition d'escalade | Destination | Condition de déclenchement |
+|---|---|---|
+| La demande nécessite un plan d'implémentation | `plan-depuis-issue` | L'utilisateur demande explicitement une stratégie d'intervention |
+| La demande nécessite du code | `implementer-depuis-plan` | L'utilisateur demande une modification du code source |
+| La demande nécessite un diagnostic de bug | Diagnostic / Correction | L'utilisateur signale un comportement inattendu ou une erreur |
+| La demande nécessite une revue de diff | Revue de code | L'utilisateur fournit un diff ou une PR à relire |
+| La demande nécessite une mise à jour de documentation | Documentation | L'utilisateur demande d'écrire ou de modifier un fichier `.md` |
+| Aucune des conditions ci-dessus | Fin | L'exploration a répondu à la question |
+
+L'escalade n'est jamais automatique. Le workflow signale la recommandation et attend une instruction explicite.
+
+---
+
+## 6. Emplacement futur
+
+La commande sera matérialisée dans l'emplacement défini par le futur ticket d'alignement des commandes OpenCode. Les candidats possibles sont :
+
+- `.opencode/commands/explore.mjs` (si le dépôt adopte `.opencode/`)
+- `docs/agents/explore-command.md` (si le dépôt privilégie une approche documentaire)
+- tout autre emplacement validé par la configuration OpenCode projet
+
+Cette spécification sert de source de vérité fonctionnelle, indépendante de l'emplacement technique final.

--- a/documentation/spec/llm/opencode-exploration-readonly-scenarios.md
+++ b/documentation/spec/llm/opencode-exploration-readonly-scenarios.md
@@ -1,0 +1,220 @@
+# Scénarios de validation — Commande OpenCode d'exploration en lecture seule
+
+**Issue** : [#268 — OpenCode - Cadrer un workflow d'exploration en lecture seule de bout en bout](https://github.com/herveDarritchon/foundryvtt-swerpg/issues/268)
+**Doctrine de référence** : `documentation/cadrage/llm/cadrage-opencode-configuration.md` (section 18)
+**Spécification** : `documentation/spec/llm/opencode-exploration-readonly-command.md`
+
+---
+
+## Scénario 1 — Compréhension d'une convention
+
+**Entrée** : « Où est définie la fonction `calcSkillRank` et combien de paramètres prend-elle ? »
+
+**Comportement attendu** :
+- Recherche de la fonction par grep textuel.
+- Lecture du fichier contenant la définition.
+- Lecture du contexte proche pour identifier les paramètres.
+
+**Format de sortie attendu** :
+```markdown
+## Résumé
+Recherche de `calcSkillRank` dans le codebase. La fonction est définie dans `module/lib/skill-ranks.mjs`.
+
+## Constats
+- Fichier : `module/lib/skill-ranks.mjs:12`
+- Signature : `calcSkillRank(actor, skillId, options)`
+- 3 paramètres : `actor` (SwerpgActor), `skillId` (string), `options` (object optionnel)
+
+## Suite recommandée
+Fin — la question est résolue.
+```
+
+**Critère d'acceptation** : la sortie contient le fichier, la ligne et la signature réels.
+
+---
+
+## Scénario 2 — Cartographie d'un module
+
+**Entrée** : « Liste tous les fichiers du module `module/importer/` et leur rôle principal. »
+
+**Comportement attendu** :
+- Recherche par glob de tous les fichiers dans `module/importer/`.
+- Analyse rapide du rôle de chaque fichier (par le nom, les exports, ou l'en-tête).
+
+**Format de sortie attendu** :
+```markdown
+## Résumé
+Cartographie du module `module/importer/` (N fichiers).
+
+## Constats
+- `module/importer/items/weapon-ogg-dude.mjs` — Import des armes OggDude
+- `module/importer/items/armor-ogg-dude.mjs` — Import des armures OggDude
+- `module/importer/items/gear-ogg-dude.mjs` — Import de l'équipement OggDude
+- ...
+
+## Suite recommandée
+Fin — la cartographie est complète.
+```
+
+**Critère d'acceptation** : chaque fichier est listé avec un rôle correctement identifié.
+
+---
+
+## Scénario 3 — Identification de fichiers concernés
+
+**Entrée** : « Quels fichiers faut-il modifier pour ajouter un nouveau type de compétence ? »
+
+**Comportement attendu** :
+- Recherche des fichiers qui définissent les types de compétences.
+- Analyse des fichiers de config, data model, et templates concernés.
+- Synthèse documentaire sans proposition de plan.
+
+**Format de sortie attendu** :
+```markdown
+## Résumé
+Identification des fichiers impactés par l'ajout d'un type de compétence.
+
+## Constats
+- `module/config/attributes.mjs` — Définition des types de compétences existants
+- `module/models/actor-type.mjs` — Data model contenant les skills
+- `templates/sheets/partials/_skills.hbs` — Template d'affichage
+- `lang/en.json` et `lang/fr.json` — Clés i18n des types
+
+## Suite recommandée
+Planification — un plan d'implémentation serait utile avant de modifier ces fichiers.
+```
+
+**Critère d'acceptation** : la liste inclut au moins les fichiers de config, modèle et templates.
+
+---
+
+## Scénario 4 — Vérification d'une règle documentée
+
+**Entrée** : « Vérifie que l'ADR-0011 est bien respectée dans le code actuel. »
+
+**Comportement attendu** :
+- Lecture de l'ADR-0011 pour identifier la règle.
+- Recherche dans le code des patterns conformes ou non conformes.
+- Synthèse factuelle.
+
+**Format de sortie attendu** :
+```markdown
+## Résumé
+Vérification de l'application d'ADR-0011 dans le code.
+
+## Constats
+- L'ADR impose le stockage dans `flags.swerpg.logs` : ✅ respecté dans `module/utils/audit-log.mjs`
+- Aucune écriture directe dans `system.*` pour les logs : ✅ vérifié
+- ...
+
+## Suite recommandée
+Fin — la règle est correctement appliquée.
+```
+
+**Critère d'acceptation** : la sortie cite des fichiers et lignes précis avec verdict ✅/❌.
+
+---
+
+## Scénario 5 — Refus correct d'une demande d'écriture
+
+**Entrée** : « Trouve où est défini le seuil de blessure et ajoute un commentaire pour le documenter. »
+
+**Comportement attendu** :
+- Identification du fichier contenant le seuil de blessure.
+- Refus explicite de modifier le fichier.
+- Proposition d'escalade vers documentation ou implémentation.
+
+**Format de sortie attendu** :
+```markdown
+## Résumé
+Recherche du seuil de blessure effectuée. La demande d'écriture est hors périmètre.
+
+## Constats
+- Fichier : `module/lib/soak.mjs:24`
+- La constante `WOUND_THRESHOLD` est définie ici.
+
+## Suite recommandée
+Cette demande nécessite une écriture de code ou de documentation, ce qui dépasse le périmètre d'exploration. Merci de reformuler avec :
+- `plan-depuis-issue` pour planifier l'ajout de documentation
+- `implementer-depuis-plan` pour implémenter le changement
+```
+
+**Critère d'acceptation** : le constat est fourni mais le fichier n'est pas modifié.
+
+---
+
+## Scénario 6 — Escalade correcte vers planification
+
+**Entrée** : « J'aimerais ajouter un nouveau type d'item. Fais-moi un plan. »
+
+**Comportement attendu** :
+- Identification des fichiers concernés par l'ajout (exploration).
+- Refus de produire le plan dans le workflow d'exploration.
+- Escalade vers `plan-depuis-issue`.
+
+**Format de sortie attendu** :
+```markdown
+## Résumé
+Analyse exploratoire du périmètre « ajouter un nouveau type d'item ».
+
+## Constats
+- Les types d'items sont enregistrés dans `module/config/system.mjs`
+- Chaque type a un data model dans `module/models/`
+- ...
+
+## Suite recommandée
+Cette demande nécessite une planification. Utilise `plan-depuis-issue` avec le résultat de cette exploration.
+```
+
+**Critère d'acceptation** : l'exploration livre ses constats puis oriente vers le skill de planification.
+
+---
+
+## Scénario 7 — Demande hors sujet
+
+**Entrée** : « Quelle est la météo aujourd'hui ? »
+
+**Comportement attendu** :
+- Constat que la question ne relève pas du projet SWERPG.
+- Réponse explicite sur les limites du périmètre.
+
+**Format de sortie attendu** :
+```markdown
+Cette question ne concerne pas le codebase SWERPG. Le workflow d'exploration est limité à l'analyse du projet. Je ne peux pas répondre à cette demande.
+```
+
+**Critère d'acceptation** : pas de tentative de réponse hors périmètre, pas de perte de temps sur une recherche externe.
+
+---
+
+## Scénario 8 — Escalade vers implémentation
+
+**Entrée** : « Maintenant que tu as trouvé le fichier, ajoute la fonction manquante. »
+
+**Comportement attendu** :
+- Constat qu'une exploration a déjà eu lieu.
+- Refus d'implémenter dans le workflow d'exploration.
+- Escalade vers `implementer-depuis-plan`.
+
+**Format de sortie attendu** :
+```markdown
+## Suite recommandée
+Cette demande nécessite une implémentation, ce qui dépasse le périmètre d'exploration. Utilise `implementer-depuis-plan` avec un plan préalable.
+```
+
+**Critère d'acceptation** : pas de code écrit, escalade claire.
+
+---
+
+## Résumé des cas couverts
+
+| # | Type | Périmètre |
+|---|---|---|
+| 1 | Compréhension de convention | Recherche ciblée, lecture de code |
+| 2 | Cartographie de module | Glob, analyse de rôle des fichiers |
+| 3 | Identification de fichiers impactés | Recherche transverse, synthèse |
+| 4 | Vérification de règle documentée | ADR vs code réel, verdict |
+| 5 | Refus de demande d'écriture | Blocage correct sans modification |
+| 6 | Escalade vers planification | Constats + routage |
+| 7 | Demande hors sujet | Refus poli, pas d'action |
+| 8 | Escalade vers implémentation | Refus + routage |


### PR DESCRIPTION
## Summary

Cadre complet du workflow d'exploration en lecture seule pour OpenCode dans le projet SWERPG, depuis l'intention utilisateur jusqu'au résultat restitué, avec un sous-agent `explore` strictement limité à la lecture.

## Changements

- **`documentation/cadrage/llm/cadrage-opencode-configuration.md`** — Ajout section 18 normative : workflow d'exploration (intentions, exclusions, agent/permissions, contrat sortie, escalade, profondeur)
- **`documentation/spec/llm/opencode-exploration-readonly-command.md`** — Spécification opérable de la future commande : contrat entrée, exécution sous-agent `explore`, contrat sortie, matrice d'escalade, emplacement futur
- **`documentation/spec/llm/opencode-exploration-readonly-scenarios.md`** — 8 scénarios de validation manuelle (compréhension, cartographie, vérification ADR, refus d'écriture, escalade vers planification/implémentation, demande hors sujet)
- **`documentation/plan/llm/268-plan-workflow-exploration-readonly.md`** — Plan d'implémentation de l'issue

## Décisions d'architecture

1. **Commande documentée, pas skill** — Conforme à la doctrine #267 (commandes pour les routines, skills pour le savoir)
2. **Sous-agent `explore` seul** — Périmètre strictement lecture seule, pas de dérive de scope
3. **Sortie courte et sourcée** — Synthèse + références fichier:ligne, pas de logs bruts
4. **Escalade explicite** — Pas de franchissement automatique des frontières de rôle
5. **Spécification documentaire d'abord** — Indépendante de l'emplacement runtime final

## Validation

- 4 fichiers, 779 lignes ajoutées
- Documentation uniquement (aucun code applicatif touché)

Closes #268