### PR TITLE
docs(opencode): cadrer le workflow de tests et diagnostic d'echec avant modification (issue #270)

### DIFF
--- a/documentation/cadrage/llm/cadrage-opencode-configuration.md
+++ b/documentation/cadrage/llm/cadrage-opencode-configuration.md
@@ -1424,3 +1424,171 @@ Le workflow de planification doit impérativement respecter les règles suivante
 Si une demande d'exploration révèle un besoin de planification, le workflow d'exploration s'arrête et oriente vers ce workflow de planification. Les constats de l'exploration sont transmis comme base de travail.
 
 L'escalade n'est jamais automatique. Le workflow signale la recommandation et attend une instruction explicite.
+
+---
+
+## 20. Workflow de tests et diagnostic d'échec — Issue #270
+
+Cette section formalise le workflow cible pour les demandes d'exécution de tests, de lint et de vérifications mécaniques, avec une priorité donnée au diagnostic et à l'explication des échecs avant toute correction, conformément à l'issue [#270](https://github.com/herveDarritchon/foundryvtt-swerpg/issues/270).
+
+### 20.1. Principe
+
+Le workflow de tests et diagnostic d'échec est un workflow en **3 phases strictement séparées** :
+
+1. **Exécution mécanique** — Lancer la commande de vérification (tests, lint, format, script) et capturer le résultat.
+2. **Diagnostic** — Analyser l'échec uniquement si la phase 1 échoue, en travaillant sur un volume réduit et pertinent.
+3. **Correction** — Étape séparée et optionnelle, déclenchée explicitement par l'utilisateur après réception du diagnostic.
+
+Il est conçu pour être exécuté avec une intervention LLM minimale : les phases mécaniques sont pilotées par scripts, seuls l'analyse d'échec et l'arbitrage justifient un modèle plus capable.
+
+### 20.2. Intentions déclenchantes
+
+Le workflow de tests et diagnostic est adapté aux demandes suivantes :
+
+- exécuter des tests unitaires Vitest (toute la suite, un dossier, un fichier, un pattern) ;
+- exécuter des tests de couverture Vitest ;
+- exécuter des tests E2E Playwright (headless, headed, CI, UI) ;
+- vérifier le format Prettier sans appliquer de correction ;
+- lancer le lint ESLint sur tout ou partie du code ;
+- exécuter un script mécanique projet (ex. `validate-logging-migration`) ;
+- analyser la cause d'un échec de vérification mécanique.
+
+### 20.3. Exclusions explicites
+
+Ne pas utiliser ce workflow pour :
+
+- explorer ou comprendre du code existant (→ workflow d'exploration `#268`) ;
+- planifier une implémentation (→ workflow de planification `#269`) ;
+- implémenter ou modifier du code pour corriger un échec ;
+- corriger automatiquement des erreurs de format ou de lint ;
+- rédiger de nouveaux tests (→ implémentation dédiée) ;
+- modifier les configurations de test ou de build.
+
+### 20.4. Agent et permissions par phase
+
+#### Phase 1 — Exécution
+
+| Propriété | Valeur |
+|---|---|
+| Type d'agent | Exécution mécanique (script) |
+| Modèle cible | Aucun (exécution script) ou économique |
+| Autonomie | Exécution seule, pas d'analyse |
+| Outils autorisés | Commande shell pour lancer la vérification |
+| Interdits | Modification de code, analyse, correction |
+
+#### Phase 2 — Diagnostic
+
+| Propriété | Valeur |
+|---|---|
+| Type d'agent | Général / Diagnostic |
+| Modèle cible | Intermédiaire ou raisonnement selon complexité |
+| Autonomie | Lecture seule sur le code, analyse de la sortie d'erreur |
+| Outils autorisés | Recherche fichiers, recherche textuelle, lecture fichiers, extraction de logs |
+| Interdits | Édition, écriture, correction, exécution de nouvelles vérifications |
+
+#### Phase 3 — Correction
+
+| Propriété | Valeur |
+|---|---|
+| Type d'agent | Implémentation |
+| Déclenchement | Explicite par l'utilisateur après réception du diagnostic |
+| Périmètre | Correction minimale ciblée |
+| Note | Non détaillée dans ce workflow — renvoi vers `implementer-depuis-plan` ou workflow de correction dédié |
+
+### 20.5. Contrat de sortie
+
+**Phase 1 — Exécution** (toujours produite) :
+
+```
+Commande exécutée : <commande>
+Statut : <succès/échec>
+Durée : <secondes>
+Fichiers testés : <nombre> (si applicable)
+Tests passés : <nombre> (si applicable)
+Tests échoués : <nombre> (si applicable)
+Sortie complète : <référence vers fichier temporaire si longue>
+```
+
+**Phase 2 — Diagnostic** (produite seulement si échec et si l'utilisateur le demande) :
+
+```
+Périmètre analysé : <fichiers/modules>
+Cause probable : <hypothèse>
+Fichiers incriminés : <liste>
+Extrait pertinent : <code/log extrait>
+Suggestion de correction : <description courte>
+Complexité estimée : <faible/moyenne/élevée>
+Modèle recommandé pour la correction : <type>
+```
+
+**Phase 3 — Correction** : non détaillée dans ce workflow.
+
+Règles de sobriété :
+
+- la sortie de la phase 1 ne doit pas être envoyée intégralement au modèle si elle est longue ;
+- seuls le statut, le message d'erreur principal et les fichiers incriminés sont transmis au diagnostic ;
+- le diagnostic ne doit pas contenir de code correctif exécutable, seulement une description ;
+- pas de transition automatique vers la correction.
+
+### 20.6. Variantes de profondeur
+
+| Profondeur | Usage typique | Phases activées |
+|---|---|---|
+| `check` | Simple exécution, résultat binaire | Phase 1 uniquement |
+| `check --diagnose` | Exécution + diagnostic en cas d'échec | Phase 1 + Phase 2 |
+| `check --fix` (demande explicite) | Exécution + diagnostic + proposition de correction (attente validation) | Phase 1 + Phase 2 + Phase 3 (validation requise) |
+
+### 20.7. Sous-commandes prévues
+
+| Sous-commande | Outil | Commande exécutée |
+|---|---|---|
+| `check tests` | Vitest | `pnpm test` ou `pnpm vitest run <filtre>` |
+| `check coverage` | Vitest + V8 | `pnpm test:coverage` |
+| `check e2e` | Playwright | `pnpm e2e` (ou headed/ci/ui) |
+| `check lint` | ESLint | `pnpm exec eslint <cibles>` |
+| `check format` | Prettier | `pnpm fmt:check` |
+| `check script <nom>` | Script projet | `bash scripts/<nom>.sh` |
+| `check all` | Tous | Exécution séquentielle de toutes les vérifications |
+
+### 20.8. Garde-fous
+
+Le workflow de tests et diagnostic doit impérativement respecter les règles suivantes :
+
+1. **Exécuter ≠ Analyser ≠ Corriger** — Chaque phase est une étape distincte avec des permissions différentes.
+2. **Pas de correction automatique** — Même si la correction est évidente, le workflow attend une instruction explicite.
+3. **Pas d'élargissement du scope** — La vérification se limite à ce qui a été demandé.
+4. **Pas de modification de code pendant le diagnostic** — Le diagnostic est lecture seule.
+5. **Pas de reformulation du besoin** — Une demande de test ne devient pas une demande d'implémentation.
+6. **Volume réduit pour le diagnostic** — Seuls les éléments pertinents (statut, erreur, fichiers) sont transmis au modèle.
+
+### 20.9. Cas nécessitant une question à l'utilisateur
+
+Le workflow doit poser une question à l'utilisateur dans les cas suivants :
+
+- le filtre de tests est ambigu (plusieurs interprétations possibles) ;
+- l'échec est massif (>50% des tests) ;
+- l'échec semble lié à l'infrastructure de test (mock, setup) plutôt qu'au code métier ;
+- la cause de l'échec est incertaine et plusieurs hypothèses coexistent ;
+- la vérification demandée n'existe pas (ex. `check <outil-inconnu>`).
+
+### 20.10. Escalade depuis l'exploration et la planification
+
+Si une demande d'exploration révèle un besoin de vérification, ou si une planification nécessite une validation par les tests, le workflow s'arrête et oriente vers ce workflow de tests et diagnostic.
+
+Réciproquement, si le diagnostic d'un échec révèle un problème d'architecture ou un besoin de planification, une escalade vers le workflow de planification `#269` peut être proposée.
+
+L'escalade n'est jamais automatique. Le workflow signale la recommandation et attend une instruction explicite.
+
+### 20.11. Articulation avec la chaîne complète des workflows
+
+```
+Exploration (#268) → Planification (#269) → Exécution/Développement → Tests/Diagnostic (ce workflow) → Correction (séparée)
+```
+
+- L'exploration prépare le terrain.
+- La planification décide de la stratégie.
+- L'implémentation produit le code.
+- Les tests valident et diagnostiquent les écarts.
+- La correction ne vient qu'après un diagnostic validé.
+
+Chaque transition est explicite et attend une instruction utilisateur.

--- a/documentation/plan/llm/270-plan-workflow-test-diagnostics.md
+++ b/documentation/plan/llm/270-plan-workflow-test-diagnostics.md
@@ -1,0 +1,439 @@
+# Plan d'implémentation — OpenCode : cadrer un workflow de tests et d'analyse d'échec avant modification
+
+**Issue** : [#270 — OpenCode - Cadrer un workflow de tests et d'analyse d'echec avant modification](https://github.com/herveDarritchon/foundryvtt-swerpg/issues/270)
+**ADR** : `documentation/architecture/adr/adr-0004-vitest-testing-strategy.md`, `documentation/architecture/adr/adr-0012-unit-tests-readable-diagnostics.md`
+**Module(s) impacté(s)** : `documentation/cadrage/llm/cadrage-opencode-configuration.md` (modification), `documentation/spec/llm/opencode-test-diagnostics-command.md` (création), `documentation/spec/llm/opencode-test-diagnostics-scenarios.md` (création)
+
+---
+
+## 1. Objectif
+
+Définir un workflow complet pour l'exécution de tests, de lint et de vérifications mécaniques dans OpenCode, avec une priorité donnée au diagnostic et à l'explication des échecs avant toute correction.
+
+Le résultat attendu est un cadre opérable qui :
+- prend en charge les demandes de vérification mécanique (tests, lint, format, scripts projet) de bout en bout ;
+- sépare explicitement l'exécution mécanique, le diagnostic des échecs et la décision éventuelle de correction ;
+- limite l'usage du modèle LLM aux cas où l'outil seul ne suffit pas (interprétation, analyse, arbitrage) ;
+- s'articule proprement avec la doctrine `#267`, le workflow d'exploration `#268` et le workflow de planification `#269`.
+
+---
+
+## 2. Périmètre
+
+### Inclus dans cette US / ce ticket
+
+- Formaliser le workflow cible d'exécution et d'analyse de vérifications mécaniques.
+- Définir les intentions utilisateur qui doivent router vers ce workflow.
+- Définir le contrat d'exécution : séquence en 3 phases (exécution → diagnostic → correction).
+- Définir les vérifications couvertes par le workflow :
+  - tests unitaires Vitest (`pnpm test`, `pnpm vitest run ...`)
+  - tests de couverture Vitest (`pnpm test:coverage`)
+  - tests E2E Playwright (`pnpm e2e`, `pnpm e2e:headed`, `pnpm e2e:ci`)
+  - vérification de format Prettier (`pnpm fmt:check`)
+  - lint ESLint (`pnpm exec eslint ...`)
+  - scripts mécaniques projet (ex. `scripts/validate-logging-migration.sh`)
+- Produire la spécification documentaire d'une future commande OpenCode de test/diagnostic.
+- Produire une matrice de scénarios de validation manuelle.
+
+### Exclu de cette US / ce ticket
+
+- Implémentation effective d'une commande OpenCode exécutable.
+- Création ou modification d'un skill dédié (le workflow sera porté par une commande, pas un skill).
+- Correction automatique des échecs détectés (la correction est une étape séparée et optionnelle).
+- Toute écriture de code applicatif SWERPG.
+- Toute modification du code source (même pour corriger un échec de test).
+- Toute automatisation d'escalade vers implémentation sans instruction explicite.
+- Toute mise à jour de l'issue GitHub elle-même.
+- Toute redéfinition des workflows d'exploration et planification déjà cadrés par `#268` et `#269`.
+
+---
+
+## 3. Constat sur l'existant
+
+### 3.1. La doctrine OpenCode couvre déjà les principes structurants
+
+`documentation/cadrage/llm/cadrage-opencode-configuration.md` formalise déjà les règles applicables aux vérifications mécaniques :
+
+- **Section 4.5 (Tests)** : les tests sont une activité distincte ; l'exécution ne doit pas entraîner l'envoi systématique des logs au modèle ; le premier rôle est d'expliquer l'échec.
+- **Section 4.6 (Lint, format et vérifications mécaniques)** : ces tâches doivent être pilotées par scripts ; le modèle n'intervient que pour analyser un échec.
+- **Section 4.7 (Ségrégation entre action mécanique, interprétation et correction)** : énonce la règle centrale "Exécuter ≠ Analyser ≠ Corriger" et détaille les 3 étapes séparées.
+
+### 3.2. Les workflows d'exploration et de planification existent déjà
+
+La section 18 (issue `#268`) définit le workflow d'exploration en lecture seule. La section 19 (issue `#269`) définit le workflow de planification en lecture seule.
+
+Le workflow de tests/diagnostic vient compléter cette chaîne : il est le troisième volet après l'exploration et la planification, avant l'implémentation et la correction.
+
+### 3.3. L'existant projet révèle l'état réel des vérifications mécaniques
+
+**Tests Vitest** :
+- 2 configurations coexistent : `vitest.config.mjs` (défaut, setup minimal, ~80+ fichiers de test) et `vitest.config.js` (coverage, clearMocks, setup complet).
+- Scripts package.js : `test`, `test:watch`, `test:coverage`.
+- Plus de 1500 tests dans `tests/` couvrant documents, dés, import OggDude, applications, lib, etc.
+
+**Tests E2E Playwright** :
+- Configuration complète dans `playwright.config.ts`.
+- Scripts : `e2e`, `e2e:headed`, `e2e:ci`, `e2e:ui`.
+- Documentation dédiée : `documentation/tests/e2e/playwright-e2e-guide.md`.
+
+**Lint ESLint** :
+- Configuration `eslint.config.mjs` existante et opérationnelle.
+- Mais **aucun script `lint` n'est encore déclaré dans `package.json`**.
+- Les références dans la documentation utilisent `pnpm exec eslint ...` ou `pnpm eslint ...` (via `npx`).
+- Une commande `fmt:check` existe pour Prettier.
+
+**Scripts mécaniques projet** :
+- `scripts/validate-logging-migration.sh` : valide la migration du logging (console → logger centralisé).
+- `scripts/e2e-foundry-start.sh` : gestion du conteneur Docker Foundry pour E2E.
+
+### 3.4. La dépendance `Blocked by #256` n'est pas un blocage technique
+
+Comme pour `#268` et `#269`, la référence GitHub `#256` pointe vers une PR `talent-tree` déjà mergée, sans lien apparent avec le périmètre OpenCode / documentation. Cette dépendance est traitée comme un risque de traçabilité documentaire, pas comme un blocage technique réel.
+
+### 3.5. Aucun artefact documentaire dédié au workflow de tests/diagnostic n'existe encore
+
+Le repo contient aujourd'hui :
+- une doctrine générale (cadrage OpenCode) ;
+- un workflow d'exploration documenté (`#268`) ;
+- un workflow de planification documenté (`#269`) ;
+- des skills de planification, implémentation, écriture de plan ;
+- une infrastructure de tests riche mais sans workflow OpenCode formalisé.
+
+Il manque :
+- une spécification documentaire explicite du workflow de tests/diagnostic OpenCode ;
+- une matrice de scénarios de validation ;
+- la section normative dans le cadrage OpenCode.
+
+---
+
+## 4. Décisions d'architecture
+
+### 4.1. Commande documentée plutôt que skill dédié
+
+**Question** : faut-il cadrer le workflow de tests/diagnostic comme un nouveau skill ou comme une commande OpenCode documentée ?
+
+**Options envisagées** :
+- créer un skill dédié aux vérifications mécaniques ;
+- cadrer une future commande OpenCode distincte ;
+- faire les deux.
+
+**Décision** : cadrer le workflow comme une future **commande OpenCode de test et diagnostic**, sans skill dédié.
+
+**Justification** :
+- `#267` classe les vérifications mécaniques parmi les activités à faible risque, adaptées aux commandes/scripts plutôt qu'aux skills.
+- L'audit `#267` recommande explicitement de ne pas créer de skill pour les activités mécaniques (lint, tests automatisés).
+- Le savoir projet à capitaliser est faible ici : le besoin est un flux standard, pas une connaissance métier durable.
+- Cohérence avec les workflows `#268` (commande d'exploration) et `#269` (commande de planification).
+
+### 4.2. Séparation stricte en 3 phases : exécution → diagnostic → correction
+
+**Question** : comment organiser la séquence d'intervention pour une demande de test/vérification ?
+
+**Options envisagées** :
+- workflow monolithique (tout-en-un : exécuter, analyser, corriger) ;
+- 2 phases (exécution + analyse, puis correction si besoin) ;
+- 3 phases séparées (exécution, diagnostic, correction).
+
+**Décision** : retenir **3 phases strictement séparées**.
+
+**Justification** :
+- C'est le principe central énoncé dans le cadrage OpenCode (§4.7).
+- Chaque phase a un agent, un modèle et des permissions différents.
+- Cela évite qu'une simple demande d'exécution de tests déclenche une correction non sollicitée.
+- L'exécution doit être pilotée par script avec intervention LLM minimale.
+- Le diagnostic est la seule phase qui justifie un modèle plus capable.
+- La correction est une étape optionnelle, déclenchée explicitement.
+
+### 4.3. Périmètre des vérifications couvertes par le workflow
+
+**Question** : quelles vérifications mécaniques le workflow doit-il couvrir ?
+
+**Options envisagées** :
+- limiter à Vitest uniquement ;
+- couvrir Vitest + lint ;
+- couvrir toutes les vérifications projet (tests, lint, format, scripts, E2E).
+
+**Décision** : couvrir **toutes les vérifications mécaniques projet** dans le workflow, avec un paramètre de sélection.
+
+**Justification** :
+- L'issue demande explicitement "tests, lint et vérifications mécaniques".
+- L'existant projet montre que plusieurs outils sont déjà configurés (ESLint, Prettier, Vitest, Playwright, scripts shell).
+- Un workflow unique avec sous-commandes est plus simple que des workflows séparés par outil.
+- Cohérent avec la doctrine : toutes ces tâches relèvent du même profil d'exécution mécanique.
+
+Sous-commandes prévues :
+- `check tests` — exécution Vitest
+- `check coverage` — couverture Vitest
+- `check e2e` — tests Playwright (avec variantes headed/ci)
+- `check lint` — ESLint (exécution explicite)
+- `check format` — Prettier check
+- `check script <nom>` — script projet (ex. validate-logging-migration)
+- `check all` — toutes les vérifications applicables
+
+### 4.4. Le workflow s'arrête au diagnostic exploitable
+
+**Question** : le workflow doit-il inclure une correction automatique des échecs ?
+
+**Options envisagées** :
+- inclure la correction dans le même workflow ;
+- arrêter le workflow au diagnostic et laisser la correction en étape séparée.
+
+**Décision** : arrêter le workflow au **diagnostic exploitable**.
+
+**Justification** :
+- L'acceptance criterion `#270` demande explicitement "avant modification".
+- La règle "exécuter ≠ analyser ≠ corriger" est fondamentale dans le cadrage OpenCode.
+- La correction nécessite un agent, un modèle et des permissions différents.
+- Permet à l'utilisateur de valider le diagnostic avant d'engager une correction.
+- Cohérent avec le workflow de planification `#269` qui s'arrête aussi au plan validé.
+
+### 4.5. Le diagnostic doit être ciblé, pas un dump de logs
+
+**Question** : quel format de sortie pour le diagnostic en cas d'échec ?
+
+**Options envisagées** :
+- envoyer l'intégralité des logs au modèle pour analyse ;
+- pré-filtrer le résultat de la commande pour extraire le périmètre utile ;
+- les deux selon la complexité.
+
+**Décision** : le diagnostic doit travailler sur **un volume réduit et pertinent** extrait de la sortie de la commande.
+
+**Justification** :
+- Le cadrage OpenCode (§4.7) le stipule explicitement.
+- ADR-0012 impose des diagnostics lisibles et ciblés.
+- Évite la consommation inutile de tokens sur des logs massifs.
+- La sortie utile comprend : commande exécutée, statut de sortie, message d'erreur principal, fichiers concernés, extrait minimal de log.
+
+### 4.6. Phase 1 (exécution) : agent économique ou local, sans modèle
+
+**Question** : quel niveau de modèle pour l'exécution mécanique ?
+
+**Décision** : l'exécution mécanique est confiée à un **agent économique ou local**, ou mieux à une **exécution script sans modèle**.
+
+**Justification** :
+- Conforme à la doctrine : ce qui peut être fait par script doit être fait par script.
+- Aucune intelligence n'est requise pour lancer une commande de test et en capturer la sortie.
+- Un modèle économique suffit pour interpréter le statut de sortie et décider de la suite.
+
+### 4.7. Phase 2 (diagnostic) : modèle intermédiaire ou de raisonnement
+
+**Question** : quel niveau de modèle pour le diagnostic d'échec ?
+
+**Décision** : le diagnostic utilise un **modèle intermédiaire ou de raisonnement** selon la complexité de l'échec.
+
+**Justification** :
+- Un échec simple (test qui ne passe pas, erreur ESLint évidente) peut être diagnostiqué par un modèle intermédiaire.
+- Un échec complexe (régression transverse, mock obsolète, dépendance cassée) justifie un modèle de raisonnement.
+- Le diagnostic doit inclure : hypothèse de cause, fichiers concernés, suggestion de correction minimale.
+
+### 4.8. Phase 3 (correction) : étape séparée, non incluse dans ce workflow
+
+**Décision** : la correction est une **étape séparée et optionnelle**, déclenchée explicitement par l'utilisateur après réception du diagnostic.
+
+**Justification** :
+- Cohérence avec le périmètre "avant modification" de l'issue.
+- La correction mobilise un agent d'implémentation, pas un agent de diagnostic.
+- Évite les corrections automatiques non sollicitées.
+- L'utilisateur peut choisir de corriger lui-même, de reporter, ou de demander une correction.
+
+### 4.9. Traitement de la dépendance `#256`
+
+**Décision** : la référence `Blocked by #256` est traitée comme une **anomalie de traçabilité documentaire**, pas comme un blocage technique.
+
+**Justification** :
+- `#256` pointe vers une PR talent tree mergée, sans lien avec OpenCode ou les tests.
+- Même constat que pour `#268` et `#269`.
+- À signaler dans le plan comme risque de traçabilité, sans impact sur l'exécution du ticket.
+
+---
+
+## 5. Plan de travail détaillé
+
+### Étape 1 — Ajouter une section normative dédiée au workflow de tests et diagnostic
+
+**Quoi faire** :
+- Étendre `documentation/cadrage/llm/cadrage-opencode-configuration.md` avec une nouvelle section (section 20) dédiée au workflow de tests et diagnostic d'échec.
+- Y formaliser :
+  - intention utilisateur ;
+  - niveau de risque ;
+  - type d'agent par phase ;
+  - permissions par phase ;
+  - contrat de sortie par phase ;
+  - articulation avec exploration, planification, implémentation et correction.
+- Structurer la section en 3 sous-sections correspondant aux 3 phases : exécution, diagnostic, correction.
+
+**Fichiers à modifier** :
+- `documentation/cadrage/llm/cadrage-opencode-configuration.md`
+
+**Risques spécifiques** :
+- Répéter la doctrine existante sans l'opérationnaliser.
+- Créer une section trop lourde qui duplique les §4.5, 4.6, 4.7 déjà présents.
+
+### Étape 2 — Spécifier la future commande OpenCode de test et diagnostic
+
+**Quoi faire** :
+- Créer une spécification documentaire `opencode-test-diagnostics-command.md` dans `documentation/spec/llm/`.
+- Définir :
+  - les demandes éligibles (exécuter des tests, lancer le lint, vérifier le format, exécuter un script) ;
+  - les entrées acceptées (filtres de tests, sous-commande, profondeur de diagnostic) ;
+  - la séquence en 3 phases ;
+  - les outils autorisés par phase ;
+  - les interdits par phase ;
+  - la structure de sortie attendue par phase ;
+  - les garde-fous explicites.
+
+**Fichiers à créer** :
+- `documentation/spec/llm/opencode-test-diagnostics-command.md`
+
+**Risques spécifiques** :
+- Produire une spec trop liée au runtime OpenCode actuel.
+- Négliger la variété des sous-commandes (tests, lint, format, E2E, scripts).
+
+### Étape 3 — Formaliser les contrats de sortie par phase
+
+**Quoi faire** :
+- Définir le format de sortie pour chaque phase :
+
+**Phase 1 — Exécution** :
+```
+Commande exécutée : <commande>
+Statut : <succès/échec>
+Durée : <secondes>
+Fichiers testés : <nombre> (si applicable)
+Tests passés : <nombre> (si applicable)
+Tests échoués : <nombre> (si applicable)
+Sortie complète : <référence vers fichier temporaire si longue>
+```
+
+**Phase 2 — Diagnostic** (déclenché seulement si échec) :
+```
+Périmètre analysé : <fichiers/modules>
+Cause probable : <hypothèse>
+Fichiers incriminés : <liste>
+Extrait pertinent : <code/log extrait>
+Suggestion de correction : <description courte>
+Complexité estimée : <faible/moyenne/élevée>
+Modèle recommandé pour la correction : <type>
+```
+
+**Phase 3 — Correction** (déclenchée explicitement) :
+Non détaillée dans ce ticket (renvoi vers `implementer-depuis-plan` ou workflow de correction).
+
+**Fichiers à modifier** :
+- `documentation/spec/llm/opencode-test-diagnostics-command.md`
+
+**Risques spécifiques** :
+- Formats trop verbeux pour une exécution rapide.
+- Formats trop pauvres pour un diagnostic utile.
+
+### Étape 4 — Définir le routage et les garde-fous
+
+**Quoi faire** :
+- Documenter explicitement les règles de routage :
+  - demande de test simple → exécution uniquement ;
+  - demande de test avec analyse → exécution + diagnostic ;
+  - demande de correction → exécution + diagnostic + proposition de correction (attente validation).
+- Documenter les interdits :
+  - pas de correction automatique sans validation ;
+  - pas d'élargissement du scope au-delà de la demande ;
+  - pas de modification de code pendant le diagnostic ;
+  - pas de reformulation du plan de test en plan d'implémentation.
+- Documenter les cas nécessitant une question à l'utilisateur :
+  - filtre de tests ambigu ;
+  - échec massif (>50% des tests) ;
+  - échec sur l'infrastructure de test (mock, setup) vs code métier ;
+  - diagnostic incertain.
+
+**Fichiers à modifier** :
+- `documentation/spec/llm/opencode-test-diagnostics-command.md`
+
+**Risques spécifiques** :
+- Garde-fous trop faibles (risque de dérive).
+- Garde-fous trop nombreux (blocage du workflow).
+
+### Étape 5 — Articuler avec les workflows voisins
+
+**Quoi faire** :
+- Décrire la chaîne complète des workflows OpenCode :
+```
+Exploration (#268) → Planification (#269) → Exécution de tests (ce ticket) → Diagnostic → Correction (séparée)
+```
+- Préciser les transitions :
+  - l'exploration peut détecter un besoin de test et orienter vers ce workflow ;
+  - la planification peut inclure une validation par les tests ;
+  - l'implémentation (implementer-depuis-plan) doit pouvoir déclencher une vérification post-implémentation ;
+  - le diagnostic peut escalader vers planification si l'échec révèle un problème d'architecture.
+
+**Fichiers à modifier** :
+- `documentation/spec/llm/opencode-test-diagnostics-command.md`
+- `documentation/cadrage/llm/cadrage-opencode-configuration.md`
+
+**Risques spécifiques** :
+- Créer des dépendances circulaires entre workflows.
+- Surcharger la spécification avec des cas d'escalade rares.
+
+### Étape 6 — Produire une matrice de validation manuelle
+
+**Quoi faire** :
+- Créer des scénarios couvrant au minimum :
+  - exécution simple de tous les tests (succès et échec) ;
+  - exécution filtrée (un dossier, un fichier, un pattern) ;
+  - lint avec et sans erreurs ;
+  - vérification de format avec et sans écarts ;
+  - échec de test avec diagnostic simple (assertion incorrecte) ;
+  - échec de test avec diagnostic complexe (mock obsolète, régression) ;
+  - demande ambiguë (pas de précision sur le type de vérification) ;
+  - refus correct de corriger automatiquement ;
+  - escalade correcte vers implémentation ou planification ;
+  - exécution E2E simple ;
+  - exécution d'un script projet (validate-logging-migration).
+
+**Fichiers à créer** :
+- `documentation/spec/llm/opencode-test-diagnostics-scenarios.md`
+
+**Risques spécifiques** :
+- Oublier des cas limites (échec de l'outil lui-même, timeout).
+- Scénarios trop théoriques pour être rejoués.
+
+---
+
+## 6. Fichiers modifiés
+
+| Fichier | Action | Description du changement |
+|---|---|---|
+| `documentation/plan/llm/270-plan-workflow-test-diagnostics.md` | création | Plan canonique de l'issue |
+| `documentation/cadrage/llm/cadrage-opencode-configuration.md` | modification | Ajout d'une section 20 dédiée au workflow de tests et diagnostic d'échec |
+| `documentation/spec/llm/opencode-test-diagnostics-command.md` | création | Spécification opérable de la future commande OpenCode de test et diagnostic |
+| `documentation/spec/llm/opencode-test-diagnostics-scenarios.md` | création | Scénarios de validation manuelle et matrice d'escalade |
+
+---
+
+## 7. Risques
+
+| Risque | Impact | Mitigation |
+|---|---|---|
+| Confondre exécution et correction | L'agent corrige avant d'avoir diagnostiqué | Séparation stricte en 3 phases avec permissions différentes |
+| Confondre diagnostic et implémentation | Le diagnostic propose du code au lieu d'une analyse | Contrat de sortie borné : hypothèse, cause, fichiers, pas de code correctif |
+| Périmètre trop large (trop de sous-commandes) | Spécification difficile à implémenter | Prioriser Vitest + lint comme socle minimal, E2E et scripts comme extensions |
+| Aucun script lint dans package.json | Impossible d'exécuter "pnpm lint" | La spec documente l'appel explicite `pnpm exec eslint ...` et recommande d'ajouter le script dans un ticket ultérieur |
+| Sortie de test trop volumineuse pour le modèle | Consommation excessive de tokens | Filtrer la sortie : statut + erreurs + fichiers incriminés uniquement |
+| Dépendance `#256` incohérente | Mauvaise lecture des prérequis | Documenter la dépendance comme anomalie de traçabilité, pas comme blocage technique |
+| Validation trop théorique | Workflow non fiable en pratique | Prévoir une batterie de scénarios manuels représentatifs couvrant succès, échec simple, échec complexe |
+
+---
+
+## 8. Proposition d'ordre de commit
+
+1. `docs(opencode): formaliser le workflow de tests et diagnostic d'echec`
+2. `docs(opencode): specifier la commande de test et diagnostic`
+3. `docs(opencode): ajouter les scenarios de validation du workflow de tests`
+
+---
+
+## 9. Dépendances avec les autres US
+
+- `#267` est une dépendance doctrinale amont : elle valide l'orchestration assistée, classe les vérifications mécaniques en risque faible, fixe la règle commandes vs skills.
+- `#268` et `#269` sont des dépendances fonctionnelles voisines : les workflows d'exploration et de planification doivent pouvoir escalader vers ce workflow de tests/diagnostic, et réciproquement.
+- Une future étape d'alignement des commandes OpenCode reste probable pour matérialiser réellement la commande, mais n'est pas bloquante pour ce ticket documentaire.
+- La correction des échecs détectés reste volontairement séparée : elle sera couverte par un ticket dédié ou par `implementer-depuis-plan`.
+- La référence `Blocked by #256` doit être clarifiée : GitHub pointe vers une PR talent-tree mergée sans lien avec OpenCode. Traitée comme anomalie documentaire.

--- a/documentation/spec/llm/opencode-test-diagnostics-command.md
+++ b/documentation/spec/llm/opencode-test-diagnostics-command.md
@@ -1,0 +1,294 @@
+# Spécification — Commande OpenCode de test et diagnostic d'échec
+
+**Issue** : [#270 — OpenCode - Cadrer un workflow de tests et d'analyse d'echec avant modification](https://github.com/herveDarritchon/foundryvtt-swerpg/issues/270)
+**Doctrine de référence** : `documentation/cadrage/llm/cadrage-opencode-configuration.md` (section 20)
+
+---
+
+## 1. Objectif
+
+Cette spécification décrit la future commande OpenCode de test et diagnostic d'échec. Elle formalise le contrat d'entrée, le contrat d'exécution, le contrat de sortie et la matrice d'escalade, sans présumer de l'emplacement exact de stockage des commandes dans le dépôt (à définir dans un ticket d'alignement technique).
+
+La commande exécute des vérifications mécaniques (tests, lint, format, scripts projet) et produit un diagnostic ciblé en cas d'échec, sans jamais corriger automatiquement ni modifier le code source.
+
+---
+
+## 2. Contrat d'entrée
+
+### 2.1. Types de demandes éligibles
+
+La commande est déclenchée pour les intentions suivantes :
+
+- **Exécuter des tests** : « Lance les tests », « Exécute `pnpm test` », « Fais passer les tests du dossier `tests/documents/` »
+- **Vérifier le format** : « Vérifie le format Prettier », « Lance `pnpm fmt:check` »
+- **Lancer le lint** : « Vérifie le lint ESLint », « Lance ESLint sur le module X »
+- **Exécuter un script projet** : « Lance la validation de migration du logging », « Exécute `validate-logging-migration` »
+- **Analyser un échec** : « Les tests échouent, peux-tu analyser pourquoi ? », « Diagnostique cet échec de test »
+- **Vérification complète** : « Fais une vérification complète du projet », « Lance `check all` »
+
+### 2.2. Types de demandes exclues
+
+La commande refuse ou redirige les demandes suivantes :
+
+- **Explorer** : « Où est définie la fonction X ? » → escalade vers le workflow d'exploration `#268`
+- **Planifier** : « Fais un plan pour ajouter la fonctionnalité Y » → escalade vers `plan-depuis-issue`
+- **Corriger** : « Corrige le bug dans Z » → escalade vers diagnostic / correction
+- **Implémenter** : « Ajoute la fonction X dans le fichier Y » → escalade vers `implementer-depuis-plan`
+- **Écrire des tests** : « Ajoute des tests pour le module X » → implémentation dédiée
+
+### 2.3. Entrées acceptées
+
+| Type d'entrée | Format | Exemple |
+|---|---|---|
+| Sous-commande explicite | `check <sous-commande>` | `check tests` |
+| Sous-commande + filtre | `check <sous-commande> <filtre>` | `check tests tests/documents/` |
+| Profondeur de diagnostic | `check --diagnose` ou `check --fix` | `check tests --diagnose` |
+| Demande textuelle | Phrase libre | « Lance les tests du dossier importer » |
+| Résultat précédent | Sortie d'une commande + demande d'analyse | Sortie de `pnpm test` + « Analyse cet échec » |
+
+### 2.4. Profondeur de diagnostic
+
+| Mode | Usage typique | Phases activées |
+|---|---|---|
+| `check` (défaut) | Vérification rapide, résultat binaire | Phase 1 uniquement |
+| `check --diagnose` | Exécution + analyse en cas d'échec | Phase 1 + Phase 2 |
+| `check --fix` | Exécution + analyse + proposition de correction (attente validation) | Phase 1 + Phase 2 + Phase 3 (validation requise) |
+
+---
+
+## 3. Contrat d'exécution
+
+### 3.1. Phase 1 — Exécution mécanique
+
+**Agent** : exécution script, pas de modèle ou modèle économique.
+
+**Outils autorisés** :
+- Commande shell pour lancer la vérification (bash)
+- Lecture du statut de sortie et de la sortie standard/erreur
+
+**Interdits** :
+- Modification de code
+- Analyse ou interprétation du résultat
+- Lancement de vérifications supplémentaires non demandées
+
+**Sortie produite** :
+```
+Commande exécutée : <commande exacte>
+Statut : <succès/échec>
+Durée : <secondes>
+Fichiers testés : <nombre> (si applicable)
+Tests passés : <nombre> (si applicable)
+Tests échoués : <nombre> (si applicable)
+Sortie complète : <référence vers fichier temporaire si longue>
+```
+
+### 3.2. Phase 2 — Diagnostic
+
+**Déclenchement** : seulement si la phase 1 échoue et si l'utilisateur le demande (mode `--diagnose` ou `--fix`).
+
+**Agent** : général / diagnostic, modèle intermédiaire ou de raisonnement selon complexité.
+
+**Outils autorisés** :
+- Recherche de fichiers (glob)
+- Recherche textuelle (grep, regex)
+- Lecture de fichiers (read, avec offset/limit)
+- Extraction de logs à partir de la sortie de la phase 1
+
+**Interdits** :
+- Édition ou écriture de fichiers
+- Modification de code
+- Lancement de nouvelles vérifications
+- Correction même partielle
+
+**Sortie produite** :
+```
+Périmètre analysé : <fichiers/modules concernés>
+Cause probable : <hypothèse>
+Fichiers incriminés : <liste>
+Extrait pertinent : <code/log extrait>
+Suggestion de correction : <description courte>
+Complexité estimée : <faible/moyenne/élevée>
+Modèle recommandé pour la correction : <type>
+```
+
+### 3.3. Phase 3 — Correction
+
+**Déclenchement** : seulement sur instruction explicite de l'utilisateur après réception du diagnostic.
+
+**Agent** : implémentation.
+
+**Détail** : non spécifié dans ce document. Renvoi vers `implementer-depuis-plan` ou workflow de correction dédié.
+
+---
+
+## 4. Contrat de sortie
+
+### 4.1. Format par défaut (mode `check`)
+
+```
+## Résultat
+
+Vérification : <sous-commande>
+Statut : ✅ SUCCÈS / ❌ ÉCHEC
+Durée : <secondes>
+
+### Détails
+- Commande : <commande exécutée>
+- Fichiers testés : <nombre>
+- Tests passés : <nombre>
+- Tests échoués : <nombre>
+```
+
+### 4.2. Format avec diagnostic (mode `--diagnose` ou `--fix`)
+
+```
+## Résultat
+
+Vérification : <sous-commande>
+Statut : ❌ ÉCHEC
+Durée : <secondes>
+
+### Détails d'exécution
+- Commande : <commande exécutée>
+- Fichiers testés : <nombre>
+- Tests passés : <nombre>
+- Tests échoués : <nombre>
+
+### Diagnostic
+- Périmètre analysé : <fichiers/modules>
+- Cause probable : <hypothèse>
+- Fichiers incriminés : <liste>
+- Extrait pertinent :
+```
+<code ou log>
+```
+- Suggestion de correction : <description>
+- Complexité estimée : <faible/moyenne/élevée>
+
+### Suite recommandée
+- Corriger : demande une implémentation de correction
+- Ignorer : l'échec est acceptable ou connu
+- Reporter : créer une issue pour investigation ultérieure
+```
+
+### 4.3. Règles de sobriété
+
+- La sortie complète de la phase 1 n'est pas envoyée au modèle si elle dépasse 50 lignes.
+- Seuls le statut, le message d'erreur principal et les fichiers incriminés sont transmis au diagnostic.
+- Le diagnostic ne contient pas de code correctif exécutable, seulement une description textuelle.
+- Pas de transition automatique vers la phase 3.
+
+---
+
+## 5. Sous-commandes détaillées
+
+### 5.1. `check tests` — Tests unitaires Vitest
+
+| Propriété | Valeur |
+|---|---|
+| Commande par défaut | `pnpm test` |
+| Commande avec filtre | `pnpm vitest run <filtre>` |
+| Commande coverage | `pnpm test:coverage` |
+| Configuration | `vitest.config.mjs` (défaut) ou `vitest.config.js` (coverage) |
+| Filtres acceptés | Chemin de dossier, chemin de fichier, pattern grep |
+
+### 5.2. `check e2e` — Tests E2E Playwright
+
+| Propriété | Valeur |
+|---|---|
+| Commande par défaut | `pnpm e2e` |
+| Variante headed | `pnpm e2e:headed` |
+| Variante CI | `pnpm e2e:ci` |
+| Variante UI | `pnpm e2e:ui` |
+| Configuration | `playwright.config.ts` |
+
+### 5.3. `check lint` — Lint ESLint
+
+| Propriété | Valeur |
+|---|---|
+| Commande | `pnpm exec eslint <cibles>` |
+| Cible par défaut | `module/ tests/ scripts/` |
+| Note | Aucun script `lint` n'existe dans `package.json` à ce stade ; la commande documente l'appel direct |
+
+### 5.4. `check format` — Format Prettier
+
+| Propriété | Valeur |
+|---|---|
+| Commande | `pnpm fmt:check` |
+| Note | Vérification uniquement, pas de correction automatique |
+
+### 5.5. `check script <nom>` — Scripts projet
+
+| Propriété | Valeur |
+|---|---|
+| Commande | `bash scripts/<nom>.sh` |
+| Scripts connus | `validate-logging-migration`, `e2e-foundry-start` |
+| Note | Le nom du script est passé sans l'extension `.sh` |
+
+### 5.6. `check all` — Vérification complète
+
+Exécute séquentiellement : `check tests`, `check lint`, `check format`.
+
+---
+
+## 6. Garde-fous
+
+### 6.1. Règles impératives
+
+1. **Exécuter ≠ Analyser ≠ Corriger** — Chaque phase est une étape distincte avec des permissions différentes.
+2. **Pas de correction automatique** — Même si la correction est évidente, le workflow attend une instruction explicite.
+3. **Pas d'élargissement du scope** — La vérification se limite à ce qui a été demandé.
+4. **Pas de modification de code pendant le diagnostic** — Le diagnostic est lecture seule.
+5. **Pas de reformulation du besoin** — Une demande de test ne devient pas une demande d'implémentation.
+6. **Volume réduit pour le diagnostic** — Seuls les éléments pertinents (statut, erreur, fichiers) sont transmis au modèle.
+
+### 6.2. Cas nécessitant une question à l'utilisateur
+
+Le workflow doit poser une question à l'utilisateur dans les cas suivants :
+
+- Le filtre de tests est ambigu (plusieurs interprétations possibles).
+- L'échec est massif (>50% des tests).
+- L'échec semble lié à l'infrastructure de test (mock, setup) plutôt qu'au code métier.
+- La cause de l'échec est incertaine et plusieurs hypothèses coexistent.
+- La vérification demandée n'existe pas (sous-commande inconnue).
+
+---
+
+## 7. Matrice d'escalade
+
+| Condition d'escalade | Destination | Déclenchement |
+|---|---|---|
+| La demande nécessite une exploration préalable | Workflow d'exploration `#268` | L'utilisateur demande à comprendre avant de vérifier |
+| La demande nécessite une planification | `plan-depuis-issue` | Le diagnostic révèle un problème d'architecture |
+| La demande nécessite une implémentation | `implementer-depuis-plan` | L'utilisateur demande du code après le diagnostic |
+| La demande nécessite une correction de bug | Diagnostic / Correction | L'utilisateur signale un comportement inattendu |
+| Aucune des conditions ci-dessus | Fin | La vérification a répondu au besoin |
+
+L'escalade n'est jamais automatique. Le workflow signale la recommandation et attend une instruction explicite.
+
+---
+
+## 8. Articulation avec les workflows voisins
+
+```
+Exploration (#268) → Planification (#269) → Implémentation → Tests/Diagnostic (ce workflow) → Correction (séparée)
+```
+
+- L'exploration livre des constats. Si elle détecte un besoin de vérification, elle oriente vers cette commande.
+- La planification peut recommander une validation par les tests après implémentation.
+- L'implémentation (`implementer-depuis-plan`) doit pouvoir déclencher une vérification post-implémentation.
+- La correction est une étape séparée qui suit le diagnostic.
+
+Chaque transition est explicite et nécessite une instruction utilisateur.
+
+---
+
+## 9. Emplacement futur
+
+La commande sera matérialisée dans l'emplacement défini par le futur ticket d'alignement des commandes OpenCode. Les candidats possibles sont :
+
+- `.opencode/commands/check.mjs` (si le dépôt adopte `.opencode/`)
+- `docs/agents/check-command.md` (si le dépôt privilégie une approche documentaire)
+- tout autre emplacement validé par la configuration OpenCode projet
+
+Cette spécification sert de source de vérité fonctionnelle, indépendante de l'emplacement technique final.

--- a/documentation/spec/llm/opencode-test-diagnostics-scenarios.md
+++ b/documentation/spec/llm/opencode-test-diagnostics-scenarios.md
@@ -1,0 +1,250 @@
+# Scénarios de validation — Commande OpenCode de test et diagnostic d'échec
+
+**Issue** : [#270 — OpenCode - Cadrer un workflow de tests et d'analyse d'echec avant modification](https://github.com/herveDarritchon/foundryvtt-swerpg/issues/270)
+**Doctrine de référence** : `documentation/cadrage/llm/cadrage-opencode-configuration.md` (section 20)
+**Spécification** : `documentation/spec/llm/opencode-test-diagnostics-command.md`
+
+---
+
+## Scénario 1 — Exécution simple de tous les tests (succès)
+
+**Entrée** : « Lance tous les tests Vitest. »
+
+**Comportement attendu** :
+- Exécution de `pnpm test`.
+- Capture du statut, du nombre de fichiers testés, tests passés/échoués.
+- Production du contrat de sortie Phase 1 sans déclencher de diagnostic.
+
+**Format de sortie attendu** :
+```
+## Résultat
+
+Vérification : tests
+Statut : ✅ SUCCÈS
+Durée : <secondes>
+
+### Détails
+- Commande : pnpm test
+- Fichiers testés : 80+
+- Tests passés : 1500+
+- Tests échoués : 0
+```
+
+**Critère d'acceptation** : le résultat est produit sans analyse ni diagnostic. Aucun fichier n'est modifié.
+
+---
+
+## Scénario 2 — Exécution simple de tous les tests (échec)
+
+**Entrée** : « Lance tous les tests Vitest. »
+
+**Comportement attendu** :
+- Exécution de `pnpm test`.
+- Capture du statut d'échec, du nombre de tests échoués, des fichiers incriminés.
+- Production du contrat de sortie Phase 1 avec statut échec.
+- Pas de diagnostic automatique (mode `check` par défaut).
+
+**Format de sortie attendu** :
+```
+## Résultat
+
+Vérification : tests
+Statut : ❌ ÉCHEC
+Durée : <secondes>
+
+### Détails
+- Commande : pnpm test
+- Fichiers testés : 80+
+- Tests passés : 1495
+- Tests échoués : 5
+```
+
+**Critère d'acceptation** : l'échec est signalé sans analyse automatique. L'utilisateur peut demander un diagnostic en mode `--diagnose`.
+
+---
+
+## Scénario 3 — Exécution filtrée avec diagnostic
+
+**Entrée** : « Lance les tests du dossier `tests/documents/` avec diagnostic. »
+
+**Comportement attendu** :
+- Exécution de `pnpm vitest run tests/documents/`.
+- En cas d'échec, déclenchement automatique de la phase 2 (mode `--diagnose`).
+- Analyse de la sortie d'erreur : extraction des fichiers en échec, message d'assertion, ligne concernée.
+- Production du diagnostic avec hypothèse de cause et suggestion de correction.
+
+**Format de sortie attendu** :
+```
+## Résultat
+
+Vérification : tests (tests/documents/)
+Statut : ❌ ÉCHEC
+Durée : <secondes>
+
+### Détails d'exécution
+- Commande : pnpm vitest run tests/documents/
+- Fichiers testés : 12
+- Tests passés : 45
+- Tests échoués : 2
+
+### Diagnostic
+- Périmètre analysé : tests/documents/actor-creation.test.mjs
+- Cause probable : une assertion attend une valeur différente après un changement de modèle
+- Fichiers incriminés : tests/documents/actor-creation.test.mjs:142
+- Extrait pertinent :
+  Expected: 3
+  Received: 2
+- Suggestion de correction : mettre à jour la valeur attendue dans le test ou corriger le calcul dans le modèle
+- Complexité estimée : faible
+
+### Suite recommandée
+- Corriger : demande une implémentation de correction
+- Ignorer : l'échec est acceptable ou connu
+- Reporter : créer une issue pour investigation ultérieure
+```
+
+**Critère d'acceptation** : le diagnostic est produit avec les fichiers, lignes et cause probable. Aucune correction n'est appliquée.
+
+---
+
+## Scénario 4 — Lint ESLint avec et sans erreurs
+
+**Entrée** : « Vérifie le lint sur `module/` et `tests/`. »
+
+**Comportement attendu** :
+- Exécution de `pnpm exec eslint module/ tests/`.
+- Capture du statut et du nombre d'erreurs/warnings.
+- En cas d'erreur en mode `--diagnose`, extraction des fichiers incriminés et des règles violées.
+
+**Critère d'acceptation** : la commande distingue les erreurs des warnings. Le diagnostic liste les fichiers et les règles ESLint concernées.
+
+---
+
+## Scénario 5 — Vérification de format Prettier
+
+**Entrée** : « Vérifie le format Prettier. »
+
+**Comportement attendu** :
+- Exécution de `pnpm fmt:check`.
+- Signalement des fichiers non formatés sans appliquer de correction.
+
+**Critère d'acceptation** : aucun fichier n'est modifié. Les fichiers non conformes sont listés sans correction.
+
+---
+
+## Scénario 6 — Échec de test avec diagnostic complexe (régression)
+
+**Entrée** : « Lance les tests d'import OggDude avec diagnostic. »
+
+**Comportement attendu** :
+- Exécution de `pnpm vitest run tests/importer/`.
+- En cas d'échec, analyse de la cause : régression après modification du mapper, mock obsolète, fixture manquante.
+- Diagnostic incluant l'hypothèse de régression, les fichiers modifiés récemment (diff), et le fichier de test concerné.
+
+**Critère d'acceptation** : le diagnostic mentionne la cause probable de régression en reliant l'échec aux modifications récentes.
+
+---
+
+## Scénario 7 — Demande ambiguë (pas de précision sur le type de vérification)
+
+**Entrée** : « Vérifie que tout va bien. »
+
+**Comportement attendu** :
+- Détection que la demande est ambiguë (pas de sous-commande explicite).
+- Question à l'utilisateur pour préciser le type de vérification souhaitée.
+- Proposition des options disponibles : tests, lint, format, script, ou tout.
+
+**Critère d'acceptation** : le workflow pose une question au lieu de tout exécuter par défaut.
+
+---
+
+## Scénario 8 — Refus correct de corriger automatiquement
+
+**Entrée** : « Lance les tests et corrige les échecs. »
+
+**Comportement attendu** :
+- Exécution des tests (phase 1).
+- En cas d'échec, production du diagnostic (phase 2).
+- Refus explicite de corriger automatiquement.
+- Proposition d'escalade vers `implementer-depuis-plan` ou workflow de correction.
+
+**Format de sortie attendu** :
+```
+### Suite recommandée
+- Corriger : demande une implémentation de correction via `implementer-depuis-plan`
+- Ignorer : l'échec est acceptable ou connu
+- Reporter : créer une issue pour investigation ultérieure
+```
+
+**Critère d'acceptation** : aucune correction n'est appliquée. L'escalade est clairement proposée.
+
+---
+
+## Scénario 9 — Escalade correcte vers implémentation ou planification
+
+**Entrée** : Diagnostic d'un échec révélant un problème d'architecture + « Corrige le problème. »
+
+**Comportement attendu** :
+- Le diagnostic a déjà été produit.
+- Détection que la correction dépasse le périmètre du workflow de tests.
+- Proposition d'escalade vers planification (si le problème est architectural) ou vers implémentation (si la correction est localisée).
+
+**Critère d'acceptation** : la correction n'est pas tentée dans ce workflow. L'escalade est claire et argumentée.
+
+---
+
+## Scénario 10 — Exécution E2E simple
+
+**Entrée** : « Lance les tests E2E Chromium. »
+
+**Comportement attendu** :
+- Exécution de `pnpm e2e -- --project=chromium`.
+- Capture du statut (succès/échec), du nombre de tests et de la durée.
+- Pas de diagnostic automatique sauf mode `--diagnose`.
+
+**Critère d'acceptation** : la commande E2E est exécutée avec le bon project. Résultat binaire.
+
+---
+
+## Scénario 11 — Exécution d'un script projet (validate-logging-migration)
+
+**Entrée** : « Exécute la validation de migration du logging. »
+
+**Comportement attendu** :
+- Exécution de `bash scripts/validate-logging-migration.sh`.
+- Capture du statut (succès/échec) et du message principal (PASS/FAIL pour chaque vérification).
+- En mode `--diagnose` et en cas d'échec, extraction des fichiers contenant des appels `console.xxx`.
+
+**Critère d'acceptation** : le script projet est exécuté avec les bons paramètres. Le résultat est interprété correctement.
+
+---
+
+## Scénario 12 — Sous-commande inconnue
+
+**Entrée** : « Lance `check toto`. »
+
+**Comportement attendu** :
+- Détection que `toto` n'est pas une sous-commande valide.
+- Question à l'utilisateur pour préciser la vérification souhaitée.
+- Liste des sous-commandes disponibles : tests, e2e, lint, format, script, all.
+
+**Critère d'acceptation** : le workflow ne tente pas d'exécuter une commande inconnue. Il demande une clarification.
+
+---
+
+## Résumé des cas couverts
+
+| # | Type | Périmètre |
+|---|---|---|
+| 1 | Exécution tests (succès) | Workflow nominal — succès |
+| 2 | Exécution tests (échec sans diagnostic) | Phase 1 uniquement |
+| 3 | Exécution filtrée avec diagnostic | Phase 1 + Phase 2 |
+| 4 | Lint ESLint | Sous-commande lint |
+| 5 | Format Prettier | Sous-commande format |
+| 6 | Diagnostic complexe (régression) | Diagnostic avancé |
+| 7 | Demande ambiguë | Question à l'utilisateur |
+| 8 | Refus de corriger automatiquement | Garde-fou anti-dérive |
+| 9 | Escalade vers implémentation/planification | Routage |
+| 10 | E2E Playwright | Sous-commande e2e |
+| 11 | Script projet | Sous-commande script |
+| 12 | Sous-commande inconnue | Gestion d'erreur |


### PR DESCRIPTION
## Summary

- Formalisation du workflow de tests, lint et vérifications mécaniques dans OpenCode.
- Ajout de la **section 20** dans `documentation/cadrage/llm/cadrage-opencode-configuration.md` : 3 phases (exécution → diagnostic → correction), sous-commandes, garde-fous, escalade.
- Création de `documentation/spec/llm/opencode-test-diagnostics-command.md` : spécification complète de la future commande `check` (contrats d'entrée/exécution/sortie, 6 sous-commandes, matrice d'escalade).
- Création de `documentation/spec/llm/opencode-test-diagnostics-scenarios.md` : 12 scénarios de validation manuelle.
- Création du plan canonique `documentation/plan/llm/270-plan-workflow-test-diagnostics.md`.

## Files changed

| File | Action |
|---|---|
| `documentation/cadrage/llm/cadrage-opencode-configuration.md` | modification (section 20) |
| `documentation/plan/llm/270-plan-workflow-test-diagnostics.md` | création |
| `documentation/spec/llm/opencode-test-diagnostics-command.md` | création |
| `documentation/spec/llm/opencode-test-diagnostics-scenarios.md` | création |

Closes #270