### PR TITLE
feat(talent-node): add atomic persistence helper and forget flow

### DIFF
--- a/documentation/plan/character-sheet/specialization-tree/312-stabiliser-la-persistance-acteur-et-limpact-xp.md
+++ b/documentation/plan/character-sheet/specialization-tree/312-stabiliser-la-persistance-acteur-et-limpact-xp.md
@@ -1,0 +1,81 @@
+# US17.2 — Plan d'implémentation : Stabiliser la persistance acteur et l'impact XP
+
+## Contexte
+
+Issue : [#312 — US17.2 - Stabiliser la persistance acteur et l'impact XP](https://github.com/herveDarritchon/foundryvtt-swerpg/issues/312)
+
+Références :
+
+- `documentation/ways-of-work/plan/specialization-tree-v1/us17-talent-node-purchase-and-forget/project-plan.md`
+- `documentation/ways-of-work/plan/specialization-tree-v1/us17-talent-node-purchase-and-forget/issues-checklist.md`
+- `documentation/cadrage/character-sheet/specialization-tree/cadrage-amelioration-achat-oubli-talent-arbre-specialisation.md`
+- `documentation/plan/character-sheet/specialization-tree/311-creer-le-service-metier-dachat-et-doubli-de-noeud.md`
+
+L'existant dispose déjà d'un contrat métier central via `processTalentNodeProgression()` et d'un flux `purchaseTalentNode()` qui applique un patch acteur sur l'achat. Le besoin de US17.2 est de stabiliser la couche applicative de persistance pour qu'achat et oubli appliquent toujours `talentPurchases` et `experience.spent` dans une seule mise à jour, sans divergence avec la convention XP actuelle de l'acteur.
+
+## Objectif
+
+Garantir qu'un achat ou un oubli validé produit un patch acteur unique, cohérent et réutilisable, aligné sur `system.progression.talentPurchases` et `system.progression.experience.spent`, afin de préparer les futures interactions UI et la synchronisation des vues sans réintroduire de logique métier.
+
+## Périmètre
+
+### Inclus
+
+- stabilisation de la structure persistée des entrées `talentPurchases` ;
+- persistance atomique progression + XP via un unique `actor.update()` ;
+- ajout du flux de persistance d'oubli, symétrique au flux d'achat ;
+- alignement explicite sur la convention XP existante (`experience.spent`) ;
+- tests de non-régression sur patch, remboursement et absence d'update partielle.
+
+### Exclus
+
+- view-model UI des nœuds (`US17.3`) ;
+- branchement des clics, confirmations et notifications (`US17.4`) ;
+- refresh arbre / onglet Talents (`US17.5`) ;
+- extension du périmètre audit log au-delà du comportement déjà présent côté achat (`US17.6`).
+
+## Fichiers pressentis
+
+| Fichier | Rôle |
+| --- | --- |
+| `module/lib/talent-node/talent-node-persistence.mjs` | Nouveau helper applicatif pour transformer un résultat métier valide en patch acteur atomique |
+| `module/lib/talent-node/talent-node-purchase.mjs` | Déléguer la persistance d'achat au helper partagé et conserver le contrat public existant |
+| `module/lib/talent-node/talent-node-forget.mjs` | Nouveau point d'entrée applicatif pour persister l'oubli d'un nœud |
+| `module/lib/talent-node/talent-node-progression.mjs` | Confirmer/compléter les métadonnées minimales nécessaires au patch applicatif |
+| `tests/lib/talent-node/talent-node-persistence.test.mjs` | Vérifier la construction du patch atomique et les garde-fous applicatifs |
+| `tests/lib/talent-node/talent-node-purchase.test.mjs` | Réaligner les assertions d'achat sur la couche de persistance partagée |
+| `tests/lib/talent-node/talent-node-forget.test.mjs` | Couvrir oubli nominal, remboursement XP et refus sans effet de bord |
+
+## Plan d'implémentation
+
+### Étape 1 — Formaliser le patch acteur atomique partagé
+
+**Fichiers :** `module/lib/talent-node/talent-node-persistence.mjs`, `module/lib/talent-node/talent-node-progression.mjs`
+
+1. Introduire un helper applicatif unique qui reçoit l'acteur et le `payload` valide du service métier.
+2. Centraliser dans ce helper le patch `actor.update()` sur `system.progression.talentPurchases` et `system.progression.experience.spent`.
+3. Verrouiller la forme persistée minimale d'un achat (`treeId`, `treeUuid`, `nodeId`, `talentId`, `talentUuid`, `specializationId`) pour éviter toute divergence entre achat et oubli.
+
+### Étape 2 — Brancher achat et oubli sur la même couche de persistance
+
+**Fichiers :** `module/lib/talent-node/talent-node-purchase.mjs`, `module/lib/talent-node/talent-node-forget.mjs`, `module/lib/talent-node/talent-node-persistence.mjs`
+
+1. Faire déléguer `purchaseTalentNode()` au helper partagé sans changer son contrat d'appel actuel.
+2. Ajouter un flux `forgetTalentNode()` qui réutilise `processTalentNodeProgression(..., 'forget')` puis applique le même mécanisme atomique de persistance.
+3. Garder l'impact XP strictement aligné avec la convention existante : achat = incrément de `experience.spent`, oubli autorisé = décrément/remboursement dans le même patch.
+
+### Étape 3 — Verrouiller les non-régressions applicatives
+
+**Fichiers :** `tests/lib/talent-node/talent-node-persistence.test.mjs`, `tests/lib/talent-node/talent-node-purchase.test.mjs`, `tests/lib/talent-node/talent-node-forget.test.mjs`
+
+1. Vérifier qu'un succès achat/oubli produit toujours un unique patch contenant à la fois progression et XP.
+2. Vérifier qu'aucun `actor.update()` n'est déclenché quand la validation métier échoue en amont.
+3. Couvrir explicitement l'ajout d'achat, le retrait d'achat, le remboursement XP et la stabilité des entrées persistées.
+
+## Définition de done
+
+- [ ] Achat et oubli appliquent la progression et l'XP dans un seul `actor.update()`.
+- [ ] La structure persistée des entrées `talentPurchases` est identique quel que soit le flux.
+- [ ] L'oubli autorisé retire l'entrée ciblée et ajuste `experience.spent` selon la convention actuelle.
+- [ ] Aucun patch partiel n'est émis quand le service métier refuse l'action.
+- [ ] Les tests applicatifs couvrent les flux nominaux et les principaux refus sans effet de bord.

--- a/module/lib/talent-node/talent-node-forget.mjs
+++ b/module/lib/talent-node/talent-node-forget.mjs
@@ -1,0 +1,47 @@
+import { processTalentNodeProgression } from './talent-node-progression.mjs'
+import { applyTalentNodePatch } from './talent-node-persistence.mjs'
+
+/**
+ * @typedef {Object} ForgetResult
+ * @property {boolean} ok - Whether the forget operation succeeded.
+ * @property {string} [reason] - Human-readable failure description (only when ok === false).
+ * @property {string} [reasonCode] - Machine-readable failure reason code (only when ok === false).
+ * @property {string[]} [dependents] - Blocking dependent node IDs (only when reasonCode is NODE_HAS_DEPENDENTS).
+ * @property {Object} [purchase] - The removed purchase entry (only when ok === true).
+ * @property {string} purchase.treeId
+ * @property {string|null} purchase.treeUuid
+ * @property {string} purchase.nodeId
+ * @property {string} purchase.talentId
+ * @property {string|null} purchase.talentUuid
+ * @property {string} purchase.specializationId
+ * @property {number} purchase.cost
+ */
+
+/**
+ * Forget a previously purchased talent node for an actor.
+ * Delegates business validation to the central progression service,
+ * then persists the removal and XP refund atomically via the shared
+ * persistence helper.
+ *
+ * XP convention: oubli autorisé decrements experience.spent by the node cost,
+ * symmetric to the purchase increment.
+ *
+ * @param {object} actor - The actor document instance.
+ * @param {string} specializationId - The specialization identifier.
+ * @param {string} nodeId - The node identifier within the specialization tree.
+ * @returns {Promise<ForgetResult>}
+ */
+export async function forgetTalentNode(actor, specializationId, nodeId) {
+  const result = processTalentNodeProgression(actor, specializationId, nodeId, 'forget')
+
+  if (!result.ok) {
+    const forgetResult = { ok: false, reason: result.reason, reasonCode: result.reasonCode }
+    if (result.dependents) {
+      forgetResult.dependents = result.dependents
+    }
+    return forgetResult
+  }
+
+  const { payload } = result
+  return applyTalentNodePatch(actor, payload, 'forget')
+}

--- a/module/lib/talent-node/talent-node-persistence.mjs
+++ b/module/lib/talent-node/talent-node-persistence.mjs
@@ -1,0 +1,77 @@
+import { logger } from '../../utils/logger.mjs'
+
+/**
+ * @typedef {Object} PersistenceResult
+ * @property {boolean} ok - Whether the persistence succeeded.
+ * @property {string} [reason] - Human-readable failure description (only when ok === false).
+ * @property {string} [reasonCode] - Machine-readable failure reason code (only when ok === false).
+ * @property {Object} [purchase] - The purchase entry that was added or removed (only when ok === true).
+ * @property {string} purchase.treeId
+ * @property {string|null} purchase.treeUuid
+ * @property {string} purchase.nodeId
+ * @property {string} purchase.talentId
+ * @property {string|null} purchase.talentUuid
+ * @property {string} purchase.specializationId
+ * @property {number} purchase.cost
+ */
+
+/**
+ * Apply a validated talent node progression payload as a single atomic actor update.
+ *
+ * This helper centralises the Foundry persistence step so that both purchase and
+ * forget flows emit an identical `actor.update()` structure.  It must only be
+ * called after `processTalentNodeProgression()` has returned `ok: true`.
+ *
+ * The minimum persisted shape of a purchase entry is:
+ *   { treeId, treeUuid, nodeId, talentId, talentUuid, specializationId }
+ *
+ * @param {object} actor - The actor document instance.
+ * @param {object} payload - The validated payload from processTalentNodeProgression.
+ * @param {string} payload.specializationId
+ * @param {string} payload.treeId
+ * @param {string|null} payload.treeUuid
+ * @param {string} payload.nodeId
+ * @param {string} payload.talentId
+ * @param {string|null} payload.talentUuid
+ * @param {number} payload.cost
+ * @param {Array} payload.updatedPurchases - New talentPurchases array to persist.
+ * @param {number} payload.updatedSpent - New experience.spent value to persist.
+ * @param {'purchase'|'forget'} action - The action that produced this payload.
+ * @returns {Promise<PersistenceResult>}
+ */
+export async function applyTalentNodePatch(actor, payload, action) {
+  if (!actor) {
+    logger.warn('[TalentNodePersistence] applyTalentNodePatch called without actor')
+    return { ok: false, reason: 'Missing actor', reasonCode: 'node-invalid' }
+  }
+
+  if (!payload) {
+    logger.warn('[TalentNodePersistence] applyTalentNodePatch called without payload')
+    return { ok: false, reason: 'Missing payload', reasonCode: 'node-invalid' }
+  }
+
+  await actor.update({
+    'system.progression.talentPurchases': payload.updatedPurchases,
+    'system.progression.experience.spent': payload.updatedSpent,
+  })
+
+  const purchaseEntry = {
+    treeId: payload.treeId,
+    treeUuid: payload.treeUuid,
+    nodeId: payload.nodeId,
+    talentId: payload.talentId,
+    talentUuid: payload.talentUuid,
+    specializationId: payload.specializationId,
+    cost: payload.cost,
+  }
+
+  logger.debug('[TalentNodePersistence] Patch applied', {
+    action,
+    actorId: actor.id,
+    nodeId: payload.nodeId,
+    specializationId: payload.specializationId,
+    updatedSpent: payload.updatedSpent,
+  })
+
+  return { ok: true, purchase: purchaseEntry }
+}

--- a/module/lib/talent-node/talent-node-purchase.mjs
+++ b/module/lib/talent-node/talent-node-purchase.mjs
@@ -1,6 +1,7 @@
 import { logger } from '../../utils/logger.mjs'
 import { recordTalentNodePurchase } from '../../utils/audit-log.mjs'
 import { processTalentNodeProgression } from './talent-node-progression.mjs'
+import { applyTalentNodePatch } from './talent-node-persistence.mjs'
 
 /**
  * @typedef {Object} PurchaseResult
@@ -9,8 +10,10 @@ import { processTalentNodeProgression } from './talent-node-progression.mjs'
  * @property {string} [reasonCode] - Machine-readable failure reason code (only when ok === false).
  * @property {Object} [purchase] - Purchase data (only when ok === true).
  * @property {string} purchase.treeId
+ * @property {string|null} purchase.treeUuid
  * @property {string} purchase.nodeId
  * @property {string} purchase.talentId
+ * @property {string|null} purchase.talentUuid
  * @property {string} purchase.specializationId
  * @property {number} purchase.cost
  */
@@ -18,8 +21,8 @@ import { processTalentNodeProgression } from './talent-node-progression.mjs'
 /**
  * Purchase a talent node for an actor.
  * Delegates business validation to the central progression service,
- * persists the purchase and XP atomically, then records an audit entry
- * (non-blocking).
+ * persists the purchase and XP atomically via the shared persistence helper,
+ * then records an audit entry (non-blocking).
  *
  * @param {object} actor - The actor document instance.
  * @param {string} specializationId - The specialization identifier.
@@ -36,10 +39,10 @@ export async function purchaseTalentNode(actor, specializationId, nodeId) {
   const { payload } = result
   const currentSpent = actor.system?.progression?.experience?.spent ?? 0
 
-  await actor.update({
-    'system.progression.talentPurchases': payload.updatedPurchases,
-    'system.progression.experience.spent': payload.updatedSpent,
-  })
+  const persisted = await applyTalentNodePatch(actor, payload, 'purchase')
+  if (!persisted.ok) {
+    return persisted
+  }
 
   try {
     await recordTalentNodePurchase(actor, {
@@ -61,10 +64,5 @@ export async function purchaseTalentNode(actor, specializationId, nodeId) {
     })
   }
 
-  const purchaseEntry = payload.updatedPurchases[payload.updatedPurchases.length - 1]
-
-  return {
-    ok: true,
-    purchase: { ...purchaseEntry, cost: payload.cost },
-  }
+  return persisted
 }

--- a/tests/lib/talent-node/talent-node-forget.test.mjs
+++ b/tests/lib/talent-node/talent-node-forget.test.mjs
@@ -1,0 +1,311 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('../../../module/utils/logger.mjs', () => ({
+  logger: {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+}))
+
+vi.mock('../../../module/lib/talent-node/talent-tree-resolver.mjs', () => ({
+  resolveSpecializationTree: vi.fn(),
+}))
+
+import { resolveSpecializationTree } from '../../../module/lib/talent-node/talent-tree-resolver.mjs'
+import { forgetTalentNode } from '../../../module/lib/talent-node/talent-node-forget.mjs'
+import { REASON_CODE } from '../../../module/lib/talent-node/talent-node-state.mjs'
+
+// ---------------------------------------------------------------------------
+// Builders
+// ---------------------------------------------------------------------------
+
+function buildActor(overrides = {}) {
+  return {
+    id: 'actor-001',
+    system: {
+      details: {
+        specializations: [{ specializationId: 'spec-1', name: 'Bodyguard' }],
+      },
+      progression: {
+        talentPurchases: [
+          { treeId: 'tree-1', treeUuid: null, nodeId: 'r1c1', talentId: 'talent-parry', talentUuid: null, specializationId: 'spec-1' },
+        ],
+        experience: { gained: 100, spent: 5 },
+      },
+    },
+    update: vi.fn().mockResolvedValue(undefined),
+    ...overrides,
+  }
+}
+
+function buildResolvedTree(nodeOverrides = [], connectionOverrides = []) {
+  return {
+    tree: {
+      id: 'tree-1',
+      system: {
+        specializationId: 'spec-1',
+        nodes: [
+          { nodeId: 'r1c1', talentId: 'talent-parry', row: 1, column: 1, cost: 5 },
+          { nodeId: 'r2c1', talentId: 'talent-deflect', row: 2, column: 1, cost: 10 },
+          ...nodeOverrides,
+        ],
+        connections: [{ from: 'r1c1', to: 'r2c1' }, ...connectionOverrides],
+      },
+    },
+    state: 'available',
+  }
+}
+
+// ---------------------------------------------------------------------------
+// forgetTalentNode — nominal flows
+// ---------------------------------------------------------------------------
+
+describe('forgetTalentNode', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  describe('nominal forget flow', () => {
+    it('forgets a purchased leaf node and refunds XP atomically', async () => {
+      const actor = buildActor()
+      resolveSpecializationTree.mockReturnValue(buildResolvedTree())
+
+      const result = await forgetTalentNode(actor, 'spec-1', 'r1c1')
+
+      expect(result.ok).toBe(true)
+      expect(result.purchase).toMatchObject({
+        treeId: 'tree-1',
+        treeUuid: null,
+        nodeId: 'r1c1',
+        talentId: 'talent-parry',
+        talentUuid: null,
+        specializationId: 'spec-1',
+        cost: 5,
+      })
+    })
+
+    it('calls actor.update exactly once with both talentPurchases and experience.spent', async () => {
+      const actor = buildActor()
+      resolveSpecializationTree.mockReturnValue(buildResolvedTree())
+
+      await forgetTalentNode(actor, 'spec-1', 'r1c1')
+
+      expect(actor.update).toHaveBeenCalledTimes(1)
+      expect(actor.update).toHaveBeenCalledWith({
+        'system.progression.talentPurchases': [],
+        'system.progression.experience.spent': 0,
+      })
+    })
+
+    it('removes only the forgotten node, keeping other purchases intact', async () => {
+      const actor = buildActor({
+        system: {
+          details: { specializations: [{ specializationId: 'spec-1' }] },
+          progression: {
+            talentPurchases: [
+              { treeId: 'tree-1', treeUuid: null, nodeId: 'r1c1', talentId: 'talent-parry', talentUuid: null, specializationId: 'spec-1' },
+              { treeId: 'tree-1', treeUuid: null, nodeId: 'r2c1', talentId: 'talent-deflect', talentUuid: null, specializationId: 'spec-1' },
+            ],
+            experience: { gained: 100, spent: 15 },
+          },
+        },
+      })
+      resolveSpecializationTree.mockReturnValue(buildResolvedTree())
+
+      // r2c1 is a leaf (no node after it), so forgetting it is allowed
+      const result = await forgetTalentNode(actor, 'spec-1', 'r2c1')
+
+      expect(result.ok).toBe(true)
+      expect(actor.update).toHaveBeenCalledWith({
+        'system.progression.talentPurchases': [
+          { treeId: 'tree-1', treeUuid: null, nodeId: 'r1c1', talentId: 'talent-parry', talentUuid: null, specializationId: 'spec-1' },
+        ],
+        'system.progression.experience.spent': 5,
+      })
+    })
+
+    it('XP refund is symmetric to the purchase cost', async () => {
+      const actor = buildActor({
+        system: {
+          details: { specializations: [{ specializationId: 'spec-1' }] },
+          progression: {
+            talentPurchases: [
+              { treeId: 'tree-1', treeUuid: null, nodeId: 'r2c1', talentId: 'talent-deflect', talentUuid: null, specializationId: 'spec-1' },
+            ],
+            // Simulating that r2c1 (cost 10) was purchased, r1c1 is not a dependency we care about here
+            experience: { gained: 100, spent: 10 },
+          },
+        },
+      })
+      // Patch tree so r2c1 is a root (row 1) to avoid lock logic complications
+      const treeWithR2Root = {
+        tree: {
+          id: 'tree-1',
+          system: {
+            specializationId: 'spec-1',
+            nodes: [{ nodeId: 'r2c1', talentId: 'talent-deflect', row: 1, column: 1, cost: 10 }],
+            connections: [],
+          },
+        },
+        state: 'available',
+      }
+      resolveSpecializationTree.mockReturnValue(treeWithR2Root)
+
+      const result = await forgetTalentNode(actor, 'spec-1', 'r2c1')
+
+      expect(result.ok).toBe(true)
+      const [patchArg] = actor.update.mock.calls[0]
+      expect(patchArg['system.progression.experience.spent']).toBe(0) // 10 - 10
+    })
+  })
+
+  // ---------------------------------------------------------------------------
+  // forgetTalentNode — rejection cases (no actor.update emitted)
+  // ---------------------------------------------------------------------------
+
+  describe('rejection — no actor.update emitted', () => {
+    it('returns error when actor is null', async () => {
+      const result = await forgetTalentNode(null, 'spec-1', 'r1c1')
+
+      expect(result.ok).toBe(false)
+      expect(result.reasonCode).toBe(REASON_CODE.NODE_INVALID)
+      expect(result.reason).toContain('Missing actor')
+    })
+
+    it('returns error when specializationId is missing', async () => {
+      const actor = buildActor()
+      const result = await forgetTalentNode(actor, '', 'r1c1')
+
+      expect(result.ok).toBe(false)
+      expect(result.reasonCode).toBe(REASON_CODE.NODE_INVALID)
+      expect(actor.update).not.toHaveBeenCalled()
+    })
+
+    it('returns error when nodeId is missing', async () => {
+      const actor = buildActor()
+      const result = await forgetTalentNode(actor, 'spec-1', '')
+
+      expect(result.ok).toBe(false)
+      expect(result.reasonCode).toBe(REASON_CODE.NODE_INVALID)
+      expect(actor.update).not.toHaveBeenCalled()
+    })
+
+    it('returns error when specialization is not owned', async () => {
+      const actor = buildActor()
+      actor.system.details.specializations = []
+
+      const result = await forgetTalentNode(actor, 'spec-unknown', 'r1c1')
+
+      expect(result.ok).toBe(false)
+      expect(result.reasonCode).toBe(REASON_CODE.SPECIALIZATION_NOT_OWNED)
+      expect(actor.update).not.toHaveBeenCalled()
+    })
+
+    it('returns error when tree is unresolved', async () => {
+      const actor = buildActor()
+      resolveSpecializationTree.mockReturnValue({ tree: null, state: 'unresolved' })
+
+      const result = await forgetTalentNode(actor, 'spec-1', 'r1c1')
+
+      expect(result.ok).toBe(false)
+      expect(result.reasonCode).toBe(REASON_CODE.TREE_NOT_FOUND)
+      expect(actor.update).not.toHaveBeenCalled()
+    })
+
+    it('returns error when tree is incomplete', async () => {
+      const actor = buildActor()
+      resolveSpecializationTree.mockReturnValue({ tree: null, state: 'incomplete' })
+
+      const result = await forgetTalentNode(actor, 'spec-1', 'r1c1')
+
+      expect(result.ok).toBe(false)
+      expect(result.reasonCode).toBe(REASON_CODE.TREE_INCOMPLETE)
+      expect(actor.update).not.toHaveBeenCalled()
+    })
+
+    it('returns error when node is not found in tree', async () => {
+      const actor = buildActor()
+      resolveSpecializationTree.mockReturnValue(buildResolvedTree())
+
+      const result = await forgetTalentNode(actor, 'spec-1', 'nonexistent')
+
+      expect(result.ok).toBe(false)
+      expect(result.reasonCode).toBe(REASON_CODE.NODE_NOT_FOUND)
+      expect(actor.update).not.toHaveBeenCalled()
+    })
+
+    it('returns error when node is not purchased', async () => {
+      const actor = buildActor({
+        system: {
+          details: { specializations: [{ specializationId: 'spec-1' }] },
+          progression: {
+            talentPurchases: [],
+            experience: { gained: 100, spent: 0 },
+          },
+        },
+      })
+      resolveSpecializationTree.mockReturnValue(buildResolvedTree())
+
+      const result = await forgetTalentNode(actor, 'spec-1', 'r1c1')
+
+      expect(result.ok).toBe(false)
+      expect(result.reasonCode).toBe(REASON_CODE.NODE_NOT_PURCHASED)
+      expect(actor.update).not.toHaveBeenCalled()
+    })
+
+    it('returns NODE_HAS_DEPENDENTS with dependent list when a downstream node is still purchased', async () => {
+      const actor = buildActor({
+        system: {
+          details: { specializations: [{ specializationId: 'spec-1' }] },
+          progression: {
+            talentPurchases: [
+              { treeId: 'tree-1', treeUuid: null, nodeId: 'r1c1', talentId: 'talent-parry', talentUuid: null, specializationId: 'spec-1' },
+              { treeId: 'tree-1', treeUuid: null, nodeId: 'r2c1', talentId: 'talent-deflect', talentUuid: null, specializationId: 'spec-1' },
+            ],
+            experience: { gained: 100, spent: 15 },
+          },
+        },
+      })
+      resolveSpecializationTree.mockReturnValue(buildResolvedTree())
+
+      // r1c1 → r2c1 is connected; r2c1 is purchased, so r1c1 cannot be forgotten
+      const result = await forgetTalentNode(actor, 'spec-1', 'r1c1')
+
+      expect(result.ok).toBe(false)
+      expect(result.reasonCode).toBe(REASON_CODE.NODE_HAS_DEPENDENTS)
+      expect(result.dependents).toContain('r2c1')
+      expect(actor.update).not.toHaveBeenCalled()
+    })
+  })
+
+  // ---------------------------------------------------------------------------
+  // Persisted entry structure invariants
+  // ---------------------------------------------------------------------------
+
+  describe('persisted entry structure', () => {
+    it('the purchase entry returned has the canonical shape with all 7 fields', async () => {
+      const actor = buildActor()
+      resolveSpecializationTree.mockReturnValue(buildResolvedTree())
+
+      const result = await forgetTalentNode(actor, 'spec-1', 'r1c1')
+
+      expect(result.ok).toBe(true)
+      expect(Object.keys(result.purchase)).toEqual(
+        expect.arrayContaining(['treeId', 'treeUuid', 'nodeId', 'talentId', 'talentUuid', 'specializationId', 'cost']),
+      )
+    })
+
+    it('the patch contains both system.progression keys', async () => {
+      const actor = buildActor()
+      resolveSpecializationTree.mockReturnValue(buildResolvedTree())
+
+      await forgetTalentNode(actor, 'spec-1', 'r1c1')
+
+      const [patchArg] = actor.update.mock.calls[0]
+      expect(patchArg).toHaveProperty('system.progression.talentPurchases')
+      expect(patchArg).toHaveProperty('system.progression.experience.spent')
+    })
+  })
+})

--- a/tests/lib/talent-node/talent-node-persistence.test.mjs
+++ b/tests/lib/talent-node/talent-node-persistence.test.mjs
@@ -1,0 +1,205 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('../../../module/utils/logger.mjs', () => ({
+  logger: {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+}))
+
+import { logger } from '../../../module/utils/logger.mjs'
+import { applyTalentNodePatch } from '../../../module/lib/talent-node/talent-node-persistence.mjs'
+
+function buildActor(overrides = {}) {
+  return {
+    id: 'actor-001',
+    system: {
+      progression: {
+        talentPurchases: [],
+        experience: { gained: 100, spent: 0 },
+      },
+    },
+    update: vi.fn().mockResolvedValue(undefined),
+    ...overrides,
+  }
+}
+
+function buildPayload(overrides = {}) {
+  return {
+    specializationId: 'spec-1',
+    treeId: 'tree-1',
+    treeUuid: null,
+    nodeId: 'r1c1',
+    talentId: 'talent-parry',
+    talentUuid: null,
+    cost: 5,
+    updatedPurchases: [
+      { treeId: 'tree-1', treeUuid: null, nodeId: 'r1c1', talentId: 'talent-parry', talentUuid: null, specializationId: 'spec-1' },
+    ],
+    updatedSpent: 5,
+    ...overrides,
+  }
+}
+
+describe('applyTalentNodePatch', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  describe('happy path', () => {
+    it('calls actor.update with both talentPurchases and experience.spent in a single call', async () => {
+      const actor = buildActor()
+      const payload = buildPayload()
+
+      await applyTalentNodePatch(actor, payload, 'purchase')
+
+      expect(actor.update).toHaveBeenCalledTimes(1)
+      expect(actor.update).toHaveBeenCalledWith({
+        'system.progression.talentPurchases': payload.updatedPurchases,
+        'system.progression.experience.spent': 5,
+      })
+    })
+
+    it('returns ok=true with the complete purchase entry on success', async () => {
+      const actor = buildActor()
+      const payload = buildPayload()
+
+      const result = await applyTalentNodePatch(actor, payload, 'purchase')
+
+      expect(result.ok).toBe(true)
+      expect(result.purchase).toMatchObject({
+        treeId: 'tree-1',
+        treeUuid: null,
+        nodeId: 'r1c1',
+        talentId: 'talent-parry',
+        talentUuid: null,
+        specializationId: 'spec-1',
+        cost: 5,
+      })
+    })
+
+    it('handles forget action with empty updatedPurchases (XP refunded)', async () => {
+      const actor = buildActor({
+        system: {
+          progression: {
+            talentPurchases: [
+              { treeId: 'tree-1', treeUuid: null, nodeId: 'r1c1', talentId: 'talent-parry', talentUuid: null, specializationId: 'spec-1' },
+            ],
+            experience: { gained: 100, spent: 5 },
+          },
+        },
+      })
+      const payload = buildPayload({ updatedPurchases: [], updatedSpent: 0 })
+
+      const result = await applyTalentNodePatch(actor, payload, 'forget')
+
+      expect(result.ok).toBe(true)
+      expect(actor.update).toHaveBeenCalledWith({
+        'system.progression.talentPurchases': [],
+        'system.progression.experience.spent': 0,
+      })
+    })
+
+    it('passes through UUID fields when present', async () => {
+      const actor = buildActor()
+      const payload = buildPayload({
+        treeUuid: 'Item.tree-uuid-001',
+        talentUuid: 'Item.talent-uuid-001',
+        updatedPurchases: [
+          {
+            treeId: 'tree-1',
+            treeUuid: 'Item.tree-uuid-001',
+            nodeId: 'r1c1',
+            talentId: 'talent-parry',
+            talentUuid: 'Item.talent-uuid-001',
+            specializationId: 'spec-1',
+          },
+        ],
+      })
+
+      const result = await applyTalentNodePatch(actor, payload, 'purchase')
+
+      expect(result.ok).toBe(true)
+      expect(result.purchase.treeUuid).toBe('Item.tree-uuid-001')
+      expect(result.purchase.talentUuid).toBe('Item.talent-uuid-001')
+    })
+
+    it('emits a debug log entry on success', async () => {
+      const actor = buildActor()
+      const payload = buildPayload()
+
+      await applyTalentNodePatch(actor, payload, 'purchase')
+
+      expect(logger.debug).toHaveBeenCalledWith(
+        '[TalentNodePersistence] Patch applied',
+        expect.objectContaining({
+          action: 'purchase',
+          actorId: 'actor-001',
+          nodeId: 'r1c1',
+          specializationId: 'spec-1',
+          updatedSpent: 5,
+        }),
+      )
+    })
+  })
+
+  describe('guard clauses — no actor.update emitted', () => {
+    it('returns ok=false when actor is null', async () => {
+      const payload = buildPayload()
+
+      const result = await applyTalentNodePatch(null, payload, 'purchase')
+
+      expect(result.ok).toBe(false)
+      expect(result.reasonCode).toBe('node-invalid')
+      expect(result.reason).toContain('Missing actor')
+    })
+
+    it('returns ok=false when payload is null', async () => {
+      const actor = buildActor()
+
+      const result = await applyTalentNodePatch(actor, null, 'purchase')
+
+      expect(result.ok).toBe(false)
+      expect(result.reasonCode).toBe('node-invalid')
+      expect(result.reason).toContain('Missing payload')
+      expect(actor.update).not.toHaveBeenCalled()
+    })
+
+    it('emits a warn log when actor is missing', async () => {
+      await applyTalentNodePatch(null, buildPayload(), 'purchase')
+
+      expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('[TalentNodePersistence]'))
+    })
+
+    it('emits a warn log when payload is missing', async () => {
+      const actor = buildActor()
+      await applyTalentNodePatch(actor, null, 'purchase')
+
+      expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('[TalentNodePersistence]'))
+    })
+  })
+
+  describe('patch structure invariants', () => {
+    it('always issues exactly one actor.update per call', async () => {
+      const actor = buildActor()
+      const payload = buildPayload()
+
+      await applyTalentNodePatch(actor, payload, 'purchase')
+
+      expect(actor.update).toHaveBeenCalledTimes(1)
+    })
+
+    it('the patch contains both progression and XP keys', async () => {
+      const actor = buildActor()
+      const payload = buildPayload()
+
+      await applyTalentNodePatch(actor, payload, 'purchase')
+
+      const [patchArg] = actor.update.mock.calls[0]
+      expect(patchArg).toHaveProperty('system.progression.talentPurchases')
+      expect(patchArg).toHaveProperty('system.progression.experience.spent')
+    })
+  })
+})


### PR DESCRIPTION
## Summary

- Extract `applyTalentNodePatch()` as shared helper ensuring single atomic `actor.update()` with both `talentPurchases` and `experience.spent` keys
- Add `forgetTalentNode()` entry point with symmetric XP refund, reusing `processTalentNodeProgression(..., 'forget')` and the shared helper
- Refactor `purchaseTalentNode()` to delegate persistence to the shared helper — no more split updates

## Tests

- 131 tests pass across all 8 talent-node test files (Vitest)
- 26 new tests: persistence guard clauses, atomic patch shape invariants, forget nominals, dependent-blocking, and refund amounts

## Implementation plan

`documentation/plan/character-sheet/specialization-tree/312-stabiliser-la-persistance-acteur-et-limpact-xp.md`

## Notes

Out of scope per plan: view-model UI (US17.3), click/confirmation wiring (US17.4), tree refresh (US17.5), audit log (US17.6).

Closes #312

🤖 Generated with [Claude Code](https://claude.com/claude-code)