### PR TITLE
feat(specialization-tree): expose actionable node view model

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -114,6 +114,8 @@
           "NODE_INVALID": "Node data is invalid",
           "NODE_LOCKED": "Prerequisites not met",
           "NOT_ENOUGH_XP": "Not enough XP",
+          "NODE_NOT_PURCHASED": "Node not purchased",
+          "NODE_HAS_DEPENDENTS": "Node has purchased dependents",
           "UNKNOWN": "Unknown reason"
         },
         "TOOLTIP": {
@@ -139,7 +141,9 @@
         "ACTION": {
           "CENTER": "Center",
           "ZOOM_IN": "Zoom in",
-          "ZOOM_OUT": "Zoom out"
+          "ZOOM_OUT": "Zoom out",
+          "PURCHASE": "Purchase",
+          "FORGET": "Forget"
         }
       },
       "ACTIONS": {

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -94,6 +94,8 @@
           "NODE_INVALID": "Données du nœud invalides",
           "NODE_LOCKED": "Prérequis non remplis",
           "NOT_ENOUGH_XP": "XP insuffisants",
+          "NODE_NOT_PURCHASED": "Nœud non acheté",
+          "NODE_HAS_DEPENDENTS": "Le nœud a des dépendants achetés",
           "UNKNOWN": "Raison inconnue"
         },
         "TOOLTIP": {
@@ -119,7 +121,9 @@
         "ACTION": {
           "CENTER": "Centrer",
           "ZOOM_IN": "Zoom avant",
-          "ZOOM_OUT": "Zoom arrière"
+          "ZOOM_OUT": "Zoom arrière",
+          "PURCHASE": "Acheter",
+          "FORGET": "Oublier"
         }
       },
       "ACTIONS": {

--- a/module/applications/specialization-tree-app.mjs
+++ b/module/applications/specialization-tree-app.mjs
@@ -4,6 +4,7 @@ import { purchaseTalentNode } from '../lib/talent-node/talent-node-purchase.mjs'
 import { resolveTalentDetail } from '../lib/talent-node/talent-reference-resolver.mjs'
 import { selectDefaultTreeKey } from '../lib/specialization-tree/default-tree-selector.mjs'
 import { buildRenderViewModel } from './specialization-tree/render-view-model.mjs'
+import { actionableNodeViewModel } from './specialization-tree/actionable-node-view-model.mjs'
 import { enrichNode, getReasonLabelKey, NODE_STATE, NODE_STATE_VARIANTS } from './specialization-tree/node-ui-state.mjs'
 import { NODE_WIDTH, NODE_HEIGHT, computeNodePosition, buildConnectionAnchors } from './specialization-tree/layout.mjs'
 import { logger } from '../utils/logger.mjs'
@@ -151,9 +152,20 @@ export function buildSpecializationTreeContext(actor, selectedKey = null) {
     })
 
     const nodeStates = getTreeNodesStates(actor, currentTreeId, currentTreeData)
+    const localize = game.i18n.localize.bind(game.i18n)
     renderNodes = renderNodes.map((node) => {
       const stateResult = nodeStates.get(node.nodeId) ?? { state: NODE_STATE.INVALID }
-      return enrichNode(node, stateResult, game.i18n.localize.bind(game.i18n))
+      const enriched = enrichNode(node, stateResult, localize)
+      return {
+        ...enriched,
+        actionable: actionableNodeViewModel({
+          renderNode: enriched,
+          actor,
+          specializationId: currentTreeId,
+          tree: currentTreeData,
+          localize,
+        }),
+      }
     })
 
     renderConnections = buildConnectionAnchors(renderNodes, viewModel.connections)

--- a/module/applications/specialization-tree/actionable-node-view-model.mjs
+++ b/module/applications/specialization-tree/actionable-node-view-model.mjs
@@ -1,0 +1,94 @@
+import { NODE_STATE, REASON_CODE } from '../../lib/talent-node/talent-node-state.mjs'
+import { processTalentNodeProgression } from '../../lib/talent-node/talent-node-progression.mjs'
+import { getReasonLabelKey } from './node-ui-state.mjs'
+
+const ACTION_LABEL_KEYS = Object.freeze({
+  purchase: 'SWERPG.TALENT.SPECIALIZATION_TREE_APP.ACTION.PURCHASE',
+  forget: 'SWERPG.TALENT.SPECIALIZATION_TREE_APP.ACTION.FORGET',
+})
+
+/**
+ * Build an actionable sub-view-model for a single tree node.
+ *
+ * This function is ***pure*** with respect to Foundry globals: it takes
+ * a `localize` callback rather than accessing `game.i18n` directly.
+ * Business validation is delegated to `processTalentNodeProgression()`.
+ *
+ * @param {object} options
+ * @param {object} options.renderNode   - Enriched render node (must carry `nodeState`,
+ *        `reasonCode`, `nodeId`, `talentId`, `xpCost` from `enrichNode`).
+ * @param {object} options.actor        - The actor document instance.
+ * @param {string} options.specializationId - Active specialization/tree key.
+ * @param {object|null} options.tree    - The resolved specialization tree item.
+ * @param {(key: string) => string} options.localize - i18n localize callback.
+ * @returns {import('./types.mjs').ActionableNodeViewModel}
+ */
+export function actionableNodeViewModel({ renderNode, actor, specializationId, tree, localize }) {
+  const state = renderNode.nodeState
+  const reasonCode = renderNode.reasonCode
+
+  let canPurchase = false
+  let canForget = false
+  let primaryAction = null
+  let blockingDependents = []
+
+  if (state === NODE_STATE.AVAILABLE) {
+    canPurchase = true
+    primaryAction = 'purchase'
+  } else if (state === NODE_STATE.PURCHASED) {
+    const progression = processTalentNodeProgression(actor, specializationId, renderNode.nodeId, 'forget')
+    if (progression.ok) {
+      canForget = true
+      primaryAction = 'forget'
+    } else if (progression.reasonCode === REASON_CODE.NODE_HAS_DEPENDENTS) {
+      blockingDependents = progression.dependents ?? []
+    }
+  }
+
+  const actionLabel = primaryAction ? localize(ACTION_LABEL_KEYS[primaryAction]) : null
+
+  let blockedReasonCode = null
+  if (state === NODE_STATE.PURCHASED && !canForget && blockingDependents.length > 0) {
+    blockedReasonCode = REASON_CODE.NODE_HAS_DEPENDENTS
+  } else if (state !== NODE_STATE.AVAILABLE && state !== NODE_STATE.PURCHASED) {
+    blockedReasonCode = reasonCode || null
+  }
+
+  const blockedReasonLabel = blockedReasonCode ? localize(getReasonLabelKey(blockedReasonCode)) : null
+
+  const actionRef = buildActionRef(specializationId, tree, renderNode)
+
+  return {
+    canPurchase,
+    canForget,
+    primaryAction,
+    actionLabel,
+    blockedReasonCode,
+    blockedReasonLabel,
+    blockingDependents,
+    actionRef,
+  }
+}
+
+/**
+ * @param {string} specializationId
+ * @param {object|null} tree
+ * @param {object} renderNode
+ * @returns {import('./types.mjs').ActionRef}
+ */
+function buildActionRef(specializationId, tree, renderNode) {
+  const treeId = tree?.id ?? tree?._id ?? null
+  const treeUuid = tree?.uuid ?? null
+  const treeNode = tree?.system?.nodes?.find((n) => n.nodeId === renderNode.nodeId)
+  const talentUuid = treeNode?.talentUuid ?? null
+
+  return {
+    specializationId,
+    treeId,
+    treeUuid,
+    nodeId: renderNode.nodeId,
+    talentId: renderNode.talentId,
+    talentUuid,
+    cost: renderNode.xpCost,
+  }
+}

--- a/module/applications/specialization-tree/types.mjs
+++ b/module/applications/specialization-tree/types.mjs
@@ -70,4 +70,29 @@
  * @property {RenderViewModelMetadata} metadata - View-model summary metadata.
  */
 
+/**
+ * Stable action reference for the future UI purchase/forget flow.
+ * @typedef {Object} ActionRef
+ * @property {string} specializationId - The specialization identifier.
+ * @property {string|null} treeId - The tree document ID.
+ * @property {string|null} treeUuid - The tree document UUID.
+ * @property {string} nodeId - The node identifier.
+ * @property {string} talentId - The talent business key.
+ * @property {string|null} talentUuid - The talent document UUID.
+ * @property {number} cost - XP cost of the node.
+ */
+
+/**
+ * Actionable sub-view-model describing the primary user action possible on a node.
+ * @typedef {Object} ActionableNodeViewModel
+ * @property {boolean} canPurchase - Whether the node can be purchased.
+ * @property {boolean} canForget - Whether the node can be forgotten.
+ * @property {'purchase'|'forget'|null} primaryAction - The recommended primary action (or null if blocked).
+ * @property {string|null} actionLabel - Localized label for the primary action.
+ * @property {string|null} blockedReasonCode - Machine-readable blocked reason code.
+ * @property {string|null} blockedReasonLabel - Localized blocked reason label.
+ * @property {string[]} blockingDependents - NodeIds of purchased dependents blocking forget.
+ * @property {ActionRef} actionRef - Stable reference for the future interaction flow.
+ */
+
 export default {}

--- a/tests/applications/specialization-tree-app.test.mjs
+++ b/tests/applications/specialization-tree-app.test.mjs
@@ -574,6 +574,46 @@ describe('specialization-tree application', () => {
     }
   })
 
+  it('includes actionable view-model for every render node', () => {
+    const actor = createActor({
+      system: {
+        details: {
+          specializations: [{ specializationId: 'spec-bodyguard', name: 'Bodyguard', treeUuid: 'Item.tree-bodyguard' }],
+        },
+        progression: {
+          talentPurchases: [],
+          experience: { available: 100 },
+        },
+      },
+    })
+
+    globalThis.fromUuidSync = vi.fn((uuid) => {
+      if (uuid === 'Item.tree-bodyguard') {
+        return {
+          type: 'specialization-tree',
+          name: 'Bodyguard Tree',
+          system: { nodes: [{ nodeId: 'r1c1', talentId: 'Item.talent-tough', row: 1, column: 1, cost: 10 }], connections: [{ from: 'r1c1', to: 'r2c1' }] },
+        }
+      }
+      if (uuid === 'Item.talent-tough') return { name: 'Tough' }
+      return null
+    })
+
+    const context = buildSpecializationTreeContext(actor)
+
+    expect(context.renderNodes, 'should have at least one render node').not.toHaveLength(0)
+    for (const node of context.renderNodes) {
+      expect(node.actionable).toBeDefined()
+      expect(typeof node.actionable.canPurchase).toBe('boolean')
+      expect(typeof node.actionable.canForget).toBe('boolean')
+      expect(['purchase', 'forget', null]).toContain(node.actionable.primaryAction)
+      expect(node.actionable.actionRef).toBeDefined()
+      expect(typeof node.actionable.actionRef.specializationId).toBe('string')
+      expect(typeof node.actionable.actionRef.nodeId).toBe('string')
+      expect(typeof node.actionable.actionRef.cost).toBe('number')
+    }
+  })
+
   it('builds renderConnections with correct from/to center positions', () => {
     const actor = createActor({
       system: {

--- a/tests/applications/specialization-tree/actionable-node-view-model.test.mjs
+++ b/tests/applications/specialization-tree/actionable-node-view-model.test.mjs
@@ -1,0 +1,266 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { actionableNodeViewModel } from '../../../module/applications/specialization-tree/actionable-node-view-model.mjs'
+import { NODE_STATE, REASON_CODE } from '../../../module/lib/talent-node/talent-node-state.mjs'
+
+vi.mock('../../../module/lib/talent-node/talent-node-progression.mjs', () => {
+  const actual = vi.importActual('../../../module/lib/talent-node/talent-node-progression.mjs')
+  return {
+    ...actual,
+    processTalentNodeProgression: vi.fn(),
+  }
+})
+
+import { processTalentNodeProgression } from '../../../module/lib/talent-node/talent-node-progression.mjs'
+
+const localize = (key) => `[${key}]`
+
+function buildRenderNode(overrides = {}) {
+  return {
+    nodeId: 'r1c1',
+    talentId: 'Item.talent-grit',
+    talentName: 'Grit',
+    isRanked: true,
+    xpCost: 10,
+    row: 1,
+    column: 1,
+    x: 20,
+    y: 20,
+    nodeState: NODE_STATE.AVAILABLE,
+    reasonCode: null,
+    nodeStateLabel: '[Available]',
+    reasonLabel: null,
+    variant: {},
+    ...overrides,
+  }
+}
+
+function buildTree(overrides = {}) {
+  return {
+    id: 'tree-1',
+    uuid: 'Item.tree-1',
+    system: {
+      nodes: [
+        { nodeId: 'r1c1', talentId: 'Item.talent-grit', talentUuid: 'Item.talent-grit', row: 1, column: 1, cost: 10 },
+        { nodeId: 'r2c1', talentId: 'Item.talent-tough', talentUuid: 'Item.talent-tough', row: 2, column: 1, cost: 15 },
+      ],
+      connections: [{ from: 'r1c1', to: 'r2c1' }],
+    },
+    ...overrides,
+  }
+}
+
+function buildActor(overrides = {}) {
+  return {
+    id: 'actor-1',
+    name: 'Test',
+    system: {
+      details: {
+        specializations: [{ specializationId: 'spec-bodyguard', name: 'Bodyguard' }],
+      },
+      progression: {
+        talentPurchases: [],
+        experience: { gained: 100, spent: 0, available: 100 },
+      },
+    },
+    ...overrides,
+  }
+}
+
+describe('actionableNodeViewModel', () => {
+  describe('AVAILABLE node', () => {
+    it('sets canPurchase true and primaryAction purchase', () => {
+      const renderNode = buildRenderNode({ nodeState: NODE_STATE.AVAILABLE })
+      const result = actionableNodeViewModel({ renderNode, actor: buildActor(), specializationId: 'spec', tree: buildTree(), localize })
+
+      expect(result.canPurchase).toBe(true)
+      expect(result.canForget).toBe(false)
+      expect(result.primaryAction).toBe('purchase')
+      expect(result.actionLabel).toBe('[SWERPG.TALENT.SPECIALIZATION_TREE_APP.ACTION.PURCHASE]')
+      expect(result.blockedReasonCode).toBeNull()
+      expect(result.blockedReasonLabel).toBeNull()
+      expect(result.blockingDependents).toEqual([])
+    })
+  })
+
+  describe('PURCHASED node — forgettable', () => {
+    it('sets canForget true and primaryAction forget when no blocking dependents', () => {
+      processTalentNodeProgression.mockReturnValue({
+        ok: true,
+        action: 'forget',
+        payload: {
+          specializationId: 'spec-bodyguard',
+          treeId: 'tree-1',
+          treeUuid: 'Item.tree-1',
+          nodeId: 'r1c1',
+          talentId: 'Item.talent-grit',
+          talentUuid: 'Item.talent-grit',
+          cost: 10,
+          updatedPurchases: [],
+          updatedSpent: 0,
+        },
+      })
+
+      const renderNode = buildRenderNode({ nodeState: NODE_STATE.PURCHASED, reasonCode: REASON_CODE.ALREADY_PURCHASED })
+
+      const result = actionableNodeViewModel({
+        renderNode,
+        actor: buildActor(),
+        specializationId: 'spec-bodyguard',
+        tree: buildTree(),
+        localize,
+      })
+
+      expect(result.canForget).toBe(true)
+      expect(result.canPurchase).toBe(false)
+      expect(result.primaryAction).toBe('forget')
+      expect(result.actionLabel).toBe('[SWERPG.TALENT.SPECIALIZATION_TREE_APP.ACTION.FORGET]')
+      expect(result.blockedReasonCode).toBeNull()
+      expect(result.blockingDependents).toEqual([])
+    })
+  })
+
+  describe('PURCHASED node — blocked by dependents', () => {
+    it('sets canForget false, primaryAction null, and lists blocking dependents', () => {
+      processTalentNodeProgression.mockReturnValue({
+        ok: false,
+        action: 'forget',
+        reason: 'Node "r1c1" cannot be forgotten: dependent nodes are still purchased',
+        reasonCode: REASON_CODE.NODE_HAS_DEPENDENTS,
+        dependents: ['r2c1'],
+      })
+
+      const renderNode = buildRenderNode({ nodeState: NODE_STATE.PURCHASED, reasonCode: REASON_CODE.ALREADY_PURCHASED })
+
+      const result = actionableNodeViewModel({
+        renderNode,
+        actor: buildActor(),
+        specializationId: 'spec-bodyguard',
+        tree: buildTree(),
+        localize,
+      })
+
+      expect(result.canForget).toBe(false)
+      expect(result.canPurchase).toBe(false)
+      expect(result.primaryAction).toBeNull()
+      expect(result.actionLabel).toBeNull()
+      expect(result.blockedReasonCode).toBe(REASON_CODE.NODE_HAS_DEPENDENTS)
+      expect(result.blockedReasonLabel).toBe('[SWERPG.TALENT.SPECIALIZATION_TREE_APP.REASON.NODE_HAS_DEPENDENTS]')
+      expect(result.blockingDependents).toEqual(['r2c1'])
+    })
+  })
+
+  describe('LOCKED node', () => {
+    it('sets no primary action and exposes blockedReasonCode', () => {
+      const renderNode = buildRenderNode({
+        nodeState: NODE_STATE.LOCKED,
+        reasonCode: REASON_CODE.NOT_ENOUGH_XP,
+      })
+
+      const result = actionableNodeViewModel({ renderNode, actor: buildActor(), specializationId: 'spec', tree: buildTree(), localize })
+
+      expect(result.canPurchase).toBe(false)
+      expect(result.canForget).toBe(false)
+      expect(result.primaryAction).toBeNull()
+      expect(result.actionLabel).toBeNull()
+      expect(result.blockedReasonCode).toBe(REASON_CODE.NOT_ENOUGH_XP)
+      expect(result.blockedReasonLabel).toBe('[SWERPG.TALENT.SPECIALIZATION_TREE_APP.REASON.NOT_ENOUGH_XP]')
+      expect(result.blockingDependents).toEqual([])
+    })
+
+    it('handles node-locked reason code (prerequisites)', () => {
+      const renderNode = buildRenderNode({
+        nodeState: NODE_STATE.LOCKED,
+        reasonCode: REASON_CODE.NODE_LOCKED,
+      })
+
+      const result = actionableNodeViewModel({ renderNode, actor: buildActor(), specializationId: 'spec', tree: buildTree(), localize })
+
+      expect(result.primaryAction).toBeNull()
+      expect(result.blockedReasonCode).toBe(REASON_CODE.NODE_LOCKED)
+    })
+  })
+
+  describe('INVALID node', () => {
+    it('sets no primary action and exposes blockedReasonCode', () => {
+      const invalidReasons = [
+        REASON_CODE.SPECIALIZATION_NOT_OWNED,
+        REASON_CODE.TREE_NOT_FOUND,
+        REASON_CODE.TREE_INCOMPLETE,
+        REASON_CODE.NODE_NOT_FOUND,
+        REASON_CODE.NODE_INVALID,
+      ]
+
+      for (const reasonCode of invalidReasons) {
+        const renderNode = buildRenderNode({
+          nodeState: NODE_STATE.INVALID,
+          reasonCode,
+        })
+
+        const result = actionableNodeViewModel({ renderNode, actor: buildActor(), specializationId: 'spec', tree: buildTree(), localize })
+
+        expect(result.canPurchase).toBe(false)
+        expect(result.canForget).toBe(false)
+        expect(result.primaryAction).toBeNull()
+        expect(result.blockedReasonCode).toBe(reasonCode)
+        expect(result.blockingDependents).toEqual([])
+      }
+    })
+  })
+
+  describe('actionRef', () => {
+    it('builds a stable action reference from the render node and tree', () => {
+      const renderNode = buildRenderNode({ nodeState: NODE_STATE.AVAILABLE })
+      const tree = buildTree()
+
+      const result = actionableNodeViewModel({
+        renderNode,
+        actor: buildActor(),
+        specializationId: 'spec-bodyguard',
+        tree,
+        localize,
+      })
+
+      expect(result.actionRef).toEqual({
+        specializationId: 'spec-bodyguard',
+        treeId: 'tree-1',
+        treeUuid: 'Item.tree-1',
+        nodeId: 'r1c1',
+        talentId: 'Item.talent-grit',
+        talentUuid: 'Item.talent-grit',
+        cost: 10,
+      })
+    })
+
+    it('resolves talentUuid from the tree node when available', () => {
+      const renderNode = buildRenderNode({ nodeState: NODE_STATE.AVAILABLE })
+      const tree = buildTree()
+
+      const result = actionableNodeViewModel({
+        renderNode,
+        actor: buildActor(),
+        specializationId: 'spec-bodyguard',
+        tree,
+        localize,
+      })
+
+      expect(result.actionRef.talentUuid).toBe('Item.talent-grit')
+    })
+
+    it('sets treeId and treeUuid to null when no tree provided', () => {
+      const renderNode = buildRenderNode({ nodeState: NODE_STATE.AVAILABLE })
+
+      const result = actionableNodeViewModel({
+        renderNode,
+        actor: buildActor(),
+        specializationId: 'spec',
+        tree: null,
+        localize,
+      })
+
+      expect(result.actionRef.treeId).toBeNull()
+      expect(result.actionRef.treeUuid).toBeNull()
+      expect(result.actionRef.talentUuid).toBeNull()
+    })
+  })
+})


### PR DESCRIPTION
## Contexte

Issue : [#313 — US17.3 - Exposer un view-model de noeud actionnable](https://github.com/herveDarritchon/foundryvtt-swerpg/issues/313)

Plan : `documentation/plan/character-sheet/specialization-tree/313-exposer-un-view-model-de-noeud-actionnable.md`

## Resume des changements

Ajout d'un sous-view-model actionnable sur chaque noeud de l'arbre de specialisation, decrivant l'action principale possible (achat/oubli), les blocages eventuels et la reference metier stable pour les futures interactions UI.

### Fichiers crees
- `module/applications/specialization-tree/actionable-node-view-model.mjs` — Builder pur du sous-view-model actionnable
- `tests/applications/specialization-tree/actionable-node-view-model.test.mjs` — 9 tests unitaires

### Fichiers modifies
- `module/applications/specialization-tree/types.mjs` — Types JSDoc `ActionRef`, `ActionableNodeViewModel`
- `module/applications/specialization-tree-app.mjs` — Branchement de `actionableNodeViewModel` dans `buildSpecializationTreeContext()` : chaque `renderNode` expose desormais `.actionable`
- `lang/en.json` — Cles i18n `ACTION.PURCHASE`, `ACTION.FORGET`, `REASON.NODE_NOT_PURCHASED`, `REASON.NODE_HAS_DEPENDENTS`
- `lang/fr.json` — Memes cles en francais
- `tests/applications/specialization-tree-app.test.mjs` — 1 test d'integration

## Contrat expose par noeud

```js
actionable: {
  canPurchase,          // boolean
  canForget,            // boolean
  primaryAction,        // 'purchase' | 'forget' | null
  actionLabel,          // string (localise) | null
  blockedReasonCode,    // string | null
  blockedReasonLabel,   // string (localise) | null
  blockingDependents,   // string[] (nodeIds)
  actionRef,            // { specializationId, treeId, treeUuid, nodeId, talentId, talentUuid, cost }
}
```

## Tests

- 9 tests unitaires (mock de `processTalentNodeProgression`) : AVAILABLE → purchase, PURCHASED oubliable → forget, PURCHASED bloque → blockingDependents, LOCKED/INVALID → blocage, actionRef
- 1 test d'integration dans specialization-tree-app : verifie presence et structure du contrat actionnable dans le contexte
- 145 tests passent au total (5 fichiers)

## Notes techniques

- Aucune regle metier d'achat/oubli dans l'application — delegation à `processTalentNodeProgression()`
- `actionableNodeViewModel` est pur : pas d'acces à `game`, pas d'effet de bord Foundry
- `blockingDependents` exploite `processTalentNodeProgression(..., "forget")` pour detecter les dependants bloquants
- Les deux cles i18n manquantes (`NODE_NOT_PURCHASED`, `NODE_HAS_DEPENDENTS`) ont ete ajoutees

## Perimetre

Inclus :
- Contrat actionnable sur chaque renderNode
- Reference d'action stable (`actionRef`)
- i18n FR/EN
- Tests

Exclus (US ulterieures) :
- Persistance acteur (US17.2)
- Clics, confirmations, interactions (US17.4)
- Refresh après mutation (US17.5)
- Audit log (US17.6)