### PR TITLE
feat(specialization-tree): extract minimal layout module from SpecializationTreeApp

### DIFF
--- a/documentation/plan/character-sheet/specialization-tree/297-definir-le-layout-graphique-minimal.md
+++ b/documentation/plan/character-sheet/specialization-tree/297-definir-le-layout-graphique-minimal.md
@@ -1,0 +1,97 @@
+# US16.4 — Plan d'implémentation : Définir le layout graphique minimal
+
+## Contexte
+
+Issue : [#297 — US16.4 - Définir le layout graphique minimal](https://github.com/herveDarritchon/foundryvtt-swerpg/issues/297)
+
+Références :
+
+- `documentation/plan/character-sheet/specialization-tree/us16-2-current-tree-render-view-model.md`
+- `documentation/plan/character-sheet/specialization-tree/296-mapper-les-etats-et-raisons-de-noeud-vers-l-ui.md`
+- `documentation/cadrage/character-sheet/specialization-tree/cadrage-us16-decoupage-rendu-graphique-arbres-specialisation.md`
+
+L'existant fournit déjà l'entrée métier nécessaire :
+
+- `buildRenderViewModel()` expose `row`, `column` et les connexions du tree courant ;
+- `module/applications/specialization-tree-app.mjs` calcule déjà un layout minimal inline via `NODE_WIDTH`, `NODE_HEIGHT`, `H_GAP`, `V_GAP`, `PADDING` et `computeNodePosition()` ;
+- les positions de connexions sont encore reconstruites dans l'application à partir des centres de nœuds.
+
+Le besoin de l'issue est de verrouiller un contrat de layout simple, déterministe et centralisé, sans couplage supplémentaire à PIXI.
+
+## Objectif
+
+Transformer les coordonnées logiques `row` / `column` du view-model en positions graphiques stables, puis en points d'ancrage de connexions, via un module pur dédié au layout minimal.
+
+## Périmètre
+
+### Inclus
+
+- constantes de layout minimales (taille de nœud, gaps, padding) ;
+- conversion `row` / `column` → `x` / `y` ;
+- calcul des points d'ancrage de connexion à partir des nœuds positionnés ;
+- couverture de test du contrat de layout.
+
+### Exclus
+
+- zoom, pan, drag ou fit-to-view ;
+- auto-layout complexe ;
+- recalcul métier des connexions ;
+- dessin PIXI et variantes visuelles des nœuds.
+
+## Fichiers pressentis
+
+| Fichier                                                    | Rôle                                                      |
+| ---------------------------------------------------------- | --------------------------------------------------------- |
+| `module/applications/specialization-tree/layout.mjs`       | Nouveau module pur de layout minimal                      |
+| `module/applications/specialization-tree-app.mjs`          | Remplacer le calcul inline par l'appel au layout dédié    |
+| `tests/applications/specialization-tree/layout.test.mjs`   | Tests unitaires purs du contrat de layout                 |
+| `tests/applications/specialization-tree-app.test.mjs`      | Vérification d'intégration du contexte consommé par l'app |
+
+## Plan d'implémentation
+
+### Étape 1 — Extraire le layout minimal dans un module pur
+
+**Fichiers :** `module/applications/specialization-tree/layout.mjs`
+
+**Actions :**
+
+1. Centraliser les constantes `NODE_WIDTH`, `NODE_HEIGHT`, `H_GAP`, `V_GAP` et `PADDING` dans un module dédié.
+2. Définir une fonction pure qui transforme un nœud `{ row, column }` en position graphique `{ x, y }`.
+3. Définir une fonction pure qui dérive les ancrages de connexions depuis les nœuds déjà positionnés, sans dépendre de PIXI.
+4. Garder le contrat volontairement minimal : coordonnées stables, déterministes et sans effet de bord.
+
+**Validation visée :** le layout peut être testé sans `game`, `ui`, `canvas` ni renderer PIXI.
+
+### Étape 2 — Brancher `SpecializationTreeApp` sur ce contrat unique
+
+**Fichiers :** `module/applications/specialization-tree-app.mjs`
+
+**Actions :**
+
+1. Remplacer le calcul inline des positions de nœuds par l'appel au module de layout.
+2. Construire `renderConnections` à partir des positions calculées plutôt que via une logique locale dispersée.
+3. Conserver `buildRenderViewModel()` comme source unique de `row`, `column` et des connexions métier.
+4. Laisser hors scope tout comportement de caméra ou de centrage avancé.
+
+**Validation visée :** le contexte de rendu expose des coordonnées et connexions cohérentes sans introduire de nouvelle logique métier dans l'application.
+
+### Étape 3 — Verrouiller le contrat par des tests ciblés
+
+**Fichiers :** `tests/applications/specialization-tree/layout.test.mjs`, `tests/applications/specialization-tree-app.test.mjs`
+
+**Actions :**
+
+1. Ajouter des tests unitaires sur le mapping `row` / `column` → `x` / `y` avec padding et gaps.
+2. Couvrir le calcul des centres de connexion entre deux nœuds positionnés.
+3. Vérifier les cas dégradés : liste vide, connexion vers nœud absent, coordonnées de base en `(0, 0)` logique.
+4. Garder un test d'intégration qui vérifie que `buildSpecializationTreeContext()` expose toujours `renderNodes` et `renderConnections` alignés avec le layout centralisé.
+
+**Validation visée :** le contrat observable de layout est figé et reste simple à faire évoluer sans casser le rendu.
+
+## Définition de done
+
+- [ ] Les constantes minimales de layout sont centralisées dans un module dédié.
+- [ ] Les nœuds sont positionnés uniquement à partir de `row` / `column`.
+- [ ] Les connexions relient les bons centres de nœuds positionnés.
+- [ ] `SpecializationTreeApp` ne conserve plus de logique de layout inline dispersée.
+- [ ] Les tests couvrent le contrat minimal de layout et son intégration applicative.

--- a/module/applications/specialization-tree-app.mjs
+++ b/module/applications/specialization-tree-app.mjs
@@ -5,6 +5,7 @@ import { resolveTalentDetail } from '../lib/talent-node/talent-reference-resolve
 import { selectDefaultTreeKey } from '../lib/specialization-tree/default-tree-selector.mjs'
 import { buildRenderViewModel } from './specialization-tree/render-view-model.mjs'
 import { enrichNode, getReasonLabelKey, NODE_STATE, NODE_STATE_VARIANTS } from './specialization-tree/node-ui-state.mjs'
+import { NODE_WIDTH, NODE_HEIGHT, computeNodePosition, buildConnectionAnchors } from './specialization-tree/layout.mjs'
 import { logger } from '../utils/logger.mjs'
 
 const { api } = foundry.applications
@@ -17,12 +18,6 @@ const SPECIALIZATION_TREE_STATE_LABELS = Object.freeze({
 
 const MIN_VIEWPORT_SIZE = 320
 
-const NODE_WIDTH = 120
-const NODE_HEIGHT = 48
-const H_GAP = 24
-const V_GAP = 24
-const PADDING = 20
-
 /**
  * Compute the viewport size from a host element.
  * @param {HTMLElement|null|undefined} host - The DOM element hosting the PIXI viewport.
@@ -34,13 +29,6 @@ export function getViewportDimensions(host) {
   return {
     width: Math.max(Math.round(rect?.width || host?.clientWidth || 0), MIN_VIEWPORT_SIZE),
     height: Math.max(Math.round(rect?.height || host?.clientHeight || 0), MIN_VIEWPORT_SIZE),
-  }
-}
-
-export function computeNodePosition(row, column) {
-  return {
-    x: column * (NODE_WIDTH + H_GAP) + PADDING,
-    y: row * (NODE_HEIGHT + V_GAP) + PADDING,
   }
 }
 
@@ -168,25 +156,7 @@ export function buildSpecializationTreeContext(actor, selectedKey = null) {
       return enrichNode(node, stateResult, game.i18n.localize.bind(game.i18n))
     })
 
-    const nodePositionMap = new Map()
-    for (const node of renderNodes) {
-      nodePositionMap.set(node.nodeId, {
-        centerX: node.x + NODE_WIDTH / 2,
-        centerY: node.y + NODE_HEIGHT / 2,
-      })
-    }
-
-    renderConnections = viewModel.connections.map((viewConn) => {
-      const fromPos = nodePositionMap.get(viewConn.fromNodeId) ?? { centerX: 0, centerY: 0 }
-      const toPos = nodePositionMap.get(viewConn.toNodeId) ?? { centerX: 0, centerY: 0 }
-      return {
-        fromX: fromPos.centerX,
-        fromY: fromPos.centerY,
-        toX: toPos.centerX,
-        toY: toPos.centerY,
-        type: viewConn.type ?? null,
-      }
-    })
+    renderConnections = buildConnectionAnchors(renderNodes, viewModel.connections)
   }
 
   return {

--- a/module/applications/specialization-tree/layout.mjs
+++ b/module/applications/specialization-tree/layout.mjs
@@ -1,0 +1,88 @@
+/**
+ * @module module/applications/specialization-tree/layout
+ * @description Minimal layout module for the specialization tree renderer.
+ *
+ * Provides stable, deterministic pixel coordinates derived from logical
+ * row/column grid positions. This module is pure — it has no dependency
+ * on `game`, `ui`, `canvas`, PIXI, or any Foundry runtime.
+ *
+ * Contract:
+ * - Constants are frozen and may be imported by other modules.
+ * - `computeNodePosition(row, column)` maps grid → pixel space.
+ * - `computeNodeCenter(node)` returns the center of a positioned node.
+ * - `buildConnectionAnchors(renderNodes, connections)` builds anchor
+ *   points for connection lines from already-positioned nodes.
+ */
+
+/** Width of a single talent node in pixels. */
+export const NODE_WIDTH = 120
+
+/** Height of a single talent node in pixels. */
+export const NODE_HEIGHT = 48
+
+/** Horizontal gap between nodes in pixels. */
+export const H_GAP = 24
+
+/** Vertical gap between nodes in pixels. */
+export const V_GAP = 24
+
+/** Padding from the top-left origin in pixels. */
+export const PADDING = 20
+
+/**
+ * Compute the pixel position of a node from its logical row and column.
+ *
+ * @param {number} row Logical row (1-based or 0-based grid row).
+ * @param {number} column Logical column (1-based or 0-based grid column).
+ * @returns {{ x: number, y: number }} Top-left pixel coordinates.
+ */
+export function computeNodePosition(row, column) {
+  return {
+    x: column * (NODE_WIDTH + H_GAP) + PADDING,
+    y: row * (NODE_HEIGHT + V_GAP) + PADDING,
+  }
+}
+
+/**
+ * Compute the center point of a positioned node's bounding box.
+ *
+ * @param {{ x: number, y: number }} node A positioned node with `x` and `y`.
+ * @returns {{ centerX: number, centerY: number }} Center coordinates in pixels.
+ */
+export function computeNodeCenter(node) {
+  return {
+    centerX: node.x + NODE_WIDTH / 2,
+    centerY: node.y + NODE_HEIGHT / 2,
+  }
+}
+
+/**
+ * Build connection anchor points from positioned render nodes and connection
+ * definitions.
+ *
+ * @param {Array<{ nodeId: string, x: number, y: number }>} renderNodes Nodes already positioned with `x`, `y`.
+ * @param {Array<{ fromNodeId: string, toNodeId: string, type?: string }>} connections Connection descriptors.
+ * @returns {Array<{ fromX: number, fromY: number, toX: number, toY: number, type: string|null }>}
+ *   Connection anchor points. Missing nodes yield `(0, 0)` anchors.
+ */
+export function buildConnectionAnchors(renderNodes, connections) {
+  const nodePositionMap = new Map()
+
+  for (const node of renderNodes) {
+    const center = computeNodeCenter(node)
+    nodePositionMap.set(node.nodeId, center)
+  }
+
+  return connections.map((viewConn) => {
+    const fromPos = nodePositionMap.get(viewConn.fromNodeId) ?? { centerX: 0, centerY: 0 }
+    const toPos = nodePositionMap.get(viewConn.toNodeId) ?? { centerX: 0, centerY: 0 }
+
+    return {
+      fromX: fromPos.centerX,
+      fromY: fromPos.centerY,
+      toX: toPos.centerX,
+      toY: toPos.centerY,
+      type: viewConn.type ?? null,
+    }
+  })
+}

--- a/tests/applications/specialization-tree-app.test.mjs
+++ b/tests/applications/specialization-tree-app.test.mjs
@@ -54,7 +54,6 @@ describe('specialization-tree application', () => {
   let SpecializationTreeApp
   let buildSpecializationTreeContext
   let getViewportDimensions
-  let computeNodePosition
   let computeTreeBoundingBox
   let computeCenteredOffset
   let resolveTalentItem
@@ -230,7 +229,6 @@ describe('specialization-tree application', () => {
       default: SpecializationTreeApp,
       buildSpecializationTreeContext,
       getViewportDimensions,
-      computeNodePosition,
       computeTreeBoundingBox,
       computeCenteredOffset,
     } = await import('../../module/applications/specialization-tree-app.mjs'))
@@ -308,15 +306,6 @@ describe('specialization-tree application', () => {
     const host = createMockHost({ width: 120, height: 180 })
 
     expect(getViewportDimensions(host)).toEqual({ width: 320, height: 320 })
-  })
-
-  it('computes node position from row and column', () => {
-    const pos = computeNodePosition(1, 2)
-    expect(pos.x).toBe(2 * (120 + 24) + 20)
-    expect(pos.y).toBe(1 * (48 + 24) + 20)
-    const pos2 = computeNodePosition(0, 0)
-    expect(pos2.x).toBe(20)
-    expect(pos2.y).toBe(20)
   })
 
   it('selects the last available specialization as current tree', () => {

--- a/tests/applications/specialization-tree/layout.test.mjs
+++ b/tests/applications/specialization-tree/layout.test.mjs
@@ -1,0 +1,138 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  NODE_WIDTH,
+  NODE_HEIGHT,
+  H_GAP,
+  V_GAP,
+  PADDING,
+  computeNodePosition,
+  computeNodeCenter,
+  buildConnectionAnchors,
+} from '../../../module/applications/specialization-tree/layout.mjs'
+
+describe('layout constants', () => {
+  it('defines expected default values', () => {
+    expect(NODE_WIDTH).toBe(120)
+    expect(NODE_HEIGHT).toBe(48)
+    expect(H_GAP).toBe(24)
+    expect(V_GAP).toBe(24)
+    expect(PADDING).toBe(20)
+  })
+})
+
+describe('computeNodePosition', () => {
+  it('computes x from column and y from row with gaps and padding', () => {
+    const pos = computeNodePosition(1, 2)
+    expect(pos.x).toBe(2 * (NODE_WIDTH + H_GAP) + PADDING)
+    expect(pos.y).toBe(1 * (NODE_HEIGHT + V_GAP) + PADDING)
+  })
+
+  it('returns padding-only coordinates for (0, 0)', () => {
+    const pos = computeNodePosition(0, 0)
+    expect(pos.x).toBe(PADDING)
+    expect(pos.y).toBe(PADDING)
+  })
+
+  it('handles negative row and column', () => {
+    const pos = computeNodePosition(-1, -1)
+    expect(pos.x).toBe(-1 * (NODE_WIDTH + H_GAP) + PADDING)
+    expect(pos.y).toBe(-1 * (NODE_HEIGHT + V_GAP) + PADDING)
+  })
+})
+
+describe('computeNodeCenter', () => {
+  it('returns the center of a positioned node', () => {
+    const node = { x: 40, y: 50 }
+    const center = computeNodeCenter(node)
+    expect(center.centerX).toBe(40 + NODE_WIDTH / 2)
+    expect(center.centerY).toBe(50 + NODE_HEIGHT / 2)
+  })
+
+  it('handles node at origin', () => {
+    const node = { x: 0, y: 0 }
+    const center = computeNodeCenter(node)
+    expect(center.centerX).toBe(NODE_WIDTH / 2)
+    expect(center.centerY).toBe(NODE_HEIGHT / 2)
+  })
+})
+
+describe('buildConnectionAnchors', () => {
+  const positionedNodes = [
+    { nodeId: 'n1', x: 20, y: 20 },
+    { nodeId: 'n2', x: 164, y: 20 },
+  ]
+
+  it('builds anchors for a single connection between two nodes', () => {
+    const connections = [{ fromNodeId: 'n1', toNodeId: 'n2', type: 'straight' }]
+
+    const anchors = buildConnectionAnchors(positionedNodes, connections)
+
+    expect(anchors).toHaveLength(1)
+    expect(anchors[0].fromX).toBe(20 + NODE_WIDTH / 2)
+    expect(anchors[0].fromY).toBe(20 + NODE_HEIGHT / 2)
+    expect(anchors[0].toX).toBe(164 + NODE_WIDTH / 2)
+    expect(anchors[0].toY).toBe(20 + NODE_HEIGHT / 2)
+    expect(anchors[0].type).toBe('straight')
+  })
+
+  it('defaults type to null when not provided', () => {
+    const connections = [{ fromNodeId: 'n1', toNodeId: 'n2' }]
+
+    const anchors = buildConnectionAnchors(positionedNodes, connections)
+
+    expect(anchors[0].type).toBeNull()
+  })
+
+  it('returns empty array when no connections given', () => {
+    expect(buildConnectionAnchors(positionedNodes, [])).toEqual([])
+  })
+
+  it('returns empty array when nodes list is empty', () => {
+    const connections = [{ fromNodeId: 'n1', toNodeId: 'n2', type: 'straight' }]
+    expect(buildConnectionAnchors([], connections)).toHaveLength(1)
+  })
+
+  it('uses (0, 0) anchor when a referenced node is missing', () => {
+    const connections = [
+      { fromNodeId: 'n1', toNodeId: 'missing', type: 'straight' },
+    ]
+
+    const anchors = buildConnectionAnchors(positionedNodes, connections)
+
+    expect(anchors[0].fromX).toBe(20 + NODE_WIDTH / 2)
+    expect(anchors[0].fromY).toBe(20 + NODE_HEIGHT / 2)
+    expect(anchors[0].toX).toBe(0)
+    expect(anchors[0].toY).toBe(0)
+  })
+
+  it('handles multiple connections', () => {
+    const nodes = [
+      { nodeId: 'n1', x: 20, y: 20 },
+      { nodeId: 'n2', x: 164, y: 20 },
+      { nodeId: 'n3', x: 20, y: 92 },
+    ]
+    const connections = [
+      { fromNodeId: 'n1', toNodeId: 'n2', type: 'straight' },
+      { fromNodeId: 'n1', toNodeId: 'n3', type: 'angled' },
+    ]
+
+    const anchors = buildConnectionAnchors(nodes, connections)
+
+    expect(anchors).toHaveLength(2)
+    expect(anchors[0].type).toBe('straight')
+    expect(anchors[1].type).toBe('angled')
+  })
+
+  it('preserves node positions and does not mutate inputs', () => {
+    const nodes = [{ nodeId: 'n1', x: 20, y: 20 }]
+    const connections = [{ fromNodeId: 'n1', toNodeId: 'n1', type: 'straight' }]
+    const originalNodesX = nodes[0].x
+    const originalNodesY = nodes[0].y
+
+    buildConnectionAnchors(nodes, connections)
+
+    expect(nodes[0].x).toBe(originalNodesX)
+    expect(nodes[0].y).toBe(originalNodesY)
+  })
+})


### PR DESCRIPTION
## Summary

- Extract inline layout constants (`NODE_WIDTH`, `NODE_HEIGHT`, `H_GAP`, `V_GAP`, `PADDING`) and position/anchor computation into a pure module `module/applications/specialization-tree/layout.mjs`
- Replace inline `computeNodePosition` and `nodePositionMap` loop in `SpecializationTreeApp` with imports from the dedicated layout module
- Add 13 pure unit tests for the layout contract in `tests/applications/specialization-tree/layout.test.mjs`
- Update integration tests to remove the now-extracted `computeNodePosition` import and test

Closes #297

## Technical notes

- The layout module is pure (no dependency on `game`, `ui`, `canvas`, or PIXI)
- `buildConnectionAnchors` accepts already-positioned render nodes and connection descriptors, returning anchor points with `fromX`/`fromY`/`toX`/`toY`
- Viewport utilities (`computeTreeBoundingBox`, `computeCenteredOffset`) remain in the app file as they are coupled to PIXI rendering

## Tests

- 122 tests pass (4 test files)
- Lint: 0 errors on new and modified files

## Plan

`documentation/plan/character-sheet/specialization-tree/297-definir-le-layout-graphique-minimal.md`

## Known limits

- Missing-node connections fallback to `(0, 0)` anchors (explicit, documented contract)