### PR TITLE
feat(specialization-tree): expose minimal consultation detail

### DIFF
--- a/documentation/plan/character-sheet/specialization-tree/299-exposer-un-detail-minimal-de-consultation.md
+++ b/documentation/plan/character-sheet/specialization-tree/299-exposer-un-detail-minimal-de-consultation.md
@@ -1,0 +1,98 @@
+# US16.6 — Plan d'implémentation : Exposer un détail minimal de consultation
+
+## Contexte
+
+Issue : [#299 — US16.6 - Exposer un détail minimal de consultation](https://github.com/herveDarritchon/foundryvtt-swerpg/issues/299)
+
+Références :
+
+- `documentation/plan/character-sheet/specialization-tree/296-mapper-les-etats-et-raisons-de-noeud-vers-l-ui.md`
+- `documentation/plan/character-sheet/specialization-tree/297-definir-le-layout-graphique-minimal.md`
+- `documentation/plan/character-sheet/specialization-tree/298-dessiner-les-connexions-et-les-noeuds-dans-pixi.md`
+- `documentation/ways-of-work/plan/specialization-tree-v1/us16-graphical-tree-rendering/project-plan.md`
+
+L'existant fournit déjà les briques principales :
+
+- `buildSpecializationTreeContext()` expose `renderNodes` avec `talentName`, `xpCost`, `nodeStateLabel` et `reasonLabel` ;
+- `SpecializationTreeApp` dispose déjà d'un viewport PIXI et d'un conteneur de tooltip dans le template ;
+- le mapping d'état / raison localisée a déjà été cadré par US16.3.
+
+Le besoin de l'issue est maintenant de transformer cette base en détail de consultation léger, lisible et strictement sans action métier ni état de sélection persistant.
+
+## Objectif
+
+Permettre à l'utilisateur de consulter, depuis un nœud du tree, un détail minimal (nom, coût, état, raison si applicable) via un tooltip accessible ou un libellé adjacent, sans achat implicite, sans panneau complexe et sans mémoire durable de sélection.
+
+## Périmètre
+
+### Inclus
+
+- déclenchement d'un détail consultatif depuis un nœud rendu ;
+- affichage des informations minimales demandées par l'issue ;
+- comportement éphémère de show / hide sans état applicatif persistant ;
+- tests ciblés sur le contrat de consultation read-only.
+
+### Exclus
+
+- achat de nœud ou prévisualisation d'achat ;
+- panneau latéral interactif ou popover persistant ;
+- nouvelle logique métier de calcul d'état / raison ;
+- zoom, pan ou autre navigation avancée.
+
+## Fichiers pressentis
+
+| Fichier                                               | Rôle                                                        |
+| ----------------------------------------------------- | ----------------------------------------------------------- |
+| `module/applications/specialization-tree-app.mjs`     | Porter le flux de consultation read-only et le cycle show/hide |
+| `templates/applications/specialization-tree-app.hbs`  | Stabiliser le conteneur de détail minimal accessible        |
+| `styles/applications.less`                            | Garantir une présentation légère, lisible et non intrusive  |
+| `tests/applications/specialization-tree-app.test.mjs` | Verrouiller l'absence d'action métier et l'affichage minimal |
+
+## Plan d'implémentation
+
+### Étape 1 — Découpler la consultation de toute action métier
+
+**Fichiers :** `module/applications/specialization-tree-app.mjs`
+
+**Actions :**
+
+1. Définir un chemin d'interaction dédié à la consultation du détail, distinct de toute logique d'achat.
+2. Faire en sorte que l'interaction sur un nœud n'appelle aucune mutation document ni service métier dans le cadre de US16.6.
+3. Supprimer la dépendance à un état de sélection persistant pour afficher le détail ; le tooltip doit pouvoir s'ouvrir puis se refermer sans mémoriser durablement le nœud courant.
+4. Réutiliser uniquement les données déjà présentes dans `renderNodes` (`talentName`, `xpCost`, `nodeStateLabel`, `reasonLabel`).
+
+**Validation visée :** consulter un nœud n'entraîne aucun achat, aucune notification métier et aucune persistance d'état UI.
+
+### Étape 2 — Exposer un détail minimal accessible et éphémère
+
+**Fichiers :** `module/applications/specialization-tree-app.mjs`, `templates/applications/specialization-tree-app.hbs`, `styles/applications.less`
+
+**Actions :**
+
+1. Réutiliser le conteneur de tooltip existant ou un libellé adjacent léger pour afficher nom, coût XP, état et raison localisée si présente.
+2. Donner au conteneur un comportement accessible et purement consultatif : structure lisible, état masqué/visible explicite, aucune interaction interne requise.
+3. Fermer le détail sur sortie de contexte pertinente (nouveau rendu, changement d'arbre, clic hors nœud ou équivalent léger retenu), sans conserver d'historique de sélection.
+4. Garder un rendu sobre qui reste compréhensible pour les nœuds `locked`, `invalid` et `unresolved`.
+
+**Validation visée :** le détail minimal est visible à la demande, compréhensible, non bloquant et toujours temporaire.
+
+### Étape 3 — Sécuriser le contrat par des tests applicatifs ciblés
+
+**Fichiers :** `tests/applications/specialization-tree-app.test.mjs`
+
+**Actions :**
+
+1. Vérifier qu'une interaction de consultation affiche bien le détail minimal attendu pour un nœud.
+2. Vérifier que la raison n'est affichée que pour les états qui en portent une, sans faux message sur un nœud disponible.
+3. Vérifier qu'aucune interaction de consultation n'appelle la logique d'achat, ne déclenche de notification métier ou ne mutile le document.
+4. Vérifier que le détail se masque proprement et qu'aucun état de sélection n'est conservé entre deux interactions ou après rerender.
+
+**Validation visée :** le comportement observable reste strictement read-only et conforme aux critères d'acceptation de l'issue.
+
+## Définition de done
+
+- [ ] Un nœud expose un détail minimal consultatif avec nom, coût, état et raison si applicable.
+- [ ] Le détail ne déclenche aucune action métier.
+- [ ] Aucun état de sélection persistant n'est conservé par l'application.
+- [ ] Le conteneur de détail reste léger, accessible et non interactif.
+- [ ] Les tests couvrent l'affichage minimal et l'absence de couplage avec l'achat.

--- a/module/applications/specialization-tree-app.mjs
+++ b/module/applications/specialization-tree-app.mjs
@@ -240,8 +240,6 @@ export default class SpecializationTreeApp extends api.HandlebarsApplicationMixi
 
   #renderNodesCache = null
 
-  #selectedNodeId = null
-
   #viewport = { scale: 1, x: 0, y: 0 }
 
   #minZoom = 0.5
@@ -677,11 +675,9 @@ export default class SpecializationTreeApp extends api.HandlebarsApplicationMixi
         const capturedNode = node
         hitArea.on('pointerdown', (event) => {
           event.stopPropagation()
-          if (capturedNode.nodeState === NODE_STATE.AVAILABLE) {
-            this.#purchaseNode(capturedNode)
-          } else {
-            this.#showNodeTooltip(capturedNode)
-          }
+          // US16.6 — Node interaction is read-only consultation;
+          // purchase is not triggered from default node click.
+          this.#showNodeTooltip(capturedNode)
         })
         this.#treeContainer.addChild(hitArea)
       }
@@ -717,14 +713,12 @@ export default class SpecializationTreeApp extends api.HandlebarsApplicationMixi
     }
 
     tooltip.hidden = false
-    this.#selectedNodeId = node.nodeId
   }
 
   #hideNodeTooltip() {
     const root = typeof HTMLElement !== 'undefined' && this.element instanceof HTMLElement ? this.element : (this.element?.[0] ?? this.element)
     const tooltip = root?.querySelector?.('[data-node-tooltip]')
     if (tooltip) tooltip.hidden = true
-    this.#selectedNodeId = null
   }
 
   async #purchaseNode(node) {
@@ -759,7 +753,6 @@ export default class SpecializationTreeApp extends api.HandlebarsApplicationMixi
 
     this.#treeContainer = null
     this.#renderNodesCache = null
-    this.#selectedNodeId = null
     this.#viewport = { scale: 1, x: 0, y: 0 }
 
     if (this.pixiApp) {

--- a/templates/applications/specialization-tree-app.hbs
+++ b/templates/applications/specialization-tree-app.hbs
@@ -50,7 +50,7 @@
             data-specialization-tree-viewport
             aria-label='{{viewportAriaLabel}}'
           ></div>
-          <div class='specialization-tree-app__node-tooltip' data-node-tooltip hidden>
+          <div class='specialization-tree-app__node-tooltip' data-node-tooltip role='tooltip' aria-live='polite' hidden>
             <div class='specialization-tree-app__node-tooltip-header' data-tooltip-header></div>
             <div class='specialization-tree-app__node-tooltip-body' data-tooltip-body></div>
           </div>

--- a/tests/applications/specialization-tree-app.test.mjs
+++ b/tests/applications/specialization-tree-app.test.mjs
@@ -2395,6 +2395,361 @@ describe('specialization-tree application', () => {
     })
   })
 
+  describe('consultation detail (US16.6)', () => {
+    it('shows tooltip with talent name, xpCost, state and reason for a locked node', async () => {
+      const actor = createActor({
+        system: {
+          details: {
+            specializations: [{ specializationId: 'spec-bodyguard', name: 'Bodyguard', treeUuid: 'Item.tree-bodyguard' }],
+          },
+          progression: {
+            talentPurchases: [],
+            experience: { available: 0 },
+          },
+        },
+      })
+
+      globalThis.fromUuidSync = vi.fn((uuid) => {
+        if (uuid === 'Item.tree-bodyguard') {
+          return {
+            type: 'specialization-tree',
+            name: 'Bodyguard Tree',
+            system: {
+              nodes: [{ nodeId: 'r1c1', talentId: 'Item.talent-tough', talentUuid: 'Item.talent-tough', row: 1, column: 1, cost: 10 }],
+              connections: [{ from: 'r1c1', to: 'r1c1' }],
+            },
+          }
+        }
+        if (uuid === 'Item.talent-tough') return { name: 'Tough', system: { isRanked: false } }
+        return null
+      })
+
+      const context = buildSpecializationTreeContext(actor)
+      const node = context.renderNodes[0]
+
+      expect(node.nodeState).toBe('locked')
+      expect(node.reasonLabel).toBe('Not enough XP')
+
+      const headerEl = { textContent: '' }
+      const bodyEl = { innerHTML: '' }
+
+      const tooltip = {
+        hidden: true,
+        querySelector: vi.fn((selector) => {
+          if (selector === '[data-tooltip-header]') return headerEl
+          if (selector === '[data-tooltip-body]') return bodyEl
+          return null
+        }),
+      }
+
+      const app = new SpecializationTreeApp()
+      app.actor = actor
+      app.document = actor
+      const host = createMockHost({ width: 640, height: 480 })
+      app.element = {
+        querySelector: vi.fn((selector) => {
+          if (selector === '[data-specialization-tree-viewport]') return host
+          if (selector === '[data-node-tooltip]') return tooltip
+          return null
+        }),
+      }
+
+      await app._onRender(context, { resetView: false })
+
+      // Click on the node — should show tooltip (consultation)
+      const stage = app.pixiApp.stage
+      const container = stage.children.find((child) => child.position && child.scale)
+      const nodeHitArea = container.children.find((child) => child._listeners?.pointerdown)
+      nodeHitArea._listeners.pointerdown({ stopPropagation: vi.fn() })
+
+      expect(tooltip.hidden).toBe(false)
+      expect(headerEl.textContent).toBe('Tough')
+      expect(bodyEl.innerHTML).toContain('Cost')
+      expect(bodyEl.innerHTML).toContain('10 XP')
+      expect(bodyEl.innerHTML).toContain('State')
+      expect(bodyEl.innerHTML).toContain('Locked')
+      expect(bodyEl.innerHTML).toContain('Reason')
+      expect(bodyEl.innerHTML).toContain('Not enough XP')
+    })
+
+    it('shows tooltip without reason for an available node', async () => {
+      const actor = createActor({
+        system: {
+          details: {
+            specializations: [{ specializationId: 'spec-bodyguard', name: 'Bodyguard', treeUuid: 'Item.tree-bodyguard' }],
+          },
+          progression: {
+            talentPurchases: [],
+            experience: { available: 100 },
+          },
+        },
+      })
+
+      globalThis.fromUuidSync = vi.fn((uuid) => {
+        if (uuid === 'Item.tree-bodyguard') {
+          return {
+            type: 'specialization-tree',
+            name: 'Bodyguard Tree',
+            system: {
+              nodes: [{ nodeId: 'r1c1', talentId: 'Item.talent-tough', talentUuid: 'Item.talent-tough', row: 1, column: 1, cost: 10 }],
+              connections: [{ from: 'r1c1', to: 'r1c1' }],
+            },
+          }
+        }
+        if (uuid === 'Item.talent-tough') return { name: 'Tough', system: { isRanked: false } }
+        return null
+      })
+
+      const context = buildSpecializationTreeContext(actor)
+      const node = context.renderNodes[0]
+
+      expect(node.nodeState).toBe('available')
+      expect(node.reasonLabel).toBeNull()
+
+      const headerEl = { textContent: '' }
+      const bodyEl = { innerHTML: '' }
+
+      const tooltip = {
+        hidden: true,
+        querySelector: vi.fn((selector) => {
+          if (selector === '[data-tooltip-header]') return headerEl
+          if (selector === '[data-tooltip-body]') return bodyEl
+          return null
+        }),
+      }
+
+      const app = new SpecializationTreeApp()
+      app.actor = actor
+      app.document = actor
+      const host = createMockHost({ width: 640, height: 480 })
+      app.element = {
+        querySelector: vi.fn((selector) => {
+          if (selector === '[data-specialization-tree-viewport]') return host
+          if (selector === '[data-node-tooltip]') return tooltip
+          return null
+        }),
+      }
+
+      await app._onRender(context, { resetView: false })
+
+      const stage = app.pixiApp.stage
+      const container = stage.children.find((child) => child.position && child.scale)
+      const nodeHitArea = container.children.find((child) => child._listeners?.pointerdown)
+      nodeHitArea._listeners.pointerdown({ stopPropagation: vi.fn() })
+
+      expect(tooltip.hidden).toBe(false)
+      expect(headerEl.textContent).toBe('Tough')
+      expect(bodyEl.innerHTML).toContain('Cost')
+      expect(bodyEl.innerHTML).toContain('State')
+      expect(bodyEl.innerHTML).not.toContain('Reason')
+    })
+
+    it('does not trigger purchase or document mutation on node click', async () => {
+      const actor = createActor({
+        system: {
+          details: {
+            specializations: [{ specializationId: 'spec-bodyguard', name: 'Bodyguard', treeUuid: 'Item.tree-bodyguard' }],
+          },
+          progression: {
+            talentPurchases: [],
+            experience: { available: 100 },
+          },
+        },
+      })
+
+      globalThis.fromUuidSync = vi.fn((uuid) => {
+        if (uuid === 'Item.tree-bodyguard') {
+          return {
+            type: 'specialization-tree',
+            name: 'Bodyguard Tree',
+            system: {
+              nodes: [{ nodeId: 'r1c1', talentId: 'Item.talent-tough', talentUuid: 'Item.talent-tough', row: 1, column: 1, cost: 10 }],
+              connections: [{ from: 'r1c1', to: 'r1c1' }],
+            },
+          }
+        }
+        if (uuid === 'Item.talent-tough') return { name: 'Tough', system: { isRanked: false } }
+        return null
+      })
+
+      const headerEl = { textContent: '' }
+      const bodyEl = { innerHTML: '' }
+
+      const tooltip = {
+        hidden: true,
+        querySelector: vi.fn((selector) => {
+          if (selector === '[data-tooltip-header]') return headerEl
+          if (selector === '[data-tooltip-body]') return bodyEl
+          return null
+        }),
+      }
+
+      const app = new SpecializationTreeApp()
+      app.actor = actor
+      app.document = actor
+      const host = createMockHost({ width: 640, height: 480 })
+      app.element = {
+        querySelector: vi.fn((selector) => {
+          if (selector === '[data-specialization-tree-viewport]') return host
+          if (selector === '[data-node-tooltip]') return tooltip
+          return null
+        }),
+      }
+
+      const context = buildSpecializationTreeContext(actor)
+      await app._onRender(context, { resetView: false })
+
+      // Simulate node click — should show tooltip, not mutate document.
+      const stage = app.pixiApp.stage
+      const container = stage.children.find((child) => child.position && child.scale)
+      const nodeHitArea = container.children.find((child) => child._listeners?.pointerdown)
+      const stopPropagation = vi.fn()
+
+      nodeHitArea._listeners.pointerdown({ stopPropagation })
+
+      expect(stopPropagation).toHaveBeenCalled()
+      expect(tooltip.hidden).toBe(false)
+      expect(actor.update).not.toHaveBeenCalled()
+    })
+
+    it('hides tooltip on stage background click', async () => {
+      const actor = createActor({
+        system: {
+          details: {
+            specializations: [{ specializationId: 'spec-bodyguard', name: 'Bodyguard', treeUuid: 'Item.tree-bodyguard' }],
+          },
+          progression: {
+            talentPurchases: [],
+            experience: { available: 100 },
+          },
+        },
+      })
+
+      globalThis.fromUuidSync = vi.fn((uuid) => {
+        if (uuid === 'Item.tree-bodyguard') {
+          return {
+            type: 'specialization-tree',
+            name: 'Bodyguard Tree',
+            system: {
+              nodes: [{ nodeId: 'r1c1', talentId: 'Item.talent-tough', talentUuid: 'Item.talent-tough', row: 1, column: 1, cost: 10 }],
+              connections: [{ from: 'r1c1', to: 'r1c1' }],
+            },
+          }
+        }
+        if (uuid === 'Item.talent-tough') return { name: 'Tough', system: { isRanked: false } }
+        return null
+      })
+
+      const headerEl = { textContent: '' }
+      const bodyEl = { innerHTML: '' }
+
+      const tooltip = {
+        hidden: true,
+        querySelector: vi.fn((selector) => {
+          if (selector === '[data-tooltip-header]') return headerEl
+          if (selector === '[data-tooltip-body]') return bodyEl
+          return null
+        }),
+      }
+
+      const app = new SpecializationTreeApp()
+      app.actor = actor
+      app.document = actor
+      const host = createMockHost({ width: 640, height: 480 })
+      app.element = {
+        querySelector: vi.fn((selector) => {
+          if (selector === '[data-specialization-tree-viewport]') return host
+          if (selector === '[data-node-tooltip]') return tooltip
+          return null
+        }),
+      }
+
+      const context = buildSpecializationTreeContext(actor)
+      await app._onRender(context, { resetView: false })
+
+      const stage = app.pixiApp.stage
+
+      // Show the tooltip first by clicking on a node
+      const container = stage.children.find((child) => child.position && child.scale)
+      const nodeHitArea = container.children.find((child) => child._listeners?.pointerdown)
+      nodeHitArea._listeners.pointerdown({ stopPropagation: vi.fn() })
+      expect(tooltip.hidden).toBe(false)
+
+      // Click on stage background — should hide tooltip and clear any selection state
+      stage._listeners.pointerdown({ global: { x: 10, y: 10 } })
+      expect(tooltip.hidden).toBe(true)
+    })
+
+    it('hides tooltip on rerender', async () => {
+      const actor = createActor({
+        system: {
+          details: {
+            specializations: [{ specializationId: 'spec-bodyguard', name: 'Bodyguard', treeUuid: 'Item.tree-bodyguard' }],
+          },
+          progression: {
+            talentPurchases: [],
+            experience: { available: 100 },
+          },
+        },
+      })
+
+      globalThis.fromUuidSync = vi.fn((uuid) => {
+        if (uuid === 'Item.tree-bodyguard') {
+          return {
+            type: 'specialization-tree',
+            name: 'Bodyguard Tree',
+            system: {
+              nodes: [{ nodeId: 'r1c1', talentId: 'Item.talent-tough', talentUuid: 'Item.talent-tough', row: 1, column: 1, cost: 10 }],
+              connections: [{ from: 'r1c1', to: 'r1c1' }],
+            },
+          }
+        }
+        if (uuid === 'Item.talent-tough') return { name: 'Tough', system: { isRanked: false } }
+        return null
+      })
+
+      const headerEl = { textContent: '' }
+      const bodyEl = { innerHTML: '' }
+
+      const tooltip = {
+        hidden: true,
+        querySelector: vi.fn((selector) => {
+          if (selector === '[data-tooltip-header]') return headerEl
+          if (selector === '[data-tooltip-body]') return bodyEl
+          return null
+        }),
+      }
+
+      const app = new SpecializationTreeApp()
+      app.actor = actor
+      app.document = actor
+      const host = createMockHost({ width: 640, height: 480 })
+      app.element = {
+        querySelector: vi.fn((selector) => {
+          if (selector === '[data-specialization-tree-viewport]') return host
+          if (selector === '[data-node-tooltip]') return tooltip
+          return null
+        }),
+      }
+
+      const context = buildSpecializationTreeContext(actor)
+
+      // First render
+      await app._onRender(context, { resetView: false })
+
+      // Show the tooltip by clicking on a node
+      const stage = app.pixiApp.stage
+      const container = stage.children.find((child) => child.position && child.scale)
+      const nodeHitArea = container.children.find((child) => child._listeners?.pointerdown)
+      nodeHitArea._listeners.pointerdown({ stopPropagation: vi.fn() })
+      expect(tooltip.hidden).toBe(false)
+
+      // Rerender — tooltip should be hidden
+      await app._onRender(context, { resetView: false })
+      expect(tooltip.hidden).toBe(true)
+    })
+  })
+
   describe('viewport stability', () => {
     it('preserves viewport camera when re-rendering the same specialization tree', async () => {
       const actor = createActor({


### PR DESCRIPTION
## Linked issue
Closes #299

## Context
US16.6 - Exposer un détail minimal de consultation for the specialization tree

## Summary
- Node click now always opens a read-only tooltip instead of triggering purchase (pure consultation)
- Removed the `#selectedNodeId` private field (no persistent selection state)
- Added `role='tooltip'` and `aria-live='polite'` to the tooltip template container for accessibility
- 5 new Vitest tests covering tooltip content for locked/available nodes, no document mutation on click, hide on background click, and hide on rerender

## Technical notes
- The tooltip CSS (`styles/applications.less`) already existed and was not modified — it provides a dark, non-intrusive card at bottom-right
- Validation noted in branch context (not re-run in this PR command): 76/76 in `specialization-tree-app.test.mjs`, 255/255 across all application tests

## Point d'attention
`#purchaseNode` remains in the class and can still be called programmatically; only the default node click handler was changed to consultation-only
