### PR TITLE
feat(specialization-tree): clarify node states with pictograms, active/passive cues

### DIFF
--- a/.opencode/agents/cmd-implement-plan.md
+++ b/.opencode/agents/cmd-implement-plan.md
@@ -2,7 +2,7 @@
 name: "cmd-implement-plan"
 description: Implémente strictement un plan approuvé via le skill implementer-depuis-plan, avec lecture ciblée et tests associés.
 mode: subagent
-model: openai/gpt-5.4
+model: opencode/big-pickle
 reasoningEffort: medium
 textVerbosity: low
 temperature: 0.1

--- a/documentation/plan/character-sheet/specialization-tree/327-gux2-clarifier-les-etats-des-noeuds-avec-couleurs-contraste-et-pictogrammes.md
+++ b/documentation/plan/character-sheet/specialization-tree/327-gux2-clarifier-les-etats-des-noeuds-avec-couleurs-contraste-et-pictogrammes.md
@@ -1,0 +1,79 @@
+# GUX2 — Plan d'implémentation : clarifier les états des nœuds avec couleurs, contraste et pictogrammes
+
+## Contexte
+
+- Issue : [#327 — GUX2 - Clarifier les états des nœuds avec couleurs, contraste et pictogrammes](https://github.com/herveDarritchon/foundryvtt-swerpg/issues/327)
+- Parent : [#325 — Graphical UX Refresh - Rendre l'arbre de spécialisation plus lisible et actionnable](https://github.com/herveDarritchon/foundryvtt-swerpg/issues/325)
+- Références utiles :
+  - `documentation/plan/character-sheet/talent/234-plan-appliquer-variantes-visuelles-etats-noeud.md`
+  - `documentation/plan/character-sheet/talent/235-plan-fix-afficher-detail-noeuds-raisons-blocage-vue-graphique.md`
+  - `documentation/plan/character-sheet/specialization-tree/296-mapper-les-etats-et-raisons-de-noeud-vers-l-ui.md`
+
+Le besoin exprimé par l'issue est de rendre l'état de chaque nœud immédiatement compréhensible sans dépendre uniquement de la couleur : type métier actif/passif, contraste selon disponibilité/achat, pictogrammes d'état, coût XP plus stable visuellement, et lisibilité maintenue des nœuds verrouillés.
+
+## Objectif
+
+Renforcer le contrat visuel du specialization tree pour que chaque nœud expose clairement son type et son état métier en combinant couleur, contraste, iconographie et hiérarchie visuelle, sans modifier les règles domaine ni réintroduire de logique métier côté UI.
+
+## Périmètre
+
+### Inclus
+
+- clarification des variantes visuelles des états `purchased`, `available`, `locked`, `invalid` ;
+- différenciation visuelle explicite des nœuds actifs/passifs ;
+- ajout d'un pictogramme d'état ou d'un marqueur équivalent non dépendant de la couleur seule ;
+- stabilisation de l'affichage du coût XP dans la carte de nœud ;
+- maintien d'une bonne lisibilité des nœuds verrouillés pour la planification ;
+- tests ciblés du mapping état/type -> rendu observable.
+
+### Exclus
+
+- modification des règles de calcul d'état ou de `reasonCode` ;
+- refonte du hover et des connexions (`#328`) ;
+- transformation du panneau de détail en panneau d'action (`#329`) ;
+- microcopy/légende globale hors besoins stricts de cohérence locale (`#330`).
+
+## Fichiers pressentis
+
+| Fichier | Rôle |
+| --- | --- |
+| `module/applications/specialization-tree/node-ui-state.mjs` | Canoniser les variantes visuelles et métadonnées UI des nœuds |
+| `module/applications/specialization-tree-app.mjs` | Brancher le rendu PIXI/view-model sur le nouveau contrat visuel |
+| `lang/fr.json` | Libellés FR complémentaires si pictogrammes/légende locale en ont besoin |
+| `lang/en.json` | Libellés EN complémentaires si pictogrammes/légende locale en ont besoin |
+| `tests/applications/specialization-tree/node-ui-state.test.mjs` | Verrouiller le mapping état/type -> variante/iconographie |
+| `tests/applications/specialization-tree-app.test.mjs` | Vérifier l'intégration du contrat dans le rendu applicatif |
+
+## Plan d'implémentation
+
+### Étape 1 — Canoniser le langage visuel des nœuds
+
+**Fichiers :** `module/applications/specialization-tree/node-ui-state.mjs`
+
+1. Définir une matrice unique qui combine état métier, type de nœud et attributs de rendu observables : palette, contraste, opacité, bordure, pictogramme, traitement du coût XP.
+2. Réserver au moins un indice non chromatique par état pour éviter une lecture dépendante de la couleur seule.
+3. Prévoir explicitement le cas des nœuds verrouillés afin qu'ils restent planifiables et lisibles, sans paraître désactivés au point de masquer le contenu.
+
+### Étape 2 — Appliquer ce contrat au view-model et au rendu de l'arbre
+
+**Fichiers :** `module/applications/specialization-tree-app.mjs`
+
+1. Enrichir les nœuds rendus avec les métadonnées nécessaires : type métier, variant UI, pictogramme, style du coût XP, niveau de contraste.
+2. Remplacer les choix visuels dispersés par la consommation du mapper dédié pour garder une seule source de vérité applicative.
+3. Vérifier que le coût XP conserve une place stable et lisible quel que soit l'état du nœud.
+
+### Étape 3 — Finaliser les libellés utiles et verrouiller les tests
+
+**Fichiers :** `lang/fr.json`, `lang/en.json`, `tests/applications/specialization-tree/node-ui-state.test.mjs`, `tests/applications/specialization-tree-app.test.mjs`
+
+1. Ajouter les clés i18n minimales seulement si le contrat retenu expose des libellés ou descriptions d'icônes côté UI.
+2. Couvrir les combinaisons clés : actif/passif x `purchased`/`available`/`locked`/`invalid`.
+3. Vérifier que les nœuds verrouillés restent lisibles et que le coût XP ne change pas de hiérarchie visuelle selon l'état.
+
+## Définition de done
+
+- [ ] Chaque nœud exprime son état avec au moins deux signaux visuels cohérents, dont un non basé uniquement sur la couleur.
+- [ ] Les nœuds actifs et passifs sont distinguables sans ambiguïté.
+- [ ] Les nœuds verrouillés restent lisibles pour la planification.
+- [ ] Le coût XP reste stable, visible et cohérent sur l'ensemble des états.
+- [ ] Le mapping visuel est centralisé et couvert par des tests ciblés.

--- a/documentation/plan/character-sheet/specialization-tree/327-gux2-clarifier-les-etats-des-noeuds-avec-couleurs-contraste-et-pictogrammes.md
+++ b/documentation/plan/character-sheet/specialization-tree/327-gux2-clarifier-les-etats-des-noeuds-avec-couleurs-contraste-et-pictogrammes.md
@@ -1,79 +1,132 @@
-# GUX2 — Plan d'implémentation : clarifier les états des nœuds avec couleurs, contraste et pictogrammes
+---
+goal: Clarifier les états des nœuds de l'arbre de spécialisation avec couleurs, contraste et pictogrammes
+version: 2.0
+date_created: 2026-05-21
+last_updated: 2026-05-21
+status: 'In progress'
+tags: feature, specialization-tree, visual-refresh, gux
+---
 
-## Contexte
+# Introduction
 
-- Issue : [#327 — GUX2 - Clarifier les états des nœuds avec couleurs, contraste et pictogrammes](https://github.com/herveDarritchon/foundryvtt-swerpg/issues/327)
-- Parent : [#325 — Graphical UX Refresh - Rendre l'arbre de spécialisation plus lisible et actionnable](https://github.com/herveDarritchon/foundryvtt-swerpg/issues/325)
-- Références utiles :
-  - `documentation/plan/character-sheet/talent/234-plan-appliquer-variantes-visuelles-etats-noeud.md`
-  - `documentation/plan/character-sheet/talent/235-plan-fix-afficher-detail-noeuds-raisons-blocage-vue-graphique.md`
-  - `documentation/plan/character-sheet/specialization-tree/296-mapper-les-etats-et-raisons-de-noeud-vers-l-ui.md`
+![Status: In progress](https://img.shields.io/badge/status-In%20progress-yellow)
 
-Le besoin exprimé par l'issue est de rendre l'état de chaque nœud immédiatement compréhensible sans dépendre uniquement de la couleur : type métier actif/passif, contraste selon disponibilité/achat, pictogrammes d'état, coût XP plus stable visuellement, et lisibilité maintenue des nœuds verrouillés.
+Mettre à jour le contrat visuel des nœuds de l'arbre de spécialisation pour que chaque nœud expose clairement son type (actif/passif) et son état métier (acheté/disponible/verrouillé/invalide) en combinant **couleur, contraste, iconographie SVG et hiérarchie visuelle**, sans modifier les règles domaine.
 
-## Objectif
+Ce plan remplace la v1 (implémentée partiellement dans PR #333) pour corriger les écarts détectés avec le cadrage `cadrage-refonte-graphique.md` §3.
 
-Renforcer le contrat visuel du specialization tree pour que chaque nœud expose clairement son type et son état métier en combinant couleur, contraste, iconographie et hiérarchie visuelle, sans modifier les règles domaine ni réintroduire de logique métier côté UI.
+## 1. Requirements & Constraints
 
-## Périmètre
+- **REQ-001**: La couleur de fond du nœud doit exprimer le type métier : bleu pour passif, rouge pour actif (cadrage §3.1.1)
+- **REQ-002**: La luminosité de la couleur doit exprimer l'état d'achat : dense + bordure lumineuse pour acheté, atténué + bordure terne pour disponible (cadrage §3.1.1)
+- **REQ-003**: Chaque nœud doit porter un pictogramme SVG chargé comme texture PIXI, positionné en haut-droit (cadrage §3.1.2)
+- **REQ-004**: Les icônes SVG sont : `sell-card.svg` (acheté), `buy-card.svg` (disponible), `padlock.svg` (verrouillé), `hazard-sign.svg` (invalide)
+- **REQ-005**: Les nœuds verrouillés doivent rester lisibles pour la planification : texte 65-70% opacité, bordure grise nette, fond sombre pas noir, coût XP toujours lisible (cadrage §3.2)
+- **REQ-006**: Le coût XP doit être stable et structuré, optionnellement avec pastille `[5 XP]` pour les nœuds disponibles (cadrage §3.3)
+- **REQ-007**: Au moins un indice non chromatique par état (le pictogramme SVG)
+- **REQ-008**: Aucune modification des règles de calcul d'état ou de `reasonCode`
+- **CON-001**: Les fichiers SVG existent déjà dans `assets/images/icons/` — pas de création d'assets
+- **CON-002**: Le module `node-ui-state.mjs` doit rester pur (zéro dépendance Foundry/PIXI)
+- **CON-003**: Les clés i18n existantes sont réutilisées ; n'ajouter que si nécessaire
+- **PAT-001**: Suivre le pattern `enrichNode()` existant pour l'enrichissement des nœuds
+- **PAT-002**: Centraliser tout le mapping visuel dans `node-ui-state.mjs`
 
-### Inclus
+## 2. Implementation Steps
 
-- clarification des variantes visuelles des états `purchased`, `available`, `locked`, `invalid` ;
-- différenciation visuelle explicite des nœuds actifs/passifs ;
-- ajout d'un pictogramme d'état ou d'un marqueur équivalent non dépendant de la couleur seule ;
-- stabilisation de l'affichage du coût XP dans la carte de nœud ;
-- maintien d'une bonne lisibilité des nœuds verrouillés pour la planification ;
-- tests ciblés du mapping état/type -> rendu observable.
+### Implementation Phase 1 — Correction des couleurs : palette active/passive + luminance état
 
-### Exclus
+- GOAL-001: Rebaser la palette `NODE_STATE_VARIANTS` sur le système bleu (passif) / rouge (actif) avec différenciation par luminance entre acheté et disponible, et renforcer la lisibilité des verrouillés.
 
-- modification des règles de calcul d'état ou de `reasonCode` ;
-- refonte du hover et des connexions (`#328`) ;
-- transformation du panneau de détail en panneau d'action (`#329`) ;
-- microcopy/légende globale hors besoins stricts de cohérence locale (`#330`).
+| Task | Description | Completed | Date |
+| ---- | ----------- | --------- | ---- |
+| TASK-001 | Définir la matrice combinant état × type → attributs : fillColor, borderColor, borderWidth, alpha, textColor, costColor avec bleu (passif) / rouge (actif) en teinte de base | | |
+| TASK-002 | Appliquer la luminance : acheté → saturation élevée + bordure lumineuse (borderWidth+glow) ; disponible → saturation réduite + bordure terne | | |
+| TASK-003 | Mettre à jour la matrice des verrouillés : fond sombre mais pas noir (ex: `0x1a1a1a`), texte 65-70% opacité, bordure grise nette (borderWidth 2), coût XP en `0x999999` | | |
+| TASK-004 | Mettre à jour la matrice des invalides : teinte rouge sombre, bordure rouge terne, texte lisible | | |
+| TASK-005 | Conserver l'indicateur iconographique actif/passif (`nodeTypeIcon`) en complément de la couleur | ✅ PR #333 | 2026-05-21 |
+| TASK-006 | Mettre à jour `enrichNode()` si la signature change pour accepter les nouvelles données | | |
+| TASK-007 | Mettre à jour les tests `node-ui-state.test.mjs` : vérifier chaque combinaison état × type avec les nouvelles couleurs | | |
 
-## Fichiers pressentis
+### Implementation Phase 2 — Pictogrammes SVG chargés comme textures PIXI
 
-| Fichier | Rôle |
-| --- | --- |
-| `module/applications/specialization-tree/node-ui-state.mjs` | Canoniser les variantes visuelles et métadonnées UI des nœuds |
-| `module/applications/specialization-tree-app.mjs` | Brancher le rendu PIXI/view-model sur le nouveau contrat visuel |
-| `lang/fr.json` | Libellés FR complémentaires si pictogrammes/légende locale en ont besoin |
-| `lang/en.json` | Libellés EN complémentaires si pictogrammes/légende locale en ont besoin |
-| `tests/applications/specialization-tree/node-ui-state.test.mjs` | Verrouiller le mapping état/type -> variante/iconographie |
-| `tests/applications/specialization-tree-app.test.mjs` | Vérifier l'intégration du contrat dans le rendu applicatif |
+- GOAL-002: Remplacer les pictogrammes Unicode par des sprites PIXI chargés depuis `assets/images/icons/`, positionnés en haut-droit du nœud.
 
-## Plan d'implémentation
+| Task | Description | Completed | Date |
+| ---- | ----------- | --------- | ---- |
+| TASK-008 | Exporter les constantes de chemins SVG dans `node-ui-state.mjs` : `NODE_STATE_SVG_ICONS` mappant chaque état → chemin relatif | | |
+| TASK-009 | Créer une fonction utilitaire `loadStatePictogram(state): Promise<PIXI.Texture>` dans la couche applicative (hors module pur) | | |
+| TASK-010 | Implémenter un cache de textures (`Map<string, PIXI.Texture>`) pour éviter de recharger les SVGs à chaque render | | |
+| TASK-011 | Dans `#drawTree()` de `specialization-tree-app.mjs` : charger la texture au premier render, créer un `PIXI.Sprite` positionné en haut-droit (node.x + NODE_WIDTH - 20, node.y + 4) | | |
+| TASK-012 | Fallback : si le chargement SVG échoue, afficher le pictogramme Unicode comme fallback | | |
+| TASK-013 | Mettre à jour les tests de rendu PIXI dans `specialization-tree-app.test.mjs` : vérifier la présence du Sprite | | |
+| TASK-014 | Supprimer le rendu Unicode des pictogrammes en bas-droit (remplacé par SVG en haut-droit) | | |
 
-### Étape 1 — Canoniser le langage visuel des nœuds
+### Implementation Phase 3 — Stabilisation du coût XP
 
-**Fichiers :** `module/applications/specialization-tree/node-ui-state.mjs`
+- GOAL-003: Rendre l'affichage du coût XP plus structuré et cohérent visuellement entre tous les états.
 
-1. Définir une matrice unique qui combine état métier, type de nœud et attributs de rendu observables : palette, contraste, opacité, bordure, pictogramme, traitement du coût XP.
-2. Réserver au moins un indice non chromatique par état pour éviter une lecture dépendante de la couleur seule.
-3. Prévoir explicitement le cas des nœuds verrouillés afin qu'ils restent planifiables et lisibles, sans paraître désactivés au point de masquer le contenu.
+| Task | Description | Completed | Date |
+| ---- | ----------- | --------- | ---- |
+| TASK-015 | Pour les nœuds disponibles : afficher le coût XP dans une pastille/badge `[5 XP]` avec une couleur plus visible | | |
+| TASK-016 | Pour les nœuds achetés : afficher le coût XP en texte secondaire (grisé) | | |
+| TASK-017 | Pour les nœuds verrouillés et invalides : coût XP en texte lisible, identique au texte principal | | |
+| TASK-018 | Mettre à jour `#drawTree()` : appliquer le style de coût selon l'état du nœud | | |
+| TASK-019 | Mettre à jour les tests de rendu PIXI pour vérifier le style du coût XP par état | | |
 
-### Étape 2 — Appliquer ce contrat au view-model et au rendu de l'arbre
+### Implementation Phase 4 — Finalisation i18n et documentation
 
-**Fichiers :** `module/applications/specialization-tree-app.mjs`
+- GOAL-004: Ajouter les clés i18n minimales et finaliser la documentation.
 
-1. Enrichir les nœuds rendus avec les métadonnées nécessaires : type métier, variant UI, pictogramme, style du coût XP, niveau de contraste.
-2. Remplacer les choix visuels dispersés par la consommation du mapper dédié pour garder une seule source de vérité applicative.
-3. Vérifier que le coût XP conserve une place stable et lisible quel que soit l'état du nœud.
+| Task | Description | Completed | Date |
+| ---- | ----------- | --------- | ---- |
+| TASK-020 | Ajouter les clés i18n dans `lang/en.json` et `lang/fr.json` si des libellés SVG ou badges sont introduits | | |
+| TASK-021 | Mettre à jour la Définition of Done dans ce plan | | |
+| TASK-022 | Exécuter la suite complète de tests (`pnpm test`) | | |
 
-### Étape 3 — Finaliser les libellés utiles et verrouiller les tests
+## 3. Alternatives
 
-**Fichiers :** `lang/fr.json`, `lang/en.json`, `tests/applications/specialization-tree/node-ui-state.test.mjs`, `tests/applications/specialization-tree-app.test.mjs`
+- **ALT-001** (implémenté dans PR #333) : Pictogrammes Unicode au lieu de SVG. Rejeté car le cadrage demande explicitement des SVG et les assets existent déjà. Les caractères Unicode sont moins précis visuellement et ne peuvent pas être stylisés (couleur, taille, rotation).
+- **ALT-002** (implémenté dans PR #333) : Couleur par état (vert/bleu/gris/rouge foncé) au lieu de couleur par type (bleu passif/rouge actif). Rejeté car le cadrage §3.1.1 spécifie que la couleur doit porter la distinction actif/passif, pas l'état d'achat.
+- **ALT-003** : Distinction actif/passif uniquement par icône sans couleur. Rejeté car le cadrage veut un système redondant : couleur + icône + pictogramme.
 
-1. Ajouter les clés i18n minimales seulement si le contrat retenu expose des libellés ou descriptions d'icônes côté UI.
-2. Couvrir les combinaisons clés : actif/passif x `purchased`/`available`/`locked`/`invalid`.
-3. Vérifier que les nœuds verrouillés restent lisibles et que le coût XP ne change pas de hiérarchie visuelle selon l'état.
+## 4. Dependencies
 
-## Définition de done
+- **DEP-001**: `assets/images/icons/sell-card.svg` — existe déjà
+- **DEP-002**: `assets/images/icons/buy-card.svg` — existe déjà
+- **DEP-003**: `assets/images/icons/padlock.svg` — existe déjà
+- **DEP-004**: `assets/images/icons/hazard-sign.svg` — existe déjà
+- **DEP-005**: PR #333 (branche `feat/327-clarifier-etats-noeuds-couleurs-contraste-pictogrammes`) — doit être soit mergée puis corrigée, soit remplacée
 
-- [ ] Chaque nœud exprime son état avec au moins deux signaux visuels cohérents, dont un non basé uniquement sur la couleur.
-- [ ] Les nœuds actifs et passifs sont distinguables sans ambiguïté.
-- [ ] Les nœuds verrouillés restent lisibles pour la planification.
-- [ ] Le coût XP reste stable, visible et cohérent sur l'ensemble des états.
-- [ ] Le mapping visuel est centralisé et couvert par des tests ciblés.
+## 5. Files
+
+- **FILE-001**: `module/applications/specialization-tree/node-ui-state.mjs` — matrice des variantes visuelles, constantes SVG, `enrichNode()`
+- **FILE-002**: `module/applications/specialization-tree-app.mjs` — rendu PIXI avec sprites SVG, badge XP, palette mise à jour
+- **FILE-003**: `tests/applications/specialization-tree/node-ui-state.test.mjs` — tests mapping état/type → variante
+- **FILE-004**: `tests/applications/specialization-tree-app.test.mjs` — tests rendu PIXI (sprites, badge, palette)
+- **FILE-005**: `lang/en.json` — clés i18n si nouveaux libellés
+- **FILE-006**: `lang/fr.json` — clés i18n si nouveaux libellés
+
+## 6. Testing
+
+- **TEST-001**: Vérifier que chaque combinaison `{state} × {type}` produit la variante visuelle correcte (couleur, luminance, bordure)
+- **TEST-002**: Vérifier que les pictogrammes SVG sont chargés et affichés comme sprites PIXI en haut-droit
+- **TEST-003**: Vérifier le fallback Unicode quand le SVG ne charge pas
+- **TEST-004**: Vérifier que le coût XP s'affiche avec le bon style selon l'état : badge pour disponible, texte secondaire pour acheté, texte normal pour verrouillé/invalide
+- **TEST-005**: Vérifier que les nœuds verrouillés ont texte 65-70% opacité et bordure grise nette
+- **TEST-006**: Vérifier qu'aucune régression sur les tests existants (3363 tests passent)
+
+## 7. Risks & Assumptions
+
+- **RISK-001**: Les textures PIXI chargées depuis des fichiers SVG peuvent ne pas s'afficher correctement selon le rendu SVG du navigateur. Mitigation : test manuel sur Chrome/Firefox/Safari.
+- **RISK-002**: Le cache de textures peut consommer de la mémoire si de nombreux SVGs sont chargés. Mitigation : 4 icônes seulement, impact négligeable.
+- **RISK-003**: PR #333 a déjà modifié les fichiers ; la rebase ou le remplacement peut causer des conflits. Mitigation : travailler sur la même branche et forcer le push, ou créer une nouvelle branche depuis develop.
+- **ASSUMPTION-001**: Les fichiers SVG dans `assets/images/icons/` sont compatibles PIXI (pas de SVG complexe avec CSS externe).
+- **ASSUMPTION-002**: Le système de couleurs bleu/rouge pour actif/passif est cohérent avec l'identité visuelle Star Wars Edge (holographique bleu pour les compétences passives, rouge/ambre pour les actions actives).
+
+## 8. Related Specifications / Further Reading
+
+- [Cadrage refonte graphique — §3 (Améliorations des nœuds)](file:///Users/hervedarritchon/Workspace/Perso/FoundryVTT/foundryvtt-swerpg/documentation/cadrage/character-sheet/specialization-tree/cadrage-refonte-graphique.md)
+- [Issue #327 — GUX2](https://github.com/herveDarritchon/foundryvtt-swerpg/issues/327)
+- [PR #333 — Implémentation v1 (à corriger)](https://github.com/herveDarritchon/foundryvtt-swerpg/pull/333)
+- [Plan précédent v1](file:///Users/hervedarritchon/Workspace/Perso/FoundryVTT/foundryvtt-swerpg/documentation/plan/character-sheet/talent/234-plan-appliquer-variantes-visuelles-etats-noeud.md)
+- [Plan précédent : mapping états](file:///Users/hervedarritchon/Workspace/Perso/FoundryVTT/foundryvtt-swerpg/documentation/plan/character-sheet/specialization-tree/296-mapper-les-etats-et-raisons-de-noeud-vers-l-ui.md)

--- a/documentation/plan/character-sheet/specialization-tree/327-gux2-corriger-statut-actif-passif-talents-arbre-specialisation.md
+++ b/documentation/plan/character-sheet/specialization-tree/327-gux2-corriger-statut-actif-passif-talents-arbre-specialisation.md
@@ -1,0 +1,120 @@
+# GUX2 — Plan d'implementation : Corriger le statut actif/passif des talents dans l'arbre de specialisation
+
+## Contexte
+
+Issue parente : [#327 — GUX2](https://github.com/herveDarritchon/foundryvtt-swerpg/issues/327)
+
+Un ecart fonctionnel subsiste dans l'arbre de specialisation : les talents passifs devraient etre affiches avec la variante bleue et les talents actifs avec la variante rouge, mais l'UI remonte actuellement les talents passifs comme actifs.
+
+Le diagnostic montre deux causes distinctes dans la chaine complete :
+
+- le rendu de l'arbre s'appuie sur un booleen `isActive`, mais ce booleen est aujourd'hui derive via `!!item.system?.activation`, ce qui transforme toute valeur d'activation non vide, y compris `passive`, en `true` ;
+- le mapping OggDude ne prend pas explicitement en charge le contrat reel `ActivationValue`, alors que la regle metier attendue est : `taPassive` => passif, toute autre valeur non vide => actif.
+
+Le modele canonique des talents est deja porte par `system.activation` dans `module/models/talent.mjs`. Le plan doit donc corriger la resolution, l'import et la documentation locale du modele, sans refondre le renderer PIXI ni la palette de `node-ui-state.mjs`.
+
+## Objectif
+
+Retablir une chaine coherente de bout en bout pour que :
+
+- un talent importe comme passif reste `system.activation = 'passive'` ;
+- un talent importe comme actif reste `system.activation = 'active'` ;
+- l'arbre de specialisation derive `isActive` uniquement des talents reellement actifs ;
+- la documentation du modele n'entretienne plus l'ambiguite entre l'ancien booleen `active` et le champ canonique `activation`.
+
+## Perimetre
+
+### Inclus
+
+- correction du mapping OggDude `ActivationValue` pour les talents ;
+- correction de la derivee `isActive` utilisee par l'arbre et les vues consolidees ;
+- alignement de la documentation locale du modele `talent` sur `system.activation` ;
+- mise a jour des tests unitaires et applicatifs couvrant cette chaine.
+
+### Exclus
+
+- changement des couleurs ou du contrat visuel de `node-ui-state.mjs` ;
+- ajout d'un troisieme etat visuel specifique pour `unspecified` ;
+- refonte du renderer PIXI de `SpecializationTreeApp` ;
+- migration large d'anciens donnees hors du besoin prouve par ce bug.
+
+## Fichiers pressentis
+
+| Fichier | Role |
+| --- | --- |
+| `module/importer/mappings/oggdude-talent-activation-map.mjs` | Porter le vrai contrat OggDude pour `ActivationValue` |
+| `module/importer/mappers/oggdude-talent-mapper.mjs` | Lire `ActivationValue` en priorite dans le contexte talent |
+| `module/lib/talent-node/talent-reference-resolver.mjs` | Deriver `isActive` a partir de `system.activation === 'active'` |
+| `module/models/talent.mjs` | Aligner le typedef/documentation sur `activation` plutot que `active` |
+| `tests/importer/talent-mappings.spec.mjs` | Verrouiller le mapping OggDude `taPassive` / autres valeurs |
+| `tests/lib/talent-node/talent-reference-resolver.test.mjs` | Verrouiller la derivee `isActive` pour `active` vs `passive` |
+| `tests/applications/specialization-tree-app.test.mjs` | Verrouiller la resolution utilisee par l'app de l'arbre |
+| `tests/applications/sheets/character-sheet-talents.test.mjs` | Verrouiller les definitions consolidees exposees a l'UI |
+
+## Plan d'implementation
+
+### Etape 1 — Recaler le contrat d'import OggDude sur `ActivationValue`
+
+**Fichiers :** `module/importer/mappings/oggdude-talent-activation-map.mjs`, `module/importer/mappers/oggdude-talent-mapper.mjs`, `tests/importer/talent-mappings.spec.mjs`
+
+1. Faire lire `ActivationValue` avant `Activation` et `ActivationType` dans la construction du contexte talent OggDude.
+2. Adapter `resolveTalentActivation()` pour reconnaitre explicitement `taPassive` comme `passive`.
+3. Definir le fallback metier attendu pour les codes OggDude reels : toute valeur non vide differente de `taPassive` doit etre mappee vers `active`.
+4. Conserver un comportement neutre pour les valeurs absentes ou vides si aucun code d'activation n'est fourni.
+5. Mettre a jour les tests de mapping pour couvrir au minimum `taPassive`, une valeur non vide representative d'un talent actif, et les cas vides.
+
+**Validation visee :** un talent importe depuis OggDude expose un `system.activation` conforme a la regle metier fournie par la source.
+
+### Etape 2 — Corriger la derivee `isActive` utilisee par l'arbre
+
+**Fichiers :** `module/lib/talent-node/talent-reference-resolver.mjs`, `tests/lib/talent-node/talent-reference-resolver.test.mjs`, `tests/applications/specialization-tree-app.test.mjs`, `tests/applications/sheets/character-sheet-talents.test.mjs`
+
+1. Remplacer les derives actuelles `!!item.system?.activation` par une regle explicite basee sur `item.system?.activation === 'active'`.
+2. Appliquer cette correction a toutes les branches de resolution : `fromUuidSync`, recherche `game.items`, index compendium et map des definitions consolidees.
+3. Verifier que `passive` donne `isActive = false`, `active` donne `isActive = true`, et qu'une absence d'activation ne force pas un actif par defaut.
+4. Mettre a jour les attentes de tests existantes qui considerent aujourd'hui a tort qu'un talent `passive` est actif.
+
+**Validation visee :** l'app d'arbre et les vues derivees recoivent un booleen `isActive` semantiquement correct, sans toucher au renderer lui-meme.
+
+### Etape 3 — Aligner la documentation du modele talent
+
+**Fichiers :** `module/models/talent.mjs`
+
+1. Remplacer dans le typedef `TalentData` la mention obsolete `active` par le champ canonique `activation`.
+2. Verifier que les commentaires et la schema definition racontent la meme chose sur le modele de donnees.
+3. Garder ce changement strictement documentaire tant qu'aucune logique runtime supplementaire n'est necessaire.
+
+**Validation visee :** le modele ne laisse plus penser qu'un booleen `TalentData.active` est la source de verite, alors que le champ reel est `system.activation`.
+
+### Etape 4 — Verrouiller la chaine complete par des tests cibles
+
+**Fichiers :** `tests/importer/talent-mappings.spec.mjs`, `tests/lib/talent-node/talent-reference-resolver.test.mjs`, `tests/applications/specialization-tree-app.test.mjs`, `tests/applications/sheets/character-sheet-talents.test.mjs`
+
+1. Ajouter un test unitaire qui prouve que `taPassive` est importe en `passive`.
+2. Ajouter un test unitaire qui prouve qu'une autre valeur OggDude non vide produit `active`.
+3. Ajouter ou ajuster un test de resolution montrant qu'un talent `passive` produit `isActive = false`.
+4. Ajouter ou ajuster un test applicatif montrant que les definitions consolidees de talents passifs restent passives jusqu'a l'UI.
+5. Verifier qu'aucun test n'impose encore implicitement la logique fautive basee sur la verite d'une chaine.
+
+**Validation visee :** la regression est couverte au niveau import, resolution et consommation UI.
+
+## Risques et points d'attention
+
+- Le code OggDude reel utilise peut varier entre `ActivationValue`, `Activation` et `ActivationType` selon les exports ; il faut conserver l'ordre de priorite sans casser les jeux de donnees deja supportes.
+- Certains tests existants ont encode le bug actuel comme comportement attendu ; il faudra les corriger en meme temps que le code pour eviter une fausse impression de regression.
+- Le renderer PIXI ne doit pas etre modifie si la correction de `isActive` suffit a retablir les couleurs rouge/bleu deja portees par `node-ui-state.mjs`.
+
+## Definition de done
+
+- [ ] Un talent OggDude avec `ActivationValue = taPassive` est importe en `system.activation = 'passive'`.
+- [ ] Un talent OggDude avec une autre valeur d'activation non vide est importe en `system.activation = 'active'`.
+- [ ] Un talent `passive` ne produit plus `isActive = true` dans `talent-reference-resolver`.
+- [ ] `SpecializationTreeApp` recoit bien des talents passifs en bleu et des talents actifs en rouge sans changement du renderer.
+- [ ] Le typedef de `module/models/talent.mjs` reference `activation` comme champ canonique.
+- [ ] Les tests cibles couvrant import, resolution et UI passent avec le comportement corrige.
+
+## References liees
+
+- `documentation/plan/character-sheet/specialization-tree/327-gux2-clarifier-les-etats-des-noeuds-avec-couleurs-contraste-et-pictogrammes.md`
+- `module/applications/specialization-tree/node-ui-state.mjs`
+- `module/models/talent.mjs`

--- a/module/applications/specialization-tree-app.mjs
+++ b/module/applications/specialization-tree-app.mjs
@@ -203,7 +203,7 @@ export function buildSpecializationTreeContext(actor, selectedKey = null) {
 
     const viewModel = buildRenderViewModel(currentTreeData, (node) => {
       const detail = resolveTalentDetail(node)
-      return detail ? { name: detail.name, uuid: node.talentUuid ?? node.talentId ?? '', isRanked: detail.isRanked } : null
+      return detail ? { name: detail.name, uuid: node.talentUuid ?? node.talentId ?? '', isRanked: detail.isRanked, isActive: detail.isActive } : null
     })
 
     renderNodes = viewModel.nodes.map((viewNode) => {
@@ -213,6 +213,7 @@ export function buildSpecializationTreeContext(actor, selectedKey = null) {
         talentId: viewNode.talentId,
         talentName: viewNode.talent.name,
         isRanked: viewNode.isRanked,
+        isActive: viewNode.isActive,
         xpCost: viewNode.cost,
         row: viewNode.row,
         column: viewNode.column,
@@ -730,14 +731,29 @@ export default class SpecializationTreeApp extends api.HandlebarsApplicationMixi
 
       for (const node of renderNodes) {
         const v = node.variant ?? NODE_STATE_VARIANTS[NODE_STATE.AVAILABLE]
+
+        // Type indicator (active/passive icon) — top-left corner
+        const typeIcon = node.nodeTypeIcon ?? ''
+        const nameOffsetX = typeIcon ? 14 : 4
+        if (typeIcon) {
+          const typeText = new PIXI.Text(typeIcon, {
+            fontFamily: 'Arial',
+            fontSize: 9,
+            fill: v.textColor,
+          })
+          typeText.x = node.x + 4
+          typeText.y = node.y + 5
+          this.#treeContainer.addChild(typeText)
+        }
+
         const nameText = new PIXI.Text(node.talentName, {
           fontFamily: 'Arial',
           fontSize: 10,
           fill: v.textColor,
           wordWrap: true,
-          wordWrapWidth: NODE_WIDTH - 8,
+          wordWrapWidth: NODE_WIDTH - nameOffsetX - 4,
         })
-        nameText.x = node.x + 4
+        nameText.x = node.x + nameOffsetX
         nameText.y = node.y + 4
         this.#treeContainer.addChild(nameText)
 
@@ -749,6 +765,18 @@ export default class SpecializationTreeApp extends api.HandlebarsApplicationMixi
         costText.x = node.x + 4
         costText.y = node.y + NODE_HEIGHT - 14
         this.#treeContainer.addChild(costText)
+
+        // State pictogram — bottom-right corner (non-color signal)
+        if (v.pictogram) {
+          const pictogramText = new PIXI.Text(v.pictogram, {
+            fontFamily: 'Arial',
+            fontSize: 10,
+            fill: v.pictogramColor,
+          })
+          pictogramText.x = node.x + NODE_WIDTH - pictogramText.width - 4
+          pictogramText.y = node.y + NODE_HEIGHT - 14
+          this.#treeContainer.addChild(pictogramText)
+        }
 
         // Ranked indicator — shown only when the node is explicitly ranked
         if (node.isRanked) {

--- a/module/applications/specialization-tree-app.mjs
+++ b/module/applications/specialization-tree-app.mjs
@@ -6,7 +6,13 @@ import { resolveTalentDetail } from '../lib/talent-node/talent-reference-resolve
 import { selectDefaultTreeKey } from '../lib/specialization-tree/default-tree-selector.mjs'
 import { buildRenderViewModel } from './specialization-tree/render-view-model.mjs'
 import { actionableNodeViewModel } from './specialization-tree/actionable-node-view-model.mjs'
-import { enrichNode, getReasonLabelKey, NODE_STATE, NODE_STATE_VARIANTS } from './specialization-tree/node-ui-state.mjs'
+import {
+  enrichNode,
+  getReasonLabelKey,
+  NODE_STATE,
+  NODE_STATE_SVG_ICONS,
+  NODE_STATE_VARIANTS,
+} from './specialization-tree/node-ui-state.mjs'
 import { NODE_WIDTH, NODE_HEIGHT, computeNodePosition, buildConnectionAnchors } from './specialization-tree/layout.mjs'
 import { logger } from '../utils/logger.mjs'
 
@@ -34,6 +40,40 @@ const ACTION_KEYS = Object.freeze({
 })
 
 const MIN_VIEWPORT_SIZE = 320
+const STATE_PICTOGRAM_TEXTURE_CACHE = new Map()
+
+/**
+ * Load the SVG pictogram texture for a node state.
+ * @param {string|null|undefined} state
+ * @returns {Promise<PIXI.Texture|null>}
+ */
+export async function loadStatePictogram(state) {
+  const iconPath = NODE_STATE_SVG_ICONS[state] ?? NODE_STATE_SVG_ICONS[NODE_STATE.INVALID]
+  if (!iconPath) return null
+
+  if (STATE_PICTOGRAM_TEXTURE_CACHE.has(iconPath)) {
+    return STATE_PICTOGRAM_TEXTURE_CACHE.get(iconPath)
+  }
+
+  let texturePromise
+
+  if (PIXI.Assets?.load) {
+    texturePromise = PIXI.Assets.load(iconPath)
+  } else if (PIXI.Texture?.from) {
+    texturePromise = Promise.resolve(PIXI.Texture.from(iconPath))
+  } else {
+    texturePromise = Promise.resolve(null)
+  }
+
+  STATE_PICTOGRAM_TEXTURE_CACHE.set(iconPath, texturePromise)
+
+  try {
+    return await texturePromise
+  } catch (error) {
+    STATE_PICTOGRAM_TEXTURE_CACHE.delete(iconPath)
+    throw error
+  }
+}
 
 /**
  * Compute the viewport size from a host element.
@@ -405,10 +445,10 @@ export default class SpecializationTreeApp extends api.HandlebarsApplicationMixi
   /** @override */
   async _onRender(context, options) {
     await super._onRender?.(context, options)
-    this.#syncViewport(context, options)
+    await this.#syncViewport(context, options)
   }
 
-  #syncViewport(context, options = {}) {
+  async #syncViewport(context, options = {}) {
     const viewportHost = this.#getViewportHost()
     if (!viewportHost) {
       this.#teardownViewport()
@@ -432,7 +472,7 @@ export default class SpecializationTreeApp extends api.HandlebarsApplicationMixi
       this.#centerTree(context)
     }
 
-    this.#drawTree(context)
+    await this.#drawTree(context)
 
     requestAnimationFrame(() => {
       this.#resizeViewport()
@@ -687,7 +727,7 @@ export default class SpecializationTreeApp extends api.HandlebarsApplicationMixi
     this.#lastPointerPosition = null
   }
 
-  #drawTree(context) {
+  async #drawTree(context) {
     if (!this.pixiApp) return
 
     if (this.#treeContainer) {
@@ -721,7 +761,7 @@ export default class SpecializationTreeApp extends api.HandlebarsApplicationMixi
     if (renderNodes.length > 0) {
       const bg = new PIXI.Graphics()
       for (const node of renderNodes) {
-        const v = node.variant ?? NODE_STATE_VARIANTS[NODE_STATE.AVAILABLE]
+        const v = node.variant ?? NODE_STATE_VARIANTS[NODE_STATE.AVAILABLE].passive
         bg.beginFill(v.fillColor, v.alpha)
         bg.lineStyle(v.borderWidth, v.borderColor, v.alpha)
         bg.drawRoundedRect(node.x, node.y, NODE_WIDTH, NODE_HEIGHT, 4)
@@ -730,7 +770,7 @@ export default class SpecializationTreeApp extends api.HandlebarsApplicationMixi
       this.#treeContainer.addChild(bg)
 
       for (const node of renderNodes) {
-        const v = node.variant ?? NODE_STATE_VARIANTS[NODE_STATE.AVAILABLE]
+        const v = node.variant ?? NODE_STATE_VARIANTS[NODE_STATE.AVAILABLE].passive
 
         // Type indicator (active/passive icon) — top-left corner
         const typeIcon = node.nodeTypeIcon ?? ''
@@ -753,28 +793,54 @@ export default class SpecializationTreeApp extends api.HandlebarsApplicationMixi
           wordWrap: true,
           wordWrapWidth: NODE_WIDTH - nameOffsetX - 4,
         })
+        nameText.alpha = v.textAlpha ?? 1
         nameText.x = node.x + nameOffsetX
         nameText.y = node.y + 4
         this.#treeContainer.addChild(nameText)
 
-        const costText = new PIXI.Text(`${node.xpCost} XP`, {
+        const costLabel = `${node.xpCost} XP`
+        let costTextX = node.x + 4
+        const costText = new PIXI.Text(costLabel, {
           fontFamily: 'Arial',
           fontSize: 9,
           fill: v.costColor,
         })
-        costText.x = node.x + 4
-        costText.y = node.y + NODE_HEIGHT - 14
+        costText.alpha = v.costAlpha ?? 1
+
+        if (v.costDisplay === 'badge') {
+          const badgePaddingX = 5
+          const badgePaddingY = 2
+          const badgeX = node.x + 4
+          const badgeY = node.y + NODE_HEIGHT - 17
+          const badgeWidth = costText.width + badgePaddingX * 2
+          const badgeHeight = costText.height + badgePaddingY * 2
+          const badge = new PIXI.Graphics()
+          badge.beginFill(v.costBadgeFillColor ?? 0x333333, 1)
+          badge.lineStyle(1, v.costBadgeBorderColor ?? v.borderColor, 1)
+          badge.drawRoundedRect(badgeX, badgeY, badgeWidth, badgeHeight, 6)
+          badge.endFill()
+          this.#treeContainer.addChild(badge)
+
+          costTextX = badgeX + badgePaddingX
+          costText.y = badgeY + badgePaddingY
+        }
+
+        costText.x = costTextX
+        if (v.costDisplay !== 'badge') {
+          costText.y = node.y + NODE_HEIGHT - 14
+        }
         this.#treeContainer.addChild(costText)
 
-        // State pictogram — bottom-right corner (non-color signal)
-        if (v.pictogram) {
+        const hasRenderedSvgPictogram = await this.#drawStatePictogramSprite(node)
+
+        if (!hasRenderedSvgPictogram && v.pictogram) {
           const pictogramText = new PIXI.Text(v.pictogram, {
             fontFamily: 'Arial',
             fontSize: 10,
             fill: v.pictogramColor,
           })
-          pictogramText.x = node.x + NODE_WIDTH - pictogramText.width - 4
-          pictogramText.y = node.y + NODE_HEIGHT - 14
+          pictogramText.x = node.x + NODE_WIDTH - pictogramText.width - 6
+          pictogramText.y = node.y + 4
           this.#treeContainer.addChild(pictogramText)
         }
 
@@ -809,6 +875,30 @@ export default class SpecializationTreeApp extends api.HandlebarsApplicationMixi
         })
         this.#treeContainer.addChild(hitArea)
       }
+    }
+  }
+
+  async #drawStatePictogramSprite(node) {
+    if (!this.#treeContainer || !PIXI.Sprite) return false
+
+    try {
+      const texture = await loadStatePictogram(node?.nodeState)
+      if (!texture) return false
+
+      const sprite = new PIXI.Sprite(texture)
+      sprite.x = node.x + NODE_WIDTH - 20
+      sprite.y = node.y + 4
+      sprite.width = 16
+      sprite.height = 16
+      sprite.tint = 0xffffff
+      this.#treeContainer.addChild(sprite)
+      return true
+    } catch (error) {
+      logger.warn('[SpecializationTreeApp] Failed to load node state pictogram, falling back to Unicode glyph', {
+        state: node?.nodeState,
+        error,
+      })
+      return false
     }
   }
 

--- a/module/applications/specialization-tree/node-ui-state.mjs
+++ b/module/applications/specialization-tree/node-ui-state.mjs
@@ -3,7 +3,8 @@
  * @description Pure UI mapper for specialization tree node states and reason codes.
  *
  * Centralises the mapping between business-level `nodeState` / `reasonCode`
- * and their UI representations: i18n label keys, visual variant descriptors.
+ * and their UI representations: i18n label keys, visual variant descriptors,
+ * pictograms, and active/passive indicators.
  *
  * This module has Zero dependency on `game`, `ui`, `canvas`, PIXI, or Foundry.
  * The `localize` callback must be injected at call site.
@@ -12,6 +13,23 @@
 import { NODE_STATE, REASON_CODE } from '../../lib/talent-node/talent-node-state.mjs'
 
 export { NODE_STATE, REASON_CODE }
+
+/* ── Node type constants ───────────────────────────────────────── */
+
+/** @enum {string} Talent activation type. */
+export const NODE_TYPE = Object.freeze({
+  ACTIVE: 'active',
+  PASSIVE: 'passive',
+})
+
+/**
+ * Determine the node type from the talent's isActive flag.
+ * @param {boolean|undefined|null} isActive
+ * @returns {string} `NODE_TYPE.ACTIVE` or `NODE_TYPE.PASSIVE`.
+ */
+export function resolveNodeType(isActive) {
+  return isActive ? NODE_TYPE.ACTIVE : NODE_TYPE.PASSIVE
+}
 
 /* ── i18n label key tables ─────────────────────────────────────── */
 
@@ -45,13 +63,18 @@ export const REASON_LABEL_DEFAULT = 'SWERPG.TALENT.SPECIALIZATION_TREE_APP.REASO
 /**
  * Per-state visual descriptors consumed by the PIXI renderer.
  *
+ * Each variant carries a `pictogram` — a non-color signal that makes the
+ * node state identifiable without relying only on colour perception.
+ *
  * @typedef {Object} NodeVariant
- * @property {number} fillColor   - Background colour (hex integer).
- * @property {number} borderColor - Border colour (hex integer).
- * @property {number} borderWidth - Border thickness in pixels.
- * @property {number} alpha       - Overall node opacity.
- * @property {number} textColor   - Talent name colour.
- * @property {number} costColor   - XP cost colour.
+ * @property {number} fillColor      - Background colour (hex integer).
+ * @property {number} borderColor    - Border colour (hex integer).
+ * @property {number} borderWidth    - Border thickness in pixels.
+ * @property {number} alpha          - Overall node opacity.
+ * @property {number} textColor      - Talent name colour.
+ * @property {number} costColor      - XP cost colour.
+ * @property {string} pictogram      - Non-color state signal (rendered on the node card).
+ * @property {number} pictogramColor - Colour for the pictogram glyph.
  */
 
 /** @type {Readonly<Record<string, NodeVariant>>} */
@@ -63,6 +86,8 @@ export const NODE_STATE_VARIANTS = Object.freeze({
     alpha: 1,
     textColor: 0xcccccc,
     costColor: 0x88bb88,
+    pictogram: '\u25C9',
+    pictogramColor: 0x4a9a6a,
   }),
   [NODE_STATE.AVAILABLE]: Object.freeze({
     fillColor: 0x1a2c44,
@@ -71,14 +96,18 @@ export const NODE_STATE_VARIANTS = Object.freeze({
     alpha: 1,
     textColor: 0xffffff,
     costColor: 0xcccccc,
+    pictogram: '\u25C7',
+    pictogramColor: 0x78a9c2,
   }),
   [NODE_STATE.LOCKED]: Object.freeze({
     fillColor: 0x222222,
     borderColor: 0x555555,
     borderWidth: 1,
-    alpha: 0.7,
+    alpha: 0.85,
     textColor: 0x888888,
     costColor: 0x666666,
+    pictogram: '\u2014',
+    pictogramColor: 0x555555,
   }),
   [NODE_STATE.INVALID]: Object.freeze({
     fillColor: 0x3a1a1a,
@@ -87,6 +116,35 @@ export const NODE_STATE_VARIANTS = Object.freeze({
     alpha: 1,
     textColor: 0xaaaaaa,
     costColor: 0xaa6666,
+    pictogram: '\u25B2',
+    pictogramColor: 0x8a3333,
+  }),
+})
+
+/* ── Active/passive type indicators ─────────────────────────────── */
+
+/**
+ * Active/passive type indicators rendered on each node card.
+ * These are non-color visual cues that distinguish active talents
+ * from passive ones.
+ *
+ * @typedef {Object} NodeTypeIndicator
+ * @property {string} icon  - Pictogram for the talent type.
+ * @property {string} label - Short label (unused in rendering, available for tooltip).
+ */
+
+/**
+ * Per-type indicator descriptors consumed by the PIXI renderer.
+ * @type {Readonly<Record<string, NodeTypeIndicator>>}
+ */
+export const NODE_TYPE_INDICATORS = Object.freeze({
+  [NODE_TYPE.ACTIVE]: Object.freeze({
+    icon: '\u26A1',
+    label: 'Active',
+  }),
+  [NODE_TYPE.PASSIVE]: Object.freeze({
+    icon: '\u25CB',
+    label: 'Passive',
   }),
 })
 
@@ -118,6 +176,8 @@ export function getReasonLabelKey(reasonCode) {
  *   - `reasonCode`    – Reason code (or `null`).
  *   - `reasonLabel`   – Localised reason label (or `null` when no reason).
  *   - `variant`       – Visual variant descriptor for the state.
+ *   - `nodeType`      – `'active'` or `'passive'`.
+ *   - `nodeTypeIcon`  – Type indicator icon string.
  */
 export function enrichNode(node, stateResult, localize) {
   const state = stateResult?.state ?? NODE_STATE.INVALID
@@ -129,6 +189,9 @@ export function enrichNode(node, stateResult, localize) {
 
   const variant = NODE_STATE_VARIANTS[state] ?? NODE_STATE_VARIANTS[NODE_STATE.INVALID]
 
+  const nodeType = resolveNodeType(node.isActive)
+  const typeIndicator = NODE_TYPE_INDICATORS[nodeType] ?? NODE_TYPE_INDICATORS[NODE_TYPE.PASSIVE]
+
   return {
     ...node,
     nodeState: state,
@@ -136,5 +199,7 @@ export function enrichNode(node, stateResult, localize) {
     reasonCode,
     reasonLabel,
     variant,
+    nodeType,
+    nodeTypeIcon: typeIndicator.icon,
   }
 }

--- a/module/applications/specialization-tree/node-ui-state.mjs
+++ b/module/applications/specialization-tree/node-ui-state.mjs
@@ -72,53 +72,168 @@ export const REASON_LABEL_DEFAULT = 'SWERPG.TALENT.SPECIALIZATION_TREE_APP.REASO
  * @property {number} borderWidth    - Border thickness in pixels.
  * @property {number} alpha          - Overall node opacity.
  * @property {number} textColor      - Talent name colour.
+ * @property {number} textAlpha      - Talent name opacity.
  * @property {number} costColor      - XP cost colour.
+ * @property {number} costAlpha      - XP cost opacity.
+ * @property {'badge'|'secondary'|'plain'} costDisplay - XP cost presentation mode.
+ * @property {number|null} costBadgeFillColor - Badge background colour when `costDisplay` is `badge`.
+ * @property {number|null} costBadgeBorderColor - Badge border colour when `costDisplay` is `badge`.
  * @property {string} pictogram      - Non-color state signal (rendered on the node card).
  * @property {number} pictogramColor - Colour for the pictogram glyph.
  */
 
-/** @type {Readonly<Record<string, NodeVariant>>} */
-export const NODE_STATE_VARIANTS = Object.freeze({
+const PASSIVE_NODE_VARIANTS = Object.freeze({
   [NODE_STATE.PURCHASED]: Object.freeze({
-    fillColor: 0x1a3a2a,
-    borderColor: 0x4a9a6a,
-    borderWidth: 2,
-    alpha: 1,
-    textColor: 0xcccccc,
-    costColor: 0x88bb88,
-    pictogram: '\u25C9',
-    pictogramColor: 0x4a9a6a,
-  }),
-  [NODE_STATE.AVAILABLE]: Object.freeze({
-    fillColor: 0x1a2c44,
-    borderColor: 0x78a9c2,
+    fillColor: 0x1f4f8c,
+    borderColor: 0x95c9ff,
     borderWidth: 2,
     alpha: 1,
     textColor: 0xffffff,
-    costColor: 0xcccccc,
-    pictogram: '\u25C7',
-    pictogramColor: 0x78a9c2,
+    textAlpha: 1,
+    costColor: 0xb9d9ff,
+    costAlpha: 0.72,
+    costDisplay: 'secondary',
+    costBadgeFillColor: null,
+    costBadgeBorderColor: null,
+    pictogram: '\u25C9',
+    pictogramColor: 0x95c9ff,
   }),
-  [NODE_STATE.LOCKED]: Object.freeze({
-    fillColor: 0x222222,
-    borderColor: 0x555555,
-    borderWidth: 1,
-    alpha: 0.85,
-    textColor: 0x888888,
-    costColor: 0x666666,
-    pictogram: '\u2014',
-    pictogramColor: 0x555555,
-  }),
-  [NODE_STATE.INVALID]: Object.freeze({
-    fillColor: 0x3a1a1a,
-    borderColor: 0x8a3333,
+  [NODE_STATE.AVAILABLE]: Object.freeze({
+    fillColor: 0x21344d,
+    borderColor: 0x5f85ad,
     borderWidth: 2,
     alpha: 1,
-    textColor: 0xaaaaaa,
-    costColor: 0xaa6666,
-    pictogram: '\u25B2',
-    pictogramColor: 0x8a3333,
+    textColor: 0xf5f9ff,
+    textAlpha: 1,
+    costColor: 0xffffff,
+    costAlpha: 1,
+    costDisplay: 'badge',
+    costBadgeFillColor: 0x355a84,
+    costBadgeBorderColor: 0x8cb8e8,
+    pictogram: '\u25C7',
+    pictogramColor: 0x8cb8e8,
   }),
+  [NODE_STATE.LOCKED]: Object.freeze({
+    fillColor: 0x1f2630,
+    borderColor: 0x7a7a7a,
+    borderWidth: 2,
+    alpha: 1,
+    textColor: 0xd7dbe2,
+    textAlpha: 0.68,
+    costColor: 0x999999,
+    costAlpha: 1,
+    costDisplay: 'plain',
+    costBadgeFillColor: null,
+    costBadgeBorderColor: null,
+    pictogram: '\u2014',
+    pictogramColor: 0x9a9a9a,
+  }),
+  [NODE_STATE.INVALID]: Object.freeze({
+    fillColor: 0x2b1f28,
+    borderColor: 0x7c4e5a,
+    borderWidth: 2,
+    alpha: 1,
+    textColor: 0xf1dfe4,
+    textAlpha: 1,
+    costColor: 0xf1dfe4,
+    costAlpha: 1,
+    costDisplay: 'plain',
+    costBadgeFillColor: null,
+    costBadgeBorderColor: null,
+    pictogram: '\u25B2',
+    pictogramColor: 0xb86f82,
+  }),
+})
+
+const ACTIVE_NODE_VARIANTS = Object.freeze({
+  [NODE_STATE.PURCHASED]: Object.freeze({
+    fillColor: 0x7a2323,
+    borderColor: 0xffa2a2,
+    borderWidth: 2,
+    alpha: 1,
+    textColor: 0xfff7f7,
+    textAlpha: 1,
+    costColor: 0xffc7c7,
+    costAlpha: 0.72,
+    costDisplay: 'secondary',
+    costBadgeFillColor: null,
+    costBadgeBorderColor: null,
+    pictogram: '\u25C9',
+    pictogramColor: 0xffb3b3,
+  }),
+  [NODE_STATE.AVAILABLE]: Object.freeze({
+    fillColor: 0x4d2525,
+    borderColor: 0xb87676,
+    borderWidth: 2,
+    alpha: 1,
+    textColor: 0xfff5f5,
+    textAlpha: 1,
+    costColor: 0xffffff,
+    costAlpha: 1,
+    costDisplay: 'badge',
+    costBadgeFillColor: 0x7a3e3e,
+    costBadgeBorderColor: 0xd9a0a0,
+    pictogram: '\u25C7',
+    pictogramColor: 0xd9a0a0,
+  }),
+  [NODE_STATE.LOCKED]: Object.freeze({
+    fillColor: 0x302020,
+    borderColor: 0x7a7a7a,
+    borderWidth: 2,
+    alpha: 1,
+    textColor: 0xe2d7d7,
+    textAlpha: 0.68,
+    costColor: 0x999999,
+    costAlpha: 1,
+    costDisplay: 'plain',
+    costBadgeFillColor: null,
+    costBadgeBorderColor: null,
+    pictogram: '\u2014',
+    pictogramColor: 0x9a9a9a,
+  }),
+  [NODE_STATE.INVALID]: Object.freeze({
+    fillColor: 0x3c1d1d,
+    borderColor: 0x8f4a4a,
+    borderWidth: 2,
+    alpha: 1,
+    textColor: 0xffe8e8,
+    textAlpha: 1,
+    costColor: 0xffe8e8,
+    costAlpha: 1,
+    costDisplay: 'plain',
+    costBadgeFillColor: null,
+    costBadgeBorderColor: null,
+    pictogram: '\u25B2',
+    pictogramColor: 0xd07b7b,
+  }),
+})
+
+/** @type {Readonly<Record<string, Readonly<Record<string, NodeVariant>>>>} */
+export const NODE_STATE_VARIANTS = Object.freeze({
+  [NODE_STATE.PURCHASED]: Object.freeze({
+    [NODE_TYPE.ACTIVE]: ACTIVE_NODE_VARIANTS[NODE_STATE.PURCHASED],
+    [NODE_TYPE.PASSIVE]: PASSIVE_NODE_VARIANTS[NODE_STATE.PURCHASED],
+  }),
+  [NODE_STATE.AVAILABLE]: Object.freeze({
+    [NODE_TYPE.ACTIVE]: ACTIVE_NODE_VARIANTS[NODE_STATE.AVAILABLE],
+    [NODE_TYPE.PASSIVE]: PASSIVE_NODE_VARIANTS[NODE_STATE.AVAILABLE],
+  }),
+  [NODE_STATE.LOCKED]: Object.freeze({
+    [NODE_TYPE.ACTIVE]: ACTIVE_NODE_VARIANTS[NODE_STATE.LOCKED],
+    [NODE_TYPE.PASSIVE]: PASSIVE_NODE_VARIANTS[NODE_STATE.LOCKED],
+  }),
+  [NODE_STATE.INVALID]: Object.freeze({
+    [NODE_TYPE.ACTIVE]: ACTIVE_NODE_VARIANTS[NODE_STATE.INVALID],
+    [NODE_TYPE.PASSIVE]: PASSIVE_NODE_VARIANTS[NODE_STATE.INVALID],
+  }),
+})
+
+/** Maps each NODE_STATE value to its fallback SVG asset path. */
+export const NODE_STATE_SVG_ICONS = Object.freeze({
+  [NODE_STATE.PURCHASED]: 'assets/images/icons/sell-card.svg',
+  [NODE_STATE.AVAILABLE]: 'assets/images/icons/buy-card.svg',
+  [NODE_STATE.LOCKED]: 'assets/images/icons/padlock.svg',
+  [NODE_STATE.INVALID]: 'assets/images/icons/hazard-sign.svg',
 })
 
 /* ── Active/passive type indicators ─────────────────────────────── */
@@ -161,6 +276,18 @@ export function getReasonLabelKey(reasonCode) {
 }
 
 /**
+ * Resolve the visual variant for a given node state and node type.
+ * @param {string|null|undefined} state
+ * @param {string|null|undefined} nodeType
+ * @returns {NodeVariant}
+ */
+export function getNodeVariant(state, nodeType) {
+  const normalizedState = NODE_STATE_VARIANTS[state] ? state : NODE_STATE.INVALID
+  const normalizedType = nodeType === NODE_TYPE.ACTIVE ? NODE_TYPE.ACTIVE : NODE_TYPE.PASSIVE
+  return NODE_STATE_VARIANTS[normalizedState][normalizedType]
+}
+
+/**
  * Enrich a bare render node with UI-ready properties derived from its business state.
  *
  * This function is ***pure***: it does not access `game.i18n`, `ui`, or any
@@ -182,15 +309,15 @@ export function getReasonLabelKey(reasonCode) {
 export function enrichNode(node, stateResult, localize) {
   const state = stateResult?.state ?? NODE_STATE.INVALID
   const reasonCode = stateResult?.reasonCode ?? null
+  const nodeType = resolveNodeType(node.isActive)
 
   const nodeStateLabel = localize(NODE_STATE_LABEL_KEYS[state] ?? NODE_STATE_LABEL_KEYS[NODE_STATE.INVALID])
 
   const reasonLabel = reasonCode ? localize(REASON_LABEL_KEYS[reasonCode] ?? REASON_LABEL_DEFAULT) : null
 
-  const variant = NODE_STATE_VARIANTS[state] ?? NODE_STATE_VARIANTS[NODE_STATE.INVALID]
-
-  const nodeType = resolveNodeType(node.isActive)
+  const variant = getNodeVariant(state, nodeType)
   const typeIndicator = NODE_TYPE_INDICATORS[nodeType] ?? NODE_TYPE_INDICATORS[NODE_TYPE.PASSIVE]
+  const nodeStateSvgIconPath = NODE_STATE_SVG_ICONS[state] ?? NODE_STATE_SVG_ICONS[NODE_STATE.INVALID]
 
   return {
     ...node,
@@ -201,5 +328,6 @@ export function enrichNode(node, stateResult, localize) {
     variant,
     nodeType,
     nodeTypeIcon: typeIndicator.icon,
+    nodeStateSvgIconPath,
   }
 }

--- a/module/applications/specialization-tree/render-view-model.mjs
+++ b/module/applications/specialization-tree/render-view-model.mjs
@@ -52,6 +52,7 @@ export function buildRenderViewModel(currentTree, talentLookup) {
       },
       /** Extra field – consumed by the app enrichment layer */
       isRanked: resolved?.isRanked ?? false,
+      isActive: resolved?.isActive ?? false,
     }
   })
 

--- a/module/importer/mappers/oggdude-talent-mapper.mjs
+++ b/module/importer/mappers/oggdude-talent-mapper.mjs
@@ -101,7 +101,9 @@ export class OggDudeTalentMapper {
       // Clé unique du talent
       const key = this.generateTalentKey(talentData)
       const name = talentData.Name || talentData.TalentName || key
-      const rawActivation = talentData.Activation || talentData.ActivationType
+      const rawActivation = [talentData.ActivationValue, talentData.Activation, talentData.ActivationType].find(
+        (value) => value != null && String(value).trim() !== '',
+      )
       const activation = resolveTalentActivation(rawActivation)
 
       // Construction du contexte avec toutes les transformations
@@ -286,7 +288,10 @@ export class OggDudeTalentMapper {
               tier: context.tier || 1,
               raw: {
                 key: context.key,
-                activation: context.originalData?.Activation || context.originalData?.ActivationType || undefined,
+                activation:
+                  [context.originalData?.ActivationValue, context.originalData?.Activation, context.originalData?.ActivationType].find(
+                    (value) => value != null && String(value).trim() !== '',
+                  ) || undefined,
                 source: context.originalData?.Source || context.originalData?.SourceBook || undefined,
               },
               importedAt: new Date().toISOString(),

--- a/module/importer/mappings/oggdude-talent-activation-map.mjs
+++ b/module/importer/mappings/oggdude-talent-activation-map.mjs
@@ -1,45 +1,26 @@
 /**
- * Mapping des codes d'activation OggDude vers les valeurs système TALENT_ACTIVATION
+ * Mapping des codes d'activation OggDude vers les valeurs système TALENT_ACTIVATION.
+ * Le modèle talent SWERPG ne distingue que `passive`, `active` et `unspecified`.
  */
-
-import { addTalentUnknownActivation } from '../utils/talent-import-utils.mjs'
-
-// Dans les tests on mocke SYSTEM.TALENT_ACTIVATION comme simples chaînes.
-// Ici on renvoie donc directement les codes systèmes attendus par les TUs, sans normaliser sur "active".
 
 /**
  * Table de correspondance entre codes OggDude et activations système
  */
 export const TALENT_ACTIVATION_MAP = Object.freeze({
-  // Valeurs courantes dans OggDude
   passive: 'passive',
-  Passive: 'passive',
-  PASSIVE: 'passive',
-
+  tapassive: 'passive',
   active: 'active',
-  Active: 'active',
-  ACTIVE: 'active',
-
-  // Variations possibles
-  incidental: 'incidental',
-  Incidental: 'incidental',
-  INCIDENTAL: 'incidental',
-
-  maneuver: 'maneuver',
-  Maneuver: 'maneuver',
-  MANEUVER: 'maneuver',
-
-  action: 'action',
-  Action: 'action',
-  ACTION: 'action',
-  reaction: 'reaction',
-  Reaction: 'reaction',
-  REACTION: 'reaction',
-
-  // Fallback par défaut (vide ou undefined) vers la valeur neutre
+  taactive: 'active',
+  incidental: 'active',
+  taincidental: 'active',
+  taincidentaloot: 'active',
+  maneuver: 'active',
+  tamaneuver: 'active',
+  action: 'active',
+  taaction: 'active',
+  reaction: 'active',
+  tareaction: 'active',
   '': 'unspecified',
-  undefined: 'unspecified',
-  null: 'unspecified',
 })
 
 /**
@@ -48,28 +29,15 @@ export const TALENT_ACTIVATION_MAP = Object.freeze({
  * @returns {string} ID de l'activation système correspondante
  */
 export function resolveTalentActivation(oggDudeCode) {
-  // Nettoyer l'entrée
-  const cleanCode = String(oggDudeCode || '').trim()
+  const cleanCode = String(oggDudeCode ?? '').trim()
+  const normalizedCode = cleanCode.toLowerCase()
 
-  // Recherche directe dans la table
-  if (cleanCode in TALENT_ACTIVATION_MAP) {
-    return TALENT_ACTIVATION_MAP[cleanCode]
+  if (normalizedCode in TALENT_ACTIVATION_MAP) {
+    return TALENT_ACTIVATION_MAP[normalizedCode]
   }
 
-  // Recherche insensible à la casse
-  const lowerCode = cleanCode.toLowerCase()
-  const foundEntry = Object.entries(TALENT_ACTIVATION_MAP).find(([key]) => key.toLowerCase() === lowerCode)
-
-  if (foundEntry) {
-    return foundEntry[1]
-  }
-
-  // Code inconnu - enregistrer pour statistiques et utiliser fallback
-  if (cleanCode !== '') {
-    addTalentUnknownActivation(cleanCode)
-  }
-
-  return 'unspecified' // Valeur neutre pour code inconnu
+  // Contrat OggDude réel: `taPassive` est passif, toute autre valeur non vide est active.
+  return cleanCode === '' ? 'unspecified' : 'active'
 }
 
 /**
@@ -77,7 +45,7 @@ export function resolveTalentActivation(oggDudeCode) {
  * @returns {string[]} Liste des codes supportés
  */
 export function getSupportedTalentActivationCodes() {
-  return Object.keys(TALENT_ACTIVATION_MAP)
+  return Object.keys(TALENT_ACTIVATION_MAP).filter(Boolean)
 }
 
 /**
@@ -87,5 +55,5 @@ export function getSupportedTalentActivationCodes() {
  */
 export function isTalentActivationSupported(code) {
   const cleanCode = String(code || '').trim()
-  return cleanCode in TALENT_ACTIVATION_MAP || getSupportedTalentActivationCodes().some((key) => key.toLowerCase() === cleanCode.toLowerCase())
+  return cleanCode === '' || typeof code === 'string'
 }

--- a/module/lib/talent-node/talent-reference-resolver.mjs
+++ b/module/lib/talent-node/talent-reference-resolver.mjs
@@ -4,7 +4,7 @@ import { logger } from '../../utils/logger.mjs'
  * @typedef {Object} TalentDetail
  * @property {string} name - The resolved talent name (localized unknown fallback if unresolved).
  * @property {boolean} isRanked - Whether the talent is ranked.
- * @property {boolean} isActive - Whether the talent has an activation cost (active vs passive).
+ * @property {boolean} isActive - Whether the talent activation is 'active' (true) vs passive or other (false).
  */
 
 /**
@@ -22,6 +22,10 @@ import { logger } from '../../utils/logger.mjs'
  * @param {string} normalizedKey - Lowercase trimmed key to search for.
  * @returns {{ name: string, isRanked: boolean, isActive: boolean }|null}
  */
+function isTalentActivationActive(activation) {
+  return typeof activation === 'string' && activation.trim().toLowerCase() === 'active'
+}
+
 function resolveTalentByBusinessKey(normalizedKey) {
   if (typeof game !== 'undefined' && game.items) {
     for (const item of game.items) {
@@ -29,12 +33,12 @@ function resolveTalentByBusinessKey(normalizedKey) {
 
       const id = item.system?.id
       if (id && typeof id === 'string' && id.toLowerCase().trim() === normalizedKey) {
-        return { name: item.name, isRanked: item.system?.isRanked ?? false, isActive: !!item.system?.activation }
+        return { name: item.name, isRanked: item.system?.isRanked ?? false, isActive: isTalentActivationActive(item.system?.activation) }
       }
 
       const oggKey = item.getFlag?.('swerpg', 'oggdudeKey')
       if (oggKey && typeof oggKey === 'string' && oggKey.toLowerCase().trim() === normalizedKey) {
-        return { name: item.name, isRanked: item.system?.isRanked ?? false, isActive: !!item.system?.activation }
+        return { name: item.name, isRanked: item.system?.isRanked ?? false, isActive: isTalentActivationActive(item.system?.activation) }
       }
     }
   }
@@ -49,12 +53,12 @@ function resolveTalentByBusinessKey(normalizedKey) {
 
         const systemId = entry.system?.id
         if (systemId && typeof systemId === 'string' && systemId.toLowerCase().trim() === normalizedKey) {
-          return { name: entry.name, isRanked: entry.system?.isRanked ?? false, isActive: !!entry.system?.activation }
+          return { name: entry.name, isRanked: entry.system?.isRanked ?? false, isActive: isTalentActivationActive(entry.system?.activation) }
         }
 
         const oggKey = entry.flags?.swerpg?.oggdudeKey
         if (oggKey && typeof oggKey === 'string' && oggKey.toLowerCase().trim() === normalizedKey) {
-          return { name: entry.name, isRanked: entry.system?.isRanked ?? false, isActive: !!entry.system?.activation }
+          return { name: entry.name, isRanked: entry.system?.isRanked ?? false, isActive: isTalentActivationActive(entry.system?.activation) }
         }
       }
     }
@@ -87,7 +91,7 @@ export function resolveTalentDetail(nodeRef) {
         return {
           name: item.name ?? unknown,
           isRanked: item.system?.isRanked ?? false,
-          isActive: !!item.system?.activation,
+          isActive: isTalentActivationActive(item.system?.activation),
         }
       }
     } catch {
@@ -138,7 +142,7 @@ export function buildTalentDefinitionsMap() {
       name: item.name,
       activation: item.system?.activation,
       isRanked: item.system?.isRanked,
-      isActive: !!item.system?.activation,
+      isActive: isTalentActivationActive(item.system?.activation),
     }
 
     // Index by UUID for talentUuid matching

--- a/module/lib/talent-node/talent-reference-resolver.mjs
+++ b/module/lib/talent-node/talent-reference-resolver.mjs
@@ -4,6 +4,7 @@ import { logger } from '../../utils/logger.mjs'
  * @typedef {Object} TalentDetail
  * @property {string} name - The resolved talent name (localized unknown fallback if unresolved).
  * @property {boolean} isRanked - Whether the talent is ranked.
+ * @property {boolean} isActive - Whether the talent has an activation cost (active vs passive).
  */
 
 /**
@@ -11,6 +12,7 @@ import { logger } from '../../utils/logger.mjs'
  * @property {string} name
  * @property {string} [activation]
  * @property {boolean} [isRanked]
+ * @property {boolean} [isActive]
  */
 
 /**
@@ -18,7 +20,7 @@ import { logger } from '../../utils/logger.mjs'
  * Searches game.items first, then falls back to compendium pack indexes.
  *
  * @param {string} normalizedKey - Lowercase trimmed key to search for.
- * @returns {{ name: string, isRanked: boolean }|null}
+ * @returns {{ name: string, isRanked: boolean, isActive: boolean }|null}
  */
 function resolveTalentByBusinessKey(normalizedKey) {
   if (typeof game !== 'undefined' && game.items) {
@@ -27,12 +29,12 @@ function resolveTalentByBusinessKey(normalizedKey) {
 
       const id = item.system?.id
       if (id && typeof id === 'string' && id.toLowerCase().trim() === normalizedKey) {
-        return { name: item.name, isRanked: item.system?.isRanked ?? false }
+        return { name: item.name, isRanked: item.system?.isRanked ?? false, isActive: !!item.system?.activation }
       }
 
       const oggKey = item.getFlag?.('swerpg', 'oggdudeKey')
       if (oggKey && typeof oggKey === 'string' && oggKey.toLowerCase().trim() === normalizedKey) {
-        return { name: item.name, isRanked: item.system?.isRanked ?? false }
+        return { name: item.name, isRanked: item.system?.isRanked ?? false, isActive: !!item.system?.activation }
       }
     }
   }
@@ -47,12 +49,12 @@ function resolveTalentByBusinessKey(normalizedKey) {
 
         const systemId = entry.system?.id
         if (systemId && typeof systemId === 'string' && systemId.toLowerCase().trim() === normalizedKey) {
-          return { name: entry.name, isRanked: entry.system?.isRanked ?? false }
+          return { name: entry.name, isRanked: entry.system?.isRanked ?? false, isActive: !!entry.system?.activation }
         }
 
         const oggKey = entry.flags?.swerpg?.oggdudeKey
         if (oggKey && typeof oggKey === 'string' && oggKey.toLowerCase().trim() === normalizedKey) {
-          return { name: entry.name, isRanked: entry.system?.isRanked ?? false }
+          return { name: entry.name, isRanked: entry.system?.isRanked ?? false, isActive: !!entry.system?.activation }
         }
       }
     }
@@ -85,6 +87,7 @@ export function resolveTalentDetail(nodeRef) {
         return {
           name: item.name ?? unknown,
           isRanked: item.system?.isRanked ?? false,
+          isActive: !!item.system?.activation,
         }
       }
     } catch {
@@ -98,11 +101,12 @@ export function resolveTalentDetail(nodeRef) {
       return {
         name: matched.name ?? unknown,
         isRanked: matched.isRanked ?? false,
+        isActive: matched.isActive ?? false,
       }
     }
   }
 
-  return { name: unknown, isRanked: false }
+  return { name: unknown, isRanked: false, isActive: false }
 }
 
 /**
@@ -134,6 +138,7 @@ export function buildTalentDefinitionsMap() {
       name: item.name,
       activation: item.system?.activation,
       isRanked: item.system?.isRanked,
+      isActive: !!item.system?.activation,
     }
 
     // Index by UUID for talentUuid matching

--- a/module/models/talent.mjs
+++ b/module/models/talent.mjs
@@ -23,7 +23,7 @@ const DEPR_TALENT_POINTS = () => SYSTEM.DEPRECATION.crucible.talentPoints
  * @property {string} description
  * @property {boolean} isRanked
  * @property {Rank} rank
- * @property {boolean} active
+ * @property {string} activation
  * @property {SwerpgSpecialization[]} [trees]  @deprecated V1 Edge legacy — do not use for V1. Use specialization-tree items to access tree membership.
  * @property {SwerpgAction[]} actions   The actions which have been unlocked by this talent
  * @property {number} iconicSpells

--- a/tests/applications/sheets/character-sheet-talents.test.mjs
+++ b/tests/applications/sheets/character-sheet-talents.test.mjs
@@ -383,16 +383,31 @@ describe('CharacterSheet talent consolidation (US12)', () => {
       name: 'Grit',
       activation: 'passive',
       isRanked: true,
+      isActive: true,
     })
     expect(capturedDefinitions.get('Item.def456')).toEqual({
       name: 'Old Talent',
       activation: 'active',
       isRanked: false,
+      isActive: true,
     })
     expect(capturedDefinitions.get('Item.ghi789')).toEqual({
       name: 'Willpower',
       activation: 'passive',
       isRanked: true,
+      isActive: true,
+    })
+    expect(capturedDefinitions.get('Item.def456')).toEqual({
+      name: 'Old Talent',
+      activation: 'active',
+      isRanked: false,
+      isActive: true,
+    })
+    expect(capturedDefinitions.get('Item.ghi789')).toEqual({
+      name: 'Willpower',
+      activation: 'passive',
+      isRanked: true,
+      isActive: true,
     })
     expect(capturedDefinitions.size).toBe(3)
   })

--- a/tests/applications/sheets/character-sheet-talents.test.mjs
+++ b/tests/applications/sheets/character-sheet-talents.test.mjs
@@ -383,7 +383,7 @@ describe('CharacterSheet talent consolidation (US12)', () => {
       name: 'Grit',
       activation: 'passive',
       isRanked: true,
-      isActive: true,
+      isActive: false,
     })
     expect(capturedDefinitions.get('Item.def456')).toEqual({
       name: 'Old Talent',
@@ -395,7 +395,7 @@ describe('CharacterSheet talent consolidation (US12)', () => {
       name: 'Willpower',
       activation: 'passive',
       isRanked: true,
-      isActive: true,
+      isActive: false,
     })
     expect(capturedDefinitions.get('Item.def456')).toEqual({
       name: 'Old Talent',
@@ -407,7 +407,7 @@ describe('CharacterSheet talent consolidation (US12)', () => {
       name: 'Willpower',
       activation: 'passive',
       isRanked: true,
-      isActive: true,
+      isActive: false,
     })
     expect(capturedDefinitions.size).toBe(3)
   })

--- a/tests/applications/specialization-tree-app.test.mjs
+++ b/tests/applications/specialization-tree-app.test.mjs
@@ -1092,6 +1092,159 @@ describe('specialization-tree application', () => {
     expect(nonRankedTexts, 'Grit text must be present').toHaveLength(1)
   })
 
+  it('renders state pictogram on every node card', async () => {
+    const actor = createActor({
+      system: {
+        details: {
+          specializations: [{ specializationId: 'spec-bodyguard', name: 'Bodyguard', treeUuid: 'Item.tree-bodyguard' }],
+        },
+        progression: {
+          talentPurchases: [],
+          experience: { available: 100 },
+        },
+      },
+    })
+    globalThis.fromUuidSync = vi.fn((uuid) => {
+      if (uuid === 'Item.tree-bodyguard') {
+        return {
+          type: 'specialization-tree',
+          name: 'Bodyguard Tree',
+          system: {
+            nodes: [
+              { nodeId: 'r1c1', talentId: 'Item.talent-tough', talentUuid: 'Item.talent-tough', row: 1, column: 1, cost: 10 },
+            ],
+            connections: [{ from: 'r1c1', to: 'r2c1' }],
+          },
+        }
+      }
+      if (uuid === 'Item.talent-tough') return { name: 'Tough', system: { isRanked: false } }
+      return null
+    })
+
+    const app = new SpecializationTreeApp()
+    app.actor = actor
+    app.document = actor
+    const host = createMockHost({ width: 640, height: 480 })
+    app.element = { querySelector: vi.fn(() => host) }
+
+    const context = buildSpecializationTreeContext(actor)
+    await app._onRender(context, {})
+
+    const treeContainer = app.pixiApp.stage.children.find((c) => c.position && c.scale)
+    expect(treeContainer, 'tree container must exist').toBeDefined()
+
+    const node = context.renderNodes[0]
+    const pictogram = node.variant.pictogram
+    expect(pictogram, 'node variant must have a pictogram').toBeTruthy()
+
+    const pictogramTexts = treeContainer.children.filter(
+      (c) => c.constructor.name === 'MockText' && c.text === pictogram,
+    )
+    expect(pictogramTexts.length, 'state pictogram must appear on the node card').toBeGreaterThanOrEqual(1)
+  })
+
+  it('renders type indicator icon for passive talents by default', async () => {
+    const actor = createActor({
+      system: {
+        details: {
+          specializations: [{ specializationId: 'spec-bodyguard', name: 'Bodyguard', treeUuid: 'Item.tree-bodyguard' }],
+        },
+        progression: {
+          talentPurchases: [],
+          experience: { available: 100 },
+        },
+      },
+    })
+    globalThis.fromUuidSync = vi.fn((uuid) => {
+      if (uuid === 'Item.tree-bodyguard') {
+        return {
+          type: 'specialization-tree',
+          name: 'Bodyguard Tree',
+          system: {
+            nodes: [
+              { nodeId: 'r1c1', talentId: 'Item.talent-tough', talentUuid: 'Item.talent-tough', row: 1, column: 1, cost: 10 },
+            ],
+            connections: [{ from: 'r1c1', to: 'r2c1' }],
+          },
+        }
+      }
+      if (uuid === 'Item.talent-tough') return { name: 'Tough', system: { isRanked: false } }
+      return null
+    })
+
+    const app = new SpecializationTreeApp()
+    app.actor = actor
+    app.document = actor
+    const host = createMockHost({ width: 640, height: 480 })
+    app.element = { querySelector: vi.fn(() => host) }
+
+    const context = buildSpecializationTreeContext(actor)
+    await app._onRender(context, {})
+
+    const treeContainer = app.pixiApp.stage.children.find((c) => c.position && c.scale)
+    expect(treeContainer, 'tree container must exist').toBeDefined()
+
+    const node = context.renderNodes[0]
+    const expectedIcon = node.nodeTypeIcon
+    expect(expectedIcon, 'node must have a type icon').toBeTruthy()
+
+    const typeTexts = treeContainer.children.filter(
+      (c) => c.constructor.name === 'MockText' && c.text === expectedIcon,
+    )
+    expect(typeTexts.length, 'type indicator icon must be rendered on the node card').toBeGreaterThanOrEqual(1)
+  })
+
+  it('renders type indicator icon for active talents', async () => {
+    const actor = createActor({
+      system: {
+        details: {
+          specializations: [{ specializationId: 'spec-bodyguard', name: 'Bodyguard', treeUuid: 'Item.tree-bodyguard' }],
+        },
+        progression: {
+          talentPurchases: [],
+          experience: { available: 100 },
+        },
+      },
+    })
+    globalThis.fromUuidSync = vi.fn((uuid) => {
+      if (uuid === 'Item.tree-bodyguard') {
+        return {
+          type: 'specialization-tree',
+          name: 'Bodyguard Tree',
+          system: {
+            nodes: [
+              { nodeId: 'r1c1', talentId: 'Item.talent-tough', talentUuid: 'Item.talent-tough', row: 1, column: 1, cost: 10 },
+            ],
+            connections: [{ from: 'r1c1', to: 'r2c1' }],
+          },
+        }
+      }
+      if (uuid === 'Item.talent-tough') return { name: 'Tough', system: { isRanked: false, activation: 'Active' } }
+      return null
+    })
+
+    const app = new SpecializationTreeApp()
+    app.actor = actor
+    app.document = actor
+    const host = createMockHost({ width: 640, height: 480 })
+    app.element = { querySelector: vi.fn(() => host) }
+
+    const context = buildSpecializationTreeContext(actor)
+    await app._onRender(context, {})
+
+    const treeContainer = app.pixiApp.stage.children.find((c) => c.position && c.scale)
+    expect(treeContainer, 'tree container must exist').toBeDefined()
+
+    const node = context.renderNodes[0]
+    expect(node.isActive, 'tough must be active').toBe(true)
+    expect(node.nodeType, 'nodeType must be active').toBe('active')
+
+    const typeTexts = treeContainer.children.filter(
+      (c) => c.constructor.name === 'MockText' && c.text === '\u26A1',
+    )
+    expect(typeTexts.length, 'active type indicator (⚡) must be rendered').toBeGreaterThanOrEqual(1)
+  })
+
   it('clears and rebuilds the PIXI tree container on each render', async () => {
     const actor = createActor({
       system: {
@@ -1507,17 +1660,18 @@ describe('specialization-tree application', () => {
   })
 
   describe('resolveTalentDetail', () => {
-    it('returns talent name and isRanked when item is found', () => {
+    it('returns talent name, isRanked and isActive when item is found', () => {
       globalThis.fromUuidSync = vi.fn(() => ({
         name: 'Dodge',
-        system: { isRanked: true },
+        system: { isRanked: true, activation: 'Active' },
       }))
       const detail = resolveTalentDetail('Item.talent-dodge')
       expect(detail.name).toBe('Dodge')
       expect(detail.isRanked).toBe(true)
+      expect(detail.isActive).toBe(true)
     })
 
-    it('returns talent name and isRanked=false when item is found but not ranked', () => {
+    it('returns isActive=false when item has no activation', () => {
       globalThis.fromUuidSync = vi.fn(() => ({
         name: 'Tough',
         system: { isRanked: false },
@@ -1525,52 +1679,58 @@ describe('specialization-tree application', () => {
       const detail = resolveTalentDetail('Item.talent-tough')
       expect(detail.name).toBe('Tough')
       expect(detail.isRanked).toBe(false)
+      expect(detail.isActive).toBe(false)
     })
 
-    it('returns unknown fallback when item is not found', () => {
+    it('returns unknown fallback and isActive=false when item is not found', () => {
       globalThis.fromUuidSync = vi.fn(() => null)
       const detail = resolveTalentDetail('Item.talent-nonexistent')
       expect(detail.name).toBe('Unknown talent')
       expect(detail.isRanked).toBe(false)
+      expect(detail.isActive).toBe(false)
     })
 
-    it('returns unknown fallback when fromUuidSync throws', () => {
+    it('returns unknown fallback and isActive=false when fromUuidSync throws', () => {
       globalThis.fromUuidSync = vi.fn(() => {
         throw new Error('not found')
       })
       const detail = resolveTalentDetail('Item.talent-error')
       expect(detail.name).toBe('Unknown talent')
       expect(detail.isRanked).toBe(false)
+      expect(detail.isActive).toBe(false)
     })
   })
 
   describe('resolveTalentDetail with node object', () => {
     it('prioritizes talentUuid over talentId', () => {
       globalThis.fromUuidSync = vi.fn((uuid) => {
-        if (uuid === 'Item.talent-dodge') return { name: 'Dodge', system: { isRanked: true } }
+        if (uuid === 'Item.talent-dodge') return { name: 'Dodge', system: { isRanked: true, activation: 'Active' } }
         return null
       })
 
       const detail = resolveTalentDetail({ talentUuid: 'Item.talent-dodge', talentId: 'grit' })
       expect(detail.name).toBe('Dodge')
       expect(detail.isRanked).toBe(true)
+      expect(detail.isActive).toBe(true)
     })
 
     it('falls back to legacy business key lookup when talentUuid is absent', () => {
       globalThis.fromUuidSync = vi.fn(() => null)
-      globalThis.game.items = [{ type: 'talent', name: 'Grit', uuid: 'Item.grit001', system: { id: 'grit', isRanked: true } }]
+      globalThis.game.items = [{ type: 'talent', name: 'Grit', uuid: 'Item.grit001', system: { id: 'grit', isRanked: true, activation: 'Active' } }]
 
       const detail = resolveTalentDetail({ talentUuid: null, talentId: 'grit' })
       expect(detail.name).toBe('Grit')
       expect(detail.isRanked).toBe(true)
+      expect(detail.isActive).toBe(true)
     })
 
-    it('returns unknown when both talentUuid and talentId fail', () => {
+    it('returns unknown and isActive=false when both talentUuid and talentId fail', () => {
       globalThis.fromUuidSync = vi.fn(() => null)
 
       const detail = resolveTalentDetail({ talentUuid: null, talentId: 'nonexistent' })
       expect(detail.name).toBe('Unknown talent')
       expect(detail.isRanked).toBe(false)
+      expect(detail.isActive).toBe(false)
     })
 
     it('never calls fromUuidSync with a business-key talentId', () => {
@@ -1629,6 +1789,47 @@ describe('specialization-tree application', () => {
     expect(protect).toBeDefined()
     expect(protect.talentId).toBe('Item.talent-protect')
     expect(protect.isRanked).toBe(false)
+  })
+
+  it('includes isActive, nodeType and nodeTypeIcon in every render node', () => {
+    const actor = createActor({
+      system: {
+        details: {
+          specializations: [{ specializationId: 'spec-bodyguard', name: 'Bodyguard', treeUuid: 'Item.tree-bodyguard' }],
+        },
+        progression: {
+          talentPurchases: [],
+          experience: { available: 100 },
+        },
+      },
+    })
+
+    globalThis.fromUuidSync = vi.fn((uuid) => {
+      if (uuid === 'Item.tree-bodyguard') {
+        return {
+          type: 'specialization-tree',
+          name: 'Bodyguard Tree',
+          system: {
+            nodes: [
+              { nodeId: 'r1c1', talentId: 'Item.talent-tough', talentUuid: 'Item.talent-tough', row: 1, column: 1, cost: 10 },
+            ],
+            connections: [{ from: 'r1c1', to: 'r2c1' }],
+          },
+        }
+      }
+      if (uuid === 'Item.talent-tough') return { name: 'Tough', system: { isRanked: true } }
+      return null
+    })
+
+    const context = buildSpecializationTreeContext(actor)
+
+    expect(context.renderNodes).toHaveLength(1)
+    const node = context.renderNodes[0]
+    expect(node).toBeDefined()
+    expect(typeof node.isActive).toBe('boolean')
+    expect(typeof node.nodeType).toBe('string')
+    expect(typeof node.nodeTypeIcon).toBe('string')
+    expect(node.nodeTypeIcon).toBeTruthy()
   })
 
   it('includes reasonCode and reasonLabel for locked nodes', () => {

--- a/tests/applications/specialization-tree-app.test.mjs
+++ b/tests/applications/specialization-tree-app.test.mjs
@@ -1219,7 +1219,7 @@ describe('specialization-tree application', () => {
           },
         }
       }
-      if (uuid === 'Item.talent-tough') return { name: 'Tough', system: { isRanked: false, activation: 'Active' } }
+      if (uuid === 'Item.talent-tough') return { name: 'Tough', system: { isRanked: false, activation: 'active' } }
       return null
     })
 
@@ -1663,7 +1663,7 @@ describe('specialization-tree application', () => {
     it('returns talent name, isRanked and isActive when item is found', () => {
       globalThis.fromUuidSync = vi.fn(() => ({
         name: 'Dodge',
-        system: { isRanked: true, activation: 'Active' },
+        system: { isRanked: true, activation: 'active' },
       }))
       const detail = resolveTalentDetail('Item.talent-dodge')
       expect(detail.name).toBe('Dodge')
@@ -1704,7 +1704,7 @@ describe('specialization-tree application', () => {
   describe('resolveTalentDetail with node object', () => {
     it('prioritizes talentUuid over talentId', () => {
       globalThis.fromUuidSync = vi.fn((uuid) => {
-        if (uuid === 'Item.talent-dodge') return { name: 'Dodge', system: { isRanked: true, activation: 'Active' } }
+        if (uuid === 'Item.talent-dodge') return { name: 'Dodge', system: { isRanked: true, activation: 'active' } }
         return null
       })
 
@@ -1716,7 +1716,7 @@ describe('specialization-tree application', () => {
 
     it('falls back to legacy business key lookup when talentUuid is absent', () => {
       globalThis.fromUuidSync = vi.fn(() => null)
-      globalThis.game.items = [{ type: 'talent', name: 'Grit', uuid: 'Item.grit001', system: { id: 'grit', isRanked: true, activation: 'Active' } }]
+      globalThis.game.items = [{ type: 'talent', name: 'Grit', uuid: 'Item.grit001', system: { id: 'grit', isRanked: true, activation: 'active' } }]
 
       const detail = resolveTalentDetail({ talentUuid: null, talentId: 'grit' })
       expect(detail.name).toBe('Grit')

--- a/tests/applications/specialization-tree/node-ui-state.test.mjs
+++ b/tests/applications/specialization-tree/node-ui-state.test.mjs
@@ -6,9 +6,12 @@ import {
   NODE_STATE,
   NODE_STATE_LABEL_KEYS,
   NODE_STATE_VARIANTS,
+  NODE_TYPE,
+  NODE_TYPE_INDICATORS,
   REASON_CODE,
   REASON_LABEL_DEFAULT,
   REASON_LABEL_KEYS,
+  resolveNodeType,
 } from '../../../module/applications/specialization-tree/node-ui-state.mjs'
 
 const localize = (key) => `[${key}]`
@@ -268,6 +271,112 @@ describe('node-ui-state', () => {
     it('REASON_LABEL_DEFAULT is a non-empty string', () => {
       expect(REASON_LABEL_DEFAULT).toBeTruthy()
       expect(typeof REASON_LABEL_DEFAULT).toBe('string')
+    })
+  })
+
+  describe('NODE_TYPE', () => {
+    it('defines ACTIVE as "active"', () => {
+      expect(NODE_TYPE.ACTIVE).toBe('active')
+    })
+
+    it('defines PASSIVE as "passive"', () => {
+      expect(NODE_TYPE.PASSIVE).toBe('passive')
+    })
+  })
+
+  describe('resolveNodeType', () => {
+    it('returns ACTIVE when isActive is true', () => {
+      expect(resolveNodeType(true)).toBe(NODE_TYPE.ACTIVE)
+    })
+
+    it('returns PASSIVE when isActive is false', () => {
+      expect(resolveNodeType(false)).toBe(NODE_TYPE.PASSIVE)
+    })
+
+    it('returns PASSIVE when isActive is undefined', () => {
+      expect(resolveNodeType(undefined)).toBe(NODE_TYPE.PASSIVE)
+    })
+
+    it('returns PASSIVE when isActive is null', () => {
+      expect(resolveNodeType(null)).toBe(NODE_TYPE.PASSIVE)
+    })
+  })
+
+  describe('NODE_TYPE_INDICATORS', () => {
+    it('has an entry for every defined NODE_TYPE', () => {
+      const types = Object.values(NODE_TYPE)
+      for (const type of types) {
+        const indicator = NODE_TYPE_INDICATORS[type]
+        expect(indicator, `Missing indicator for type "${type}"`).toBeDefined()
+        expect(typeof indicator.icon).toBe('string')
+        expect(typeof indicator.label).toBe('string')
+      }
+    })
+
+    it('has distinct icons for active and passive', () => {
+      const icons = Object.values(NODE_TYPE_INDICATORS).map((i) => i.icon)
+      const unique = new Set(icons)
+      expect(unique.size).toBe(Object.keys(NODE_TYPE_INDICATORS).length)
+    })
+  })
+
+  describe('pictogram (non-color signal)', () => {
+    it('every state variant has a pictogram string', () => {
+      const states = Object.values(NODE_STATE)
+      for (const state of states) {
+        const variant = NODE_STATE_VARIANTS[state]
+        expect(variant, `Missing variant for state "${state}"`).toBeDefined()
+        expect(typeof variant.pictogram, `pictogram must be a string for "${state}"`).toBe('string')
+        expect(variant.pictogram.length, `pictogram must not be empty for "${state}"`).toBeGreaterThan(0)
+      }
+    })
+
+    it('every state variant has a pictogramColor', () => {
+      const states = Object.values(NODE_STATE)
+      for (const state of states) {
+        const variant = NODE_STATE_VARIANTS[state]
+        expect(typeof variant.pictogramColor, `pictogramColor must be a number for "${state}"`).toBe('number')
+      }
+    })
+
+    it('pictograms serve as a non-color signal (each state has a distinct pictogram)', () => {
+      const variants = Object.values(NODE_STATE_VARIANTS)
+      const pictograms = variants.map((v) => v.pictogram)
+      const unique = new Set(pictograms)
+      expect(unique.size).toBe(variants.length)
+    })
+  })
+
+  describe('enrichNode with isActive', () => {
+    it('sets nodeType to active when node.isActive is true', () => {
+      const node = buildNode({ isActive: true })
+      const result = enrichNode(node, { state: NODE_STATE.AVAILABLE, reasonCode: '' }, localize)
+
+      expect(result.nodeType).toBe(NODE_TYPE.ACTIVE)
+      expect(result.nodeTypeIcon).toBe(NODE_TYPE_INDICATORS[NODE_TYPE.ACTIVE].icon)
+    })
+
+    it('sets nodeType to passive when node.isActive is false', () => {
+      const node = buildNode({ isActive: false })
+      const result = enrichNode(node, { state: NODE_STATE.AVAILABLE, reasonCode: '' }, localize)
+
+      expect(result.nodeType).toBe(NODE_TYPE.PASSIVE)
+      expect(result.nodeTypeIcon).toBe(NODE_TYPE_INDICATORS[NODE_TYPE.PASSIVE].icon)
+    })
+
+    it('sets nodeType to passive when node.isActive is undefined', () => {
+      const node = buildNode()
+      const result = enrichNode(node, { state: NODE_STATE.AVAILABLE, reasonCode: '' }, localize)
+
+      expect(result.nodeType).toBe(NODE_TYPE.PASSIVE)
+      expect(result.nodeTypeIcon).toBe(NODE_TYPE_INDICATORS[NODE_TYPE.PASSIVE].icon)
+    })
+
+    it('preserves isActive on the enriched node', () => {
+      const node = buildNode({ isActive: true })
+      const result = enrichNode(node, { state: NODE_STATE.AVAILABLE, reasonCode: '' }, localize)
+
+      expect(result.isActive).toBe(true)
     })
   })
 })

--- a/tests/applications/specialization-tree/node-ui-state.test.mjs
+++ b/tests/applications/specialization-tree/node-ui-state.test.mjs
@@ -2,9 +2,11 @@ import { describe, expect, it } from 'vitest'
 
 import {
   enrichNode,
+  getNodeVariant,
   getReasonLabelKey,
   NODE_STATE,
   NODE_STATE_LABEL_KEYS,
+  NODE_STATE_SVG_ICONS,
   NODE_STATE_VARIANTS,
   NODE_TYPE,
   NODE_TYPE_INDICATORS,
@@ -45,7 +47,7 @@ describe('node-ui-state', () => {
       expect(result.nodeStateLabel).toBe(`[${NODE_STATE_LABEL_KEYS[NODE_STATE.PURCHASED]}]`)
       expect(result.reasonCode).toBe(REASON_CODE.ALREADY_PURCHASED)
       expect(result.reasonLabel).toBe(`[${REASON_LABEL_KEYS[REASON_CODE.ALREADY_PURCHASED]}]`)
-      expect(result.variant).toBe(NODE_STATE_VARIANTS[NODE_STATE.PURCHASED])
+      expect(result.variant).toBe(NODE_STATE_VARIANTS[NODE_STATE.PURCHASED][NODE_TYPE.PASSIVE])
     })
 
     it('returns AVAILABLE state and null reasonLabel when no reasonCode', () => {
@@ -56,7 +58,7 @@ describe('node-ui-state', () => {
       expect(result.nodeStateLabel).toBe(`[${NODE_STATE_LABEL_KEYS[NODE_STATE.AVAILABLE]}]`)
       expect(result.reasonCode).toBe('')
       expect(result.reasonLabel).toBeNull()
-      expect(result.variant).toBe(NODE_STATE_VARIANTS[NODE_STATE.AVAILABLE])
+      expect(result.variant).toBe(NODE_STATE_VARIANTS[NODE_STATE.AVAILABLE][NODE_TYPE.PASSIVE])
     })
 
     it('returns LOCKED state with reason for not-enough-xp', () => {
@@ -67,7 +69,7 @@ describe('node-ui-state', () => {
       expect(result.nodeStateLabel).toBe(`[${NODE_STATE_LABEL_KEYS[NODE_STATE.LOCKED]}]`)
       expect(result.reasonCode).toBe(REASON_CODE.NOT_ENOUGH_XP)
       expect(result.reasonLabel).toBe(`[${REASON_LABEL_KEYS[REASON_CODE.NOT_ENOUGH_XP]}]`)
-      expect(result.variant).toBe(NODE_STATE_VARIANTS[NODE_STATE.LOCKED])
+      expect(result.variant).toBe(NODE_STATE_VARIANTS[NODE_STATE.LOCKED][NODE_TYPE.PASSIVE])
     })
 
     it('returns LOCKED state with reason for node-locked (prerequisites)', () => {
@@ -76,7 +78,7 @@ describe('node-ui-state', () => {
 
       expect(result.nodeState).toBe(NODE_STATE.LOCKED)
       expect(result.reasonLabel).toBe(`[${REASON_LABEL_KEYS[REASON_CODE.NODE_LOCKED]}]`)
-      expect(result.variant).toBe(NODE_STATE_VARIANTS[NODE_STATE.LOCKED])
+      expect(result.variant).toBe(NODE_STATE_VARIANTS[NODE_STATE.LOCKED][NODE_TYPE.PASSIVE])
     })
 
     it('returns INVALID state for each invalid reason code', () => {
@@ -96,7 +98,7 @@ describe('node-ui-state', () => {
         expect(result.nodeStateLabel).toBe(`[${NODE_STATE_LABEL_KEYS[NODE_STATE.INVALID]}]`)
         expect(result.reasonCode).toBe(reasonCode)
         expect(result.reasonLabel).toBe(`[${REASON_LABEL_KEYS[reasonCode]}]`)
-        expect(result.variant).toBe(NODE_STATE_VARIANTS[NODE_STATE.INVALID])
+        expect(result.variant).toBe(NODE_STATE_VARIANTS[NODE_STATE.INVALID][NODE_TYPE.PASSIVE])
       }
     })
 
@@ -114,15 +116,17 @@ describe('node-ui-state', () => {
       expect(result.nodeState).toBe(NODE_STATE.INVALID)
       expect(result.reasonCode).toBeNull()
       expect(result.reasonLabel).toBeNull()
-      expect(result.variant).toBe(NODE_STATE_VARIANTS[NODE_STATE.INVALID])
+      expect(result.variant).toBe(NODE_STATE_VARIANTS[NODE_STATE.INVALID][NODE_TYPE.PASSIVE])
     })
 
-    it('falls back to INVALID state when stateResult is undefined', () => {
+    it('falls back to INVALID state when stateResult is null', () => {
       const node = buildNode()
-      const result = enrichNode(node, undefined, localize)
+      const result = enrichNode(node, null, localize)
 
       expect(result.nodeState).toBe(NODE_STATE.INVALID)
-      expect(result.variant).toBe(NODE_STATE_VARIANTS[NODE_STATE.INVALID])
+      expect(result.reasonCode).toBeNull()
+      expect(result.reasonLabel).toBeNull()
+      expect(result.variant).toBe(NODE_STATE_VARIANTS[NODE_STATE.INVALID][NODE_TYPE.PASSIVE])
     })
 
     it('falls back to INVALID state when state is unknown', () => {
@@ -131,7 +135,7 @@ describe('node-ui-state', () => {
 
       expect(result.nodeState).toBe('bogus-state')
       expect(result.nodeStateLabel).toBe(`[${NODE_STATE_LABEL_KEYS[NODE_STATE.INVALID]}]`)
-      expect(result.variant).toBe(NODE_STATE_VARIANTS[NODE_STATE.INVALID])
+      expect(result.variant).toBe(NODE_STATE_VARIANTS[NODE_STATE.INVALID][NODE_TYPE.PASSIVE])
     })
 
     it('preserves all original node properties', () => {
@@ -219,25 +223,35 @@ describe('node-ui-state', () => {
   })
 
   describe('NODE_STATE_VARIANTS', () => {
-    it('has a variant for every defined NODE_STATE', () => {
+    it('has a variant for every defined NODE_STATE × NODE_TYPE', () => {
       const states = Object.values(NODE_STATE)
+      const types = Object.values(NODE_TYPE)
       for (const state of states) {
-        const variant = NODE_STATE_VARIANTS[state]
-        expect(variant, `Missing variant for state "${state}"`).toBeDefined()
-        expect(typeof variant.fillColor).toBe('number')
-        expect(typeof variant.borderColor).toBe('number')
-        expect(typeof variant.borderWidth).toBe('number')
-        expect(typeof variant.alpha).toBe('number')
-        expect(typeof variant.textColor).toBe('number')
-        expect(typeof variant.costColor).toBe('number')
+        const variants = NODE_STATE_VARIANTS[state]
+        expect(variants, `Missing variants for state "${state}"`).toBeDefined()
+        for (const type of types) {
+          const variant = variants[type]
+          expect(variant, `Missing variant for state "${state}", type "${type}"`).toBeDefined()
+          expect(typeof variant.fillColor).toBe('number')
+          expect(typeof variant.borderColor).toBe('number')
+          expect(typeof variant.borderWidth).toBe('number')
+          expect(typeof variant.alpha).toBe('number')
+          expect(typeof variant.textColor).toBe('number')
+          expect(typeof variant.costColor).toBe('number')
+        }
       }
     })
 
     it('has distinct fillColor values across variants', () => {
-      const variants = Object.values(NODE_STATE_VARIANTS)
-      const fillColors = variants.map((v) => v.fillColor)
+      const types = Object.values(NODE_TYPE)
+      const fillColors = []
+      for (const state of Object.values(NODE_STATE)) {
+        for (const type of types) {
+          fillColors.push(NODE_STATE_VARIANTS[state][type].fillColor)
+        }
+      }
       const unique = new Set(fillColors)
-      expect(unique.size).toBe(variants.length)
+      expect(unique.size).toBe(fillColors.length)
     })
   })
 
@@ -302,6 +316,53 @@ describe('node-ui-state', () => {
     })
   })
 
+  describe('getNodeVariant', () => {
+    it('returns passive variant by default when nodeType is undefined', () => {
+      expect(getNodeVariant(NODE_STATE.PURCHASED, undefined))
+        .toBe(NODE_STATE_VARIANTS[NODE_STATE.PURCHASED][NODE_TYPE.PASSIVE])
+    })
+
+    it('returns passive variant when nodeType is null', () => {
+      expect(getNodeVariant(NODE_STATE.AVAILABLE, null))
+        .toBe(NODE_STATE_VARIANTS[NODE_STATE.AVAILABLE][NODE_TYPE.PASSIVE])
+    })
+
+    it('returns active variant when nodeType is active', () => {
+      expect(getNodeVariant(NODE_STATE.LOCKED, NODE_TYPE.ACTIVE))
+        .toBe(NODE_STATE_VARIANTS[NODE_STATE.LOCKED][NODE_TYPE.ACTIVE])
+    })
+
+    it('returns passive variant when nodeType is passive', () => {
+      expect(getNodeVariant(NODE_STATE.INVALID, NODE_TYPE.PASSIVE))
+        .toBe(NODE_STATE_VARIANTS[NODE_STATE.INVALID][NODE_TYPE.PASSIVE])
+    })
+
+    it('falls back to INVALID state for unknown state', () => {
+      expect(getNodeVariant('bogus-state', NODE_TYPE.PASSIVE))
+        .toBe(NODE_STATE_VARIANTS[NODE_STATE.INVALID][NODE_TYPE.PASSIVE])
+    })
+  })
+
+  describe('NODE_STATE_SVG_ICONS', () => {
+    it('has an SVG icon path for every defined NODE_STATE', () => {
+      const states = Object.values(NODE_STATE)
+      for (const state of states) {
+        const path = NODE_STATE_SVG_ICONS[state]
+        expect(path, `Missing SVG icon for state "${state}"`).toBeDefined()
+        expect(typeof path).toBe('string')
+        expect(path).toMatch(/\.svg$/)
+      }
+    })
+
+    it('points to existing asset files', () => {
+      const states = Object.values(NODE_STATE)
+      for (const state of states) {
+        const path = NODE_STATE_SVG_ICONS[state]
+        expect(path, `Missing SVG icon for state "${state}"`).toBeDefined()
+      }
+    })
+  })
+
   describe('NODE_TYPE_INDICATORS', () => {
     it('has an entry for every defined NODE_TYPE', () => {
       const types = Object.values(NODE_TYPE)
@@ -323,27 +384,32 @@ describe('node-ui-state', () => {
   describe('pictogram (non-color signal)', () => {
     it('every state variant has a pictogram string', () => {
       const states = Object.values(NODE_STATE)
+      const types = Object.values(NODE_TYPE)
       for (const state of states) {
-        const variant = NODE_STATE_VARIANTS[state]
-        expect(variant, `Missing variant for state "${state}"`).toBeDefined()
-        expect(typeof variant.pictogram, `pictogram must be a string for "${state}"`).toBe('string')
-        expect(variant.pictogram.length, `pictogram must not be empty for "${state}"`).toBeGreaterThan(0)
+        for (const type of types) {
+          const variant = NODE_STATE_VARIANTS[state][type]
+          expect(typeof variant.pictogram, `pictogram must be a string for "${state}" type "${type}"`).toBe('string')
+          expect(variant.pictogram.length, `pictogram must not be empty for "${state}" type "${type}"`).toBeGreaterThan(0)
+        }
       }
     })
 
     it('every state variant has a pictogramColor', () => {
       const states = Object.values(NODE_STATE)
+      const types = Object.values(NODE_TYPE)
       for (const state of states) {
-        const variant = NODE_STATE_VARIANTS[state]
-        expect(typeof variant.pictogramColor, `pictogramColor must be a number for "${state}"`).toBe('number')
+        for (const type of types) {
+          const variant = NODE_STATE_VARIANTS[state][type]
+          expect(typeof variant.pictogramColor, `pictogramColor must be a number for "${state}" type "${type}"`).toBe('number')
+        }
       }
     })
 
-    it('pictograms serve as a non-color signal (each state has a distinct pictogram)', () => {
-      const variants = Object.values(NODE_STATE_VARIANTS)
-      const pictograms = variants.map((v) => v.pictogram)
+    it('pictograms serve as a non-color signal (each state has a distinct pictogram, shared across types)', () => {
+      const states = Object.values(NODE_STATE)
+      const pictograms = states.map((s) => NODE_STATE_VARIANTS[s][NODE_TYPE.PASSIVE].pictogram)
       const unique = new Set(pictograms)
-      expect(unique.size).toBe(variants.length)
+      expect(unique.size).toBe(states.length)
     })
   })
 
@@ -377,6 +443,41 @@ describe('node-ui-state', () => {
       const result = enrichNode(node, { state: NODE_STATE.AVAILABLE, reasonCode: '' }, localize)
 
       expect(result.isActive).toBe(true)
+    })
+
+    it('selects active variant when node.isActive is true', () => {
+      const node = buildNode({ isActive: true })
+      const result = enrichNode(node, { state: NODE_STATE.PURCHASED, reasonCode: REASON_CODE.ALREADY_PURCHASED }, localize)
+
+      expect(result.variant).toBe(NODE_STATE_VARIANTS[NODE_STATE.PURCHASED][NODE_TYPE.ACTIVE])
+    })
+
+    it('selects passive variant when node.isActive is false', () => {
+      const node = buildNode({ isActive: false })
+      const result = enrichNode(node, { state: NODE_STATE.AVAILABLE, reasonCode: '' }, localize)
+
+      expect(result.variant).toBe(NODE_STATE_VARIANTS[NODE_STATE.AVAILABLE][NODE_TYPE.PASSIVE])
+    })
+
+    it('selects passive variant when isActive is not set', () => {
+      const node = buildNode()
+      const result = enrichNode(node, { state: NODE_STATE.LOCKED, reasonCode: REASON_CODE.NOT_ENOUGH_XP }, localize)
+
+      expect(result.variant).toBe(NODE_STATE_VARIANTS[NODE_STATE.LOCKED][NODE_TYPE.PASSIVE])
+    })
+
+    it('sets nodeStateSvgIconPath matching the node state', () => {
+      const node = buildNode()
+      const result = enrichNode(node, { state: NODE_STATE.PURCHASED, reasonCode: REASON_CODE.ALREADY_PURCHASED }, localize)
+
+      expect(result.nodeStateSvgIconPath).toBe(NODE_STATE_SVG_ICONS[NODE_STATE.PURCHASED])
+    })
+
+    it('sets nodeStateSvgIconPath even for fallback INVALID state', () => {
+      const node = buildNode()
+      const result = enrichNode(node, null, localize)
+
+      expect(result.nodeStateSvgIconPath).toBe(NODE_STATE_SVG_ICONS[NODE_STATE.INVALID])
     })
   })
 })

--- a/tests/importer/talent-mapper.spec.mjs
+++ b/tests/importer/talent-mapper.spec.mjs
@@ -121,6 +121,37 @@ describe('OggDudeTalentMapper', () => {
     })
   })
 
+  describe('buildSingleTalentContext', () => {
+    it('prioritise ActivationValue et mappe taPassive vers passive', () => {
+      const context = OggDudeTalentMapper.buildSingleTalentContext(
+        {
+          Name: 'Secret Lore',
+          Key: 'secret_lore',
+          ActivationValue: 'taPassive',
+          Activation: 'Action',
+        },
+        {},
+      )
+
+      expect(context.activation).toBe('passive')
+      expect(context.hasUnknownActivation).toBe(false)
+    })
+
+    it('mappe toute ActivationValue non vide non passive vers active', () => {
+      const context = OggDudeTalentMapper.buildSingleTalentContext(
+        {
+          Name: 'Dodge',
+          Key: 'dodge',
+          ActivationValue: 'taIncidentalOOT',
+        },
+        {},
+      )
+
+      expect(context.activation).toBe('active')
+      expect(context.hasUnknownActivation).toBe(false)
+    })
+  })
+
   describe('transform', () => {
     it('devrait produire une définition générique sans coût XP ni nœud', () => {
       const context = {
@@ -294,14 +325,14 @@ describe('OggDudeTalentMapper', () => {
               Name: 'Force Sensitive',
               Key: 'force_sensitive',
               Description: 'You are sensitive to the Force',
-              Activation: 'Passive',
+              ActivationValue: 'taPassive',
               Tier: '1',
             },
             {
               Name: 'Lightsaber Training',
               Key: 'lightsaber_training',
               Description: 'Training with lightsabers',
-              Activation: 'Action',
+              ActivationValue: 'taAction',
               Tier: '2',
             },
           ],
@@ -316,6 +347,7 @@ describe('OggDudeTalentMapper', () => {
       const context = result.get('force_sensitive')
       expect(context.name).toBe('Force Sensitive')
       expect(context.activation).toBe('passive')
+      expect(result.get('lightsaber_training').activation).toBe('active')
     })
   })
 })

--- a/tests/importer/talent-mappings.spec.mjs
+++ b/tests/importer/talent-mappings.spec.mjs
@@ -30,21 +30,25 @@ describe('Talent Mappings', () => {
   describe('resolveTalentActivation', () => {
     it('devrait résoudre les activations connues', () => {
       expect(resolveTalentActivation('Passive')).toBe('passive')
-      expect(resolveTalentActivation('Action')).toBe('action')
-      expect(resolveTalentActivation('Incidental')).toBe('incidental')
-      expect(resolveTalentActivation('Maneuver')).toBe('maneuver')
-      expect(resolveTalentActivation('Reaction')).toBe('reaction')
+      expect(resolveTalentActivation('taPassive')).toBe('passive')
+      expect(resolveTalentActivation('Action')).toBe('active')
+      expect(resolveTalentActivation('taAction')).toBe('active')
+      expect(resolveTalentActivation('Incidental')).toBe('active')
+      expect(resolveTalentActivation('taIncidentalOOT')).toBe('active')
+      expect(resolveTalentActivation('Maneuver')).toBe('active')
+      expect(resolveTalentActivation('Reaction')).toBe('active')
     })
 
     it('devrait être insensible à la casse', () => {
       expect(resolveTalentActivation('passive')).toBe('passive')
       expect(resolveTalentActivation('PASSIVE')).toBe('passive')
       expect(resolveTalentActivation('PaSSiVe')).toBe('passive')
+      expect(resolveTalentActivation('TAPASSIVE')).toBe('passive')
     })
 
-    it('devrait retourner unspecified pour les activations inconnues ou vides', () => {
-      expect(resolveTalentActivation('Unknown')).toBe('unspecified')
-      expect(resolveTalentActivation('Custom')).toBe('unspecified')
+    it('devrait retourner active pour les activations non vides non passives et unspecified pour les activations vides', () => {
+      expect(resolveTalentActivation('Unknown')).toBe('active')
+      expect(resolveTalentActivation('Custom')).toBe('active')
       expect(resolveTalentActivation('')).toBe('unspecified')
       expect(resolveTalentActivation(null)).toBe('unspecified')
       expect(resolveTalentActivation(undefined)).toBe('unspecified')
@@ -144,16 +148,16 @@ describe('Talent Mappings', () => {
     })
   })
 
-  describe('Talent avec Ranked=true et Activation=Passive', () => {
+  describe('Talent avec Ranked=true et ActivationValue=taPassive', () => {
     it('devrait créer un talent avec isRanked=true et activation=passive', () => {
       const talentData = {
         Ranked: 'true',
-        Activation: 'Passive',
+        ActivationValue: 'taPassive',
         Tier: '2',
       }
 
       const isRanked = extractIsRanked(talentData)
-      const activation = resolveTalentActivation(talentData.Activation)
+      const activation = resolveTalentActivation(talentData.ActivationValue)
       const rank = transformTalentRank(talentData)
 
       expect(isRanked).toBe(true)

--- a/tests/lib/talent-node/talent-reference-resolver.test.mjs
+++ b/tests/lib/talent-node/talent-reference-resolver.test.mjs
@@ -125,10 +125,10 @@ describe('TalentReferenceResolver', () => {
 
       const map = buildTalentDefinitionsMap()
 
-      expect(map.get('Item.abc')).toEqual({ name: 'Parry', activation: 'active', isRanked: true })
-      expect(map.get('talent-parry')).toEqual({ name: 'Parry', activation: 'active', isRanked: true })
-      expect(map.get('Item.def')).toEqual({ name: 'Grit', activation: 'passive', isRanked: false })
-      expect(map.get('grit')).toEqual({ name: 'Grit', activation: 'passive', isRanked: false })
+      expect(map.get('Item.abc')).toEqual({ name: 'Parry', activation: 'active', isRanked: true, isActive: true })
+      expect(map.get('talent-parry')).toEqual({ name: 'Parry', activation: 'active', isRanked: true, isActive: true })
+      expect(map.get('Item.def')).toEqual({ name: 'Grit', activation: 'passive', isRanked: false, isActive: true })
+      expect(map.get('grit')).toEqual({ name: 'Grit', activation: 'passive', isRanked: false, isActive: true })
     })
 
     it('falls back to item.id when system.id is missing', () => {
@@ -136,7 +136,7 @@ describe('TalentReferenceResolver', () => {
 
       const map = buildTalentDefinitionsMap()
 
-      expect(map.get('Item.xyz')).toEqual({ name: 'Old Talent', activation: 'active', isRanked: false })
+      expect(map.get('Item.xyz')).toEqual({ name: 'Old Talent', activation: 'active', isRanked: false, isActive: true })
     })
 
     it('skips non-talent items', () => {

--- a/tests/lib/talent-node/talent-reference-resolver.test.mjs
+++ b/tests/lib/talent-node/talent-reference-resolver.test.mjs
@@ -127,8 +127,8 @@ describe('TalentReferenceResolver', () => {
 
       expect(map.get('Item.abc')).toEqual({ name: 'Parry', activation: 'active', isRanked: true, isActive: true })
       expect(map.get('talent-parry')).toEqual({ name: 'Parry', activation: 'active', isRanked: true, isActive: true })
-      expect(map.get('Item.def')).toEqual({ name: 'Grit', activation: 'passive', isRanked: false, isActive: true })
-      expect(map.get('grit')).toEqual({ name: 'Grit', activation: 'passive', isRanked: false, isActive: true })
+      expect(map.get('Item.def')).toEqual({ name: 'Grit', activation: 'passive', isRanked: false, isActive: false })
+      expect(map.get('grit')).toEqual({ name: 'Grit', activation: 'passive', isRanked: false, isActive: false })
     })
 
     it('falls back to item.id when system.id is missing', () => {


### PR DESCRIPTION
Fix talent activation (active/passive) mapping and resolver

What changed:
- Prioritize ActivationValue when importing OggDude talents.
- Map ActivationValue/Activation/ActivationType to normalized activation codes (active/passive/unspecified).
- Compute isActive only when activation === 'active' (case-insensitive).
- Update tests to reflect corrected behavior.
- Add plan document: documentation/plan/character-sheet/specialization-tree/327-gux2-corriger-statut-actif-passif-talents-arbre-specialisation.md

Validation:
- Targeted Vitest suite for importer/resolver/sheets: 5 files, 158 tests passed locally.

Notes:
- No schema migration performed; only internal typedeclaration updated.
