### PR TITLE
feat(specialization-tree): draw connections and nodes in PIXI viewport

### DIFF
--- a/documentation/plan/character-sheet/specialization-tree/298-dessiner-les-connexions-et-les-noeuds-dans-pixi.md
+++ b/documentation/plan/character-sheet/specialization-tree/298-dessiner-les-connexions-et-les-noeuds-dans-pixi.md
@@ -1,0 +1,96 @@
+# US16.5 — Plan d'implémentation : Dessiner les connexions et les nœuds dans PIXI
+
+## Contexte
+
+Issue : [#298 — US16.5 - Dessiner les connexions et les nœuds dans PIXI](https://github.com/herveDarritchon/foundryvtt-swerpg/issues/298)
+
+Références :
+
+- `documentation/plan/character-sheet/specialization-tree/296-mapper-les-etats-et-raisons-de-noeud-vers-l-ui.md`
+- `documentation/plan/character-sheet/specialization-tree/297-definir-le-layout-graphique-minimal.md`
+- `documentation/cadrage/character-sheet/specialization-tree/cadrage-us16-decoupage-rendu-graphique-arbres-specialisation.md`
+- `documentation/ways-of-work/plan/specialization-tree-v1/us16-graphical-tree-rendering/project-plan.md`
+
+L'existant fournit déjà les entrées nécessaires au rendu :
+
+- le viewport PIXI autonome de `SpecializationTreeApp` ;
+- `buildSpecializationTreeContext()` qui expose `renderNodes` et `renderConnections` pour l'arbre courant ;
+- le mapping UI des états (US16.3) et le layout minimal centralisé (US16.4).
+
+Le besoin de l'issue est maintenant de transformer ce contrat de rendu en affichage graphique lisible, strictement en lecture seule, sans réintroduire de logique métier dans PIXI.
+
+## Objectif
+
+Dessiner l'arbre courant dans le viewport PIXI en affichant les connexions, les nœuds, leurs informations minimales et leurs variantes visuelles, tout en conservant un rendu consultatif et déterministe.
+
+## Périmètre
+
+### Inclus
+
+- nettoyage du viewport avant chaque rendu ;
+- dessin des connexions avant les nœuds ;
+- dessin des cartes de nœud à partir des positions calculées ;
+- affichage du nom du talent, du coût XP et d'un indicateur ranked / non-ranked si disponible ;
+- application des variantes visuelles issues du mapping UI.
+
+### Exclus
+
+- achat de nœud ;
+- détail riche ou tooltip métier (US16.6) ;
+- zoom, pan, drag ou navigation avancée ;
+- rendu pixel-perfect, animations ou transitions.
+
+## Fichiers pressentis
+
+| Fichier                                               | Rôle                                                             |
+| ----------------------------------------------------- | ---------------------------------------------------------------- |
+| `module/applications/specialization-tree-app.mjs`     | Consommer `renderNodes` / `renderConnections` et piloter le rendu PIXI read-only |
+| `tests/applications/specialization-tree-app.test.mjs` | Vérifier le contrat observable du rendu, son cleanup et l'absence d'effet métier |
+
+## Plan d'implémentation
+
+### Étape 1 — Brancher le pipeline de dessin PIXI sur le contexte de rendu
+
+**Fichiers :** `module/applications/specialization-tree-app.mjs`
+
+**Actions :**
+
+1. Ajouter ou compléter une méthode dédiée de rendu (`#drawTree()` ou équivalent) qui reconstruit le conteneur graphique à partir du contexte courant.
+2. Dessiner les connexions via `PIXI.Graphics` avant tout rendu de nœud afin de garantir une superposition propre.
+3. Dessiner chaque nœud à partir de `x`, `y`, des dimensions centralisées par US16.4 et de la `variant` fournie par US16.3.
+
+**Validation visée :** le viewport reconstruit un arbre complet sans recalcul métier local.
+
+### Étape 2 — Rendre les informations minimales lisibles, en lecture seule
+
+**Fichiers :** `module/applications/specialization-tree-app.mjs`
+
+**Actions :**
+
+1. Ajouter les libellés visibles minimum : nom du talent, coût XP et indication ranked / non-ranked quand l'information existe.
+2. Prévoir un rendu sobre mais explicite pour les nœuds dégradés (`invalid`, `unresolved`) sans casser l'ensemble du viewport.
+3. Garder le rendu strictement consultatif : aucun appel à `purchaseTalentNode`, aucune mutation du document, aucun comportement d'achat implicite.
+
+**Validation visée :** l'arbre est lisible et distinguable visuellement sans quitter le mode lecture seule.
+
+### Étape 3 — Verrouiller le contrat de rendu par des tests ciblés
+
+**Fichiers :** `tests/applications/specialization-tree-app.test.mjs`
+
+**Actions :**
+
+1. Vérifier que le conteneur PIXI est nettoyé puis reconstruit à chaque rerender.
+2. Vérifier l'ordre de dessin observable : connexions d'abord, nœuds ensuite.
+3. Vérifier que les informations minimales et les variantes visuelles sont bien consommées depuis le contexte de rendu.
+4. Vérifier qu'aucune interaction graphique de cette sous-issue ne déclenche d'action métier.
+
+**Validation visée :** le rendu reste stable sans assertions pixel-perfect fragiles.
+
+## Définition de done
+
+- [ ] Le viewport est nettoyé puis redessiné à chaque rendu.
+- [ ] Les connexions sont visibles derrière les nœuds.
+- [ ] Les nœuds affichent au minimum le nom, le coût XP et l'indication ranked / non-ranked si disponible.
+- [ ] Les états sont distinguables visuellement via les variantes de US16.3.
+- [ ] Le rendu reste strictement en lecture seule.
+- [ ] Les tests couvrent le contrat observable sans dépendre d'un rendu pixel-perfect.

--- a/module/applications/specialization-tree-app.mjs
+++ b/module/applications/specialization-tree-app.mjs
@@ -655,6 +655,19 @@ export default class SpecializationTreeApp extends api.HandlebarsApplicationMixi
         costText.y = node.y + NODE_HEIGHT - 14
         this.#treeContainer.addChild(costText)
 
+        // Ranked indicator — shown only when the node is explicitly ranked
+        if (node.isRanked) {
+          const rankedText = new PIXI.Text('(R)', {
+            fontFamily: 'Arial',
+            fontSize: 9,
+            fill: v.costColor,
+            fontStyle: 'italic',
+          })
+          rankedText.x = node.x + NODE_WIDTH - rankedText.width - 4
+          rankedText.y = node.y + 4
+          this.#treeContainer.addChild(rankedText)
+        }
+
         const hitArea = new PIXI.Graphics()
         hitArea.beginFill(0xffffff, 0.001)
         hitArea.drawRect(node.x, node.y, NODE_WIDTH, NODE_HEIGHT)

--- a/tests/applications/specialization-tree-app.test.mjs
+++ b/tests/applications/specialization-tree-app.test.mjs
@@ -727,6 +727,210 @@ describe('specialization-tree application', () => {
     expect(app.pixiApp.stage.children.length).toBeGreaterThan(0)
   })
 
+  it('draws connections before node graphics in the PIXI container', async () => {
+    const actor = createActor({
+      system: {
+        details: {
+          specializations: [{ specializationId: 'spec-bodyguard', name: 'Bodyguard', treeUuid: 'Item.tree-bodyguard' }],
+        },
+        progression: {
+          talentPurchases: [],
+          experience: { available: 100 },
+        },
+      },
+    })
+    globalThis.fromUuidSync = vi.fn((uuid) => {
+      if (uuid === 'Item.tree-bodyguard') {
+        return {
+          type: 'specialization-tree',
+          name: 'Bodyguard Tree',
+          system: {
+            nodes: [
+              { nodeId: 'r1c1', talentId: 'Item.talent-tough', talentUuid: 'Item.talent-tough', row: 1, column: 1, cost: 10 },
+              { nodeId: 'r2c1', talentId: 'Item.talent-grit', talentUuid: 'Item.talent-grit', row: 2, column: 1, cost: 15 },
+            ],
+            connections: [{ from: 'r1c1', to: 'r2c1' }],
+          },
+        }
+      }
+      if (uuid === 'Item.talent-tough') return { name: 'Tough', system: { isRanked: false } }
+      if (uuid === 'Item.talent-grit') return { name: 'Grit', system: { isRanked: false } }
+      return null
+    })
+
+    const app = new SpecializationTreeApp()
+    app.actor = actor
+    app.document = actor
+    const host = createMockHost({ width: 640, height: 480 })
+    app.element = { querySelector: vi.fn(() => host) }
+
+    const context = buildSpecializationTreeContext(actor)
+    await app._onRender(context, {})
+
+    const treeContainer = app.pixiApp.stage.children.find((c) => c.position && c.scale)
+    expect(treeContainer, 'tree container must exist').toBeDefined()
+
+    const children = treeContainer.children
+    const graphicsChildren = children.filter((c) => c.constructor.name === 'MockGraphics')
+
+    // The first Graphics child is the connections (lineStyle is its first call)
+    const firstGraphicsCall = graphicsChildren[0]?.calls?.[0]?.[0]
+    expect(firstGraphicsCall, 'first Graphics call must be lineStyle for connections').toBe('lineStyle')
+
+    // The second Graphics child is the node backgrounds (beginFill is its first call)
+    const secondGraphicsCall = graphicsChildren[1]?.calls?.[0]?.[0]
+    expect(secondGraphicsCall, 'second Graphics call must be beginFill for node backgrounds').toBe('beginFill')
+  })
+
+  it('renders a (R) indicator on PIXI cards for ranked talents', async () => {
+    const actor = createActor({
+      system: {
+        details: {
+          specializations: [{ specializationId: 'spec-bodyguard', name: 'Bodyguard', treeUuid: 'Item.tree-bodyguard' }],
+        },
+        progression: {
+          talentPurchases: [],
+          experience: { available: 100 },
+        },
+      },
+    })
+    globalThis.fromUuidSync = vi.fn((uuid) => {
+      if (uuid === 'Item.tree-bodyguard') {
+        return {
+          type: 'specialization-tree',
+          name: 'Bodyguard Tree',
+          system: {
+            nodes: [
+              { nodeId: 'r1c1', talentId: 'Item.talent-tough', talentUuid: 'Item.talent-tough', row: 1, column: 1, cost: 10 },
+              { nodeId: 'r2c1', talentId: 'Item.talent-grit', talentUuid: 'Item.talent-grit', row: 2, column: 1, cost: 15 },
+            ],
+            connections: [{ from: 'r1c1', to: 'r2c1' }],
+          },
+        }
+      }
+      if (uuid === 'Item.talent-tough') return { name: 'Tough', system: { isRanked: true } }
+      if (uuid === 'Item.talent-grit') return { name: 'Grit', system: { isRanked: false } }
+      return null
+    })
+
+    const app = new SpecializationTreeApp()
+    app.actor = actor
+    app.document = actor
+    const host = createMockHost({ width: 640, height: 480 })
+    app.element = { querySelector: vi.fn(() => host) }
+
+    const context = buildSpecializationTreeContext(actor)
+    await app._onRender(context, {})
+
+    const treeContainer = app.pixiApp.stage.children.find((c) => c.position && c.scale)
+    expect(treeContainer, 'tree container must exist').toBeDefined()
+
+    const rankedTexts = treeContainer.children.filter(
+      (c) => c.constructor.name === 'MockText' && c.text === '(R)',
+    )
+    expect(rankedTexts, 'ranked indicator (R) must appear exactly once for Tough').toHaveLength(1)
+
+    const nonRankedTexts = treeContainer.children.filter(
+      (c) => c.constructor.name === 'MockText' && /^Grit$/.test(c.text),
+    )
+    expect(nonRankedTexts, 'Grit text must be present').toHaveLength(1)
+  })
+
+  it('clears and rebuilds the PIXI tree container on each render', async () => {
+    const actor = createActor({
+      system: {
+        details: {
+          specializations: [{ specializationId: 'spec-bodyguard', name: 'Bodyguard', treeUuid: 'Item.tree-bodyguard' }],
+        },
+        progression: {
+          talentPurchases: [],
+          experience: { available: 100 },
+        },
+      },
+    })
+    globalThis.fromUuidSync = vi.fn((uuid) => {
+      if (uuid === 'Item.tree-bodyguard') {
+        return {
+          type: 'specialization-tree',
+          name: 'Bodyguard Tree',
+          system: {
+            nodes: [{ nodeId: 'r1c1', talentId: 'Item.talent-tough', row: 1, column: 1, cost: 10 }],
+            connections: [{ from: 'r1c1', to: 'r2c1' }],
+          },
+        }
+      }
+      if (uuid === 'Item.talent-tough') return { name: 'Tough' }
+      return null
+    })
+
+    const app = new SpecializationTreeApp()
+    app.actor = actor
+    app.document = actor
+    const host = createMockHost({ width: 640, height: 480 })
+    app.element = { querySelector: vi.fn(() => host) }
+
+    const context = buildSpecializationTreeContext(actor)
+    await app._onRender(context, {})
+
+    const containerBefore = app.pixiApp.stage.children.find((c) => c.position && c.scale)
+    expect(containerBefore, 'tree container must exist after first render').toBeDefined()
+    const childrenBefore = containerBefore.children.length
+
+    await app._onRender(context, {})
+
+    const containerAfter = app.pixiApp.stage.children.find((c) => c.position && c.scale)
+    expect(containerAfter, 'tree container must exist after second render').toBeDefined()
+
+    expect(containerBefore.destroy, 'old container must have been destroyed').toHaveBeenCalled()
+    expect(containerAfter.children.length, 'new container must be rebuilt with fresh children').toBeGreaterThan(0)
+    expect(containerAfter.children.length, 'new container must have at least as many children').toBeGreaterThanOrEqual(1)
+  })
+
+  it('does not render a (R) indicator when isRanked is false', async () => {
+    const actor = createActor({
+      system: {
+        details: {
+          specializations: [{ specializationId: 'spec-bodyguard', name: 'Bodyguard', treeUuid: 'Item.tree-bodyguard' }],
+        },
+        progression: {
+          talentPurchases: [],
+          experience: { available: 100 },
+        },
+      },
+    })
+    globalThis.fromUuidSync = vi.fn((uuid) => {
+      if (uuid === 'Item.tree-bodyguard') {
+        return {
+          type: 'specialization-tree',
+          name: 'Bodyguard Tree',
+          system: {
+            nodes: [{ nodeId: 'r1c1', talentId: 'Item.talent-tough', row: 1, column: 1, cost: 10 }],
+            connections: [{ from: 'r1c1', to: 'r2c1' }],
+          },
+        }
+      }
+      if (uuid === 'Item.talent-tough') return { name: 'Tough', system: { isRanked: false } }
+      return null
+    })
+
+    const app = new SpecializationTreeApp()
+    app.actor = actor
+    app.document = actor
+    const host = createMockHost({ width: 640, height: 480 })
+    app.element = { querySelector: vi.fn(() => host) }
+
+    const context = buildSpecializationTreeContext(actor)
+    await app._onRender(context, {})
+
+    const treeContainer = app.pixiApp.stage.children.find((c) => c.position && c.scale)
+    expect(treeContainer, 'tree container must exist').toBeDefined()
+
+    const rankedTexts = treeContainer.children.filter(
+      (c) => c.constructor.name === 'MockText' && c.text === '(R)',
+    )
+    expect(rankedTexts, 'no (R) indicator must appear for non-ranked talents').toHaveLength(0)
+  })
+
   it('applies viewport transform via position.set and scale.set after draw', async () => {
     const actor = createActor({
       system: {


### PR DESCRIPTION
## Description

Implements **US16.5** — draws specialization tree connections and nodes in the dedicated PIXI viewport, in strict read-only mode.

## Changes

### Production code
- **`module/applications/specialization-tree-app.mjs`** — Added `#drawTree()` pipeline:
  - Clears previous tree container on each render
  - Draws connections first via `PIXI.Graphics` (lineStyle/moveTo/lineTo)
  - Draws node cards with backgrounds, borders (rounded rects), talent name, XP cost, and ranked indicator `(R)`
  - Applies visual variants (fillColor, borderColor, textColor, alpha) from `node-ui-state.mjs`
  - Caches `renderNodes` for `#resetView` and tooltip access

### Tests
- **`tests/applications/specialization-tree-app.test.mjs`** — 4 new tests:
  1. Draw order: connections (lineStyle) before node backgrounds (beginFill)
  2. Ranked indicator `(R)` appears for ranked talents only
  3. Container cleanup and rebuild on each render (old container destroyed)
  4. No `(R)` indicator for non-ranked talents

## Technical notes

- Rendering is strictly read-only — no purchase, no mutation
- Visual variants are consumed from the UI state map (US16.3), not computed in PIXI
- Layout coordinates are provided by the layout module (US16.4)
- Connection drawing precedes node drawing for proper visual layering

## Validation

- `pnpm vitest run tests/applications/specialization-tree-app.test.mjs` — **71/71 passed** (all existing + new tests)
- Full test suite: specialization-tree tests pass with no regressions

## Linked issue

Closes #298