### PR TITLE
test(specialization-tree): extend render contract tests (US16.8)

### DIFF
--- a/documentation/plan/character-sheet/specialization-tree/301-etendre-les-tests-de-contrat-de-rendu.md
+++ b/documentation/plan/character-sheet/specialization-tree/301-etendre-les-tests-de-contrat-de-rendu.md
@@ -1,0 +1,76 @@
+# US16.8 — Plan d'implémentation : Étendre les tests de contrat de rendu
+
+## Contexte
+
+Issue : [#301 — US16.8 - Étendre les tests de contrat de rendu](https://github.com/herveDarritchon/foundryvtt-swerpg/issues/301)
+
+Références :
+
+- `documentation/plan/character-sheet/specialization-tree/296-mapper-les-etats-et-raisons-de-noeud-vers-l-ui.md`
+- `documentation/plan/character-sheet/specialization-tree/297-definir-le-layout-graphique-minimal.md`
+- `documentation/plan/character-sheet/specialization-tree/298-dessiner-les-connexions-et-les-noeuds-dans-pixi.md`
+- `documentation/plan/character-sheet/specialization-tree/299-exposer-un-detail-minimal-de-consultation.md`
+- `documentation/cadrage/character-sheet/specialization-tree/cadrage-us16-decoupage-rendu-graphique-arbres-specialisation.md`
+
+Le rendu graphique de l'arbre de spécialisation dispose déjà d'un view-model, d'un mapping d'état/raison et d'un layout applicatif. Le besoin restant est de consolider une couverture de tests lisible qui verrouille ce contrat observable sans figer le rendu PIXI au pixel près.
+
+## Objectif
+
+Sécuriser les comportements attendus de `SpecializationTreeApp` et de `buildSpecializationTreeContext()` via des tests de contrat ciblés sur la sélection d'arbre, l'état vide, la structure du view-model, le mapping des états/raisons et l'absence d'effet métier.
+
+## Périmètre
+
+### Inclus
+
+- choix du dernier arbre disponible par défaut et fallback de sélection ;
+- état vide quand aucun arbre exploitable n'est résolu ;
+- structure observable de `renderNodes` et `renderConnections` ;
+- mapping des `nodeState`, `reasonCode` et `reasonLabel` localisés ;
+- absence de dépendance au canvas de scène ;
+- absence de comportement d'achat déclenché par le rendu.
+
+### Exclus
+
+- snapshots graphiques PIXI ;
+- assertions sur des pixels exacts ou sur un thème visuel détaillé ;
+- tests d'interactions avancées relevant du zoom/pan ou d'US17/US18.
+
+## Fichiers pressentis
+
+| Fichier                                               | Rôle                                                               |
+| ----------------------------------------------------- | ------------------------------------------------------------------ |
+| `tests/applications/specialization-tree-app.test.mjs` | Consolider et compléter les tests de contrat du view-model et du rendu observable |
+
+## Plan d'implémentation
+
+### Étape 1 — Consolider la couverture du contrat cœur
+
+**Fichiers :** `tests/applications/specialization-tree-app.test.mjs`
+
+1. Regrouper les scénarios de contrat autour des axes attendus par l'issue : sélection par défaut, fallback, état vide, nœuds et connexions.
+2. Uniformiser les fixtures minimales pour que chaque test exprime clairement le contrat métier attendu.
+3. Garder des messages d'échec explicites pour faciliter le diagnostic en cas de régression.
+
+### Étape 2 — Étendre les assertions sur le mapping UI et les garanties non fonctionnelles
+
+**Fichiers :** `tests/applications/specialization-tree-app.test.mjs`
+
+1. Vérifier explicitement les champs contractuels des nœuds rendus (`nodeState`, `nodeStateLabel`, `reasonCode`, `reasonLabel`, `variant`).
+2. Couvrir les cas localisés utiles : nœud disponible, nœud verrouillé, raison absente, raison de fallback et talent introuvable.
+3. Verrouiller que les tests passent par le view-model et le rendu observable sans dépendre d'un canvas de scène ni déclencher de logique d'achat.
+
+### Étape 3 — Réduire la fragilité de la suite de tests
+
+**Fichiers :** `tests/applications/specialization-tree-app.test.mjs`
+
+1. Remplacer ou éviter les assertions trop couplées à des détails de dessin quand une assertion sur le contrat suffit.
+2. Préférer des vérifications structurelles et sémantiques aux vérifications pixel-perfect.
+3. S'assurer que la suite documente clairement ce qui relève du contrat stable et ce qui reste un détail d'implémentation graphique.
+
+## Définition de done
+
+- [ ] Les tests couvrent explicitement le choix d'arbre par défaut, le fallback et l'état vide.
+- [ ] Les tests couvrent la structure attendue de `renderNodes` et `renderConnections`.
+- [ ] Les états et raisons exposés au rendu sont vérifiés via des assertions lisibles et localisées.
+- [ ] Aucun test de cette issue ne dépend d'un snapshot graphique PIXI ou d'assertions pixel-perfect.
+- [ ] Les tests verrouillent l'absence d'achat implicite et l'absence de dépendance au canvas de scène.

--- a/tests/applications/specialization-tree-app.test.mjs
+++ b/tests/applications/specialization-tree-app.test.mjs
@@ -378,6 +378,110 @@ describe('specialization-tree application', () => {
     expect(context.currentTreeData).toBeNull()
     expect(context.renderNodes).toEqual([])
     expect(context.renderConnections).toEqual([])
+    expect(context.hasResolvedTrees).toBe(false)
+    expect(context.showViewport).toBe(false)
+    expect(context.emptyStateTitle).toBe('No available specialization tree')
+  })
+
+  it('builds empty state when actor has no owned specializations', () => {
+    const actor = createActor({
+      system: {
+        details: {
+          specializations: [],
+        },
+      },
+    })
+
+    const context = buildSpecializationTreeContext(actor)
+
+    expect(context.hasActor).toBe(true)
+    expect(context.hasSpecializations).toBe(false)
+    expect(context.hasResolvedTrees).toBe(false)
+    expect(context.showViewport).toBe(false)
+    expect(context.specializations).toEqual([])
+    expect(context.currentTreeId).toBeNull()
+    expect(context.currentTreeData).toBeNull()
+    expect(context.renderNodes).toEqual([])
+    expect(context.renderConnections).toEqual([])
+    expect(context.emptyStateTitle).toBe('No owned specialization')
+    expect(context.emptyStateDescription).toBe(
+      'This character does not currently own any specialization to display.',
+    )
+  })
+
+  it('builds empty state when all specialization trees are unresolved', () => {
+    const actor = createActor({
+      system: {
+        details: {
+          specializations: [
+            { specializationId: 'spec-alpha', name: 'Alpha', treeUuid: 'Item.tree-alpha' },
+            { specializationId: 'spec-beta', name: 'Beta', treeUuid: 'Item.tree-beta' },
+          ],
+        },
+      },
+    })
+
+    globalThis.fromUuidSync = vi.fn(() => null)
+
+    const context = buildSpecializationTreeContext(actor)
+
+    expect(context.hasActor).toBe(true)
+    expect(context.hasSpecializations).toBe(true)
+    expect(context.hasResolvedTrees).toBe(false)
+    expect(context.showViewport).toBe(false)
+    expect(context.currentTreeId).toBeNull()
+    expect(context.currentTreeData).toBeNull()
+    expect(context.renderNodes).toEqual([])
+    expect(context.renderConnections).toEqual([])
+    expect(context.emptyStateTitle).toBe('No available specialization tree')
+    expect(context.emptyStateDescription).toBe(
+      'The owned specializations were found, but none currently resolve to a complete reference tree.',
+    )
+  })
+
+  it('builds empty state when the specialization tree is structurally incomplete', () => {
+    const actor = createActor({
+      system: {
+        details: {
+          specializations: [{ specializationId: 'spec-bodyguard', name: 'Bodyguard', treeUuid: 'Item.tree-bodyguard' }],
+        },
+      },
+    })
+
+    globalThis.fromUuidSync = vi.fn((uuid) => {
+      if (uuid === 'Item.tree-bodyguard') {
+        return {
+          type: 'specialization-tree',
+          name: 'Bodyguard Tree',
+          flags: {
+            swerpg: {
+              import: { status: 'incomplete' },
+            },
+          },
+          system: {
+            nodes: [],
+            connections: [],
+          },
+        }
+      }
+      return null
+    })
+
+    const context = buildSpecializationTreeContext(actor)
+
+    expect(context.hasSpecializations).toBe(true)
+    expect(context.hasResolvedTrees).toBe(false)
+    expect(context.showViewport).toBe(false)
+
+    expect(context.specializations).toHaveLength(1)
+    expect(context.specializations[0].state).toBe('incomplete')
+    expect(context.specializations[0].stateLabel).toBe('Incomplete tree')
+    expect(context.specializations[0].isAvailable).toBe(false)
+
+    expect(context.currentTreeId).toBeNull()
+    expect(context.renderNodes).toEqual([])
+    expect(context.renderConnections).toEqual([])
+    expect(context.emptyStateTitle).toBe('No available specialization tree')
   })
 
   it('builds renderNodes with computed positions, talent names and node states', () => {
@@ -1158,6 +1262,62 @@ describe('specialization-tree application', () => {
     expect(typeof node.variant.costColor).toBe('number')
     expect(typeof node.variant.borderWidth).toBe('number')
     expect(typeof node.variant.alpha).toBe('number')
+  })
+
+  it('sets nodeState to purchased when talent has already been purchased', () => {
+    const actor = createActor({
+      system: {
+        details: {
+          specializations: [{ specializationId: 'spec-bodyguard', name: 'Bodyguard', treeUuid: 'Item.tree-bodyguard' }],
+        },
+        progression: {
+          talentPurchases: [
+            {
+              nodeId: 'r1c1',
+              specializationId: 'spec-bodyguard',
+              treeId: 'tree-bodyguard',
+              talentId: 'Item.talent-tough',
+            },
+          ],
+          experience: { available: 100 },
+        },
+      },
+    })
+
+    globalThis.fromUuidSync = vi.fn((uuid) => {
+      if (uuid === 'Item.tree-bodyguard') {
+        return {
+          id: 'tree-bodyguard',
+          type: 'specialization-tree',
+          name: 'Bodyguard Tree',
+          system: {
+            nodes: [
+              { nodeId: 'r1c1', talentId: 'Item.talent-tough', talentUuid: 'Item.talent-tough', row: 1, column: 1, cost: 10 },
+              { nodeId: 'r2c1', talentId: 'Item.talent-grit', talentUuid: 'Item.talent-grit', row: 2, column: 1, cost: 15 },
+            ],
+            connections: [{ from: 'r1c1', to: 'r2c1' }],
+          },
+        }
+      }
+      if (uuid === 'Item.talent-tough') return { name: 'Tough', system: { isRanked: false } }
+      if (uuid === 'Item.talent-grit') return { name: 'Grit', system: { isRanked: false } }
+      return null
+    })
+
+    const context = buildSpecializationTreeContext(actor)
+
+    expect(context.renderNodes, 'should have 2 render nodes').toHaveLength(2)
+
+    const purchased = context.renderNodes.find((n) => n.nodeId === 'r1c1')
+    expect(purchased, 'r1c1 should be purchased').toBeDefined()
+    expect(purchased.nodeState, 'purchased node state').toBe('purchased')
+    expect(purchased.nodeStateLabel, 'purchased node state label').toBe('Purchased')
+    expect(purchased.reasonCode, 'purchased reason code').toBe('already-purchased')
+    expect(purchased.reasonLabel, 'purchased reason label').toBe('Already purchased')
+
+    const other = context.renderNodes.find((n) => n.nodeId === 'r2c1')
+    expect(other, 'r2c1 should exist').toBeDefined()
+    expect(other.nodeState, 'other node must not be purchased').not.toBe('purchased')
   })
 
   it('does not trigger any purchase behavior from rendering', () => {


### PR DESCRIPTION
Closes #301

## Summary
- Extend render contract tests to cover empty states (no specializations, unresolved trees, incomplete trees)
- Add test for purchased node state with localized labels
- Strengthen existing fallback selection test with additional observable fields
- No production code modified

## Tests
- `pnpm vitest run`: 1784 passed, 2 skipped, 0 failures
- All tests under `tests/applications/`: 259 passed

## Notes
- Plan file: `documentation/plan/character-sheet/specialization-tree/301-etendre-les-tests-de-contrat-de-rendu.md`
- No PIXI snapshots, no pixel-perfect assertions, no scene canvas dependency