### PR TITLE
US17.4: Brancher interactions UI et confirmations dans SpecializationTreeApp

### DIFF
--- a/documentation/plan/character-sheet/specialization-tree/313-exposer-un-view-model-de-noeud-actionnable.md
+++ b/documentation/plan/character-sheet/specialization-tree/313-exposer-un-view-model-de-noeud-actionnable.md
@@ -1,0 +1,81 @@
+# US17.3 — Plan d'implémentation : Exposer un view-model de nœud actionnable
+
+## Contexte
+
+Issue : [#313 — US17.3 - Exposer un view-model de nœud actionnable](https://github.com/herveDarritchon/foundryvtt-swerpg/issues/313)
+
+Références :
+
+- `documentation/ways-of-work/plan/specialization-tree-v1/us17-talent-node-purchase-and-forget/project-plan.md`
+- `documentation/ways-of-work/plan/specialization-tree-v1/us17-talent-node-purchase-and-forget/issues-checklist.md`
+- `documentation/cadrage/character-sheet/specialization-tree/cadrage-amelioration-achat-oubli-talent-arbre-specialisation.md`
+- `documentation/plan/character-sheet/specialization-tree/311-creer-le-service-metier-dachat-et-doubli-de-noeud.md`
+- `documentation/plan/character-sheet/specialization-tree/312-stabiliser-la-persistance-acteur-et-limpact-xp.md`
+
+L'existant expose déjà un `renderNode` enrichi avec `nodeState`, `reasonCode`, `reasonLabel` et les variantes UI, tandis que `processTalentNodeProgression()` sait déjà valider achat, oubli et dépendances bloquantes. Le besoin de US17.3 est maintenant d'assembler ces briques en un contrat UI stable, lisible et réutilisable par la future interaction utilisateur, sans réimplémenter les règles métier dans `SpecializationTreeApp`.
+
+## Objectif
+
+Enrichir chaque nœud rendu avec un sous-view-model actionnable, localisable et déterministe, décrivant l'action principale possible, les blocages éventuels et la référence métier minimale à transmettre aux futures interactions UI.
+
+## Périmètre
+
+### Inclus
+
+- exposition de `canPurchase`, `canForget`, `actionLabel`, `blockedReason`, `blockingDependents` ;
+- convention explicite de l'action principale (`purchase`, `forget` ou aucune) selon l'état courant du nœud ;
+- référence d'action stable pour le futur flux UI (`specializationId`, `treeId`/`treeUuid`, `nodeId`, `talentId`/`talentUuid`, `cost`) ;
+- couverture de test du contrat view-model et de son intégration au contexte applicatif.
+
+### Exclus
+
+- persistance acteur et `actor.update()` (`US17.2`) ;
+- clics, confirmations, notifications et permissions interactives (`US17.4`) ;
+- refresh de l'arbre et de l'onglet Talents après mutation (`US17.5`) ;
+- audit log (`US17.6`).
+
+## Fichiers pressentis
+
+| Fichier | Rôle |
+| --- | --- |
+| `module/applications/specialization-tree/actionable-node-view-model.mjs` | Nouveau builder pur du sous-view-model actionnable d'un nœud |
+| `module/applications/specialization-tree-app.mjs` | Brancher l'enrichissement actionnable dans `buildSpecializationTreeContext()` |
+| `module/applications/specialization-tree/node-ui-state.mjs` | Réutiliser/compléter le mapping i18n UI si le contrat actionnable partage des labels |
+| `lang/fr.json` | Ajouter les libellés FR des actions et blocages manquants |
+| `lang/en.json` | Ajouter les libellés EN des actions et blocages manquants |
+| `tests/applications/specialization-tree/actionable-node-view-model.test.mjs` | Tests unitaires du mapper pur |
+| `tests/applications/specialization-tree-app.test.mjs` | Vérifier l'intégration du contrat dans le contexte exposé à l'application |
+
+## Plan d'implémentation
+
+### Étape 1 — Formaliser un contrat actionnable pur par nœud
+
+**Fichiers :** `module/applications/specialization-tree/actionable-node-view-model.mjs`, `module/lib/talent-node/talent-node-progression.mjs`
+
+1. Extraire un builder pur recevant l'acteur, la spécialisation, l'arbre et le nœud courant, puis déléguant les validations à `getNodeState(...)` et `processTalentNodeProgression(..., 'purchase' | 'forget')`.
+2. Définir une convention stable : nœud `available` → action primaire `purchase`, nœud `purchased` → action primaire `forget`, autres états → aucune action primaire et blocage explicite.
+3. Normaliser une sortie unique par nœud avec au minimum `canPurchase`, `canForget`, `primaryAction`, `actionLabel`, `blockedReasonCode`, `blockedReasonLabel`, `blockingDependents` et `actionRef`.
+
+### Étape 2 — Brancher le contexte de rendu sur ce contrat unique
+
+**Fichiers :** `module/applications/specialization-tree-app.mjs`, `module/applications/specialization-tree/actionable-node-view-model.mjs`
+
+1. Enrichir chaque `renderNode` de `buildSpecializationTreeContext()` avec le sous-view-model actionnable, sans casser le contrat existant de layout, labels et variantes visuelles.
+2. Garder les règles de prérequis, d'XP et de dépendances exclusivement dans la couche métier existante, sans recalcul inline dans l'application.
+3. Exposer `blockingDependents` dans une forme stable directement réutilisable par `US17.4`, au minimum comme liste déterministe de nœuds bloquants liée au nœud courant.
+
+### Étape 3 — Compléter l'i18n et verrouiller les cas nominaux / bloquants
+
+**Fichiers :** `lang/fr.json`, `lang/en.json`, `tests/applications/specialization-tree/actionable-node-view-model.test.mjs`, `tests/applications/specialization-tree-app.test.mjs`
+
+1. Ajouter les libellés localisés nécessaires aux actions utilisateur (`purchase`, `forget`) et aux éventuels messages bloquants non encore couverts par l'i18n existante.
+2. Couvrir les cas clés : nœud disponible achetable, nœud acheté oubliable, nœud acheté bloqué par dépendants, nœud verrouillé par XP ou prérequis, nœud invalide/non résolu.
+3. Vérifier que le contexte expose une `actionRef` stable et qu'aucune construction du view-model n'appelle la persistance acteur ou ne déclenche d'effet de bord.
+
+## Définition de done
+
+- [ ] Chaque `renderNode` expose un contrat actionnable stable et documenté.
+- [ ] `SpecializationTreeApp` ne recalcule aucune règle métier d'achat/oubli.
+- [ ] Les nœuds oubliables bloqués exposent leurs dépendants bloquants de façon exploitable.
+- [ ] Les libellés d'action et de blocage passent par l'i18n FR/EN.
+- [ ] Les tests couvrent les cas nominaux et les principaux refus métier visibles par l'UI.

--- a/documentation/plan/character-sheet/specialization-tree/314-brancher-les-interactions-ui-et-confirmations-dans-specialization-tree-app.md
+++ b/documentation/plan/character-sheet/specialization-tree/314-brancher-les-interactions-ui-et-confirmations-dans-specialization-tree-app.md
@@ -1,0 +1,84 @@
+# US17.4 — Plan d'implémentation : Brancher les interactions UI et confirmations dans SpecializationTreeApp
+
+## Contexte
+
+Issue : [#314 — US17.4 - Brancher les interactions UI et confirmations dans SpecializationTreeApp](https://github.com/herveDarritchon/foundryvtt-swerpg/issues/314)
+
+Références :
+
+- `documentation/ways-of-work/plan/specialization-tree-v1/us17-talent-node-purchase-and-forget/project-plan.md`
+- `documentation/ways-of-work/plan/specialization-tree-v1/us17-talent-node-purchase-and-forget/issues-checklist.md`
+- `documentation/cadrage/character-sheet/specialization-tree/cadrage-amelioration-achat-oubli-talent-arbre-specialisation.md`
+- `documentation/plan/character-sheet/specialization-tree/311-creer-le-service-metier-dachat-et-doubli-de-noeud.md`
+- `documentation/plan/character-sheet/specialization-tree/312-stabiliser-la-persistance-acteur-et-limpact-xp.md`
+- `documentation/plan/character-sheet/specialization-tree/313-exposer-un-view-model-de-noeud-actionnable.md`
+
+L'existant dispose déjà d'un view-model actionnable par nœud, d'un flux applicatif d'achat, d'un flux applicatif d'oubli et d'un clic PIXI encore limité à la consultation via tooltip. Le besoin de US17.4 est de transformer ce clic en interaction utilisateur contrôlée, avec garde-fous de permission, confirmation explicite et notifications lisibles, sans réintroduire de logique métier dans l'application.
+
+## Objectif
+
+Permettre à `SpecializationTreeApp` de déclencher un achat ou un oubli depuis un nœud actionnable, après confirmation utilisateur, puis de restituer un retour immédiat succès/échec cohérent avec les `reasonCode` métier et les permissions Foundry.
+
+## Périmètre
+
+### Inclus
+
+- déclenchement de l'action primaire d'un nœud (`purchase` ou `forget`) depuis l'UI ;
+- garde de permission avant mutation (`actor.isOwner` ou équivalent applicatif) ;
+- confirmation localisée pour achat et oubli ;
+- notifications succès/échec alignées sur les raisons métier ;
+- fermeture/mise à jour de l'état d'interaction local après action ou annulation ;
+- tests d'intégration applicative du flux UI.
+
+### Exclus
+
+- recalcul métier achat/oubli dans l'application ;
+- synchronisation transverse arbre + onglet Talents après update acteur (`US17.5`) ;
+- audit log d'oubli ou enrichissement du payload d'audit (`US17.6`) ;
+- polish UX étendu (hover, tooltips enrichis, états visuels avancés) au-delà du flux nécessaire.
+
+## Fichiers pressentis
+
+| Fichier | Rôle |
+| --- | --- |
+| `module/applications/specialization-tree-app.mjs` | Orchestrer clic nœud, permission, confirmation, appel achat/oubli, notification et refresh local |
+| `module/lib/talent-node/talent-node-purchase.mjs` | Contrat de succès/échec déjà consommé par l'UI d'achat |
+| `module/lib/talent-node/talent-node-forget.mjs` | Contrat symétrique à brancher pour l'oubli |
+| `templates/applications/specialization-tree-app.hbs` | Ajouter si nécessaire un conteneur/état minimal pour l'interaction active côté application |
+| `lang/fr.json` | Ajouter les textes FR de confirmation, refus permission et oubli |
+| `lang/en.json` | Ajouter les textes EN de confirmation, refus permission et oubli |
+| `tests/applications/specialization-tree-app.test.mjs` | Couvrir clic actionnable, annulation, permissions, notifications achat/oubli |
+
+## Plan d'implémentation
+
+### Étape 1 — Remplacer le clic consultatif par un routeur d'action UI sûr
+
+**Fichiers :** `module/applications/specialization-tree-app.mjs`, `tests/applications/specialization-tree-app.test.mjs`
+
+1. Faire évoluer le `pointerdown` de nœud pour distinguer consultation simple et action primaire quand `node.actionable.primaryAction` existe.
+2. Centraliser un garde applicatif unique : acteur présent, nœud/actionRef valides, permission d'édition suffisante, action permise par le view-model.
+3. Conserver les règles métier exclusivement dans `actionable` et les helpers domaine, l'application ne faisant qu'orchestrer le flux.
+
+### Étape 2 — Brancher confirmations et exécution achat / oubli
+
+**Fichiers :** `module/applications/specialization-tree-app.mjs`, `module/lib/talent-node/talent-node-purchase.mjs`, `module/lib/talent-node/talent-node-forget.mjs`, `lang/fr.json`, `lang/en.json`
+
+1. Introduire un helper UI unique de confirmation basé sur `DialogV2.confirm`, capable de formater séparément achat et oubli avec nom du talent, coût XP et libellé d'action.
+2. Router l'action confirmée vers `purchaseTalentNode(...)` ou `forgetTalentNode(...)` selon `primaryAction`, sans dupliquer la validation métier ni la structure des erreurs.
+3. Mapper les retours métier vers notifications localisées : succès achat, succès oubli, échec métier explicite, refus de permission ou annulation silencieuse selon la convention retenue.
+
+### Étape 3 — Verrouiller le contrat d'intégration UI
+
+**Fichiers :** `tests/applications/specialization-tree-app.test.mjs`, `templates/applications/specialization-tree-app.hbs`
+
+1. Remplacer les assertions obsolètes “clic = tooltip seulement” par des scénarios ciblant achat autorisé, oubli autorisé, action bloquée et annulation de confirmation.
+2. Vérifier qu'aucune mutation n'est tentée sans permission, qu'aucun service métier n'est appelé si la confirmation est refusée et que la notification affichée correspond au résultat.
+3. Garder le support de consultation des nœuds non actionnables et l'absence d'effet de bord quand aucun `primaryAction` n'est disponible.
+
+## Définition de done
+
+- [ ] Un nœud actionnable peut déclencher un achat ou un oubli depuis `SpecializationTreeApp`.
+- [ ] Chaque mutation passe d'abord par une confirmation utilisateur localisée.
+- [ ] Les permissions empêchent toute mutation non autorisée avant appel métier.
+- [ ] Les notifications UI reflètent correctement succès, refus métier et blocage applicatif.
+- [ ] Les tests d'application couvrent achat, oubli, annulation et absence de permission.


### PR DESCRIPTION
Closes #314

## Context
US17.4: Brancher les interactions UI et confirmations dans SpecializationTreeApp. Cette PR ajoute les plans d'implémentation pour l'intégration des interactions utilisateur (achat/oubli de nœud) avec confirmation, permissions et notifications dans l'application d'arbre de spécialisation.

## Summary of changes
- Ajout du plan d'implémentation pour exposer un view-model de nœud actionnable (US17.3)
- Ajout du plan d'implémentation pour brancher les interactions UI et confirmations dans SpecializationTreeApp (US17.4)
- Les deux plans sont ajoutés sous 

## Technical notes
- Les plans détaillent le contrat attendu pour l'intégration UI, les permissions, la confirmation utilisateur et la gestion des notifications.
- Aucun code applicatif modifié dans cette PR, uniquement de la documentation planifiée.

## Tests run
- Vitest: 85 tests passent dans 
- Suite complète: 293 suites passent (état develop avant cette PR)

## Known limits
- Aucun

## Points of attention
- Cette PR ne modifie que la documentation (plans d'implémentation). L'intégration technique sera réalisée dans des PRs ultérieures selon ces plans.
