### PR TITLE
feat(specialization-tree): add pure render view-model builder for current tree

### DIFF
--- a/documentation/plan/character-sheet/specialization-tree/us16-2-current-tree-render-view-model.md
+++ b/documentation/plan/character-sheet/specialization-tree/us16-2-current-tree-render-view-model.md
@@ -1,0 +1,165 @@
+# US16.2 — Plan d'implémentation : Construire le view-model de rendu de l'arbre courant
+
+## Contexte
+
+Issue : [#295 — US16.2 - Construire le view-model de rendu de l'arbre courant](https://github.com/herveDarritchon/foundryvtt-swerpg/issues/295)
+
+Plan parent : `project-plan.md` (US16 Graphical Tree Rendering)
+Cadrage parent :
+`documentation/cadrage/character-sheet/specialization-tree/cadrage-us16-decoupage-rendu-graphique-arbres-specialisation.md`
+
+Règle métier : **le view-model de rendu expose, à partir du `currentTree` résolu par US16.1, une structure normalisée de
+nœuds et connexions prête à être consommée par la couche PIXI, sans logique métier dans le canvas.**
+
+## État des lieux
+
+La construction du view-model est actuellement embarquée dans `buildSpecializationTreeContext()` à
+`module/applications/specialization-tree-app.mjs`. Cette fonction (~291 lignes) mêle résolution d'arbre, layout, mapping
+d'états et préparation des données de rendu. Le view-model n'est pas extrait dans une fonction pure, isolée et testable
+unitairement.
+
+### Problème adressé par le plan
+
+1. Le code qui construit les nœuds et connexions pour le rendu PIXI est noyé dans le contexte de l'application.
+2. Il n'existe pas de contrat explicite (type/interface) pour le view-model de rendu.
+3. Le fallback sur un talent introuvable n'est pas explicite ni déterministe.
+4. Impossible de tester la structure des données de rendu sans instancier l'application complète.
+
+## Solution proposée
+
+Extraire un builder pur `buildRenderViewModel(currentTree, talentLookup)` :
+
+1. **Normalisation des nœuds** — chaque nœud expose `nodeId`, talent résolu ou fallback, coût, `row`, `column`, état
+   métier, métadonnées d'affichage.
+2. **Préparation des connexions** — transformer les arêtes du modèle domaine en une structure prête pour PIXI (
+   coordonnées, type de trait).
+3. **Fallback explicite** — talent introuvable → nœud avec état `unresolved`, données de fallback déterminées, pas
+   d'erreur silencieuse.
+
+### Contrat du view-model
+
+```js
+// RenderNode
+{
+  nodeId: string,
+    talent
+:
+  {
+    name: string, uuid
+  :
+    string
+  }
+|
+  FallbackTalent,
+    cost
+:
+  number,
+    row
+:
+  number,
+    column
+:
+  number,
+    state
+:
+  NodeState,         // locked, available, purchased, unavailable, unresolved
+    displayMeta
+:
+  {
+    label: string,
+      isPurchased
+  :
+    boolean,
+      isAvailable
+  :
+    boolean,
+      isLocked
+  :
+    boolean,
+      isUnresolved
+  :
+    boolean,
+  }
+,
+}
+
+// RenderConnection
+{
+  fromNodeId: string,
+    toNodeId
+:
+  string,
+    type
+:
+  'straight' | 'angled',
+    isActive
+:
+  boolean,
+}
+
+// RenderViewModel
+{
+  nodes: RenderNode[],
+    connections
+:
+  RenderConnection[],
+    metadata
+:
+  {
+    treeName: string,
+      treeId
+  :
+    string,
+      totalNodes
+  :
+    number,
+      totalConnections
+  :
+    number,
+  }
+,
+}
+```
+
+## Fichiers impactés
+
+| Fichier                                                         | Modifications                                              |
+|-----------------------------------------------------------------|------------------------------------------------------------|
+| `module/applications/specialization-tree/render-view-model.mjs` | Nouveau builder pur `buildRenderViewModel()`               |
+| `module/applications/specialization-tree-app.mjs`               | Remplacer la préparation embarquée par un appel au builder |
+| `module/applications/specialization-tree/types.mjs`             | Nouveau (ou existant) — types du view-model                |
+
+## Tests
+
+`tests/applications/specialization-tree/render-view-model.test.mjs` (nouveau) :
+
+- rendu nominal : tous les nœuds et connexions présents
+- talent introuvable : fallback explicite présent
+- arbre vide : view-model avec nœuds/connexions vides
+- perte de connexion si nœud source absent
+- pas de logique PIXI dans le builder
+
+## Définition de done
+
+- [ ] `buildRenderViewModel()` est une fonction pure, sans dépendance `game`, `ui`, `canvas`
+- [ ] Le view-model expose nœuds normalisés, connexions, métadonnées
+- [ ] Le fallback talent introuvable est explicite et testé
+- [ ] L'application utilise le builder plutôt que la logique embarquée
+- [ ] Couverture > 90% sur le nouveau fichier
+- [ ] Aucune régression sur les tests existants
+
+## Découpage en sous-issues
+
+| Issue | Titre                                            | Estimation |
+|-------|--------------------------------------------------|------------|
+| #295  | Story parente                                    | 2          |
+| —     | US16.2.a — Normaliser les nœuds du tree courant  | 1          |
+| —     | US16.2.b — Préparer les connexions du view-model | 1          |
+| —     | US16.2.c — Gérer le fallback talent introuvable  | 1          |
+| —     | US16.2.t — Tests du view-model de rendu          | 1          |
+
+## Dépendances
+
+- **Blocked by** : #294 (US16.1 — déterminer arbre courant)
+- **Blocked by** : Feature #200 (US16 — Graphical Tree Rendering)
+- **Blocks** : US16.3 (mapping états/raisons), US16.4 (layout graphique), US16.8 (consolidation)

--- a/documentation/ways-of-work/plan/specialization-tree-v1/us16-2-current-tree-render-view-model/issues-checklist.md
+++ b/documentation/ways-of-work/plan/specialization-tree-v1/us16-2-current-tree-render-view-model/issues-checklist.md
@@ -1,0 +1,77 @@
+# Issues Checklist — Specialization Tree V1 / US16.2 Current Tree Render View-Model
+
+## Préparation
+
+- [ ] Relire le cadrage US16.2 dans `cadrage-us16-decoupage-rendu-graphique-arbres-specialisation.md`
+- [ ] Confirmer le domaine métier `character-sheet / specialization-tree`
+- [ ] Vérifier le rattachement à l'Epic #184 et à la Feature #200
+- [ ] Vérifier le prérequis fonctionnel US16.1 sur la sélection de l'arbre courant
+
+## Story principale
+
+- [ ] Créer ou mettre à jour l'issue `#295 - US16.2 - Construire le view-model de rendu de l'arbre courant`
+- [ ] Renseigner `Priority = P0`, `Value = High`, `Component = Specialization Tree`, `Estimate = 2`
+- [ ] Ajouter les AC : nœuds normalisés, connexions prêtes au rendu, fallback talent introuvable, testabilité sans PIXI
+
+## Sous-issues recommandées
+
+### US16.2.a — Normaliser les nœuds du tree courant
+
+- [ ] Titre : `US16.2.a - Normaliser les nœuds du tree courant`
+- [ ] AC : exposer `nodeId`, talent, coût, `row`, `column`, état métier, métadonnées d'affichage
+- [ ] Priority : `P0`
+- [ ] Estimate : `1`
+- [ ] Bloquée par : `#295`
+
+### US16.2.b — Préparer les connexions du view-model
+
+- [ ] Titre : `US16.2.b - Préparer les connexions du view-model`
+- [ ] AC : exposer toutes les connexions utiles au rendu sans calcul PIXI
+- [ ] Priority : `P0`
+- [ ] Estimate : `1`
+- [ ] Bloquée par : `#295`
+
+### US16.2.c — Gérer le fallback talent introuvable
+
+- [ ] Titre : `US16.2.c - Gérer le fallback talent introuvable dans le view-model`
+- [ ] AC : fallback explicite, déterministe et non ambigu sur les talents non résolus
+- [ ] Priority : `P0`
+- [ ] Estimate : `1`
+- [ ] Bloquée par : `#295`
+
+### US16.2.t — Couvrir le contrat du view-model
+
+- [ ] Titre : `US16.2.t - Couvrir le contrat du view-model de rendu`
+- [ ] Cas : état vide, arbre nominal, exhaustivité des nœuds, exhaustivité des connexions, fallback talent introuvable, absence de dépendance PIXI
+- [ ] Priority : `P0`
+- [ ] Estimate : `1`
+- [ ] Bloquée par : `US16.2.a`, `US16.2.b`, `US16.2.c`
+
+## Dépendances GitHub à poser
+
+- [ ] `#295` **blocked by** Feature #200
+- [ ] `#295` **blocked by** prérequis US16.1 si non clos
+- [ ] `US16.2.a` **blocked by** `#295`
+- [ ] `US16.2.b` **blocked by** `#295`
+- [ ] `US16.2.c` **blocked by** `#295`
+- [ ] `US16.2.t` **blocked by** `US16.2.a`
+- [ ] `US16.2.t` **blocked by** `US16.2.b`
+- [ ] `US16.2.t` **blocked by** `US16.2.c`
+- [ ] Poser ensuite les liens **blocking** vers US16.3, US16.4 et la consolidation US16.8
+
+## Labels et board
+
+- [ ] Labels : `user-story` / `enabler` / `test`
+- [ ] Labels : `priority-high` ou équivalent `P0`, `value-high`, `specialization-tree`, `character-sheet`
+- [ ] Ajouter toutes les issues au board Kanban
+- [ ] Mettre `#295` en `Sprint Ready` seulement quand les AC sont figés
+
+## Checklist de clôture
+
+- [ ] Le contrat `currentTree` est explicite et stable
+- [ ] Le view-model expose tous les nœuds attendus
+- [ ] Le view-model expose toutes les connexions attendues
+- [ ] Le fallback talent introuvable est documenté et couvert
+- [ ] Aucune logique métier n'est nécessaire dans PIXI pour interpréter les données
+- [ ] Les dépendances GitHub vers les tickets aval sont posées
+- [ ] #295 peut être fermée sans refonte supplémentaire pour US16.3 / US16.4

--- a/documentation/ways-of-work/plan/specialization-tree-v1/us16-2-current-tree-render-view-model/project-plan.md
+++ b/documentation/ways-of-work/plan/specialization-tree-v1/us16-2-current-tree-render-view-model/project-plan.md
@@ -1,0 +1,125 @@
+# Project Plan — Specialization Tree V1 / US16.2 Current Tree Render View-Model
+
+## Contexte source
+
+- `documentation/cadrage/character-sheet/specialization-tree/cadrage-us16-decoupage-rendu-graphique-arbres-specialisation.md`
+- `documentation/cadrage/character-sheet/specialization-tree/cadrage-cles-metier-techniques-specialization-trees.md`
+- `documentation/ways-of-work/plan/specialization-tree-v1/us16-graphical-tree-rendering/project-plan.md`
+- `documentation/plan/character-sheet/talent/233-plan-afficher-arbre-par-defaut-noeuds-connexions.md`
+
+## 1. Vue d'ensemble
+
+- **Epic**: `Specialization Tree V1` (rattachement GitHub existant: Epic #184)
+- **Feature parente**: `US16 - Graphical Tree Rendering` (rattachement GitHub existant: Feature #200)
+- **Issue cible**: `#295 - US16.2 - Construire le view-model de rendu de l'arbre courant`
+
+### Résumé
+
+Construire, côté `SpecializationTreeApp`, un view-model pur et testable du tree courant pour alimenter le rendu graphique sans logique métier dans PIXI.
+
+### Valeur métier
+
+- séparer clairement domaine et rendu ;
+- préparer les tickets de layout, mapping d'états et rendu PIXI ;
+- fiabiliser le fallback sur talent introuvable ;
+- rendre le contrat de rendu testable hors canvas.
+
+## 2. Critères de succès
+
+- le contexte expose un arbre courant exploitable par la vue ;
+- chaque nœud expose `nodeId`, talent, coût, `row`, `column`, état métier et métadonnées d'affichage ;
+- les connexions sont prêtes à être consommées par la couche de rendu ;
+- le fallback talent introuvable est explicite et déterministe ;
+- aucun calcul métier n'est déplacé dans PIXI ;
+- le contrat reste testable sans rendu graphique réel.
+
+## 3. Jalons
+
+1. **Contrat d'entrée** — figer la forme du `currentTree` consommé par l'app.
+2. **Normalisation des nœuds** — construire les nœuds de rendu à partir du modèle `specialization-tree`.
+3. **Préparation des connexions** — exposer les arêtes prêtes pour le rendu.
+4. **Fallbacks et tests** — couvrir talent introuvable, état vide et non-couplage PIXI.
+
+## 4. Risques
+
+| Risque | Impact | Mitigation |
+| --- | --- | --- |
+| Confusion entre `resolvedTreeStatus` et `nodeState` | mauvais contrat UI | reprendre explicitement la convention du cadrage US16 |
+| Talent référencé mais non résolu | nœud inutilisable au rendu | fallback explicite + test dédié |
+| View-model trop couplé au layout PIXI | refactor coûteux pour US16.4/16.5 | limiter US16.2 aux données de rendu, pas au dessin |
+| Dépendance implicite à la sélection d'arbre courant | contrat instable | traiter US16.1 comme prérequis fonctionnel |
+
+## 5. Hiérarchie des work items
+
+```mermaid
+graph TD
+    A[Epic: Specialization Tree V1] --> B[Feature: US16 Graphical Tree Rendering]
+    B --> C[Story: #295 Current Tree Render View-Model]
+    C --> D[Enabler: Normaliser les nœuds de rendu]
+    C --> E[Enabler: Préparer les connexions de rendu]
+    C --> F[Enabler: Gérer les fallbacks talent introuvable]
+    C --> G[Test: Contrat du view-model]
+
+    D --> D1[Task: mapper nodeId talent cost row column]
+    D --> D2[Task: exposer état métier et métadonnées UI]
+    E --> E1[Task: transformer les connexions du modèle domaine]
+    F --> F1[Task: fallback explicite et stable]
+    G --> G1[Task: tests nœuds connexions état vide]
+    G --> G2[Task: test sans dépendance PIXI réelle]
+```
+
+## 6. Découpage GitHub recommandé
+
+| Type | Titre | Priorité | Estimate | Dépendances |
+| --- | --- | --- | --- | --- |
+| Story | `US16.2 - Construire le view-model de rendu de l'arbre courant` | P0 | 2 | Feature #200, prérequis US16.1 |
+| Enabler | `US16.2.a - Normaliser les nœuds du tree courant` | P0 | 1 | Story #295 |
+| Enabler | `US16.2.b - Préparer les connexions du view-model` | P0 | 1 | Story #295 |
+| Enabler | `US16.2.c - Gérer le fallback talent introuvable` | P0 | 1 | Story #295 |
+| Test | `US16.2.t - Couvrir le contrat du view-model de rendu` | P0 | 1 | 16.2.a, 16.2.b, 16.2.c |
+
+## 7. Dépendances et ordre recommandé
+
+1. Vérifier le prérequis **US16.1** : un arbre courant déterministe existe déjà au contrat.
+2. Créer **16.2.a** pour figer la structure des nœuds.
+3. Créer **16.2.b** pour la structure des connexions.
+4. Créer **16.2.c** pour les cas incomplets et les fallbacks.
+5. Clore avec **16.2.t** pour verrouiller le contrat avant US16.3 et US16.4.
+
+### Issues bloquées / débloquées
+
+- **Blocked by**: Feature #200 ; disponibilité du contrat `currentTree` issu de US16.1.
+- **Blocks**: US16.3 mapping états/raisons ; US16.4 layout graphique ; consolidation de US16.8.
+
+## 8. Board Kanban
+
+- **Backlog**: #295 et ses sous-issues documentées
+- **Sprint Ready**: AC validés et dépendances posées
+- **In Progress**: une seule sous-issue active à la fois sur le contrat
+- **Testing**: validation des cas vide / nominal / talent introuvable
+- **Done**: contrat du view-model figé et réutilisable par l'UI
+
+### Champs recommandés
+
+- `Priority`: `P0`
+- `Value`: `High`
+- `Component`: `Character Sheet / Specialization Tree`
+- `Estimate`: `1` ou `2`
+- `Epic`: `Specialization Tree V1`
+- `Parent Feature`: `US16`
+
+## 9. Définition de done
+
+- le contexte de l'application expose le view-model du tree courant ;
+- les nœuds et connexions sont prêts pour les tickets UI suivants ;
+- le fallback talent introuvable est visible dans le contrat ;
+- aucune dépendance PIXI n'est nécessaire pour tester le builder ;
+- les dépendances GitHub reflètent correctement ce rôle de fondation.
+
+## 10. Métriques projet
+
+- **Couverture nœuds**: 100% des nœuds du tree courant présents dans le view-model ;
+- **Couverture connexions**: 100% des connexions présentes dans le view-model ;
+- **Fallbacks**: 100% des talents introuvables reçoivent un fallback explicite ;
+- **Isolation UI**: 0 logique métier requise dans PIXI pour interpréter le contrat ;
+- **Flux**: #295 prête les entrées nécessaires à US16.3 et US16.4 sans refonte.

--- a/module/applications/specialization-tree-app.mjs
+++ b/module/applications/specialization-tree-app.mjs
@@ -3,6 +3,7 @@ import { getTreeNodesStates, NODE_STATE, REASON_CODE } from '../lib/talent-node/
 import { purchaseTalentNode } from '../lib/talent-node/talent-node-purchase.mjs'
 import { resolveTalentDetail } from '../lib/talent-node/talent-reference-resolver.mjs'
 import { selectDefaultTreeKey } from '../lib/specialization-tree/default-tree-selector.mjs'
+import { buildRenderViewModel } from './specialization-tree/render-view-model.mjs'
 import { logger } from '../utils/logger.mjs'
 
 const { api } = foundry.applications
@@ -195,21 +196,23 @@ export function buildSpecializationTreeContext(actor, selectedKey = null) {
     const resolution = resolutions.get(activeKey)
     currentTreeData = resolution?.tree ?? null
 
-    const nodes = Array.from(currentTreeData?.system?.nodes || [])
-
-    const connections = Array.from(currentTreeData?.system?.connections || [])
-
-    renderNodes = nodes.map((node) => {
-      const pos = computeNodePosition(node.row, node.column)
+    const viewModel = buildRenderViewModel(currentTreeData, (node) => {
       const detail = resolveTalentDetail(node)
+      return detail
+        ? { name: detail.name, uuid: node.talentUuid ?? node.talentId ?? '', isRanked: detail.isRanked }
+        : null
+    })
+
+    renderNodes = viewModel.nodes.map((viewNode) => {
+      const pos = computeNodePosition(viewNode.row, viewNode.column)
       return {
-        nodeId: node.nodeId,
-        talentId: node.talentId,
-        talentName: detail.name,
-        isRanked: detail.isRanked,
-        xpCost: node.cost ?? 0,
-        row: node.row,
-        column: node.column,
+        nodeId: viewNode.nodeId,
+        talentId: viewNode.talentId,
+        talentName: viewNode.talent.name,
+        isRanked: viewNode.isRanked,
+        xpCost: viewNode.cost,
+        row: viewNode.row,
+        column: viewNode.column,
         x: pos.x,
         y: pos.y,
       }
@@ -238,15 +241,15 @@ export function buildSpecializationTreeContext(actor, selectedKey = null) {
       })
     }
 
-    renderConnections = connections.map((conn) => {
-      const fromPos = nodePositionMap.get(conn.from) ?? { centerX: 0, centerY: 0 }
-      const toPos = nodePositionMap.get(conn.to) ?? { centerX: 0, centerY: 0 }
+    renderConnections = viewModel.connections.map((viewConn) => {
+      const fromPos = nodePositionMap.get(viewConn.fromNodeId) ?? { centerX: 0, centerY: 0 }
+      const toPos = nodePositionMap.get(viewConn.toNodeId) ?? { centerX: 0, centerY: 0 }
       return {
         fromX: fromPos.centerX,
         fromY: fromPos.centerY,
         toX: toPos.centerX,
         toY: toPos.centerY,
-        type: conn.type ?? null,
+        type: viewConn.type ?? null,
       }
     })
   }

--- a/module/applications/specialization-tree/render-view-model.mjs
+++ b/module/applications/specialization-tree/render-view-model.mjs
@@ -1,0 +1,105 @@
+/**
+ * @module module/applications/specialization-tree/render-view-model
+ * @description Pure builder for the specialization tree rendering view-model.
+ *
+ * This module is part of the extraction of PIXI-facing data preparation from
+ * the application layer into a pure, isolated, testable function. It produces
+ * a normalized view-model of nodes and connections that the PIXI renderer
+ * (US16.4) consumes, without any dependency on `game`, `ui`, `canvas`, or PIXI.
+ */
+
+/** @import { RenderViewModel } from './types.mjs' */
+
+/**
+ * Build a pure render view-model from a resolved specialization tree.
+ *
+ * @param {object|null|undefined} currentTree - The resolved tree data (Item or plain object
+ * with `system.nodes`, `system.connections`, `name`, `id`/`_id`).
+ * @param {Function|null|undefined} talentLookup - Callback invoked for each tree node:
+ * `(node: object) => {{ name: string, uuid: string, isRanked: boolean } | null}`.
+ * Return `null` when the talent cannot be resolved → node marked `unresolved`.
+ * @returns {RenderViewModel} Normalized view-model for PIXI rendering.
+ */
+export function buildRenderViewModel(currentTree, talentLookup) {
+  const nodes = Array.isArray(currentTree?.system?.nodes)
+    ? currentTree.system.nodes
+    : []
+  const connections = Array.isArray(currentTree?.system?.connections)
+    ? currentTree.system.connections
+    : []
+  const treeName = currentTree?.name ?? ''
+  const treeId = currentTree?.id ?? currentTree?._id ?? ''
+
+  /* ── Normalise nodes ─────────────────────────────────────────── */
+  const viewNodes = nodes.map((node) => {
+    const resolved = typeof talentLookup === 'function'
+      ? talentLookup(node)
+      : null
+
+    const isUnresolved = !resolved || !resolved.name
+    const talent = isUnresolved
+      ? { name: '', uuid: 'unknown' }
+      : { name: resolved.name, uuid: resolved.uuid ?? node.talentUuid ?? '' }
+    const state = isUnresolved ? 'unresolved' : 'available'
+    const label = talent.name
+
+    return {
+      nodeId: node.nodeId,
+      talentId: node.talentId,
+      talent,
+      cost: node.cost ?? 0,
+      row: node.row,
+      column: node.column,
+      state,
+      displayMeta: {
+        label,
+        isPurchased: false,
+        isAvailable: !isUnresolved,
+        isLocked: false,
+        isUnresolved,
+      },
+      /** Extra field – consumed by the app enrichment layer */
+      isRanked: resolved?.isRanked ?? false,
+    }
+  })
+
+  /* ── Build nodeId index for connection filtering ─────────────── */
+  const nodeIdSet = new Set()
+  for (const n of viewNodes) {
+    nodeIdSet.add(n.nodeId)
+  }
+
+  /* ── Normalise connections ───────────────────────────────────── */
+  const viewConnections = []
+  for (const conn of connections) {
+    if (!conn.from || !conn.to) continue
+    /* Drop connections whose source or target node is absent */
+    if (!nodeIdSet.has(conn.from)) continue
+    if (!nodeIdSet.has(conn.to)) continue
+
+    const type =
+      conn.type === 'straight' || conn.type === 'angled'
+        ? conn.type
+        : 'straight'
+
+    viewConnections.push({
+      fromNodeId: conn.from,
+      toNodeId: conn.to,
+      type,
+      /* isActive is populated by the state-mapping layer (US16.3) */
+      isActive: false,
+    })
+  }
+
+  /* ── Assemble view-model ─────────────────────────────────────── */
+  return {
+    nodes: viewNodes,
+    connections: viewConnections,
+    metadata: {
+      treeName,
+      treeId,
+      totalNodes: viewNodes.length,
+      totalConnections: viewConnections.length,
+    },
+  }
+}

--- a/module/applications/specialization-tree/types.mjs
+++ b/module/applications/specialization-tree/types.mjs
@@ -1,0 +1,73 @@
+/**
+ * @module module/applications/specialization-tree/types
+ * @description JSDoc typedefs for the specialization tree rendering view-model.
+ * These define the contract between the view-model builder and the PIXI render layer.
+ */
+
+/**
+ * View-model node states for the specialization tree renderer:
+ * - `locked`: Prerequisites not met or insufficient XP.
+ * - `available`: Node can be purchased (talent resolved and no blocking condition).
+ * - `purchased`: Node has been purchased by the actor.
+ * - `unavailable`: Node cannot be purchased (invalid tree, missing specialization, etc.).
+ * - `unresolved`: Talent reference could not be resolved (fallback applied).
+ *
+ * @typedef {'locked'|'available'|'purchased'|'unavailable'|'unresolved'} ViewNodeState
+ */
+
+/**
+ * A successfully resolved talent reference.
+ * @typedef {Object} ResolvedTalent
+ * @property {string} name - Display name of the talent.
+ * @property {string} uuid - UUID or business key identifying the talent item.
+ */
+
+/**
+ * A fallback used when a talent reference cannot be resolved.
+ * @typedef {Object} FallbackTalent
+ * @property {string} name - Localized unknown talent name.
+ * @property {string} uuid - Always `'unknown'` for fallback entries.
+ */
+
+/**
+ * @typedef {ResolvedTalent|FallbackTalent} TalentRef
+ */
+
+/**
+ * A normalized render node in the specialization tree view-model.
+ * @typedef {Object} RenderNode
+ * @property {string} nodeId - Unique node identifier within the tree.
+ * @property {TalentRef} talent - Resolved talent or fallback.
+ * @property {number} cost - XP cost to purchase the node.
+ * @property {number} row - Grid row position (1-based).
+ * @property {number} column - Grid column position (1-based).
+ * @property {ViewNodeState} state - Current node state for rendering.
+ * @property {{ label: string, isPurchased: boolean, isAvailable: boolean, isLocked: boolean, isUnresolved: boolean }} displayMeta - Display metadata.
+ */
+
+/**
+ * A normalized render connection between two nodes.
+ * @typedef {Object} RenderConnection
+ * @property {string} fromNodeId - Source node ID.
+ * @property {string} toNodeId - Target node ID.
+ * @property {'straight'|'angled'} type - Connection line style.
+ * @property {boolean} isActive - Whether the connection is active (source purchased).
+ */
+
+/**
+ * @typedef {Object} RenderViewModelMetadata
+ * @property {string} treeName - Display name of the tree.
+ * @property {string} treeId - Unique identifier of the tree item.
+ * @property {number} totalNodes - Count of render nodes.
+ * @property {number} totalConnections - Count of render connections.
+ */
+
+/**
+ * The complete render view-model for a specialization tree.
+ * @typedef {Object} RenderViewModel
+ * @property {RenderNode[]} nodes - Normalized render nodes.
+ * @property {RenderConnection[]} connections - Normalized render connections.
+ * @property {RenderViewModelMetadata} metadata - View-model summary metadata.
+ */
+
+export default {}

--- a/tests/applications/specialization-tree/render-view-model.test.mjs
+++ b/tests/applications/specialization-tree/render-view-model.test.mjs
@@ -1,0 +1,212 @@
+import { describe, expect, it } from 'vitest'
+
+import { buildRenderViewModel } from '../../../module/applications/specialization-tree/render-view-model.mjs'
+
+function mockTree(overrides = {}) {
+  return {
+    id: 'tree-1',
+    name: 'Jedi Sentinel',
+    system: {
+      nodes: [
+        { nodeId: 'n1', talentId: 'talent-parry', cost: 5, row: 1, column: 1 },
+        { nodeId: 'n2', talentId: 'talent-grit', cost: 10, row: 1, column: 2 },
+      ],
+      connections: [
+        { from: 'n1', to: 'n2', type: 'straight' },
+      ],
+    },
+    ...overrides,
+  }
+}
+
+function mockTalentLookup(node) {
+  const talents = {
+    'talent-parry': { name: 'Parry', uuid: 'Item.talent-parry-uuid', isRanked: true },
+    'talent-grit': { name: 'Grit', uuid: 'Item.talent-grit-uuid', isRanked: false },
+  }
+  return talents[node.talentId] ?? null
+}
+
+describe('buildRenderViewModel', () => {
+  it('returns empty view-model for null currentTree', () => {
+    const result = buildRenderViewModel(null, mockTalentLookup)
+
+    expect(result.nodes).toEqual([])
+    expect(result.connections).toEqual([])
+    expect(result.metadata.totalNodes).toBe(0)
+    expect(result.metadata.totalConnections).toBe(0)
+  })
+
+  it('returns empty view-model for undefined currentTree', () => {
+    const result = buildRenderViewModel(undefined, mockTalentLookup)
+
+    expect(result.nodes).toEqual([])
+    expect(result.connections).toEqual([])
+  })
+
+  it('returns empty view-model for tree without nodes', () => {
+    const tree = { id: 'empty', name: 'Empty', system: { nodes: [], connections: [] } }
+    const result = buildRenderViewModel(tree, mockTalentLookup)
+
+    expect(result.nodes).toEqual([])
+    expect(result.connections).toEqual([])
+    expect(result.metadata.treeName).toBe('Empty')
+    expect(result.metadata.treeId).toBe('empty')
+  })
+
+  it('normalises all nodes and connections for a nominal tree', () => {
+    const tree = mockTree()
+    const result = buildRenderViewModel(tree, mockTalentLookup)
+
+    expect(result.nodes).toHaveLength(2)
+    expect(result.connections).toHaveLength(1)
+
+    expect(result.nodes[0].nodeId).toBe('n1')
+    expect(result.nodes[0].talent.name).toBe('Parry')
+    expect(result.nodes[0].talent.uuid).toBe('Item.talent-parry-uuid')
+    expect(result.nodes[0].cost).toBe(5)
+    expect(result.nodes[0].row).toBe(1)
+    expect(result.nodes[0].column).toBe(1)
+    expect(result.nodes[0].state).toBe('available')
+    expect(result.nodes[0].displayMeta.isAvailable).toBe(true)
+    expect(result.nodes[0].displayMeta.isUnresolved).toBe(false)
+    expect(result.nodes[0].isRanked).toBe(true)
+
+    expect(result.nodes[1].nodeId).toBe('n2')
+    expect(result.nodes[1].talent.name).toBe('Grit')
+    expect(result.nodes[1].isRanked).toBe(false)
+
+    expect(result.connections[0].fromNodeId).toBe('n1')
+    expect(result.connections[0].toNodeId).toBe('n2')
+    expect(result.connections[0].type).toBe('straight')
+    expect(result.connections[0].isActive).toBe(false)
+  })
+
+  it('marks node as unresolved when talentLookup returns null', () => {
+    const tree = mockTree()
+    const result = buildRenderViewModel(tree, () => null)
+
+    expect(result.nodes).toHaveLength(2)
+    for (const node of result.nodes) {
+      expect(node.state).toBe('unresolved')
+      expect(node.talent.name).toBe('')
+      expect(node.talent.uuid).toBe('unknown')
+      expect(node.displayMeta.isUnresolved).toBe(true)
+      expect(node.displayMeta.isAvailable).toBe(false)
+    }
+  })
+
+  it('marks node as unresolved when talentLookup returns empty name', () => {
+    const tree = mockTree()
+    const result = buildRenderViewModel(tree, () => ({ name: '', uuid: '', isRanked: false }))
+
+    expect(result.nodes[0].state).toBe('unresolved')
+    expect(result.nodes[0].talent.name).toBe('')
+    expect(result.nodes[0].talent.uuid).toBe('unknown')
+  })
+
+  it('fallback to unresolved when talentLookup is not a function', () => {
+    const tree = mockTree()
+    const result = buildRenderViewModel(tree, null)
+
+    for (const node of result.nodes) {
+      expect(node.state).toBe('unresolved')
+      expect(node.talent.uuid).toBe('unknown')
+    }
+  })
+
+  it('filters connections whose source or target node is absent', () => {
+    const tree = mockTree()
+    tree.system.connections.push(
+      { from: 'n1', to: 'n-missing', type: 'straight' },
+      { from: 'n-missing', to: 'n2', type: 'straight' },
+      { from: 'n-missing', to: 'n-other-missing', type: 'straight' },
+    )
+    const result = buildRenderViewModel(tree, mockTalentLookup)
+
+    expect(result.connections).toHaveLength(1)
+    expect(result.connections[0].fromNodeId).toBe('n1')
+    expect(result.connections[0].toNodeId).toBe('n2')
+  })
+
+  it('skips connections with missing from or to fields', () => {
+    const tree = mockTree()
+    tree.system.connections.push(
+      { from: 'n1', type: 'straight' },
+      { to: 'n2', type: 'straight' },
+      {},
+    )
+    const result = buildRenderViewModel(tree, mockTalentLookup)
+
+    expect(result.connections).toHaveLength(1)
+  })
+
+  it('defaults non-standard connection types to straight', () => {
+    const tree = mockTree()
+    tree.system.connections[0].type = 'curved'
+    const result = buildRenderViewModel(tree, mockTalentLookup)
+
+    expect(result.connections[0].type).toBe('straight')
+  })
+
+  it('preserves straight and angled connection types', () => {
+    const tree = mockTree()
+    tree.system.connections = [
+      { from: 'n1', to: 'n2', type: 'straight' },
+    ]
+    let result = buildRenderViewModel(tree, mockTalentLookup)
+    expect(result.connections[0].type).toBe('straight')
+
+    tree.system.connections[0].type = 'angled'
+    result = buildRenderViewModel(tree, mockTalentLookup)
+    expect(result.connections[0].type).toBe('angled')
+  })
+
+  it('sets metadata correctly', () => {
+    const tree = mockTree({ id: 'tree-42', name: 'Jedi Consular' })
+    const result = buildRenderViewModel(tree, mockTalentLookup)
+
+    expect(result.metadata.treeName).toBe('Jedi Consular')
+    expect(result.metadata.treeId).toBe('tree-42')
+    expect(result.metadata.totalNodes).toBe(2)
+    expect(result.metadata.totalConnections).toBe(1)
+  })
+
+  it('handles tree with _id fallback for treeId', () => {
+    const tree = mockTree({ _id: 'fallback-id', id: undefined })
+    delete tree.id
+    const result = buildRenderViewModel(tree, mockTalentLookup)
+
+    expect(result.metadata.treeId).toBe('fallback-id')
+  })
+
+  it('does not mutate the input tree', () => {
+    const tree = mockTree()
+    const originalNodes = tree.system.nodes.length
+    const originalConns = tree.system.connections.length
+
+    buildRenderViewModel(tree, mockTalentLookup)
+
+    expect(tree.system.nodes).toHaveLength(originalNodes)
+    expect(tree.system.connections).toHaveLength(originalConns)
+  })
+
+  it('uses node.talentUuid for fallback uuid when resolved talent has no uuid', () => {
+    const tree = mockTree()
+    tree.system.nodes[0].talentUuid = 'Item.parry-direct-uuid'
+    const result = buildRenderViewModel(tree, (node) => ({
+      name: 'Parry',
+      isRanked: true,
+    }))
+
+    expect(result.nodes[0].talent.uuid).toBe('Item.parry-direct-uuid')
+  })
+
+  it('sets cost to 0 when node has no cost field', () => {
+    const tree = mockTree()
+    tree.system.nodes[0].cost = undefined
+    const result = buildRenderViewModel(tree, mockTalentLookup)
+
+    expect(result.nodes[0].cost).toBe(0)
+  })
+})


### PR DESCRIPTION
## Summary

- Extract a pure `buildRenderViewModel(currentTree, talentLookup)` function from the application layer into a dedicated, isolated, testable module
- Define JSDoc types (`RenderNode`, `RenderConnection`, `RenderViewModel`) as the contract between the view-model builder and the PIXI render layer
- Add explicit fallback for unresolved talents (`state: 'unresolved'`, `uuid: 'unknown'`)
- Integrate the builder into `SpecializationTreeApp.buildSpecializationTreeContext()`, replacing the inline transformation block

## Tests

- 16 new tests covering nominal rendering, unresolved talent fallback, empty tree, connection filtering, type defaults, metadata, null/undefined inputs, and non-mutation guarantee
- Full test suite: 287 project test files pass (0 regression)
- Existing `specialization-tree-app.test.mjs` (68 tests): all pass

Closes #295

## Plan

`documentation/plan/character-sheet/specialization-tree/us16-2-current-tree-render-view-model.md`