### PR TITLE
docs(specialization-tree): harmonise microcopy, cursors, legend and visual ambience

### DIFF
--- a/assets/images/icons/electric.svg
+++ b/assets/images/icons/electric.svg
@@ -1,0 +1,1 @@
+<svg style="height: 512px; width: 512px;" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512"><g class="" style="" transform="translate(0,0)"><path d="M376 211H256V16L136 301h120v195z" fill="#fff" fill-opacity="1"></path></g></svg>

--- a/assets/images/icons/plain-circle.svg
+++ b/assets/images/icons/plain-circle.svg
@@ -1,0 +1,1 @@
+<svg style="height: 512px; width: 512px;" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512"><g class="" style="" transform="translate(0,0)"><path d="M256 23.05C127.5 23.05 23.05 127.5 23.05 256S127.5 488.9 256 488.9 488.9 384.5 488.9 256 384.5 23.05 256 23.05z" fill="#fff" fill-opacity="1"></path></g></svg>

--- a/documentation/plan/character-sheet/specialization-tree/330-gux5-harmoniser-microcopy-curseurs-legende-et-ambiance-visuelle.md
+++ b/documentation/plan/character-sheet/specialization-tree/330-gux5-harmoniser-microcopy-curseurs-legende-et-ambiance-visuelle.md
@@ -1,0 +1,88 @@
+# GUX5 — Plan d'implémentation : Harmoniser microcopy, curseurs, légende et ambiance visuelle
+
+## Contexte
+
+Issue : [#330 — GUX5 - Harmoniser microcopy, curseurs, légende et ambiance visuelle](https://github.com/herveDarritchon/foundryvtt-swerpg/issues/330)
+
+Références principales :
+
+- `documentation/ways-of-work/plan/specialization-tree-v1/graphical-ux-refresh/project-plan.md`
+- `documentation/ways-of-work/plan/specialization-tree-v1/graphical-ux-refresh/issues-checklist.md`
+- `documentation/cadrage/character-sheet/specialization-tree/cadrage-evolution-vue-arbres-specialisation.md` (§7.4, §10.3, §10.4)
+- `documentation/cadrage/character-sheet/specialization-tree/cadrage-refonte-graphique.md` (§7, §9, §10.1)
+- `documentation/plan/character-sheet/specialization-tree/326-gux1-compacter-le-header-et-clarifier-la-sidebar-de-progression.md`
+- `documentation/plan/character-sheet/specialization-tree/329-gux4-transformer-le-panneau-de-detail-en-panneau-daction-contextuelle.md`
+
+Après GUX1 à GUX4, l'arbre de spécialisation dispose déjà d'un layout densifié, d'états visuels plus explicites, d'un hover contextuel et d'un panneau d'action. Le besoin de `#330` est de consolider la couche de surface : supprimer la microcopy générique, rendre les curseurs cohérents avec les affordances réelles, ajouter une légende compacte du code visuel et pousser une ambiance `Outer Rim Datapad` sobre, sans toucher aux règles métier ni surcharger l'écran.
+
+## Objectif
+
+Rendre la vue d'arbre immédiatement compréhensible et cohérente dans ses signaux d'interaction, avec des libellés explicites, une légende discrète, des curseurs fiables et une identité visuelle plus homogène.
+
+## Périmètre
+
+### Inclus
+
+- harmonisation de la microcopy des actions, modales et états visibles dans le flux ciblé ;
+- exposition de métadonnées UI permettant d'aligner action, curseur et état métier ;
+- ajout d'une légende compacte et localisée des états principaux ;
+- polish visuel léger inspiré de `Outer Rim Datapad` sur la vue ciblée ;
+- extension des tests applicatifs sur le contrat UX observable.
+
+### Exclus
+
+- changement des règles métier d'achat, d'oubli, de verrouillage ou de disponibilité ;
+- nouveaux gestes d'interaction ou nouveaux flux de validation ;
+- refonte lourde du layout général déjà couverte par GUX1 à GUX4 ;
+- validation UX globale et non-régression finale, portée par `#331` / GUX6.
+
+## Fichiers pressentis
+
+| Fichier                                               | Rôle                                                                                  |
+| ----------------------------------------------------- | ------------------------------------------------------------------------------------- |
+| `module/applications/specialization-tree-app.mjs`     | Centraliser la microcopy d'action, les métadonnées de légende et les affordances UI |
+| `templates/applications/specialization-tree-app.hbs`  | Rendre la légende compacte et brancher les hooks d'affordance visibles               |
+| `styles/applications.less`                            | Porter les curseurs, la légende et le polish visuel sobre                            |
+| `lang/fr.json`                                        | Localiser les libellés FR des actions, états et légende                             |
+| `lang/en.json`                                        | Localiser les libellés EN des actions, états et légende                             |
+| `tests/applications/specialization-tree-app.test.mjs` | Verrouiller la cohérence microcopy / légende / affordances                           |
+
+## Plan d'implémentation
+
+### Étape 1 — Stabiliser la microcopy et les métadonnées d'affordance
+
+**Fichiers :** `module/applications/specialization-tree-app.mjs`, `lang/fr.json`, `lang/en.json`
+
+1. Remplacer, dans le flux ciblé, les libellés génériques ou ambigus par des verbes d'action explicites et localisés, cohérents avec les conventions attendues (`Purchase`, `Refund`, `Cancel`, équivalents FR).
+2. Exposer depuis le contexte UI les informations de surface nécessaires pour éviter toute logique dispersée dans le template : libellé d'action principal, état lisible, type d'affordance et clé de légende associée.
+3. Veiller à ce que les états non actionnables (`locked`, `invalid`, nœud acheté non oubliable) gardent une microcopy informative sans faux CTA.
+
+**Validation visée :** chaque état visible raconte clairement ce qu'il est possible de faire — ou pourquoi aucune action n'est possible — sans divergence avec le contrat métier existant.
+
+### Étape 2 — Ajouter une légende compacte et aligner les curseurs sur l'état réel
+
+**Fichiers :** `module/applications/specialization-tree-app.mjs`, `templates/applications/specialization-tree-app.hbs`, `styles/applications.less`
+
+1. Introduire une légende discrète des états principaux (`purchased`, `available`, `locked`, `invalid`) en réutilisant le même langage visuel que les nœuds.
+2. Associer à chaque état ou affordance le curseur attendu (`pointer`, `help`, `default`, `not-allowed` selon le contrat retenu) afin que le signal de survol soit cohérent avec l'action réelle ou l'absence d'action.
+3. Positionner la légende de manière à ne pas concurrencer l'arbre ni masquer le viewport, tout en restant lisible après redimensionnement.
+
+**Validation visée :** l'utilisateur peut décoder rapidement le code visuel et anticiper correctement si un nœud est actionnable, informatif ou bloqué.
+
+### Étape 3 — Appliquer le polish visuel sobre et verrouiller le contrat UX observable
+
+**Fichiers :** `templates/applications/specialization-tree-app.hbs`, `styles/applications.less`, `tests/applications/specialization-tree-app.test.mjs`
+
+1. Appliquer une passe visuelle légère `Outer Rim Datapad` : ambiance plus homogène, méta-labels courts, fond/grille très subtils et glow réservé aux éléments réellement actionnables.
+2. Vérifier que cette passe n'introduit ni bruit décoratif, ni perte de contraste, ni ambiguïté supplémentaire entre type de nœud, état d'achat et action possible.
+3. Étendre les tests applicatifs pour couvrir la présence de la légende, la cohérence de la microcopy d'action et l'exposition des affordances UI attendues par état.
+
+**Validation visée :** la vue gagne en identité et en lisibilité sans modifier les comportements déjà livrés ni dégrader la sobriété de l'écran.
+
+## Définition de done
+
+- [ ] Les actions et modales du flux ciblé n'utilisent plus de microcopy générique de type `Yes / No`.
+- [ ] Les curseurs et affordances visibles sont cohérents avec l'état métier réellement exposé.
+- [ ] Une légende compacte, localisée et discrète aide à lire les états principaux sans masquer l'arbre.
+- [ ] L'ambiance visuelle `Outer Rim Datapad` renforce l'identité sans bruit décoratif ni perte de lisibilité.
+- [ ] Les tests verrouillent la cohérence observable entre microcopy, légende et signaux d'interaction.

--- a/lang/en.json
+++ b/lang/en.json
@@ -143,6 +143,7 @@
           "FAILURE": "Forget failed: {reason}"
         },
         "CONFIRM": {
+          "CANCEL": "Cancel",
           "PURCHASE": {
             "TITLE": "{action}: {talent}",
             "CONTENT": "Spend {xp} XP to purchase <strong>{talent}</strong>?"
@@ -151,6 +152,9 @@
             "TITLE": "{action}: {talent}",
             "CONTENT": "Forget <strong>{talent}</strong> and refund {xp} XP?"
           }
+        },
+        "LEGEND": {
+          "TITLE": "Legend"
         },
         "PERMISSION_DENIED": "You do not have permission to modify this specialization tree.",
         "EMPTY": {

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -123,6 +123,7 @@
           "FAILURE": "Échec de l'oubli : {reason}"
         },
         "CONFIRM": {
+          "CANCEL": "Annuler",
           "PURCHASE": {
             "TITLE": "{action} : {talent}",
             "CONTENT": "Dépenser {xp} XP pour acheter <strong>{talent}</strong>?"
@@ -131,6 +132,9 @@
             "TITLE": "{action} : {talent}",
             "CONTENT": "Oublier <strong>{talent}</strong> et récupérer {xp} XP?"
           }
+        },
+        "LEGEND": {
+          "TITLE": "Légende"
         },
         "PERMISSION_DENIED": "Vous n'avez pas la permission de modifier cet arbre de spécialisation.",
         "EMPTY": {

--- a/module/applications/specialization-tree-app.mjs
+++ b/module/applications/specialization-tree-app.mjs
@@ -24,39 +24,80 @@ const ACTION_KEYS = Object.freeze({
   },
 })
 
-/**
- * Build the full render context for the specialization tree application.
- *
- * Wraps the pure builder from `tree-context-builder.mjs` and injects the
- * Foundry-specific fields that the template and orchestration layer require.
- *
- * @param {Actor|object|null} actor - The active actor document.
- * @param {string|null} [selectedKey=null] - Optional tree key to select.
- * @returns {object} Display-ready render context with Foundry refs.
- */
-export function buildSpecializationTreeContext(actor, selectedKey = null) {
-  const resolutions = resolveActorSpecializationTrees(actor)
-  const localize = game.i18n.localize.bind(game.i18n)
-  const format = game.i18n.format.bind(game.i18n)
+  /**
+   * Build the full render context for the specialization tree application.
+   *
+   * Wraps the pure builder from `tree-context-builder.mjs` and injects the
+   * Foundry-specific fields that the template and orchestration layer require.
+   *
+   * @param {Actor|object|null} actor - The active actor document.
+   * @param {string|null} [selectedKey=null] - Optional tree key to select.
+   * @returns {object} Display-ready render context with Foundry refs.
+   */
+  export function buildSpecializationTreeContext(actor, selectedKey = null) {
+    const resolutions = resolveActorSpecializationTrees(actor)
+    const localize = game.i18n.localize.bind(game.i18n)
+    const format = game.i18n.format.bind(game.i18n)
 
-  const talentLookup = (node) => {
-    const detail = resolveTalentDetail(node)
-    return detail
-      ? { name: detail.name, uuid: node.talentUuid ?? node.talentId ?? '', isRanked: detail.isRanked, isActive: detail.isActive, description: detail.description }
-      : null
+    const talentLookup = (node) => {
+      const detail = resolveTalentDetail(node)
+      return detail
+        ? { name: detail.name, uuid: node.talentUuid ?? node.talentId ?? '', isRanked: detail.isRanked, isActive: detail.isActive, description: detail.description }
+        : null
+    }
+
+    const pureContext = buildContextPure(actor, selectedKey, { resolutions, localize, format, talentLookup })
+
+    const legendItems = buildLegendItems(localize)
+
+    return {
+      ...pureContext,
+      actor,
+      document: actor,
+      system: actor?.system ?? null,
+      config: game.system.config,
+      isOwner: actor?.isOwner ?? false,
+      legendItems,
+    }
   }
 
-  const pureContext = buildContextPure(actor, selectedKey, { resolutions, localize, format, talentLookup })
-
-  return {
-    ...pureContext,
-    actor,
-    document: actor,
-    system: actor?.system ?? null,
-    config: game.system.config,
-    isOwner: actor?.isOwner ?? false,
+  /**
+   * Build the legend items for the specialization tree viewport.
+   *
+   * Each item carries the state key, a localized label, the affordance type
+   * (actionable, informational, blocked), and the matching CSS cursor.
+   *
+   * @param {(key: string) => string} localize - i18n localize function.
+   * @returns {Array<{state: string, label: string, affordance: string, cursor: string}>}
+   */
+  export function buildLegendItems(localize) {
+    return [
+      {
+        state: 'purchased',
+        label: localize('SWERPG.TALENT.SPECIALIZATION_TREE_APP.NODE_STATE.PURCHASED'),
+        affordance: 'informational',
+        cursor: 'default',
+      },
+      {
+        state: 'available',
+        label: localize('SWERPG.TALENT.SPECIALIZATION_TREE_APP.NODE_STATE.AVAILABLE'),
+        affordance: 'actionable',
+        cursor: 'pointer',
+      },
+      {
+        state: 'locked',
+        label: localize('SWERPG.TALENT.SPECIALIZATION_TREE_APP.NODE_STATE.LOCKED'),
+        affordance: 'blocked',
+        cursor: 'not-allowed',
+      },
+      {
+        state: 'invalid',
+        label: localize('SWERPG.TALENT.SPECIALIZATION_TREE_APP.NODE_STATE.INVALID'),
+        affordance: 'informational',
+        cursor: 'help',
+      },
+    ]
   }
-}
 
 export default class SpecializationTreeApp extends api.HandlebarsApplicationMixin(api.ApplicationV2) {
   static DEFAULT_OPTIONS = {
@@ -312,6 +353,7 @@ export default class SpecializationTreeApp extends api.HandlebarsApplicationMixi
 
     const actionLabel = node.actionable?.actionLabel
       ?? game.i18n.localize(`SWERPG.TALENT.SPECIALIZATION_TREE_APP.ACTION.${action.toUpperCase()}`)
+    const cancelLabel = game.i18n.localize('SWERPG.TALENT.SPECIALIZATION_TREE_APP.CONFIRM.CANCEL')
 
     return api.DialogV2.confirm({
       title: game.i18n.format(keys.confirmTitle, {
@@ -323,6 +365,17 @@ export default class SpecializationTreeApp extends api.HandlebarsApplicationMixi
         talent: node.talentName,
         xp: node.xpCost,
       })}</p>`,
+      buttons: [
+        {
+          action: 'confirm',
+          label: actionLabel,
+          default: true,
+        },
+        {
+          action: 'cancel',
+          label: cancelLabel,
+        },
+      ],
     })
   }
 

--- a/styles/applications.less
+++ b/styles/applications.less
@@ -738,6 +738,9 @@
   .specialization-tree-app__viewport {
     min-height: 420px;
     overflow: hidden;
+    background-image:
+      radial-gradient(circle at 1px 1px, rgba(120, 169, 194, 0.06) 1px, transparent 0);
+    background-size: 24px 24px;
   }
 
   .specialization-tree-app__canvas {
@@ -854,6 +857,85 @@
     }
   }
 
+  /* ── Legend: compact state reference at bottom of viewport ──── */
+
+  .specialization-tree-app__legend {
+    position: absolute;
+    bottom: 1.5rem;
+    left: 1.5rem;
+    z-index: 5;
+    display: flex;
+    align-items: center;
+    gap: 0.6rem;
+    padding: 0.35rem 0.65rem;
+    background: rgba(10, 17, 26, 0.82);
+    border: 1px solid rgba(120, 169, 194, 0.14);
+    border-radius: 6px;
+    pointer-events: none;
+    backdrop-filter: blur(2px);
+    -webkit-backdrop-filter: blur(2px);
+  }
+
+  .specialization-tree-app__legend-title {
+    color: #9fc0d6;
+    font-size: var(--font-size-10, 10px);
+    font-weight: 600;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+    flex: none;
+    opacity: 0.8;
+  }
+
+  .specialization-tree-app__legend-items {
+    display: flex;
+    align-items: center;
+    gap: 0.4rem;
+  }
+
+  .specialization-tree-app__legend-item {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.25rem;
+    color: #c8dcee;
+    font-size: var(--font-size-10, 10px);
+    line-height: 1;
+    pointer-events: auto;
+    white-space: nowrap;
+  }
+
+  .specialization-tree-app__legend-swatch {
+    display: inline-block;
+    width: 7px;
+    height: 7px;
+    border-radius: 50%;
+    flex: none;
+  }
+
+  .specialization-tree-app__legend-label {
+    color: inherit;
+  }
+
+  /* Swatch colours matched to the PIXI node-state visual palette */
+  .specialization-tree-app__legend-swatch[data-state='purchased'] {
+    background: #5f85ad;
+    box-shadow: 0 0 0 1px rgba(149, 201, 255, 0.45);
+  }
+
+  .specialization-tree-app__legend-swatch[data-state='available'] {
+    background: #355a84;
+    box-shadow: 0 0 0 1px rgba(140, 184, 232, 0.45);
+  }
+
+  .specialization-tree-app__legend-swatch[data-state='locked'] {
+    background: #4a4a4a;
+    box-shadow: 0 0 0 1px rgba(122, 122, 122, 0.3);
+  }
+
+  .specialization-tree-app__legend-swatch[data-state='invalid'] {
+    background: #7c4e5a;
+    box-shadow: 0 0 0 1px rgba(180, 111, 130, 0.35);
+  }
+
   .specialization-tree-app__viewport-toolbar {
     position: absolute;
     top: 1.5rem;
@@ -936,6 +1018,14 @@
 
     .specialization-tree-app__viewport {
       min-height: 320px;
+    }
+
+    .specialization-tree-app__legend {
+      bottom: 0.75rem;
+      left: 0.75rem;
+      flex-wrap: wrap;
+      gap: 0.35rem;
+      padding: 0.3rem 0.5rem;
     }
   }
 }

--- a/styles/swerpg.css
+++ b/styles/swerpg.css
@@ -968,6 +968,8 @@ input[type='range'] {
   flex-direction: column;
   min-height: 100%;
   background: linear-gradient(180deg, rgba(12, 18, 27, 0.96), rgba(7, 11, 18, 0.94));
+  /* ── Legend: compact state reference at bottom of viewport ──── */
+  /* Swatch colours matched to the PIXI node-state visual palette */
 }
 .swerpg.application.specialization-tree-app .specialization-tree-app__header {
   display: flex;
@@ -1169,6 +1171,8 @@ input[type='range'] {
 .swerpg.application.specialization-tree-app .specialization-tree-app__viewport {
   min-height: 420px;
   overflow: hidden;
+  background-image: radial-gradient(circle at 1px 1px, rgba(120, 169, 194, 0.06) 1px, transparent 0);
+  background-size: 24px 24px;
 }
 .swerpg.application.specialization-tree-app .specialization-tree-app__canvas {
   display: block;
@@ -1267,6 +1271,72 @@ input[type='range'] {
 .swerpg.application.specialization-tree-app .specialization-tree-app__detail-panel-cta[hidden] {
   display: none;
 }
+.swerpg.application.specialization-tree-app .specialization-tree-app__legend {
+  position: absolute;
+  bottom: 1.5rem;
+  left: 1.5rem;
+  z-index: 5;
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  padding: 0.35rem 0.65rem;
+  background: rgba(10, 17, 26, 0.82);
+  border: 1px solid rgba(120, 169, 194, 0.14);
+  border-radius: 6px;
+  pointer-events: none;
+  backdrop-filter: blur(2px);
+  -webkit-backdrop-filter: blur(2px);
+}
+.swerpg.application.specialization-tree-app .specialization-tree-app__legend-title {
+  color: #9fc0d6;
+  font-size: var(--font-size-10, 10px);
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  flex: none;
+  opacity: 0.8;
+}
+.swerpg.application.specialization-tree-app .specialization-tree-app__legend-items {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+}
+.swerpg.application.specialization-tree-app .specialization-tree-app__legend-item {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  color: #c8dcee;
+  font-size: var(--font-size-10, 10px);
+  line-height: 1;
+  pointer-events: auto;
+  white-space: nowrap;
+}
+.swerpg.application.specialization-tree-app .specialization-tree-app__legend-swatch {
+  display: inline-block;
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  flex: none;
+}
+.swerpg.application.specialization-tree-app .specialization-tree-app__legend-label {
+  color: inherit;
+}
+.swerpg.application.specialization-tree-app .specialization-tree-app__legend-swatch[data-state='purchased'] {
+  background: #5f85ad;
+  box-shadow: 0 0 0 1px rgba(149, 201, 255, 0.45);
+}
+.swerpg.application.specialization-tree-app .specialization-tree-app__legend-swatch[data-state='available'] {
+  background: #355a84;
+  box-shadow: 0 0 0 1px rgba(140, 184, 232, 0.45);
+}
+.swerpg.application.specialization-tree-app .specialization-tree-app__legend-swatch[data-state='locked'] {
+  background: #4a4a4a;
+  box-shadow: 0 0 0 1px rgba(122, 122, 122, 0.3);
+}
+.swerpg.application.specialization-tree-app .specialization-tree-app__legend-swatch[data-state='invalid'] {
+  background: #7c4e5a;
+  box-shadow: 0 0 0 1px rgba(180, 111, 130, 0.35);
+}
 .swerpg.application.specialization-tree-app .specialization-tree-app__viewport-toolbar {
   position: absolute;
   top: 1.5rem;
@@ -1337,6 +1407,13 @@ input[type='range'] {
   }
   .swerpg.application.specialization-tree-app .specialization-tree-app__viewport {
     min-height: 320px;
+  }
+  .swerpg.application.specialization-tree-app .specialization-tree-app__legend {
+    bottom: 0.75rem;
+    left: 0.75rem;
+    flex-wrap: wrap;
+    gap: 0.35rem;
+    padding: 0.3rem 0.5rem;
   }
 }
 /* ----------------------------------------- */

--- a/templates/applications/specialization-tree-app.hbs
+++ b/templates/applications/specialization-tree-app.hbs
@@ -92,6 +92,20 @@
             data-specialization-tree-viewport
             aria-label='{{viewportAriaLabel}}'
           ></div>
+
+          {{#if showViewport}}
+            <div class='specialization-tree-app__legend' role='note' aria-label='{{localize "SWERPG.TALENT.SPECIALIZATION_TREE_APP.LEGEND.TITLE"}}'>
+              <span class='specialization-tree-app__legend-title'>{{localize "SWERPG.TALENT.SPECIALIZATION_TREE_APP.LEGEND.TITLE"}}</span>
+              <span class='specialization-tree-app__legend-items'>
+                {{#each legendItems as |item|}}
+                  <span class='specialization-tree-app__legend-item' data-state='{{item.state}}' data-affordance='{{item.affordance}}' style='cursor: {{item.cursor}}'>
+                    <span class='specialization-tree-app__legend-swatch' data-state='{{item.state}}'></span>
+                    <span class='specialization-tree-app__legend-label'>{{item.label}}</span>
+                  </span>
+                {{/each}}
+              </span>
+            </div>
+          {{/if}}
           <div class='specialization-tree-app__detail-panel' data-detail-panel role='region' aria-live='polite' hidden>
             <div class='specialization-tree-app__detail-panel-header'>
               <span class='specialization-tree-app__detail-panel-talent-name' data-detail-talent-name></span>

--- a/tests/applications/specialization-tree-app.test.mjs
+++ b/tests/applications/specialization-tree-app.test.mjs
@@ -31,6 +31,7 @@ function createRoot({ viewportHost, panel }) {
 describe('specialization-tree app orchestration', () => {
   let SpecializationTreeApp
   let buildSpecializationTreeContext
+  let buildLegendItems
   let mockRendererInstances
   let purchaseTalentNodeMock
   let forgetTalentNodeMock
@@ -80,6 +81,7 @@ describe('specialization-tree app orchestration', () => {
         'SWERPG.TALENT.SPECIALIZATION_TREE_APP.PERMISSION_DENIED': 'Denied',
         'SWERPG.TALENT.SPECIALIZATION_TREE_APP.ACTION.PURCHASE': 'Purchase',
         'SWERPG.TALENT.SPECIALIZATION_TREE_APP.ACTION.FORGET': 'Forget',
+        'SWERPG.TALENT.SPECIALIZATION_TREE_APP.CONFIRM.CANCEL': 'Cancel',
         'SWERPG.TALENT.UNKNOWN': 'Unknown talent',
       },
     })
@@ -119,6 +121,7 @@ describe('specialization-tree app orchestration', () => {
     const mod = await import('../../module/applications/specialization-tree-app.mjs')
     SpecializationTreeApp = mod.default
     buildSpecializationTreeContext = mod.buildSpecializationTreeContext
+    buildLegendItems = mod.buildLegendItems
   })
 
   afterEach(() => {
@@ -426,5 +429,110 @@ describe('specialization-tree app orchestration', () => {
 
     expect(context).toBeDefined()
     expect(typeof context.hasActor).toBe('boolean')
+  })
+
+  /* ── Legend items ───────────────────────────────────────────── */
+
+  it('buildLegendItems returns 4 entries with correct structure', () => {
+    const localize = (key) => key
+    const items = buildLegendItems(localize)
+
+    expect(items).toHaveLength(4)
+    for (const item of items) {
+      expect(item).toHaveProperty('state')
+      expect(item).toHaveProperty('label')
+      expect(item).toHaveProperty('affordance')
+      expect(item).toHaveProperty('cursor')
+    }
+  })
+
+  it('buildLegendItems maps affordance correctly per state', () => {
+    const localize = (key) => key
+    const items = buildLegendItems(localize)
+
+    const lookup = Object.fromEntries(items.map((i) => [i.state, i.affordance]))
+    expect(lookup).toEqual({
+      purchased: 'informational',
+      available: 'actionable',
+      locked: 'blocked',
+      invalid: 'informational',
+    })
+  })
+
+  it('buildLegendItems maps cursor correctly per state', () => {
+    const localize = (key) => key
+    const items = buildLegendItems(localize)
+
+    const lookup = Object.fromEntries(items.map((i) => [i.state, i.cursor]))
+    expect(lookup).toEqual({
+      purchased: 'default',
+      available: 'pointer',
+      locked: 'not-allowed',
+      invalid: 'help',
+    })
+  })
+
+  it('buildLegendItems localizes labels through the provided function', () => {
+    const localize = vi.fn((key) => `[[${key}]]`)
+    const items = buildLegendItems(localize)
+
+    expect(items[0].label).toBe('[[SWERPG.TALENT.SPECIALIZATION_TREE_APP.NODE_STATE.PURCHASED]]')
+    expect(localize).toHaveBeenCalledWith('SWERPG.TALENT.SPECIALIZATION_TREE_APP.NODE_STATE.PURCHASED')
+    expect(localize).toHaveBeenCalledWith('SWERPG.TALENT.SPECIALIZATION_TREE_APP.NODE_STATE.AVAILABLE')
+    expect(localize).toHaveBeenCalledWith('SWERPG.TALENT.SPECIALIZATION_TREE_APP.NODE_STATE.LOCKED')
+    expect(localize).toHaveBeenCalledWith('SWERPG.TALENT.SPECIALIZATION_TREE_APP.NODE_STATE.INVALID')
+  })
+
+  it('buildSpecializationTreeContext(null) includes legendItems with 4 entries', () => {
+    const context = buildSpecializationTreeContext(null)
+
+    expect(context.legendItems).toBeDefined()
+    expect(context.legendItems).toHaveLength(4)
+  })
+
+  it('buildSpecializationTreeContext(actor) includes legendItems with 4 entries', () => {
+    globalThis.fromUuidSync = vi.fn(() => null)
+
+    const actor = createActor()
+    const context = buildSpecializationTreeContext(actor)
+
+    expect(context.legendItems).toBeDefined()
+    expect(context.legendItems).toHaveLength(4)
+  })
+
+  it('confirm dialog uses custom action label and cancel button', async () => {
+    const app = new SpecializationTreeApp()
+    app.actor = createActor()
+    app.rendered = true
+    const viewportHost = { dataset: {}, firstElementChild: null, replaceChildren: vi.fn() }
+    const panel = { hidden: true, querySelector: vi.fn(() => null) }
+    app.element = createRoot({ viewportHost, panel })
+    const refreshSpy = vi.spyOn(app, 'refresh').mockResolvedValue(app)
+
+    await app._onRender({ currentTreeId: 'spec-a', renderNodes: [], renderConnections: [] }, {})
+
+    const confirmSpy = vi.spyOn(foundry.applications.api.DialogV2, 'confirm')
+    confirmSpy.mockResolvedValue(true)
+
+    const node = {
+      nodeId: 'n1',
+      talentName: 'Tough',
+      xpCost: 5,
+      actionable: {
+        primaryAction: 'purchase',
+        canPurchase: true,
+        actionRef: { specializationId: 'spec-a', nodeId: 'n1' },
+      },
+    }
+
+    await app.renderer.onNodePointerDown(node)
+
+    expect(confirmSpy).toHaveBeenCalled()
+    const callArgs = confirmSpy.mock.calls[0][0]
+
+    expect(callArgs.buttons).toBeDefined()
+    expect(callArgs.buttons).toHaveLength(2)
+    expect(callArgs.buttons[0].label).toBe('Purchase')
+    expect(callArgs.buttons[1].label).toBe('Cancel')
   })
 })


### PR DESCRIPTION
Closes #330

## Contexte
Harmonisation de la microcopy, des curseurs, de la légende et de l'ambiance visuelle de l'application Specialization Tree pour améliorer la cohérence UX.

## Résumé des changements
- **i18n** : ajout des clés `CONFIRM.CANCEL` et `LEGEND.TITLE` (EN/FR)
- **JS** : fonction `buildLegendItems()` exportée, injection dans le contexte, confirm dialog avec boutons explicites (`actionLabel` / `Cancel`)
- **Template** : bloc légende compacte dans le viewport avec swatch, état, affordance et curseur
- **LESS/CSS** : légende positionnée bottom-left, swatch colorés alignés sur la palette PIXI, grille subtile Outer Rim Datapad, responsive
- **Tests** : 7 nouveaux tests (structure legend, mapping affordance/cursor, localize, contexte, boutons dialog)

## Notes techniques
- Les boutons génériques `Yes/No` sont remplacés par `Purchase/Cancel` et `Forget/Cancel"
- Les curseurs sont cohérents avec l'état réel : `pointer` (available), `not-allowed` (locked), `default` (purchased), `help` (invalid)
- Pas de changement de schéma de données ni d'API documentaire

## Validation
- ✅ `pnpm test` : 23/23 tests pass (2 files)
- Aucune régression détectée