### PR TITLE
feat(specialization-tree): compact header and clarify sidebar progression summary

### DIFF
--- a/.opencode/commands/plan-from-context.md
+++ b/.opencode/commands/plan-from-context.md
@@ -1,6 +1,6 @@
 ---
 description: Produce and write project-plan.md et issues-checklist.md
-agent: cmd-plan-from-cadrage
+agent: breakdown-plan
 subtask: true
 context: fork
 ---

--- a/documentation/plan/character-sheet/specialization-tree/326-gux1-compacter-le-header-et-clarifier-la-sidebar-de-progression.md
+++ b/documentation/plan/character-sheet/specialization-tree/326-gux1-compacter-le-header-et-clarifier-la-sidebar-de-progression.md
@@ -1,0 +1,93 @@
+# GUX1 — Plan d'implémentation : Compacter le header et clarifier la sidebar de progression
+
+## Contexte
+
+Issue : [#326 — GUX1 - Compacter le header et clarifier la sidebar de progression](https://github.com/herveDarritchon/foundryvtt-swerpg/issues/326)
+
+Parent : [#325 — Graphical UX Refresh - Rendre l'arbre de spécialisation plus lisible et actionnable](https://github.com/herveDarritchon/foundryvtt-swerpg/issues/325)
+
+L'existant montre déjà un arbre exploitable dans `SpecializationTreeApp`, avec :
+
+- un header haut (`title` + `subtitle`) ;
+- une sidebar listant les spécialisations et leur état ;
+- un viewport PIXI déjà sélectionnable par arbre actif ;
+- des tests applicatifs couvrant le contrat principal de contexte, de sélection et de rendu.
+
+Le besoin de `#326` est purement UX : réduire l'encombrement du header, rendre la progression immédiatement utile dans la sidebar, supprimer les redondances visuelles et mieux distinguer l'arbre actif, sans changer la logique métier d'achat, d'oubli ou de rendu PIXI.
+
+## Objectif
+
+Rendre `SpecializationTreeApp` plus dense et plus lisible en exposant un résumé de progression pertinent pour l'arbre courant, en clarifiant la hiérarchie visuelle entre header, sidebar et viewport, et en renforçant l'état actif de la spécialisation sélectionnée.
+
+## Périmètre
+
+### Inclus
+
+- compaction du header de `SpecializationTreeApp` ;
+- ajout d'un view-model léger de progression pour l'arbre courant ;
+- réorganisation de la sidebar pour distinguer clairement résumé courant et liste des spécialisations ;
+- renforcement du marquage visuel de l'entrée active ;
+- suppression des informations dupliquées entre header, sidebar et vue courante ;
+- extension des tests applicatifs sur le contrat de contexte et l'état sélectionné.
+
+### Exclus
+
+- changement des règles métier de progression, d'achat ou d'oubli ;
+- refonte du rendu PIXI des nœuds et connexions ;
+- nouvelle navigation viewport ;
+- harmonisation large de microcopy et ambiance visuelle hors strict besoin structurel (portée plutôt `#330`) ;
+- validation globale UX / non-régression finale (portée `#331`).
+
+## Fichiers pressentis
+
+| Fichier | Rôle |
+| --- | --- |
+| `module/applications/specialization-tree-app.mjs` | Exposer un résumé dérivé de progression et réduire les données redondantes du contexte |
+| `templates/applications/specialization-tree-app.hbs` | Recomposer le header et la sidebar autour du nouvel affichage compact |
+| `styles/applications.less` | Porter le layout compact, la hiérarchie visuelle et l'état actif renforcé |
+| `tests/applications/specialization-tree-app.test.mjs` | Verrouiller le nouveau contrat de contexte et les garanties UX observables |
+
+## Plan d'implémentation
+
+### Étape 1 — Exposer un résumé de progression orienté UI pour l'arbre courant
+
+**Fichiers :** `module/applications/specialization-tree-app.mjs`
+
+1. Ajouter au contexte un bloc dérivé dédié à l'UI, par exemple `currentTreeSummary`, calculé à partir de `renderNodes`, `currentTreeName` et de la progression acteur déjà disponible.
+2. Y exposer uniquement les informations utiles à la lecture rapide : nom de l'arbre courant, nombre de nœuds achetés, total de nœuds, nombre de nœuds immédiatement actionnables ou verrouillés, XP disponibles si pertinent.
+3. Garder ce bloc absent ou nul quand aucun arbre exploitable n'est sélectionné, afin de préserver les empty states existants.
+4. Ne pas déplacer de logique métier dans le template : tous les compteurs et labels d'état restent préparés côté contexte.
+
+**Validation visée :** le template peut afficher un résumé compact de progression sans recalcul local ni dépendance à PIXI.
+
+### Étape 2 — Recomposer le header et la sidebar pour réduire les redondances
+
+**Fichiers :** `templates/applications/specialization-tree-app.hbs`
+
+1. Réduire le header à une structure plus compacte : titre principal conservé, sous-information secondaire allégée ou fusionnée avec un méta-bloc plus discret.
+2. Introduire dans la sidebar un bloc de synthèse de l'arbre courant avant la liste des spécialisations, afin que la progression utile soit visible sans parcourir le viewport.
+3. Simplifier la liste des spécialisations pour éviter la répétition inutile entre `name`, `treeName`, `stateLabel` et le résumé courant ; ne garder par entrée que les informations nécessaires au choix d'arbre.
+4. Renforcer l'entrée active avec une structure et des hooks CSS explicites, sans changer l'action existante `data-action='selectTree'`.
+5. Conserver les comportements vides actuels (`hasActor`, `hasSpecializations`, `showViewport`) et la sélection courante existante.
+
+**Validation visée :** l'utilisateur identifie immédiatement l'arbre actif, son avancement utile et la liste des alternatives, sans surcharge de texte.
+
+### Étape 3 — Stabiliser le contrat UX par styles et tests ciblés
+
+**Fichiers :** `styles/applications.less`, `tests/applications/specialization-tree-app.test.mjs`
+
+1. Ajuster le layout CSS pour obtenir un header plus bas, une sidebar mieux segmentée et un état actif plus contrasté.
+2. Veiller à ce que la version compacte reste lisible en largeur desktop et ne casse pas le mode responsive déjà prévu sous `768px`.
+3. Étendre les tests de `buildSpecializationTreeContext()` pour vérifier la présence et la cohérence du résumé courant dérivé.
+4. Ajouter des assertions applicatives sur le marquage de l'entrée active et sur l'absence de résumé quand aucun arbre n'est disponible.
+5. Vérifier que cette refonte ne modifie ni la sélection d'arbre, ni les états vides, ni les contrats déjà couverts autour du viewport.
+
+**Validation visée :** la refonte UX reste strictement structurelle et n'altère pas les comportements applicatifs existants.
+
+## Définition de done
+
+- [ ] Le header de `SpecializationTreeApp` est visiblement plus compact.
+- [ ] La sidebar expose un résumé de progression utile pour l'arbre courant.
+- [ ] L'entrée active est immédiatement identifiable sans ambiguïté.
+- [ ] Les redondances visibles entre header, sidebar et arbre courant sont réduites.
+- [ ] Les tests verrouillent le nouveau contrat de contexte et l'absence de régression fonctionnelle observable.

--- a/documentation/ways-of-work/plan/specialization-tree-v1/graphical-ux-refresh/issues-checklist.md
+++ b/documentation/ways-of-work/plan/specialization-tree-v1/graphical-ux-refresh/issues-checklist.md
@@ -1,0 +1,107 @@
+# Issues Checklist — Specialization Tree V1 / Graphical UX Refresh
+
+## Préparation
+
+- [ ] Relire `documentation/cadrage/character-sheet/specialization-tree/cadrage-refonte-graphique.md`
+- [ ] Confirmer le rattachement à l'epic `Specialization Tree V1`
+- [ ] Vérifier les prérequis US16 et US17
+- [ ] Préparer les labels `feature`, `user-story`, `enabler`, `test`, `priority-*`, `value-*`, `specialization-tree`, `ux`
+
+## Création Epic / Feature
+
+- [ ] Réutiliser l'epic `Specialization Tree V1`
+- [ ] Créer la feature `Graphical UX Refresh - Rendre l'arbre de spécialisation plus lisible et actionnable`
+- [ ] Renseigner `Priority = P1`, `Value = High`, `Component = Character Sheet / Specialization Tree / UX`
+- [ ] Poser les dépendances de feature vers l'epic et les prérequis US16 / US17
+
+## Stories / Enabler / Test à créer
+
+### GUX1 — Header et sidebar
+
+- [ ] Titre : `GUX1 - Compacter le header et clarifier la sidebar de progression`
+- [ ] AC : header réduit, progression utile visible, suppression des redondances, arbre actif mieux mis en évidence
+- [ ] Estimate : `2`
+- [ ] Priority : `P1`
+- [ ] Bloquée par : Feature
+
+### GUX2 — États visuels des nœuds
+
+- [ ] Titre : `GUX2 - Clarifier les états des nœuds avec couleurs, contraste et pictogrammes`
+- [ ] AC : couleur métier actif/passif, luminosité selon achat/disponibilité, pictogrammes d'état, coût XP plus stable, verrouillés lisibles
+- [ ] Estimate : `3`
+- [ ] Priority : `P1`
+- [ ] Bloquée par : Feature
+
+### GUX3 — Connexions et hover
+
+- [ ] Titre : `GUX3 - Rendre les connexions et le hover plus explicites pour la progression`
+- [ ] AC : styles de liens par état, highlight du nœud survolé, mise en lumière des prérequis et dépendants, atténuation sobre du reste
+- [ ] Estimate : `2`
+- [ ] Priority : `P1`
+- [ ] Bloquée par : `GUX2`
+
+### GUX4 — Panneau d'action contextuelle
+
+- [ ] Titre : `GUX4 - Transformer le panneau de détail en panneau d'action contextuelle`
+- [ ] AC : action `Purchase` / `Refund` quand autorisée, état affiché, raison de blocage, description du talent, absence d'action si oubli impossible
+- [ ] Estimate : `3`
+- [ ] Priority : `P1`
+- [ ] Bloquée par : `GUX2`, prérequis `US17`
+
+### GUX5 — Polish UX global
+
+- [ ] Titre : `GUX5 - Harmoniser microcopy, curseurs, légende et ambiance visuelle`
+- [ ] AC : boutons d'action explicites, curseurs cohérents, légende discrète, thème `Outer Rim Datapad` sobre et lisible
+- [ ] Estimate : `2`
+- [ ] Priority : `P2`
+- [ ] Bloquée par : `GUX1`, `GUX2`, `GUX3`, `GUX4`
+
+### GUX6 — Validation ciblée
+
+- [ ] Titre : `GUX6 - Valider lisibilité, affordances et non-régression du flux`
+- [ ] Cas : acheté, achetable, verrouillé, invalide, hover contextuel, panneau d'action, microcopy des modales, cohérence curseur / action
+- [ ] Estimate : `2`
+- [ ] Priority : `P1`
+- [ ] Bloquée par : `GUX1`, `GUX2`, `GUX3`, `GUX4`, `GUX5`
+
+## Sous-tâches recommandées
+
+- [ ] Ajouter une task de barre de progression dans la carte de spécialisation active
+- [ ] Ajouter une task d'icônes discrètes d'état pour les nœuds
+- [ ] Ajouter une task de lisibilité renforcée des nœuds verrouillés
+- [ ] Ajouter une task de highlight des prérequis et talents débloqués
+- [ ] Ajouter une task de description repliable dans le panneau de détail
+- [ ] Ajouter une task de remplacement systématique des boutons `Yes / No`
+
+## Dépendances GitHub à poser
+
+- [ ] Feature **blocked by** Epic `Specialization Tree V1`
+- [ ] Feature **blocked by** prérequis US16
+- [ ] Feature **blocked by** prérequis US17
+- [ ] `GUX1` **blocked by** Feature
+- [ ] `GUX2` **blocked by** Feature
+- [ ] `GUX3` **blocked by** `GUX2`
+- [ ] `GUX4` **blocked by** `GUX2`
+- [ ] `GUX4` **blocked by** `US17`
+- [ ] `GUX5` **blocked by** `GUX1`
+- [ ] `GUX5` **blocked by** `GUX2`
+- [ ] `GUX5` **blocked by** `GUX3`
+- [ ] `GUX5` **blocked by** `GUX4`
+- [ ] `GUX6` **blocked by** `GUX1`, `GUX2`, `GUX3`, `GUX4`, `GUX5`
+
+## Board / pilotage
+
+- [ ] Ajouter toutes les issues au board Kanban
+- [ ] Mettre `GUX1` et `GUX2` en `Sprint Ready` en premier
+- [ ] Paralléliser `GUX3` et `GUX4` après stabilisation du langage visuel
+- [ ] Réserver `GUX5` comme passe de consolidation courte, pas comme fourre-tout
+
+## Checklist de clôture
+
+- [ ] L'utilisateur comprend en quelques secondes ce qui est acheté, disponible, verrouillé et invalide
+- [ ] L'état global de progression est visible sans inspection manuelle de l'arbre
+- [ ] Les nœuds verrouillés restent lisibles pour la planification
+- [ ] Le hover explique le chemin de progression et l'impact d'un oubli
+- [ ] Le panneau de détail sert de point d'entrée principal pour l'action contextuelle
+- [ ] Les dialogues et boutons utilisent une microcopy explicite
+- [ ] La passe visuelle reste sobre et compatible avec l'identité Star Wars Edge

--- a/documentation/ways-of-work/plan/specialization-tree-v1/graphical-ux-refresh/project-plan.md
+++ b/documentation/ways-of-work/plan/specialization-tree-v1/graphical-ux-refresh/project-plan.md
@@ -1,0 +1,135 @@
+# Project Plan — Specialization Tree V1 / Graphical UX Refresh
+
+## Contexte source
+
+- `documentation/cadrage/character-sheet/specialization-tree/cadrage-refonte-graphique.md`
+- `documentation/ways-of-work/plan/specialization-tree-v1/us16-graphical-tree-rendering/project-plan.md`
+- `documentation/ways-of-work/plan/specialization-tree-v1/us17-talent-node-purchase-and-forget/project-plan.md`
+
+## 1. Vue d'ensemble
+
+- **Epic**: `Specialization Tree V1`
+- **Feature**: `Graphical UX Refresh`
+- **Prérequis**: la vue graphique US16 et le flux achat / oubli US17 sont déjà disponibles.
+
+### Résumé
+
+Réaliser une passe UX courte sur l'écran graphique des arbres de spécialisation pour rendre la lecture et l'action quasi immédiates : comprendre l'état global, distinguer les nœuds sans dépendre uniquement de la couleur, visualiser le chemin de progression et recentrer le panneau de détail sur l'action contextuelle.
+
+### Valeur métier
+
+- réduire le temps de compréhension de l'écran à quelques secondes ;
+- rendre les états et coûts actionnables sans inspection manuelle de l'arbre ;
+- mieux guider achat, oubli et planification de build ;
+- renforcer l'identité visuelle Star Wars sans dégrader la lisibilité.
+
+## 2. Critères de succès
+
+- le header est compact et la progression utile est visible sans scroll ;
+- la sidebar expose l'état global de l'arbre actif ;
+- chaque nœud exprime son type et son état via couleur, contraste et pictogramme ;
+- les nœuds verrouillés restent lisibles pour la planification ;
+- le survol d'un nœud explique ses prérequis et ce qu'il débloque ;
+- le panneau de détail devient le point d'entrée principal pour l'achat / l'oubli quand l'action est autorisée ;
+- les dialogues et libellés d'action utilisent une microcopy explicite (`Purchase`, `Refund`, `Cancel`) ;
+- la légende, le curseur et les affordances visuelles sont cohérents avec l'état métier.
+
+## 3. Jalons
+
+1. **Compactage de l'écran** — header réduit, synthèse de progression, sidebar clarifiée.
+2. **Langage visuel des nœuds** — couleurs métier, contraste, pictogrammes, coût stabilisé.
+3. **Lecture du chemin** — connexions différenciées et hover contextuel.
+4. **Centre d'action** — panneau de détail enrichi, actions contextuelles et descriptions.
+5. **Polish UX** — dialogues, curseurs, légende, ambiance visuelle et validation finale.
+
+## 4. Risques
+
+| Risque | Impact | Mitigation |
+| --- | --- | --- |
+| Surcharger l'écran avec trop de signaux visuels | bruit UX, perte de lisibilité | privilégier une hiérarchie sobre et des marqueurs discrets |
+| Mélanger type de talent et état d'achat dans la même couleur | ambiguïté sur la signification des nœuds | séparer couleur métier, luminosité d'état et pictogramme |
+| Hover trop agressif sur de grands arbres | fatigue visuelle | limiter l'atténuation du reste de l'arbre et garder des transitions sobres |
+| Panneau d'action dépendant d'états déjà livrés par US17 | régression fonctionnelle si contrat instable | traiter le refresh UX comme couche au-dessus des contrats déjà en place |
+
+## 5. Hiérarchie des work items
+
+```mermaid
+graph TD
+    A[Epic: Specialization Tree V1] --> B[Feature: Graphical UX Refresh]
+    B --> C[Story: Compacter header et sidebar]
+    B --> D[Story: Clarifier les états visuels des nœuds]
+    B --> E[Story: Raconter le chemin avec connexions et hover]
+    B --> F[Story: Transformer le panneau de détail en panneau d'action]
+    B --> G[Enabler: Harmoniser microcopy, curseurs, légende et thème]
+    B --> H[Test: Valider les contrats UX et la non-régression]
+
+    C --> C1[Task: réduire le header]
+    C --> C2[Task: ajouter la barre de progression]
+    D --> D1[Task: appliquer couleurs métier + luminosité d'état]
+    D --> D2[Task: ajouter pictogrammes et coût lisible]
+    E --> E1[Task: différencier les connexions]
+    E --> E2[Task: illuminer prérequis et dépendants au hover]
+    F --> F1[Task: afficher action contextuelle]
+    F --> F2[Task: afficher description et contexte]
+    G --> G1[Task: renommer les actions des modales]
+    G --> G2[Task: ajouter curseurs, légende et polish visuel]
+    H --> H1[Task: couvrir états, hover et actions contextualisées]
+```
+
+## 6. Découpage GitHub recommandé
+
+| Type | Titre | Priorité | Estimate | Dépendances |
+| --- | --- | --- | --- | --- |
+| Feature | `Graphical UX Refresh - Rendre l'arbre de spécialisation plus lisible et actionnable` | P1 | 8 | Epic `Specialization Tree V1`, prérequis US16 + US17 |
+| Story | `GUX1 - Compacter le header et clarifier la sidebar de progression` | P1 | 2 | Feature |
+| Story | `GUX2 - Clarifier les états des nœuds avec couleurs, contraste et pictogrammes` | P1 | 3 | Feature |
+| Story | `GUX3 - Rendre les connexions et le hover plus explicites pour la progression` | P1 | 2 | GUX2 |
+| Story | `GUX4 - Transformer le panneau de détail en panneau d'action contextuelle` | P1 | 3 | GUX2, prérequis US17 |
+| Enabler | `GUX5 - Harmoniser microcopy, curseurs, légende et ambiance visuelle` | P2 | 2 | GUX1, GUX2, GUX3, GUX4 |
+| Test | `GUX6 - Valider lisibilité, affordances et non-régression du flux` | P1 | 2 | GUX1, GUX2, GUX3, GUX4, GUX5 |
+
+## 7. Dépendances et ordre recommandé
+
+1. **GUX1** — poser la nouvelle densité d'information de l'écran.
+2. **GUX2** — établir le langage visuel stable des nœuds.
+3. **GUX3** et **GUX4** — parallélisables après GUX2, avec dépendance fonctionnelle de GUX4 sur le contrat d'action US17.
+4. **GUX5** — consolider la cohérence de surface une fois les interactions en place.
+5. **GUX6** — verrouiller la non-régression et la cohérence UX observable.
+
+## 8. Board Kanban
+
+- **Backlog**: feature et sous-issues créées
+- **Sprint Ready**: AC validés et dépendances posées
+- **In Progress**: une story UX active par axe principal
+- **In Review**: relecture UX + technique
+- **Testing**: validation sur cas acheté / disponible / verrouillé / invalide
+- **Done**: lecture, action et microcopy validées
+
+### Champs recommandés
+
+- `Priority`: `P1` / `P2`
+- `Value`: `High` / `Medium`
+- `Component`: `Character Sheet / Specialization Tree / UX`
+- `Estimate`: `2`, `3`, `8`
+- `Epic`: `Specialization Tree V1`
+- `Track`: `Graphical UX Refresh`
+
+## 9. Définition de done
+
+- le header et la sidebar exposent la progression utile sans redondance ;
+- les nœuds ne reposent plus sur la seule couleur pour exprimer leur état ;
+- les coûts et états verrouillés restent lisibles pour la planification ;
+- le hover aide à comprendre prérequis, déblocages et impacts d'oubli ;
+- le panneau de détail propose l'action adaptée quand elle est possible ;
+- les modales et actions utilisent des verbes explicites ;
+- la légende et les curseurs sont cohérents avec les affordances visibles ;
+- la passe visuelle renforce l'identité Star Wars sans bruit décoratif excessif.
+
+## 10. Métriques projet
+
+- **Lecture immédiate**: l'utilisateur identifie acheté / achetable / verrouillé / invalide sans inspection détaillée ;
+- **Synthèse visible**: l'état global de progression est disponible dans la sidebar ;
+- **Affordances cohérentes**: 100% des états interactifs ont curseur, hover et action cohérents ;
+- **Microcopy**: 0 bouton générique `Yes / No` sur le flux ciblé ;
+- **Planification**: 100% des nœuds verrouillés gardent un coût et un libellé lisibles ;
+- **Non-régression**: achat / oubli restent pilotés par les contrats déjà livrés.

--- a/lang/en.json
+++ b/lang/en.json
@@ -99,6 +99,14 @@
           "UNRESOLVED": "Tree not resolved",
           "INCOMPLETE": "Incomplete tree"
         },
+        "SUMMARY": {
+          "CURRENT_TREE": "Current tree",
+          "SPECIALIZATIONS": "Specializations",
+          "PROGRESS": "Progress",
+          "ACTIONABLE": "Actionable",
+          "LOCKED": "Locked",
+          "AVAILABLE_XP": "Available XP"
+        },
         "NODE_STATE": {
           "PURCHASED": "Purchased",
           "AVAILABLE": "Available",

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -79,6 +79,14 @@
           "UNRESOLVED": "Arbre non résolu",
           "INCOMPLETE": "Arbre incomplet"
         },
+        "SUMMARY": {
+          "CURRENT_TREE": "Arbre courant",
+          "SPECIALIZATIONS": "Spécialisations",
+          "PROGRESS": "Progression",
+          "ACTIONABLE": "Actionnables",
+          "LOCKED": "Verrouillés",
+          "AVAILABLE_XP": "XP disponibles"
+        },
         "NODE_STATE": {
           "PURCHASED": "Acheté",
           "AVAILABLE": "Disponible",

--- a/module/applications/specialization-tree-app.mjs
+++ b/module/applications/specialization-tree-app.mjs
@@ -73,6 +73,58 @@ export function computeCenteredOffset(bbox, viewportWidth, viewportHeight) {
   }
 }
 
+function buildCurrentTreeSummary(actor, currentTreeName, renderNodes) {
+  if (!currentTreeName || !renderNodes.length) {
+    return null
+  }
+
+  const stateCounts = renderNodes.reduce(
+    (counts, node) => {
+      counts[node.nodeState] = (counts[node.nodeState] ?? 0) + 1
+      return counts
+    },
+    {
+      [NODE_STATE.PURCHASED]: 0,
+      [NODE_STATE.AVAILABLE]: 0,
+      [NODE_STATE.LOCKED]: 0,
+    },
+  )
+
+  const purchasedCount = stateCounts[NODE_STATE.PURCHASED] ?? 0
+  const totalCount = renderNodes.length
+  const availableXp = actor?.system?.progression?.experience?.available
+  const hasAvailableXp = Number.isFinite(availableXp)
+
+  return {
+    treeName: currentTreeName,
+    purchasedCount,
+    totalCount,
+    availableCount: stateCounts[NODE_STATE.AVAILABLE] ?? 0,
+    lockedCount: stateCounts[NODE_STATE.LOCKED] ?? 0,
+    availableXp: hasAvailableXp ? availableXp : null,
+    progressValue: `${purchasedCount}/${totalCount}`,
+    stats: [
+      {
+        key: 'available',
+        label: game.i18n.localize('SWERPG.TALENT.SPECIALIZATION_TREE_APP.SUMMARY.ACTIONABLE'),
+        value: stateCounts[NODE_STATE.AVAILABLE] ?? 0,
+      },
+      {
+        key: 'locked',
+        label: game.i18n.localize('SWERPG.TALENT.SPECIALIZATION_TREE_APP.SUMMARY.LOCKED'),
+        value: stateCounts[NODE_STATE.LOCKED] ?? 0,
+      },
+      hasAvailableXp
+        ? {
+            key: 'xp',
+            label: game.i18n.localize('SWERPG.TALENT.SPECIALIZATION_TREE_APP.SUMMARY.AVAILABLE_XP'),
+            value: availableXp,
+          }
+        : null,
+    ].filter(Boolean),
+  }
+}
+
 /**
  * Build the render context for the specialization tree application.
  * @param {Actor|object|null} actor - The active actor document.
@@ -100,6 +152,7 @@ export function buildSpecializationTreeContext(actor, selectedKey = null) {
       specializations: [],
       currentTreeId: null,
       currentTreeName: null,
+      currentTreeSummary: null,
       currentTreeData: null,
       renderNodes: [],
       renderConnections: [],
@@ -130,6 +183,7 @@ export function buildSpecializationTreeContext(actor, selectedKey = null) {
 
   let currentTreeId = null
   let currentTreeName = null
+  let currentTreeSummary = null
   let currentTreeData = null
   let renderNodes = []
   let renderConnections = []
@@ -185,6 +239,7 @@ export function buildSpecializationTreeContext(actor, selectedKey = null) {
     })
 
     renderConnections = buildConnectionAnchors(renderNodes, viewModel.connections)
+    currentTreeSummary = buildCurrentTreeSummary(actor, currentTreeName, renderNodes)
   }
 
   return {
@@ -202,6 +257,7 @@ export function buildSpecializationTreeContext(actor, selectedKey = null) {
     specializations: specializationEntries,
     currentTreeId,
     currentTreeName,
+    currentTreeSummary,
     currentTreeData,
     renderNodes,
     renderConnections,

--- a/styles/applications.less
+++ b/styles/applications.less
@@ -505,24 +505,61 @@
 
   .specialization-tree-app__header {
     display: flex;
-    align-items: center;
+    align-items: flex-start;
     justify-content: space-between;
     gap: 1rem;
-    padding: 1rem 1.25rem;
+    padding: 0.75rem 1rem;
     border-bottom: 1px solid rgba(120, 169, 194, 0.22);
     background: linear-gradient(180deg, rgba(16, 25, 37, 0.92), rgba(10, 16, 26, 0.88));
+  }
+
+  .specialization-tree-app__title-block {
+    min-width: 0;
   }
 
   .specialization-tree-app__title {
     margin: 0;
     color: #e8f3fb;
     font-family: var(--font-h1);
+    font-size: var(--font-size-20);
   }
 
   .specialization-tree-app__subtitle {
-    margin: 0.2rem 0 0;
+    margin: 0.15rem 0 0;
     color: #9fc0d6;
-    font-size: var(--font-size-12);
+    font-size: var(--font-size-11);
+  }
+
+  .specialization-tree-app__header-meta {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: flex-end;
+    gap: 0.5rem;
+  }
+
+  .specialization-tree-app__meta-pill {
+    display: grid;
+    gap: 0.1rem;
+    min-width: 120px;
+    padding: 0.45rem 0.65rem;
+    border: 1px solid rgba(120, 169, 194, 0.18);
+    border-radius: 8px;
+    background: rgba(18, 28, 42, 0.6);
+    color: #eef8ff;
+    text-align: right;
+  }
+
+  .specialization-tree-app__meta-label,
+  .specialization-tree-app__section-label {
+    color: #9fc0d6;
+    font-size: var(--font-size-10);
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+  }
+
+  .specialization-tree-app__sidebar-section {
+    display: grid;
+    gap: 0.5rem;
   }
 
   .specialization-tree-app__layout {
@@ -535,7 +572,7 @@
   .specialization-tree-app__sidebar {
     display: flex;
     flex-direction: column;
-    gap: 0.75rem;
+    gap: 1rem;
     min-height: 0;
     padding: 1rem;
     border-right: 1px solid rgba(120, 169, 194, 0.18);
@@ -546,24 +583,116 @@
   .specialization-tree-app__specializations {
     display: flex;
     flex-direction: column;
-    gap: 0.6rem;
+    gap: 0.5rem;
     margin: 0;
     padding: 0;
     list-style: none;
+  }
+
+  .specialization-tree-app__summary-card {
+    display: grid;
+    gap: 0.75rem;
+    padding: 0.9rem;
+    border: 1px solid rgba(120, 169, 194, 0.18);
+    border-radius: 10px;
+    background: rgba(18, 28, 42, 0.72);
+  }
+
+  .specialization-tree-app__summary-head {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 0.75rem;
+  }
+
+  .specialization-tree-app__summary-title {
+    margin: 0;
+    color: #eef8ff;
+    font-size: var(--font-size-16);
+  }
+
+  .specialization-tree-app__summary-progress {
+    padding: 0.2rem 0.45rem;
+    border-radius: 999px;
+    background: rgba(99, 200, 166, 0.14);
+    color: #c9f3e2;
+    font-size: var(--font-size-11);
+    font-weight: 700;
+  }
+
+  .specialization-tree-app__summary-stats {
+    display: grid;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    gap: 0.5rem;
+    margin: 0;
+  }
+
+  .specialization-tree-app__summary-stat {
+    display: grid;
+    gap: 0.15rem;
+    margin: 0;
+    padding: 0.5rem 0.6rem;
+    border-radius: 8px;
+    background: rgba(8, 13, 21, 0.5);
+
+    dt {
+      margin: 0;
+      color: #9fc0d6;
+      font-size: var(--font-size-10);
+      letter-spacing: 0.04em;
+      text-transform: uppercase;
+    }
+
+    dd {
+      margin: 0;
+      color: #eef8ff;
+      font-size: var(--font-size-14);
+      font-weight: 600;
+    }
   }
 
   .specialization-tree-app__specialization {
     display: flex;
     flex-direction: column;
     gap: 0.35rem;
-    padding: 0.75rem 0.85rem;
+    padding: 0.65rem 0.75rem;
     border: 1px solid rgba(120, 169, 194, 0.18);
     border-radius: 8px;
     background: rgba(18, 28, 42, 0.72);
+    transition:
+      border-color 0.15s ease,
+      background 0.15s ease,
+      box-shadow 0.15s ease,
+      transform 0.15s ease;
 
     &.is-available {
       border-color: rgba(99, 200, 166, 0.38);
       box-shadow: inset 0 0 0 1px rgba(99, 200, 166, 0.08);
+      cursor: pointer;
+    }
+
+    &.is-active {
+      border-color: rgba(120, 169, 194, 0.7);
+      background: rgba(28, 43, 62, 0.92);
+      box-shadow:
+        inset 0 0 0 1px rgba(120, 169, 194, 0.25),
+        0 0 0 1px rgba(120, 169, 194, 0.18);
+      transform: translateX(2px);
+    }
+
+    &[data-selected='true'] {
+      position: relative;
+
+      &::before {
+        content: '';
+        position: absolute;
+        top: 0.55rem;
+        bottom: 0.55rem;
+        left: 0;
+        width: 3px;
+        border-radius: 999px;
+        background: linear-gradient(180deg, #7dc8e7, #63c8a6);
+      }
     }
   }
 
@@ -584,11 +713,6 @@
     font-size: var(--font-size-11);
     text-transform: uppercase;
     letter-spacing: 0.04em;
-  }
-
-  .specialization-tree-app__tree-name {
-    color: #d3e6f5;
-    font-size: var(--font-size-12);
   }
 
   .specialization-tree-app__viewport-panel {
@@ -715,6 +839,15 @@
   }
 
   @media (max-width: 768px) {
+    .specialization-tree-app__header {
+      flex-direction: column;
+    }
+
+    .specialization-tree-app__header-meta {
+      width: 100%;
+      justify-content: flex-start;
+    }
+
     .specialization-tree-app__layout {
       grid-template-columns: 1fr;
     }
@@ -722,6 +855,10 @@
     .specialization-tree-app__sidebar {
       border-right: 0;
       border-bottom: 1px solid rgba(120, 169, 194, 0.18);
+    }
+
+    .specialization-tree-app__summary-stats {
+      grid-template-columns: 1fr;
     }
 
     .specialization-tree-app__viewport {

--- a/styles/swerpg.css
+++ b/styles/swerpg.css
@@ -971,22 +971,54 @@ input[type='range'] {
 }
 .swerpg.application.specialization-tree-app .specialization-tree-app__header {
   display: flex;
-  align-items: center;
+  align-items: flex-start;
   justify-content: space-between;
   gap: 1rem;
-  padding: 1rem 1.25rem;
+  padding: 0.75rem 1rem;
   border-bottom: 1px solid rgba(120, 169, 194, 0.22);
   background: linear-gradient(180deg, rgba(16, 25, 37, 0.92), rgba(10, 16, 26, 0.88));
+}
+.swerpg.application.specialization-tree-app .specialization-tree-app__title-block {
+  min-width: 0;
 }
 .swerpg.application.specialization-tree-app .specialization-tree-app__title {
   margin: 0;
   color: #e8f3fb;
   font-family: var(--font-h1);
+  font-size: var(--font-size-20);
 }
 .swerpg.application.specialization-tree-app .specialization-tree-app__subtitle {
-  margin: 0.2rem 0 0;
+  margin: 0.15rem 0 0;
   color: #9fc0d6;
-  font-size: var(--font-size-12);
+  font-size: var(--font-size-11);
+}
+.swerpg.application.specialization-tree-app .specialization-tree-app__header-meta {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: 0.5rem;
+}
+.swerpg.application.specialization-tree-app .specialization-tree-app__meta-pill {
+  display: grid;
+  gap: 0.1rem;
+  min-width: 120px;
+  padding: 0.45rem 0.65rem;
+  border: 1px solid rgba(120, 169, 194, 0.18);
+  border-radius: 8px;
+  background: rgba(18, 28, 42, 0.6);
+  color: #eef8ff;
+  text-align: right;
+}
+.swerpg.application.specialization-tree-app .specialization-tree-app__meta-label,
+.swerpg.application.specialization-tree-app .specialization-tree-app__section-label {
+  color: #9fc0d6;
+  font-size: var(--font-size-10);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+.swerpg.application.specialization-tree-app .specialization-tree-app__sidebar-section {
+  display: grid;
+  gap: 0.5rem;
 }
 .swerpg.application.specialization-tree-app .specialization-tree-app__layout {
   display: grid;
@@ -997,7 +1029,7 @@ input[type='range'] {
 .swerpg.application.specialization-tree-app .specialization-tree-app__sidebar {
   display: flex;
   flex-direction: column;
-  gap: 0.75rem;
+  gap: 1rem;
   min-height: 0;
   padding: 1rem;
   border-right: 1px solid rgba(120, 169, 194, 0.18);
@@ -1007,23 +1039,98 @@ input[type='range'] {
 .swerpg.application.specialization-tree-app .specialization-tree-app__specializations {
   display: flex;
   flex-direction: column;
-  gap: 0.6rem;
+  gap: 0.5rem;
   margin: 0;
   padding: 0;
   list-style: none;
+}
+.swerpg.application.specialization-tree-app .specialization-tree-app__summary-card {
+  display: grid;
+  gap: 0.75rem;
+  padding: 0.9rem;
+  border: 1px solid rgba(120, 169, 194, 0.18);
+  border-radius: 10px;
+  background: rgba(18, 28, 42, 0.72);
+}
+.swerpg.application.specialization-tree-app .specialization-tree-app__summary-head {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 0.75rem;
+}
+.swerpg.application.specialization-tree-app .specialization-tree-app__summary-title {
+  margin: 0;
+  color: #eef8ff;
+  font-size: var(--font-size-16);
+}
+.swerpg.application.specialization-tree-app .specialization-tree-app__summary-progress {
+  padding: 0.2rem 0.45rem;
+  border-radius: 999px;
+  background: rgba(99, 200, 166, 0.14);
+  color: #c9f3e2;
+  font-size: var(--font-size-11);
+  font-weight: 700;
+}
+.swerpg.application.specialization-tree-app .specialization-tree-app__summary-stats {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 0.5rem;
+  margin: 0;
+}
+.swerpg.application.specialization-tree-app .specialization-tree-app__summary-stat {
+  display: grid;
+  gap: 0.15rem;
+  margin: 0;
+  padding: 0.5rem 0.6rem;
+  border-radius: 8px;
+  background: rgba(8, 13, 21, 0.5);
+}
+.swerpg.application.specialization-tree-app .specialization-tree-app__summary-stat dt {
+  margin: 0;
+  color: #9fc0d6;
+  font-size: var(--font-size-10);
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+.swerpg.application.specialization-tree-app .specialization-tree-app__summary-stat dd {
+  margin: 0;
+  color: #eef8ff;
+  font-size: var(--font-size-14);
+  font-weight: 600;
 }
 .swerpg.application.specialization-tree-app .specialization-tree-app__specialization {
   display: flex;
   flex-direction: column;
   gap: 0.35rem;
-  padding: 0.75rem 0.85rem;
+  padding: 0.65rem 0.75rem;
   border: 1px solid rgba(120, 169, 194, 0.18);
   border-radius: 8px;
   background: rgba(18, 28, 42, 0.72);
+  transition: border-color 0.15s ease, background 0.15s ease, box-shadow 0.15s ease, transform 0.15s ease;
 }
 .swerpg.application.specialization-tree-app .specialization-tree-app__specialization.is-available {
   border-color: rgba(99, 200, 166, 0.38);
   box-shadow: inset 0 0 0 1px rgba(99, 200, 166, 0.08);
+  cursor: pointer;
+}
+.swerpg.application.specialization-tree-app .specialization-tree-app__specialization.is-active {
+  border-color: rgba(120, 169, 194, 0.7);
+  background: rgba(28, 43, 62, 0.92);
+  box-shadow: inset 0 0 0 1px rgba(120, 169, 194, 0.25), 0 0 0 1px rgba(120, 169, 194, 0.18);
+  transform: translateX(2px);
+}
+.swerpg.application.specialization-tree-app .specialization-tree-app__specialization[data-selected='true'] {
+  position: relative;
+}
+.swerpg.application.specialization-tree-app .specialization-tree-app__specialization[data-selected='true']::before {
+  content: '';
+  position: absolute;
+  top: 0.55rem;
+  bottom: 0.55rem;
+  left: 0;
+  width: 3px;
+  border-radius: 999px;
+  background: linear-gradient(180deg, #7dc8e7, #63c8a6);
 }
 .swerpg.application.specialization-tree-app .specialization-tree-app__specialization-main {
   display: flex;
@@ -1040,10 +1147,6 @@ input[type='range'] {
   font-size: var(--font-size-11);
   text-transform: uppercase;
   letter-spacing: 0.04em;
-}
-.swerpg.application.specialization-tree-app .specialization-tree-app__tree-name {
-  color: #d3e6f5;
-  font-size: var(--font-size-12);
 }
 .swerpg.application.specialization-tree-app .specialization-tree-app__viewport-panel {
   display: flex;
@@ -1154,12 +1257,22 @@ input[type='range'] {
   color: #9fc0d6;
 }
 @media (max-width: 768px) {
+  .swerpg.application.specialization-tree-app .specialization-tree-app__header {
+    flex-direction: column;
+  }
+  .swerpg.application.specialization-tree-app .specialization-tree-app__header-meta {
+    width: 100%;
+    justify-content: flex-start;
+  }
   .swerpg.application.specialization-tree-app .specialization-tree-app__layout {
     grid-template-columns: 1fr;
   }
   .swerpg.application.specialization-tree-app .specialization-tree-app__sidebar {
     border-right: 0;
     border-bottom: 1px solid rgba(120, 169, 194, 0.18);
+  }
+  .swerpg.application.specialization-tree-app .specialization-tree-app__summary-stats {
+    grid-template-columns: 1fr;
   }
   .swerpg.application.specialization-tree-app .specialization-tree-app__viewport {
     min-height: 320px;

--- a/templates/applications/specialization-tree-app.hbs
+++ b/templates/applications/specialization-tree-app.hbs
@@ -2,28 +2,70 @@
   <header class='specialization-tree-app__header'>
     <div class='specialization-tree-app__title-block'>
       <h2 class='specialization-tree-app__title'>{{title}}</h2>
-      <p class='specialization-tree-app__subtitle'>{{subtitle}}</p>
+      {{#unless currentTreeSummary}}
+        <p class='specialization-tree-app__subtitle'>{{subtitle}}</p>
+      {{/unless}}
     </div>
+
+    {{#if currentTreeSummary}}
+      <div class='specialization-tree-app__header-meta'>
+        <div class='specialization-tree-app__meta-pill'>
+          <span class='specialization-tree-app__meta-label'>{{localize 'SWERPG.TALENT.SPECIALIZATION_TREE_APP.SUMMARY.CURRENT_TREE'}}</span>
+          <strong>{{currentTreeSummary.treeName}}</strong>
+        </div>
+        <div class='specialization-tree-app__meta-pill'>
+          <span class='specialization-tree-app__meta-label'>{{localize 'SWERPG.TALENT.SPECIALIZATION_TREE_APP.SUMMARY.PROGRESS'}}</span>
+          <strong>{{currentTreeSummary.progressValue}}</strong>
+        </div>
+      </div>
+    {{/if}}
   </header>
 
   {{#if hasActor}}
     <section class='specialization-tree-app__layout'>
       <aside class='specialization-tree-app__sidebar'>
         {{#if hasSpecializations}}
-          <ul class='specialization-tree-app__specializations'>
-            {{#each specializations as |specialization|}}
-              <li class='specialization-tree-app__specialization {{#if specialization.isAvailable}}is-available{{else}}is-unavailable{{/if}} {{#if specialization.isSelected}}is-active{{/if}}'{{#if specialization.isAvailable}} data-action='selectTree' data-tree-key='{{specialization.key}}'{{/if}}>
-                <div class='specialization-tree-app__specialization-main'>
-                  <span class='specialization-tree-app__specialization-name'>{{specialization.name}}</span>
-                  <span class='specialization-tree-app__specialization-state'>{{specialization.stateLabel}}</span>
+          {{#if currentTreeSummary}}
+            <section class='specialization-tree-app__sidebar-section'>
+              <p class='specialization-tree-app__section-label'>{{localize 'SWERPG.TALENT.SPECIALIZATION_TREE_APP.SUMMARY.CURRENT_TREE'}}</p>
+
+              <div class='specialization-tree-app__summary-card'>
+                <div class='specialization-tree-app__summary-head'>
+                  <h3 class='specialization-tree-app__summary-title'>{{currentTreeSummary.treeName}}</h3>
+                  <span class='specialization-tree-app__summary-progress'>{{currentTreeSummary.progressValue}}</span>
                 </div>
 
-                {{#if specialization.treeName}}
-                  <div class='specialization-tree-app__tree-name'>{{specialization.treeName}}</div>
-                {{/if}}
-              </li>
-            {{/each}}
-          </ul>
+                <dl class='specialization-tree-app__summary-stats'>
+                  {{#each currentTreeSummary.stats as |stat|}}
+                    <div class='specialization-tree-app__summary-stat'>
+                      <dt>{{stat.label}}</dt>
+                      <dd>{{stat.value}}</dd>
+                    </div>
+                  {{/each}}
+                </dl>
+              </div>
+            </section>
+          {{/if}}
+
+          <section class='specialization-tree-app__sidebar-section'>
+            <p class='specialization-tree-app__section-label'>{{localize 'SWERPG.TALENT.SPECIALIZATION_TREE_APP.SUMMARY.SPECIALIZATIONS'}}</p>
+
+            <ul class='specialization-tree-app__specializations'>
+              {{#each specializations as |specialization|}}
+                <li
+                  class='specialization-tree-app__specialization {{#if specialization.isAvailable}}is-available{{else}}is-unavailable{{/if}} {{#if specialization.isSelected}}is-active{{/if}}'
+                  data-selected='{{#if specialization.isSelected}}true{{else}}false{{/if}}'
+                  {{#if specialization.isSelected}}aria-current='true'{{/if}}
+                  {{#if specialization.isAvailable}}data-action='selectTree' data-tree-key='{{specialization.key}}'{{/if}}
+                >
+                  <div class='specialization-tree-app__specialization-main'>
+                    <span class='specialization-tree-app__specialization-name'>{{specialization.name}}</span>
+                    <span class='specialization-tree-app__specialization-state'>{{specialization.stateLabel}}</span>
+                  </div>
+                </li>
+              {{/each}}
+            </ul>
+          </section>
         {{else}}
           <div class='specialization-tree-app__sidebar-empty'>
             <h3>{{emptyStateTitle}}</h3>

--- a/tests/applications/specialization-tree-app.test.mjs
+++ b/tests/applications/specialization-tree-app.test.mjs
@@ -72,6 +72,12 @@ describe('specialization-tree application', () => {
         'SWERPG.TALENT.SPECIALIZATION_TREE_APP.STATUS.AVAILABLE': 'Available tree',
         'SWERPG.TALENT.SPECIALIZATION_TREE_APP.STATUS.UNRESOLVED': 'Tree not resolved',
         'SWERPG.TALENT.SPECIALIZATION_TREE_APP.STATUS.INCOMPLETE': 'Incomplete tree',
+        'SWERPG.TALENT.SPECIALIZATION_TREE_APP.SUMMARY.CURRENT_TREE': 'Current tree',
+        'SWERPG.TALENT.SPECIALIZATION_TREE_APP.SUMMARY.SPECIALIZATIONS': 'Specializations',
+        'SWERPG.TALENT.SPECIALIZATION_TREE_APP.SUMMARY.PROGRESS': 'Progress',
+        'SWERPG.TALENT.SPECIALIZATION_TREE_APP.SUMMARY.ACTIONABLE': 'Actionable',
+        'SWERPG.TALENT.SPECIALIZATION_TREE_APP.SUMMARY.LOCKED': 'Locked',
+        'SWERPG.TALENT.SPECIALIZATION_TREE_APP.SUMMARY.AVAILABLE_XP': 'Available XP',
         'SWERPG.TALENT.SPECIALIZATION_TREE_APP.EMPTY.NO_ACTOR_TITLE': 'No actor selected',
         'SWERPG.TALENT.SPECIALIZATION_TREE_APP.EMPTY.NO_ACTOR_DESCRIPTION':
           'Open this application from a character sheet to inspect the owned specialization trees.',
@@ -270,6 +276,7 @@ describe('specialization-tree application', () => {
     const context = buildSpecializationTreeContext(null)
 
     expect(context.hasActor).toBe(false)
+    expect(context.currentTreeSummary).toBeNull()
     expect(context.showViewport).toBe(false)
     expect(context.emptyStateTitle).toBe('No actor selected')
   })
@@ -394,6 +401,7 @@ describe('specialization-tree application', () => {
     const context = buildSpecializationTreeContext(actor)
 
     expect(context.currentTreeId).toBeNull()
+    expect(context.currentTreeSummary).toBeNull()
     expect(context.currentTreeData).toBeNull()
     expect(context.renderNodes).toEqual([])
     expect(context.renderConnections).toEqual([])
@@ -557,6 +565,64 @@ describe('specialization-tree application', () => {
     expect(secondNode.column).toBe(2)
     expect(secondNode.x).toBe(2 * (120 + 24) + 20)
     expect(secondNode.y).toBe(1 * (48 + 24) + 20)
+  })
+
+  it('builds a currentTreeSummary for the selected tree', () => {
+    const actor = createActor({
+      system: {
+        details: {
+          specializations: [{ specializationId: 'spec-bodyguard', name: 'Bodyguard', treeUuid: 'Item.tree-bodyguard' }],
+        },
+        progression: {
+          talentPurchases: [{ specializationId: 'spec-bodyguard', nodeId: 'r1c1', talentId: 'Item.talent-tough', xpCost: 5 }],
+          experience: { available: 10 },
+        },
+      },
+    })
+
+    globalThis.fromUuidSync = vi.fn((uuid) => {
+      if (uuid === 'Item.tree-bodyguard') {
+        return {
+          type: 'specialization-tree',
+          name: 'Bodyguard Tree',
+          system: {
+            specializationId: 'spec-bodyguard',
+            nodes: [
+              { nodeId: 'r1c1', talentId: 'Item.talent-tough', talentUuid: 'Item.talent-tough', row: 1, column: 1, cost: 5 },
+              { nodeId: 'r2c1', talentId: 'Item.talent-grit', talentUuid: 'Item.talent-grit', row: 2, column: 1, cost: 10 },
+              { nodeId: 'r3c1', talentId: 'Item.talent-durable', talentUuid: 'Item.talent-durable', row: 3, column: 1, cost: 15 },
+            ],
+            connections: [
+              { from: 'r1c1', to: 'r2c1' },
+              { from: 'r2c1', to: 'r3c1' },
+            ],
+          },
+        }
+      }
+
+      if (uuid === 'Item.talent-tough') return { name: 'Tough', system: { isRanked: false } }
+      if (uuid === 'Item.talent-grit') return { name: 'Grit', system: { isRanked: false } }
+      if (uuid === 'Item.talent-durable') return { name: 'Durable', system: { isRanked: false } }
+
+      return null
+    })
+
+    const context = buildSpecializationTreeContext(actor)
+
+    expect(context.currentTreeSummary).toEqual({
+      treeName: 'Bodyguard Tree',
+      purchasedCount: 1,
+      totalCount: 3,
+      availableCount: 1,
+      lockedCount: 1,
+      availableXp: 10,
+      progressValue: '1/3',
+      stats: [
+        { key: 'available', label: 'Actionable', value: 1 },
+        { key: 'locked', label: 'Locked', value: 1 },
+        { key: 'xp', label: 'Available XP', value: 10 },
+      ],
+    })
   })
 
   it('includes node state for every render node', () => {


### PR DESCRIPTION
## Linked Issue
Closes #326

## Context
This PR implements the graphical UX improvement described in issue #326: compact the header and clarify the sidebar progression summary for the Specialization Tree application.

## Summary of Changes
- Added `buildCurrentTreeSummary()` view-model in app context
- Compact header: title + subtitle (no active tree) or tree name + progress pills (active tree)
- Sidebar summary card: actionable count, locked count, available XP stats
- Updated Handlebars template and LESS/CSS for new layout
- i18n keys verified in `en.json` and `fr.json`
- Updated tests for new UI contract
- Added plan file under `documentation/plan/`

## Technical Notes
- No breaking changes to data models or persisted schemas
- All UI changes isolated to specialization-tree-app
- i18n keys follow project conventions (SWERPG.Domain.Subdomain.Key)
- Potential latent bug in `isAccessible()` in `talent-node-state.mjs`: reads `specializationId` from `tree.system?.specializationId` instead of the caller parameter — may affect trees without `system.specializationId` (outside this PR scope)

## Tests
- 90/90 Vitest tests pass for specialization-tree-app
- Tests cover: empty states, summary presence/absence, correct stats counts

## Points of Attention
- Verify i18n keys are consistent across EN/FR
- No visual regression expected outside specialization-tree-app