### PR TITLE
docs(opencode): cadrer le workflow de planification en lecture seule sans ecriture de code (issue #269)

### DIFF
--- a/.agents/skills/plan-depuis-issue/SKILL.md
+++ b/.agents/skills/plan-depuis-issue/SKILL.md
@@ -1,15 +1,16 @@
 ---
 name: plan-depuis-issue
 description: >
-  Génère un plan d'implémentation technique détaillé à partir d'une issue GitHub
-  pour le système Foundry VTT SWERPG. À utiliser quand l'utilisateur demande de
-  créer un plan, une spec technique, ou un découpage pour une issue ou une user
-  story. Déclenche-toi aussi quand l'utilisateur parle de "planifier", "découper",
-  "splitter", "implémenter", ou "tech lead" une issue. Le skill produit un
-  document structuré dans `documentation/plan/` qui respecte le format, l'architecture
-  et les conventions du projet. N'hésite PAS à proposer ce skill dès que
-  l'utilisateur évoque une issue en demandant comment l'aborder — même s'il ne
-  demande pas explicitement un plan.
+  Génère un plan d'implémentation technique détaillé et validé à partir d'une
+  issue GitHub pour le système Foundry VTT SWERPG. À utiliser quand l'utilisateur
+  demande de créer un plan, une spec technique, ou un découpage pour une issue ou
+  une user story. Déclenche-toi aussi quand l'utilisateur parle de "planifier",
+  "découper", "splitter", "implémenter", ou "tech lead" une issue. Le skill
+  produit un plan validé comme message structuré en suivant le format canonique
+  du projet. L'écriture du plan dans `documentation/plan/` et l'implémentation
+  sont des étapes séparées. N'hésite PAS à proposer ce skill dès que l'utilisateur
+  évoque une issue en demandant comment l'aborder — même s'il ne demande pas
+  explicitement un plan.
 license: project-internal
 compatibility:
   - claude-code
@@ -31,10 +32,12 @@ Utilise ce skill quand l'utilisateur te demande de créer un plan d'implémentat
 ## 1. Règles absolues
 
 1. **Ne jamais écrire une ligne de code d'implémentation.** Un plan décrit ce qu'il faut faire, pas le code final.
-2. **Toujours lire les plans existants** dans `documentation/plan/` avant d'écrire pour t'inspirer du format et du niveau de détail.
+2. **Toujours lire les plans existants** dans `documentation/plan/` avant d'écrire pour t'inspirer du format et du niveau de détail. Ne pas produire de fichier dans le repo : livrer le plan comme message validé.
 3. **Toujours lire les ADRs** dans `documentation/architecture/adr/` qui concernent le périmètre de l'issue.
 4. **Ne pas modifier le code existant** — le plan peut recommander des modifications, mais ne les applique pas.
 5. **Ne pas modifier les issues GitHub** — le plan est un document de travail, pas un outil de gestion de projet.
+6. **Ne pas élargir le périmètre de l'issue.** Le plan doit refléter l'issue et les arbitrages utilisateur, pas une feuille de route opportuniste.
+7. **Ne pas matérialiser automatiquement le plan dans le dépôt.** L'écriture dans `documentation/plan/` est une étape séparée, via `ecrire-plan-fichier`.
 
 ---
 
@@ -88,9 +91,9 @@ Avant de rédiger la version finale, résume les décisions prises et demande un
 
 ### 2.5. Rédiger le plan
 
-Produis un document dans `documentation/plan/<domaine>/<nom-du-plan>.md` en suivant le format standard.
+Produis un plan validé comme message structuré, en respectant le format canonique des plans existants dans `documentation/plan/`. L'écriture du plan dans le dépôt est une étape séparée : le plan est d'abord livré et validé dans la conversation. Une fois validé, l'utilisateur peut utiliser `ecrire-plan-fichier` pour le matérialiser.
 
-Le plan doit suivre la structure canonique des plans existants dans `documentation/plan/` :
+Le plan doit suivre la structure canonique :
 
 ```markdown
 # Plan d'implémentation — <Titre>
@@ -165,6 +168,9 @@ Avant de présenter le plan, vérifie :
 - [ ] Les risques sont identifiés avec des mitiations concrètes
 - [ ] Les fichiers impactés sont listés avec leur action (création/modification)
 - [ ] L'ordre de commit est réaliste
+- [ ] Aucun code d'implémentation n'est présent dans le plan
+- [ ] Le périmètre n'a pas été élargi au-delà de l'issue
+- [ ] Le plan est livré comme message validé, pas comme fichier dans le dépôt
 
 ---
 

--- a/documentation/cadrage/llm/cadrage-opencode-configuration.md
+++ b/documentation/cadrage/llm/cadrage-opencode-configuration.md
@@ -1327,3 +1327,100 @@ L'exploration ne doit pas franchir ces frontières de rôle sans instruction exp
 | Approfondie | Architecture transverse, dépendances, 5-15 fichiers | 5-10 min |
 
 La profondeur est choisie par l'utilisateur ou inférée depuis l'intention exprimée.
+
+---
+
+## 19. Workflow de planification en lecture seule — Issue #269
+
+Cette section formalise le workflow cible pour les demandes de planification d'implémentation, conformément à l'issue [#269](https://github.com/herveDarritchon/foundryvtt-swerpg/issues/269).
+
+### 19.1. Principe
+
+La planification est un workflow qui transforme une demande utilisateur (issue GitHub, URL, ou demande explicite) en **plan d'intervention structuré**, sans jamais implémenter, écrire dans le code source ni matérialiser automatiquement le plan dans le dépôt.
+
+Elle est conçue pour être exécutée par un agent de type **général / planification**, avec des permissions **lecture seule stricte** sur le code et le dépôt.
+
+### 19.2. Intentions déclenchantes
+
+Le workflow de planification est adapté aux demandes suivantes :
+
+- créer un plan depuis une issue GitHub ou une URL d'issue ;
+- créer un plan depuis une user story, une spécification ou un cadrage ;
+- créer un plan depuis un ticket technique (bug, refactor, feature) ;
+- découper une fonctionnalité complexe en étapes implémentables ;
+- analyser un périmètre et produire un plan avec décisions d'architecture, risques et ordre d'exécution.
+
+### 19.3. Exclusions explicites
+
+Ne pas utiliser ce workflow pour :
+
+- explorer ou comprendre du code existant (→ workflow d'exploration `#268`) ;
+- implémenter ou modifier du code ;
+- corriger un bug directement ;
+- écrire un fichier de plan dans `documentation/plan/` (→ étape séparée via `ecrire-plan-fichier`) ;
+- créer ou modifier des issues GitHub ;
+- relire un diff ou valider une PR.
+
+### 19.4. Agent et permissions
+
+| Propriété | Valeur |
+|---|---|
+| Type d'agent | Général / Planification |
+| Modèle cible | Standard ou économique selon la complexité du plan |
+| Autonomie | Lecture seule stricte (code et dépôt), avec capacité d'analyse forte |
+| Outils autorisés | Recherche fichiers, recherche textuelle, lecture fichiers, consultation web, questions à l'utilisateur |
+| Interdits | Édition, écriture, matérialisation automatique dans le repo, modification d'issue, élargissement du scope |
+
+### 19.5. Contrat de sortie
+
+Toute restitution de planification doit contenir :
+
+1. **Objectif** — Pourquoi ce plan ? Quel problème résout-il ?
+2. **Périmètre inclus / exclu** — Ce qui est couvert et ce qui est explicitement hors scope.
+3. **Constat sur l'existant** — Analyse de l'état actuel : ce qui existe, ce qui manque, les patterns en place.
+4. **Décisions d'architecture** — Chaque décision importante avec options envisagées, décision retenue et justification.
+5. **Plan de travail détaillé** — Découpage en étapes implémentables avec fichiers modifiés et risques spécifiques.
+6. **Fichiers modifiés** — Tableau fichier → action → description.
+7. **Risques** — Tableau risque → impact → mitigation.
+8. **Proposition d'ordre de commit** — Messages type conventional commit.
+9. **Dépendances** — Liens avec les autres US, tickets ou ADRs.
+
+Règles de sobriété :
+
+- pas de code d'implémentation dans le plan ;
+- pas d'élargissement du périmètre au-delà de l'issue ;
+- pas de décisions d'architecture implicites sans signalement ;
+- pas de matérialisation automatique du plan dans le dépôt ;
+- pas de transition automatique vers l'implémentation.
+
+### 19.6. Articulation avec les workflows voisins
+
+Le workflow de planification s'inscrit dans une chaîne explicite :
+
+```
+Exploration (#268) → Planification → Écriture du plan (ecrire-plan-fichier) → Implémentation (implementer-depuis-plan)
+```
+
+Règles de passage :
+
+- l'exploration ne planifie pas : elle prépare le terrain en livrant des constats ;
+- la planification n'écrit pas automatiquement dans le repo : elle livre un plan validé ;
+- l'implémentation exige un plan validé en amont ;
+- chaque transition est explicite et attend une instruction utilisateur.
+
+### 19.7. Garde-fous
+
+Le workflow de planification doit impérativement respecter les règles suivantes :
+
+1. **Pas de code** — Aucune ligne de code d'implémentation, même partielle.
+2. **Pas de doc écrite automatiquement** — Le plan est livré comme message, pas comme fichier dans le repo.
+3. **Pas de mise à jour d'issue** — Le plan ne modifie pas GitHub.
+4. **Pas d'élargissement du scope** — Le plan reflète l'issue et les arbitrages utilisateur, pas une feuille de route opportuniste.
+5. **Pas de choix d'architecture implicite** — Toute décision d'architecture doit être signalée et justifiée.
+6. **Pas de passage direct à l'implémentation** — Même si la solution est évidente, le workflow s'arrête au plan validé.
+
+### 19.8. Escalade depuis l'exploration
+
+Si une demande d'exploration révèle un besoin de planification, le workflow d'exploration s'arrête et oriente vers ce workflow de planification. Les constats de l'exploration sont transmis comme base de travail.
+
+L'escalade n'est jamais automatique. Le workflow signale la recommandation et attend une instruction explicite.

--- a/documentation/plan/llm/269-plan-workflow-planification-readonly.md
+++ b/documentation/plan/llm/269-plan-workflow-planification-readonly.md
@@ -1,0 +1,414 @@
+# Plan d'implémentation — OpenCode : cadrer un workflow de planification sans écriture de code
+
+**Issue** : [#269 — OpenCode - Cadrer un workflow de planification sans ecriture de code](https://github.com/herveDarritchon/foundryvtt-swerpg/issues/269)
+**ADR** : `documentation/architecture/adr/adr-0010-llm-code-ready.md`, `documentation/architecture/adr/adr-0012-unit-tests-readable-diagnostics.md`
+**Module(s) impacté(s)** : `documentation/cadrage/llm/cadrage-opencode-configuration.md` (modification), `documentation/spec/llm/opencode-planning-readonly-command.md` (création), `documentation/spec/llm/opencode-planning-readonly-scenarios.md` (création), `.agents/skills/plan-depuis-issue/SKILL.md` (modification ciblée)
+
+---
+
+## 1. Objectif
+
+Définir un workflow complet de planification OpenCode qui transforme une demande utilisateur en **plan d'intervention exploitable**, sans aucune capacité d'implémentation ni dérive de périmètre.
+
+Le résultat attendu est un cadre opérable qui :
+- cadre l'entrée, l'exécution et la sortie d'une demande de planification ;
+- interdit explicitement l'écriture de code et l'élargissement opportuniste du scope ;
+- garantit une sortie structurée couvrant périmètre, dépendances, risques, validations et ordre d'exécution ;
+- s'articule proprement avec la doctrine `#267`, le workflow d'exploration `#268` et le skill existant `plan-depuis-issue`.
+
+---
+
+## 2. Périmètre
+
+### Inclus dans cette US / ce ticket
+
+- Formaliser un workflow cible de planification OpenCode en lecture seule stricte côté code.
+- Définir les intentions utilisateur qui doivent router vers ce workflow.
+- Définir le contrat d'entrée :
+  - issue GitHub, URL, numéro d'issue, ou demande explicite de plan.
+- Définir le contrat d'exécution :
+  - lecture, recherche, analyse, synthèse, questions d'arbitrage.
+- Définir le contrat de sortie :
+  - objectif ;
+  - périmètre inclus/exclu ;
+  - constats sur l'existant ;
+  - décisions d'architecture ;
+  - étapes de travail ;
+  - fichiers visés ;
+  - risques ;
+  - validations attendues ;
+  - ordre de commit.
+- Définir les garde-fous explicites :
+  - pas d'implémentation ;
+  - pas d'élargissement du scope ;
+  - pas de modification d'issue ;
+  - pas de matérialisation automatique dans le repo.
+- Définir l'articulation entre :
+  - future commande OpenCode de planification ;
+  - skill `plan-depuis-issue` ;
+  - étape séparée d'écriture via `ecrire-plan-fichier`.
+- Produire une matrice de scénarios de validation manuelle.
+
+### Exclu de cette US / ce ticket
+
+- Implémentation effective d'une commande OpenCode exécutable.
+- Création d'un agent runtime spécifique si OpenCode n'en a pas encore la convention locale.
+- Écriture automatique du plan dans `documentation/plan/` à l'issue du workflow.
+- Toute modification du code applicatif SWERPG.
+- Toute automatisation d'implémentation après plan.
+- Toute mise à jour de l'issue GitHub elle-même.
+- Toute redéfinition du workflow d'exploration déjà cadré par `#268`.
+
+---
+
+## 3. Constat sur l'existant
+
+### 3.1. La doctrine OpenCode couvre déjà les principes structurants
+
+`documentation/cadrage/llm/cadrage-opencode-configuration.md` formalise déjà :
+- l'orchestration assistée ;
+- la séparation stricte des rôles ;
+- l'alignement des permissions sur le risque ;
+- la règle "commandes pour les routines, skills pour le savoir".
+
+La section 17 issue de `#267` classe déjà "Créer un plan depuis une issue" comme activité de **planification**, à risque **moyen**, avec validation humaine.
+
+### 3.2. Le workflow d'exploration existe déjà et doit escalader vers la planification
+
+La section 18 du cadrage et les documents issus de `#268` définissent déjà :
+- un workflow d'exploration en lecture seule ;
+- une frontière explicite avec la planification ;
+- une escalade manuelle vers `plan-depuis-issue`.
+
+Le ticket `#269` doit donc compléter cette chaîne, pas la réinventer.
+
+### 3.3. Le skill `plan-depuis-issue` apporte la méthode, mais pas encore le workflow OpenCode cible
+
+Le skill local `.agents/skills/plan-depuis-issue/SKILL.md` est déjà robuste :
+- lecture des plans existants ;
+- lecture des ADRs ;
+- exploration du codebase ;
+- questions d'arbitrage ;
+- format canonique du plan.
+
+Mais il présente un décalage avec le workflow cible retenu ici :
+- il parle encore de "produire un document structuré dans `documentation/plan/`" ;
+- il ne sépare pas explicitement la **production du plan validé** de sa **matérialisation dans le dépôt** ;
+- il n'énonce pas encore comme règle explicite l'interdiction d'**élargir le périmètre**.
+
+### 3.4. Une étape mécanique d'écriture existe déjà séparément
+
+Le skill `ecrire-plan-fichier` matérialise déjà un plan validé dans `documentation/plan/`.
+Cela confirme qu'il existe une séparation naturelle entre :
+- planifier ;
+- écrire le fichier ;
+- implémenter.
+
+Le ticket `#269` doit capitaliser sur cette séparation au lieu de la brouiller.
+
+### 3.5. Aucun artefact documentaire dédié au workflow de planification n'existe encore
+
+À ce stade, le repo contient :
+- une doctrine générale ;
+- un workflow d'exploration documenté ;
+- un skill de planification ;
+- un skill d'écriture de plan.
+
+En revanche, il manque encore :
+- une spécification documentaire explicite du workflow de planification OpenCode ;
+- une matrice de scénarios de validation ;
+- une clarification documentaire du rôle exact du skill dans ce workflow.
+
+### 3.6. La dépendance `Blocked by #256` n'est pas crédible techniquement
+
+Comme pour `#268`, la référence GitHub `#256` pointe vers une PR `talent-tree` sans lien apparent avec le périmètre OpenCode / documentation.
+
+Cette dépendance doit être traitée comme un **risque de traçabilité documentaire**, pas comme un blocage technique réel.
+
+---
+
+## 4. Décisions d'architecture
+
+### 4.1. Workflow porté par une commande documentée, pas par le skill seul
+
+**Question** : faut-il cadrer la planification comme simple évolution du skill `plan-depuis-issue`, ou comme un workflow OpenCode plus large ?
+
+**Options envisagées** :
+- faire évoluer uniquement le skill ;
+- cadrer une future commande OpenCode distincte ;
+- faire les deux.
+
+**Décision** : cadrer le workflow comme une future **commande OpenCode de planification**, tout en conservant `plan-depuis-issue` comme porteur de savoir méthodologique.
+
+**Justification** :
+- la doctrine `#267` dit explicitement : commandes pour les routines, skills pour le savoir ;
+- la planification est un workflow récurrent, donc bonne candidate pour une commande ;
+- le skill existant reste utile pour injecter méthode, format et conventions projet ;
+- cela évite de transformer un skill en pseudo-orchestrateur général.
+
+### 4.2. Agent de planification en lecture seule stricte, avec capacité d'analyse forte
+
+**Décision** : le workflow de planification doit utiliser un agent de type **général / planification**, mais avec permissions **lecture seule stricte** sur le code et le dépôt.
+
+**Justification** :
+- contrairement à l'exploration simple, la planification exige synthèse, arbitrage et structuration ;
+- la doctrine réserve les modèles plus capables aux plans complexes ;
+- l'interdiction d'écriture supprime le principal risque de dérive d'un agent plus puissant ;
+- cela sépare nettement "penser" de "faire".
+
+### 4.3. Le workflow s'arrête au plan validé, pas à l'écriture du fichier
+
+**Options envisagées** :
+- arrêter le workflow à la restitution du plan validé ;
+- inclure aussi la création du fichier Markdown dans `documentation/plan/`.
+
+**Décision** : arrêter le workflow de planification au **plan validé**.
+
+**Justification** :
+- l'écriture du fichier est déjà couverte par une étape dédiée (`ecrire-plan-fichier`) ;
+- cela renforce la séparation des responsabilités ;
+- cela maintient le workflow de planification dans un mode strictement non-modificateur ;
+- cela évite qu'une demande de planification crée automatiquement un artefact repo sans validation explicite.
+
+### 4.4. Interdire explicitement l'élargissement du périmètre
+
+**Décision** : le workflow doit contenir une règle explicite de **non-extension du scope**.
+
+**Justification** :
+- l'acceptance criterion `#269` l'exige ;
+- un agent de planification a naturellement tendance à "compléter" un sujet ;
+- le plan doit refléter l'issue et les arbitrages utilisateur, pas une feuille de route opportuniste ;
+- cela protège la traçabilité entre issue, plan et implémentation.
+
+### 4.5. La sortie doit être un plan d'intervention, pas une simple synthèse
+
+**Décision** : la sortie minimale doit imposer une structure de plan proche du format canonique déjà utilisé dans `documentation/plan/`.
+
+**Justification** :
+- un simple résumé serait insuffisant pour l'implémentation ultérieure ;
+- le projet possède déjà un format éprouvé ;
+- la cohérence documentaire facilitera ensuite l'écriture de fichier si elle est demandée.
+
+### 4.6. L'escalade depuis l'exploration et vers l'écriture/implémentation reste manuelle
+
+**Décision** : aucune transition ne doit être automatique.
+
+Le workflow doit :
+- accepter une escalade depuis l'exploration ;
+- proposer l'écriture du plan ou l'implémentation comme suites possibles ;
+- attendre une instruction explicite avant tout changement d'étape.
+
+**Justification** :
+- cohérence avec l'orchestration assistée ;
+- prévention des enchaînements implicites ;
+- réduction du risque de confusion entre lire, planifier, écrire, coder.
+
+### 4.7. Le skill `plan-depuis-issue` doit être réaligné sur le workflow cible
+
+**Décision** : ajuster le skill pour expliciter que :
+- son rôle est de produire un **plan validé** ;
+- l'écriture du fichier est une étape séparée ;
+- il ne doit ni coder ni étendre le périmètre.
+
+**Justification** :
+- aujourd'hui, le skill mélange légèrement planification et matérialisation ;
+- sans cet alignement, la doctrine et la réalité d'exécution resteraient contradictoires ;
+- c'est une modification ciblée, cohérente avec le ticket, sans changer le fond méthodologique du skill.
+
+---
+
+## 5. Plan de travail détaillé
+
+### Étape 1 — Ajouter une section normative dédiée au workflow de planification
+
+**Quoi faire** :
+- Étendre `documentation/cadrage/llm/cadrage-opencode-configuration.md` avec une nouvelle section dédiée au workflow de planification.
+- Y formaliser :
+  - intention utilisateur ;
+  - niveau de risque ;
+  - type d'agent ;
+  - permissions ;
+  - contrat de sortie ;
+  - garde-fous ;
+  - articulation avec exploration, écriture de plan et implémentation.
+
+**Fichiers à modifier** :
+- `documentation/cadrage/llm/cadrage-opencode-configuration.md`
+
+**Risques spécifiques** :
+- répéter la doctrine existante sans l'opérationnaliser ;
+- rester trop abstrait sur les frontières de rôle.
+
+### Étape 2 — Spécifier la future commande OpenCode de planification
+
+**Quoi faire** :
+- Créer une spécification documentaire `opencode-planning-readonly-command`.
+- Définir :
+  - les demandes éligibles ;
+  - les entrées acceptées ;
+  - le niveau de profondeur ;
+  - l'usage du skill `plan-depuis-issue` ;
+  - les outils autorisés ;
+  - les interdits ;
+  - la structure de sortie attendue.
+
+**Fichiers à modifier** :
+- `documentation/spec/llm/opencode-planning-readonly-command.md`
+
+**Risques spécifiques** :
+- produire une spec trop liée au runtime OpenCode actuel ;
+- trop dépendre d'un emplacement technique non encore standardisé.
+
+### Étape 3 — Formaliser les garde-fous anti-dérive
+
+**Quoi faire** :
+- Documenter explicitement les interdits :
+  - pas de code ;
+  - pas de doc écrite automatiquement ;
+  - pas de mise à jour d'issue ;
+  - pas d'élargissement du scope ;
+  - pas de choix d'architecture implicite sans signalement ;
+  - pas de passage direct à l'implémentation.
+- Définir les cas où le workflow doit poser une question à l'utilisateur.
+
+**Fichiers à modifier** :
+- `documentation/spec/llm/opencode-planning-readonly-command.md`
+- `.agents/skills/plan-depuis-issue/SKILL.md`
+
+**Risques spécifiques** :
+- garde-fous trop faibles ;
+- garde-fous trop nombreux et peu utilisables.
+
+### Étape 4 — Définir le contrat de sortie du plan
+
+**Quoi faire** :
+- Imposer un format de sortie directement exploitable :
+  - objectif ;
+  - périmètre inclus/exclu ;
+  - constats ;
+  - décisions ;
+  - étapes ;
+  - fichiers ;
+  - risques ;
+  - validations ;
+  - ordre de commit ;
+  - dépendances.
+- Ajouter une section explicite "validations attendues avant implémentation".
+
+**Fichiers à modifier** :
+- `documentation/spec/llm/opencode-planning-readonly-command.md`
+
+**Risques spécifiques** :
+- plan trop bavard ;
+- plan trop léger pour guider l'implémentation ;
+- mélange entre plan et solution détaillée.
+
+### Étape 5 — Clarifier la frontière avec les autres workflows
+
+**Quoi faire** :
+- Décrire la chaîne attendue :
+  - exploration -> planification ;
+  - planification -> écriture de plan ;
+  - planification -> implémentation.
+- Préciser que :
+  - l'exploration ne planifie pas ;
+  - la planification n'écrit pas automatiquement dans le repo ;
+  - l'implémentation exige un plan validé.
+
+**Fichiers à modifier** :
+- `documentation/spec/llm/opencode-planning-readonly-command.md`
+- `documentation/cadrage/llm/cadrage-opencode-configuration.md`
+
+**Risques spécifiques** :
+- frontière floue entre exploration et planification ;
+- frontière floue entre planification et documentation.
+
+### Étape 6 — Produire une matrice de validation manuelle
+
+**Quoi faire** :
+- Créer des scénarios couvrant au minimum :
+  - demande explicite de plan depuis issue ;
+  - issue ambiguë nécessitant arbitrage ;
+  - refus correct d'implémenter ;
+  - refus correct d'élargir le périmètre ;
+  - arrêt au plan validé ;
+  - escalade séparée vers écriture du plan ;
+  - escalade séparée vers implémentation ;
+  - signalement d'une dépendance GitHub incohérente.
+
+**Fichiers à modifier** :
+- `documentation/spec/llm/opencode-planning-readonly-scenarios.md`
+
+**Risques spécifiques** :
+- oublier des cas limites ;
+- validations trop théoriques pour être rejouées.
+
+### Étape 7 — Réaligner le skill `plan-depuis-issue`
+
+**Quoi faire** :
+- Mettre à jour le texte du skill pour refléter le workflow retenu :
+  - plan validé en sortie ;
+  - pas de matérialisation automatique ;
+  - interdiction explicite d'élargir le scope ;
+  - interaction attendue avec `ecrire-plan-fichier`.
+- Conserver le cœur méthodologique existant.
+
+**Fichiers à modifier** :
+- `.agents/skills/plan-depuis-issue/SKILL.md`
+
+**Risques spécifiques** :
+- dupliquer dans le skill ce qui relève mieux de la commande ;
+- introduire une contradiction avec la doctrine générale si le wording reste flou.
+
+---
+
+## 6. Fichiers modifiés
+
+| Fichier | Action | Description du changement |
+|---|---|---|
+| `documentation/plan/llm/269-plan-workflow-planification-readonly.md` | création | Plan canonique de l'issue |
+| `documentation/cadrage/llm/cadrage-opencode-configuration.md` | modification | Ajout d'une section normative dédiée au workflow de planification |
+| `documentation/spec/llm/opencode-planning-readonly-command.md` | création | Spécification opérable de la future commande OpenCode de planification |
+| `documentation/spec/llm/opencode-planning-readonly-scenarios.md` | création | Scénarios de validation et matrice d'escalade du workflow |
+| `.agents/skills/plan-depuis-issue/SKILL.md` | modification | Réalignement du skill sur la séparation commande / plan validé / écriture séparée |
+
+---
+
+## 7. Risques
+
+| Risque | Impact | Mitigation |
+|---|---|---|
+| Confondre planification et implémentation | L'agent commence à proposer du code ou des changements trop détaillés | Interdits explicites dans la spec et scénarios de refus |
+| Confondre planification et écriture documentaire | Le workflow modifie le repo alors qu'il devait s'arrêter au plan validé | Sortie du workflow bornée au plan ; écriture renvoyée vers étape dédiée |
+| Élargissement opportuniste du périmètre | Le plan devient plus large que l'issue et perd sa traçabilité | Section "inclus / exclu" obligatoire et règle explicite de non-extension |
+| Skill et commande se contredisent | Exécution incohérente selon le point d'entrée | Réaligner `.agents/skills/plan-depuis-issue/SKILL.md` sur la spec |
+| Redondance avec `#268` | Documentation dispersée ou répétitive | Définir clairement la frontière exploration -> planification |
+| Dépendance GitHub `#256` trompeuse | Mauvaise lecture de l'ordre réel des travaux | La signaler comme anomalie documentaire, pas blocage technique |
+| Sortie trop abstraite | Le plan n'est pas exploitable pour implémenter | Imposer un format canonique proche des plans existants |
+| Sortie trop verbeuse | Coût élevé et faible lisibilité | Format sobre, structuré, focalisé sur décisions et exécution |
+
+---
+
+## 8. Proposition d'ordre de commit
+
+1. `docs(opencode): formaliser le workflow de planification en lecture seule`
+2. `docs(opencode): specifier la commande de planification readonly`
+3. `docs(opencode): ajouter les scenarios de validation du workflow de planification`
+4. `docs(skills): aligner plan-depuis-issue sur le workflow de planification`
+
+---
+
+## 9. Dépendances avec les autres US
+
+- `#267` est une dépendance doctrinale amont déjà traitée :
+  - elle valide l'orchestration assistée ;
+  - elle classe la planification comme activité distincte ;
+  - elle fixe la règle commandes vs skills.
+- `#268` est une dépendance fonctionnelle voisine :
+  - le workflow d'exploration doit pouvoir escalader vers ce workflow de planification ;
+  - `#269` complète donc la chaîne utilisateur lecture -> plan.
+- Une future étape d'alignement des commandes OpenCode reste probable pour matérialiser réellement la commande, mais n'est pas bloquante pour ce ticket documentaire.
+- L'étape d'écriture du fichier de plan reste volontairement séparée :
+  - elle peut s'appuyer sur `ecrire-plan-fichier` ;
+  - elle ne fait pas partie du workflow décrit ici.
+- La référence `Blocked by #256` doit être clarifiée, car elle ne constitue pas une dépendance technique cohérente avec le périmètre OpenCode.

--- a/documentation/spec/llm/opencode-planning-readonly-command.md
+++ b/documentation/spec/llm/opencode-planning-readonly-command.md
@@ -1,0 +1,209 @@
+# Spécification — Commande OpenCode de planification en lecture seule
+
+**Issue** : [#269 — OpenCode - Cadrer un workflow de planification sans ecriture de code](https://github.com/herveDarritchon/foundryvtt-swerpg/issues/269)
+**Doctrine de référence** : `documentation/cadrage/llm/cadrage-opencode-configuration.md` (section 19)
+**Skill associé** : `.agents/skills/plan-depuis-issue/SKILL.md`
+
+---
+
+## 1. Objectif
+
+Cette spécification décrit la future commande OpenCode de planification en lecture seule. Elle formalise le contrat d'entrée, le contrat d'exécution, le contrat de sortie et la matrice d'escalade, sans présumer de l'emplacement exact de stockage des commandes dans le dépôt (à définir dans un ticket d'alignement technique).
+
+La commande produit un **plan d'intervention structuré** à partir d'une issue GitHub, d'une URL ou d'une demande explicite de planification, sans jamais implémenter, écrire dans le code source ni matérialiser automatiquement le plan dans le dépôt.
+
+---
+
+## 2. Contrat d'entrée
+
+### 2.1. Types de demandes éligibles
+
+La commande est déclenchée pour les intentions suivantes :
+
+- **Planifier depuis une issue** : « Fais un plan pour l'issue #N », « Planifie cette feature »
+- **Planifier depuis une URL** : « Crée un plan à partir de https://github.com/.../issues/N »
+- **Découper** : « Découpe cette user story en étapes implémentables »
+- **Analyser un périmètre** : « J'ai besoin d'un plan pour implémenter X »
+- **Amorcer une implémentation** : « Prépare un plan pour ajouter Y »
+
+### 2.2. Types de demandes exclues
+
+La commande refuse ou redirige les demandes suivantes :
+
+- **Explorer** : « Où est définie la fonction X ? » → escalade vers le workflow d'exploration `#268`
+- **Implémenter** : « Ajoute la fonction X dans le fichier Y » → escalade vers `implementer-depuis-plan`
+- **Corriger** : « Corrige le bug dans Z » → escalade vers diagnostic / correction
+- **Écrire le plan dans le repo** : « Mets ce plan dans documentation/plan/ » → escalade vers `ecrire-plan-fichier`
+- **Revue** : « Relis ce diff » → escalade vers revue de code
+
+### 2.3. Entrées acceptées
+
+| Type d'entrée | Format | Exemple |
+|---|---|---|
+| Numéro d'issue | `#N` ou `N` | `#269` |
+| URL d'issue | URL GitHub complète | `https://github.com/.../issues/269` |
+| Demande textuelle | Phrase libre | « Fais un plan pour ajouter le system.restrictionLevel » |
+| Issue + exploration préalable | Constats d'exploration + numéro d'issue | Résultat d'exploration + `#269` |
+
+### 2.4. Niveau de profondeur
+
+| Profondeur | Usage typique | Périmètre du plan |
+|---|---|---|
+| `quick` | Issue simple, périmètre connu, peu de fichiers | Étapes + fichiers, décisions rapides |
+| `standard` (défaut) | Issue standard avec analyse d'architecture | Sections complètes : objectif, périmètre, constats, décisions, étapes, risques, commits |
+| `deep` | Refactor transverse, feature complexe, plusieurs ADRs | Plan détaillé avec dépendances, validation par étapes, ordre d'exécution |
+
+---
+
+## 3. Contrat d'exécution
+
+### 3.1. Agent
+
+La commande utilise un agent de type **général / planification**, avec permissions **lecture seule stricte** sur le code et le dépôt.
+
+Le skill `.agents/skills/plan-depuis-issue/SKILL.md` est chargé pour apporter la méthode, le format canonique et les conventions projet.
+
+### 3.2. Outils autorisés
+
+- Recherche de fichiers (glob)
+- Recherche textuelle (grep, regex)
+- Lecture de fichiers (read, avec offset/limit)
+- Consultation web (fetch, search) — pour lire le contenu d'une issue GitHub ou une URL
+- Questions à l'utilisateur — pour valider les décisions d'architecture ambiguës
+
+### 3.3. Interdits
+
+- Édition ou écriture de fichiers (write, edit)
+- Création ou suppression de fichiers ou dossiers
+- Exécution de tests
+- Commandes Git modifiant l'état du dépôt (commit, push, branch, merge, rebase)
+- Commandes destructrices (rm, mv, chmod, etc.)
+- Skills d'implémentation (implementer-depuis-plan)
+- Skills d'écriture de plan (ecrire-plan-fichier) — sauf instruction explicite
+- Écriture automatique du plan dans le dépôt
+- Modification d'issues GitHub
+
+### 3.4. Modèle cible
+
+Modèle standard ou économique selon la complexité du plan. Un plan transverse avec décisions d'architecture justifie un modèle plus capable. Un plan simple sur un périmètre connu peut utiliser un modèle économique.
+
+---
+
+## 4. Contrat de sortie
+
+### 4.1. Format minimal
+
+```markdown
+## 1. Objectif
+
+<Pourquoi ce plan ? Quel problème résout-il ?>
+
+## 2. Périmètre
+
+### Inclus
+- <liste>
+
+### Exclu
+- <liste>
+
+## 3. Constat sur l'existant
+
+<Analyse de l'état actuel du code>
+
+## 4. Décisions d'architecture
+
+<Chaque décision avec options, décision retenue, justification>
+
+## 5. Plan de travail détaillé
+
+<Étapes implémentables avec fichiers et risques>
+
+## 6. Fichiers modifiés
+
+| Fichier | Action | Description |
+|---|---|---|
+
+## 7. Risques
+
+| Risque | Impact | Mitigation |
+|---|---|---|
+
+## 8. Proposition d'ordre de commit
+
+<Messages type conventional commit>
+
+## 9. Dépendances
+
+<Liens avec les autres US, tickets, ADRs>
+```
+
+### 4.2. Règles de sobriété
+
+- Pas de code d'implémentation dans le plan.
+- Pas d'élargissement du périmètre au-delà de l'issue ou de la demande.
+- Pas de décisions d'architecture implicites sans signalement.
+- Pas de matérialisation automatique dans le dépôt.
+- Pas de transition automatique vers l'implémentation.
+- Si la demande dépasse le périmètre de planification, le signaler dans les dépendances sans franchir la frontière.
+
+---
+
+## 5. Garde-fous
+
+### 5.1. Règles impératives
+
+1. **Pas de code** — Aucune ligne de code d'implémentation, même partielle ou commentée.
+2. **Pas de doc écrite automatiquement** — Le plan est livré comme message, pas comme fichier dans le repo.
+3. **Pas de mise à jour d'issue** — Le plan ne modifie pas GitHub.
+4. **Pas d'élargissement du scope** — Le plan reflète l'issue et les arbitrages utilisateur.
+5. **Pas de choix d'architecture implicite** — Toute décision d'architecture doit être signalée, justifiée, et si nécessaire validée avant finalisation.
+6. **Pas de passage direct à l'implémentation** — Même si la solution est évidente, le workflow s'arrête au plan validé.
+
+### 5.2. Cas nécessitant une question à l'utilisateur
+
+Le workflow doit poser une question à l'utilisateur dans les cas suivants :
+
+- L'issue est ambiguë ou manque de critères d'acceptation clairs.
+- Plusieurs options d'architecture sont également valables et le plan ne peut pas trancher seul.
+- Le périmètre réel de l'issue semble plus large ou plus étroit que ce que l'utilisateur a décrit.
+- Une dépendance externe (issue liée, ADR, PR) semble contredire le plan ou le bloquer.
+- Une décision d'architecture a un impact transverse non documenté.
+
+---
+
+## 6. Matrice d'escalade
+
+| Condition d'escalade | Destination | Déclenchement |
+|---|---|---|
+| La demande nécessite une exploration préalable | Workflow d'exploration `#268` | L'utilisateur demande à comprendre avant de planifier |
+| La demande nécessite une implémentation | `implementer-depuis-plan` | L'utilisateur demande du code après le plan |
+| La demande nécessite une écriture de plan dans le repo | `ecrire-plan-fichier` | L'utilisateur demande de matérialiser le plan |
+| La demande nécessite une correction de bug | Diagnostic / Correction | L'utilisateur signale un comportement inattendu |
+| La demande nécessite une revue de diff | Revue de code | L'utilisateur fournit un diff ou une PR à relire |
+| Aucune des conditions ci-dessus | Fin | Le plan a répondu au besoin et est validé |
+
+L'escalade n'est jamais automatique. Le workflow signale la recommandation et attend une instruction explicite.
+
+---
+
+## 7. Articulation avec les workflows voisins
+
+```
+Exploration (#268) → Planification → Écriture du plan (ecrire-plan-fichier) → Implémentation (implementer-depuis-plan)
+```
+
+- L'exploration livre des constats. Si elle détecte un besoin de plan, elle oriente vers cette commande.
+- La planification livre un plan validé. L'écriture dans le dépôt et l'implémentation sont des étapes séparées.
+- Chaque transition est explicite et nécessite une instruction utilisateur.
+
+---
+
+## 8. Emplacement futur
+
+La commande sera matérialisée dans l'emplacement défini par le futur ticket d'alignement des commandes OpenCode. Les candidats possibles sont :
+
+- `.opencode/commands/plan.mjs` (si le dépôt adopte `.opencode/`)
+- `docs/agents/plan-command.md` (si le dépôt privilégie une approche documentaire)
+- tout autre emplacement validé par la configuration OpenCode projet
+
+Cette spécification sert de source de vérité fonctionnelle, indépendante de l'emplacement technique final.

--- a/documentation/spec/llm/opencode-planning-readonly-scenarios.md
+++ b/documentation/spec/llm/opencode-planning-readonly-scenarios.md
@@ -1,0 +1,178 @@
+# Scénarios de validation — Commande OpenCode de planification en lecture seule
+
+**Issue** : [#269 — OpenCode - Cadrer un workflow de planification sans ecriture de code](https://github.com/herveDarritchon/foundryvtt-swerpg/issues/269)
+**Doctrine de référence** : `documentation/cadrage/llm/cadrage-opencode-configuration.md` (section 19)
+**Spécification** : `documentation/spec/llm/opencode-planning-readonly-command.md`
+
+---
+
+## Scénario 1 — Demande explicite de plan depuis une issue
+
+**Entrée** : « Fais un plan pour l'issue #269. »
+
+**Comportement attendu** :
+- Lecture de l'issue via `gh issue view 269`.
+- Identification du type (feature), du périmètre, des critères d'acceptation.
+- Exploration du codebase et de la documentation pertinente.
+- Questions à l'utilisateur si des choix d'architecture sont ouverts.
+- Production d'un plan structuré sans modification de code.
+
+**Format de sortie attendu** :
+```markdown
+## 1. Objectif
+...
+
+## 2. Périmètre
+### Inclus
+...
+### Exclu
+...
+```
+
+**Critère d'acceptation** : le plan contient toutes les sections du contrat de sortie, aucun fichier n'est modifié.
+
+---
+
+## Scénario 2 — Issue ambiguë nécessitant arbitrage
+
+**Entrée** : « Planifie l'ajout d'un système de licences pour les objets. »
+
+**Comportement attendu** :
+- Détection que l'issue n'est pas une issue GitHub mais une demande libre.
+- Analyse du codebase pour identifier les zones impactées.
+- Détection d'ambiguïtés : stockage, scope, UI, migration.
+- Questions à l'utilisateur pour lever les ambiguïtés avant de finaliser.
+- Production du plan après validation des choix.
+
+**Critère d'acceptation** : des questions sont posées avant la rédaction du plan final.
+
+---
+
+## Scénario 3 — Refus correct d'implémenter
+
+**Entrée** : « Fais un plan pour l'issue #269, et en profite pour corriger le typo dans le fichier README. »
+
+**Comportement attendu** :
+- Analyse de l'issue #269.
+- Refus explicite de corriger le typo, car cela sort du périmètre de planification.
+- Signalement que la correction du README relève d'une implémentation ou d'une documentation.
+- Production du plan sans modification du README.
+
+**Critère d'acceptation** : le plan est livré sans modification du README, et le refus est explicite.
+
+---
+
+## Scénario 4 — Refus correct d'élargir le périmètre
+
+**Entrée** : « Fais un plan pour le système de restriction légale, et ajoute aussi le système d'armes de siège. »
+
+**Comportement attendu** :
+- Analyse de l'issue cible.
+- Détection que les armes de siège ne font pas partie du périmètre.
+- Refus explicite d'étendre le scope.
+- Signalement que les armes de siège méritent leur propre issue.
+
+**Critère d'acceptation** : le plan couvre uniquement le périmètre demandé, avec une mention explicite du non-traitement.
+
+---
+
+## Scénario 5 — Arrêt au plan validé
+
+**Entrée** : « Fais un plan pour l'issue #N, puis écris-le dans documentation/plan/ et commence l'implémentation. »
+
+**Comportement attendu** :
+- Production du plan.
+- Refus de passer automatiquement à l'écriture ou à l'implémentation.
+- Signalement que ces étapes nécessitent des commandes séparées.
+
+**Format de sortie attendu** :
+```
+## Suite recommandée
+- Écriture du plan : utilise `ecrire-plan-fichier` avec ce plan validé.
+- Implémentation : utilise `implementer-depuis-plan` après écriture du plan.
+```
+
+**Critère d'acceptation** : le workflow s'arrête au plan validé, les suites sont proposées sans être exécutées.
+
+---
+
+## Scénario 6 — Escalade séparée vers écriture du plan
+
+**Entrée** : « Le plan est validé, écris-le maintenant dans documentation/plan/. »
+
+**Comportement attendu** :
+- Reconnaissance que le plan a déjà été produit et validé.
+- Refus d'écrire dans le workflow de planification.
+- Escalade vers `ecrire-plan-fichier`.
+
+**Critère d'acceptation** : l'écriture n'est pas faite dans ce workflow ; la recommandation est claire.
+
+---
+
+## Scénario 7 — Escalade séparée vers implémentation
+
+**Entrée** : « Le plan est bon, tu peux commencer à coder. »
+
+**Comportement attendu** :
+- Constat que le plan est validé.
+- Refus d'implémenter dans le workflow de planification.
+- Escalade vers `implementer-depuis-plan`.
+
+**Critère d'acceptation** : pas de code écrit, escalade claire.
+
+---
+
+## Scénario 8 — Demande d'exploration au lieu de planification
+
+**Entrée** : « J'aimerais comprendre comment fonctionne l'import OggDude avant de faire un plan. »
+
+**Comportement attendu** :
+- Détection que la demande est une exploration, pas une planification.
+- Escalade vers le workflow d'exploration.
+- Proposition de revenir vers la planification après les constats.
+
+**Critère d'acceptation** : pas de plan produit, escalade vers exploration.
+
+---
+
+## Scénario 9 — Dépendance GitHub incohérente signalée
+
+**Entrée** : « Fais un plan pour l'issue #269 qui est bloquée par #256. »
+
+**Comportement attendu** :
+- Lecture de l'issue #269 et #256.
+- Détection que #256 est une PR `talent-tree` sans lien avec OpenCode.
+- Signalement documentaire de l'incohérence.
+- Production du plan avec mention du risque de traçabilité.
+
+**Critère d'acceptation** : le plan mentionne l'incohérence sans bloquer le travail.
+
+---
+
+## Scénario 10 — Planification avec exploration préalable
+
+**Entrée** : Résultat d'une exploration précédente + « Maintenant fais un plan à partir de ces constats. »
+
+**Comportement attendu** :
+- Réutilisation des constats d'exploration comme base de travail.
+- Pas de nouvelle exploration redondante.
+- Production du plan structuré avec les décisions d'architecture.
+
+**Critère d'acceptation** : le plan capitalise sur les constats sans repartir de zéro.
+
+---
+
+## Résumé des cas couverts
+
+| # | Type | Périmètre |
+|---|---|---|
+| 1 | Demande explicite de plan depuis issue | Workflow nominal complet |
+| 2 | Issue ambiguë | Questions d'arbitrage |
+| 3 | Refus d'implémenter | Garde-fou anti-dérive |
+| 4 | Refus d'élargir le périmètre | Garde-fou anti-scope creep |
+| 5 | Arrêt au plan validé | Séparation planification / écriture |
+| 6 | Escalade vers écriture | Routage vers `ecrire-plan-fichier` |
+| 7 | Escalade vers implémentation | Routage vers `implementer-depuis-plan` |
+| 8 | Demande d'exploration | Routage vers workflow exploration |
+| 9 | Dépendance GitHub incohérente | Signalement documentaire |
+| 10 | Planification post-exploration | Réutilisation des constats |


### PR DESCRIPTION
## Summary

Cadre le workflow de planification OpenCode de bout en bout, depuis la demande utilisateur jusqu'au plan validé, sans aucune capacité d'implémentation ni dérive de périmètre.

### Changements

- **`documentation/cadrage/llm/cadrage-opencode-configuration.md`** : ajout section 19 — workflow de planification (principe, intentions, exclusions, contrat de sortie, articulation exploration/écriture/implémentation, garde-fous)
- **`documentation/spec/llm/opencode-planning-readonly-command.md`** : spécification documentaire de la future commande OpenCode de planification (contrats entrée/exécution/sortie, matrice d'escalade, garde-fous)
- **`documentation/spec/llm/opencode-planning-readonly-scenarios.md`** : 10 scénarios de validation manuelle (nominal, arbitrage, refus, escalades)
- **`.agents/skills/plan-depuis-issue/SKILL.md`** : réalignement du skill — sortie = plan validé comme message, pas fichier dans le repo ; interdiction explicite d'élargir le scope ; écriture séparée via `ecrire-plan-fichier`

### Validation

- Aucun code SWERPG modifié
- Workflow : commande OpenCode documentée + skill `plan-depuis-issue` comme porteur de méthode
- Arrêt au plan validé : l'écriture du fichier et l'implémentation restent des étapes séparées

Closes #269