### PR TITLE
test(gux6): valider lisibilité et affordances de l'arbre de spécialisation

### DIFF
--- a/documentation/plan/character-sheet/specialization-tree/331-gux6-valider-lisibilite-affordances-et-non-regression-du-flux.md
+++ b/documentation/plan/character-sheet/specialization-tree/331-gux6-valider-lisibilite-affordances-et-non-regression-du-flux.md
@@ -1,0 +1,90 @@
+# GUX6 — Plan d'implémentation : Valider lisibilité, affordances et non-régression du flux
+
+## Contexte
+
+Issue : [#331 — GUX6 - Valider lisibilité, affordances et non-régression du flux](https://github.com/herveDarritchon/foundryvtt-swerpg/issues/331)
+
+Références principales :
+
+- `documentation/ways-of-work/plan/specialization-tree-v1/graphical-ux-refresh/project-plan.md`
+- `documentation/ways-of-work/plan/specialization-tree-v1/graphical-ux-refresh/issues-checklist.md`
+- `documentation/plan/character-sheet/specialization-tree/326-gux1-compacter-le-header-et-clarifier-la-sidebar-de-progression.md`
+- `documentation/plan/character-sheet/specialization-tree/327-gux2-clarifier-les-etats-des-noeuds-avec-couleurs-contraste-et-pictogrammes.md`
+- `documentation/plan/character-sheet/specialization-tree/328-gux3-rendre-les-connexions-et-le-hover-plus-explicites-pour-la-progression.md`
+- `documentation/plan/character-sheet/specialization-tree/329-gux4-transformer-le-panneau-de-detail-en-panneau-daction-contextuelle.md`
+- `documentation/plan/character-sheet/specialization-tree/330-gux5-harmoniser-microcopy-curseurs-legende-et-ambiance-visuelle.md`
+
+GUX1 à GUX5 ont déjà défini le layout, le langage visuel, le hover contextuel, le panneau d'action et la couche de polish de surface. Le besoin de `#331` est de verrouiller, sur une matrice courte mais complète, que ces briques racontent un flux cohérent de bout en bout : les états restent lisibles, les affordances visibles correspondent bien aux actions réellement possibles, et aucune régression observable n'a été introduite sur achat, oubli, hover, microcopy ou curseurs.
+
+## Objectif
+
+Sécuriser le flux UX de l'arbre de spécialisation avec une couverture ciblée des cas clés et une passe de correction minimale strictement limitée aux écarts prouvés par cette validation.
+
+## Périmètre
+
+### Inclus
+
+- validation des états `purchased`, `available`, `locked` et `invalid` ;
+- validation du hover contextuel, du panneau d'action et de la légende ;
+- validation de la cohérence entre action réelle, microcopy visible et curseur exposé ;
+- couverture de non-régression sur le flux achat / oubli déjà livré ;
+- fix minimal uniquement si la validation révèle un écart observable.
+
+### Exclus
+
+- nouvelle évolution UX hors critères déjà cadrés par GUX1 à GUX5 ;
+- refonte métier des règles d'achat, d'oubli ou de progression ;
+- campagne E2E large ou validation cross-feature hors vue `SpecializationTreeApp` ;
+- changements décoratifs non justifiés par un écart prouvé pendant la validation.
+
+## Fichiers pressentis
+
+| Fichier                                               | Rôle                                                                          |
+| ----------------------------------------------------- | ----------------------------------------------------------------------------- |
+| `tests/applications/specialization-tree-app.test.mjs` | Couvrir la matrice UX observable de bout en bout sur l'application            |
+| `tests/applications/specialization-tree/*.test.mjs`   | Compléter les contrats ciblés de view-model et d'affordances si nécessaire    |
+| `module/applications/specialization-tree-app.mjs`     | Support d'un fix minimal si la validation prouve un écart de contexte UI      |
+| `templates/applications/specialization-tree-app.hbs`  | Support d'un fix minimal si un écart de rendu ou d'affordance est observé     |
+| `styles/applications.less`                            | Support d'un fix minimal si la cohérence visuelle ou curseur est en défaut    |
+| `lang/fr.json`                                        | Ajuster la microcopy FR uniquement si un libellé prouvé est ambigu ou erroné  |
+| `lang/en.json`                                        | Ajuster la microcopy EN uniquement si un libellé prouvé est ambigu ou erroné  |
+
+## Plan d'implémentation
+
+### Étape 1 — Formaliser la matrice de validation UX observable
+
+**Fichiers :** `tests/applications/specialization-tree-app.test.mjs`, `tests/applications/specialization-tree/*.test.mjs`
+
+1. Regrouper les scénarios attendus par `#331` autour des cas explicitement listés dans le cadrage projet : nœud acheté, achetable, verrouillé, invalide, hover contextuel, panneau d'action, microcopy des modales et cohérence curseur / action.
+2. Vérifier chaque scénario au niveau du contrat observable, sans tester le rendu PIXI fin : état exposé, CTA présent ou absent, raison de blocage, description utile, légende visible et affordance cohérente.
+3. Réutiliser autant que possible les fixtures et helpers existants issus de GUX1 à GUX5 pour garder une couverture compacte, lisible et maintenable.
+
+**Validation visée :** la suite de tests décrit clairement le flux UX attendu sans dupliquer la logique métier déjà portée ailleurs.
+
+### Étape 2 — Verrouiller la cohérence action / microcopy / affordance
+
+**Fichiers :** `tests/applications/specialization-tree-app.test.mjs`, `module/applications/specialization-tree-app.mjs`, `templates/applications/specialization-tree-app.hbs`, `styles/applications.less`, `lang/fr.json`, `lang/en.json`
+
+1. Ajouter des assertions ciblées qui prouvent qu'un nœud actionnable expose le bon verbe, le bon curseur et le bon point d'entrée d'action, tandis qu'un nœud non actionnable reste informatif sans faux CTA.
+2. Couvrir explicitement la continuité entre hover, panneau d'action et modales pour éviter les divergences de vocabulaire ou d'intention selon le point d'entrée.
+3. Si la validation met en évidence un écart, le corriger au plus près du contrat concerné, sans élargir le scope au-delà de l'observable prouvé par le scénario en échec.
+
+**Validation visée :** aucun état visible ne promet une action absente, et aucune action possible n'est masquée par une affordance incohérente.
+
+### Étape 3 — Fermer la non-régression du flux complet GUX1 → GUX5
+
+**Fichiers :** `tests/applications/specialization-tree-app.test.mjs`, `tests/applications/specialization-tree/*.test.mjs`
+
+1. Vérifier que la densité d'information, les états visuels, le hover, le panneau d'action et le polish de surface coexistent sans casser les comportements déjà livrés.
+2. Ajouter une couverture de non-régression courte sur le parcours utilisateur principal : lecture d'état, compréhension du blocage, décision via panneau, confirmation du bon verbe d'action.
+3. Éviter tout ajout de cas hors matrice `#331` afin que ce ticket reste un verrou de cohérence UX final, et non une nouvelle tranche fonctionnelle.
+
+**Validation visée :** GUX6 clôt la refresh UX en gelant les signaux observables essentiels du flux, avec un coût de maintenance faible.
+
+## Définition de done
+
+- [ ] Les cas `purchased`, `available`, `locked` et `invalid` sont couverts par une validation automatisée ciblée.
+- [ ] Le hover contextuel, le panneau d'action et la légende restent cohérents entre eux.
+- [ ] La microcopy des actions et modales est explicite et alignée sur l'action réellement permise.
+- [ ] Les curseurs et affordances visibles ne créent aucun faux signal d'interaction.
+- [ ] Tout écart révélé par cette validation est corrigé par un fix minimal strictement borné au scénario prouvé.

--- a/tests/applications/specialization-tree-app.test.mjs
+++ b/tests/applications/specialization-tree-app.test.mjs
@@ -535,4 +535,305 @@ describe('specialization-tree app orchestration', () => {
     expect(callArgs.buttons[0].label).toBe('Purchase')
     expect(callArgs.buttons[1].label).toBe('Cancel')
   })
+
+  /* ═════════════════════════════════════════════════════════════ */
+  /*  GUX6 — UX observable validation matrix                    */
+  /* ═════════════════════════════════════════════════════════════ */
+
+  describe('GUX6 — UX observable validation matrix', () => {
+    /**
+     * Helper: create a detail panel mock that records DOM updates.
+     * Returns `{ panel, els }` where `els` holds textContent/hidden references.
+     */
+    function createPanelMock() {
+      const els = {
+        nameEl: { textContent: '' },
+        costEl: { textContent: '' },
+        typeEl: { textContent: '' },
+        stateEl: { textContent: '' },
+        reasonEl: { hidden: false },
+        descriptionEl: { hidden: false, innerHTML: '' },
+        ctaEl: { hidden: false },
+        ctaLabelEl: { textContent: '' },
+      }
+
+      const panel = {
+        hidden: true,
+        querySelector: vi.fn((selector) => {
+          if (selector === '[data-detail-talent-name]') return els.nameEl
+          if (selector === '[data-detail-cost]') return els.costEl
+          if (selector === '[data-detail-type]') return els.typeEl
+          if (selector === '[data-detail-state]') return els.stateEl
+          if (selector === '[data-detail-reason]') return els.reasonEl
+          if (selector === '[data-detail-description]') return els.descriptionEl
+          if (selector === '[data-detail-cta]') return els.ctaEl
+          if (selector === '[data-detail-cta-label]') return els.ctaLabelEl
+          return null
+        }),
+      }
+
+      return { panel, els }
+    }
+
+    /* ── Per-state detail panel behaviour ─────────────────────── */
+
+    describe('locked node affordance', () => {
+      it('shows detail panel with state label and reason, no CTA', async () => {
+        const { panel, els } = createPanelMock()
+        const viewportHost = { dataset: {}, firstElementChild: null, replaceChildren: vi.fn() }
+        const app = new SpecializationTreeApp()
+        app.actor = createActor()
+        app.element = createRoot({ viewportHost, panel })
+        await app._onRender({ currentTreeId: 'spec-a', renderNodes: [], renderConnections: [] }, {})
+
+        const node = {
+          talentName: 'Durable',
+          xpCost: 15,
+          isRanked: false,
+          talentDescription: null,
+          nodeStateLabel: 'Locked',
+          reasonLabel: 'Prerequisites not met',
+          actionable: { primaryAction: null },
+        }
+
+        await app.renderer.onNodePointerDown(node)
+
+        expect(panel.hidden).toBe(false)
+        expect(els.nameEl.textContent).toBe('Durable')
+        expect(els.costEl.textContent).toContain('15 XP')
+        expect(els.stateEl.textContent).toBe('Locked')
+        expect(els.reasonEl.hidden).toBe(false)
+        expect(els.reasonEl.textContent).toBe('Prerequisites not met')
+        expect(els.ctaEl.hidden).toBe(true)
+      })
+    })
+
+    describe('invalid node affordance', () => {
+      it('shows detail panel with state label and reason, no CTA', async () => {
+        const { panel, els } = createPanelMock()
+        const viewportHost = { dataset: {}, firstElementChild: null, replaceChildren: vi.fn() }
+        const app = new SpecializationTreeApp()
+        app.actor = createActor()
+        app.element = createRoot({ viewportHost, panel })
+        await app._onRender({ currentTreeId: 'spec-a', renderNodes: [], renderConnections: [] }, {})
+
+        const node = {
+          talentName: 'Unknown talent',
+          xpCost: 0,
+          isRanked: false,
+          talentDescription: null,
+          nodeStateLabel: 'Invalid',
+          reasonLabel: 'Node not found',
+          actionable: { primaryAction: null },
+        }
+
+        await app.renderer.onNodePointerDown(node)
+
+        expect(panel.hidden).toBe(false)
+        expect(els.nameEl.textContent).toBe('Unknown talent')
+        expect(els.stateEl.textContent).toBe('Invalid')
+        expect(els.reasonEl.hidden).toBe(false)
+        expect(els.reasonEl.textContent).toBe('Node not found')
+        expect(els.ctaEl.hidden).toBe(true)
+      })
+    })
+
+    describe('purchased node blocked by dependents', () => {
+      it('shows detail panel with blocked reason and no CTA', async () => {
+        const { panel, els } = createPanelMock()
+        const viewportHost = { dataset: {}, firstElementChild: null, replaceChildren: vi.fn() }
+        const app = new SpecializationTreeApp()
+        app.actor = createActor()
+        app.element = createRoot({ viewportHost, panel })
+        await app._onRender({ currentTreeId: 'spec-a', renderNodes: [], renderConnections: [] }, {})
+
+        const node = {
+          talentName: 'Tough',
+          xpCost: 5,
+          isRanked: true,
+          talentDescription: '<p>Already owned</p>',
+          nodeStateLabel: 'Purchased',
+          reasonLabel: null,
+          actionable: {
+            primaryAction: null,
+            blockedReasonCode: 'node-has-dependents',
+            blockedReasonLabel: 'Node has purchased dependents',
+          },
+        }
+
+        await app.renderer.onNodePointerDown(node)
+
+        expect(panel.hidden).toBe(false)
+        expect(els.nameEl.textContent).toBe('Tough')
+        expect(els.stateEl.textContent).toBe('Purchased')
+        expect(els.reasonEl.hidden).toBe(false)
+        expect(els.reasonEl.textContent).toBe('Node has purchased dependents')
+        expect(els.ctaEl.hidden).toBe(true)
+        expect(els.descriptionEl.innerHTML).toBe('<p>Already owned</p>')
+      })
+    })
+
+    /* ── Action / microcopy continuity ────────────────────────── */
+
+    describe('action/microcopy continuity', () => {
+      it('confirm dialog purchase action label matches the actionable actionLabel', async () => {
+        const app = new SpecializationTreeApp()
+        app.actor = createActor()
+        app.rendered = true
+        const viewportHost = { dataset: {}, firstElementChild: null, replaceChildren: vi.fn() }
+        const panel = { hidden: true, querySelector: vi.fn(() => null) }
+        app.element = createRoot({ viewportHost, panel })
+        vi.spyOn(app, 'refresh').mockResolvedValue(app)
+
+        await app._onRender({ currentTreeId: 'spec-a', renderNodes: [], renderConnections: [] }, {})
+
+        const confirmSpy = vi.spyOn(foundry.applications.api.DialogV2, 'confirm')
+        confirmSpy.mockResolvedValue(true)
+
+        const node = {
+          nodeId: 'n1',
+          talentName: 'Tough',
+          xpCost: 5,
+          actionable: {
+            primaryAction: 'purchase',
+            canPurchase: true,
+            actionLabel: '[SWERPG.TALENT.SPECIALIZATION_TREE_APP.ACTION.PURCHASE]',
+            actionRef: { specializationId: 'spec-a', nodeId: 'n1' },
+          },
+        }
+
+        await app.renderer.onNodePointerDown(node)
+
+        expect(confirmSpy).toHaveBeenCalled()
+        const callArgs = confirmSpy.mock.calls[0][0]
+
+        // Button label uses the same actionLabel as the panel CTA would show
+        expect(callArgs.buttons[0].label).toBe('[SWERPG.TALENT.SPECIALIZATION_TREE_APP.ACTION.PURCHASE]')
+        // Title includes the actionLabel via {action} interpolation
+        expect(callArgs.title).toBe('[SWERPG.TALENT.SPECIALIZATION_TREE_APP.ACTION.PURCHASE]: Tough')
+      })
+
+      it('confirm dialog forget action label matches the actionable actionLabel', async () => {
+        const app = new SpecializationTreeApp()
+        app.actor = createActor()
+        app.rendered = true
+        const viewportHost = { dataset: {}, firstElementChild: null, replaceChildren: vi.fn() }
+        const panel = { hidden: true, querySelector: vi.fn(() => null) }
+        app.element = createRoot({ viewportHost, panel })
+        vi.spyOn(app, 'refresh').mockResolvedValue(app)
+
+        await app._onRender({ currentTreeId: 'spec-a', renderNodes: [], renderConnections: [] }, {})
+
+        const confirmSpy = vi.spyOn(foundry.applications.api.DialogV2, 'confirm')
+        confirmSpy.mockResolvedValue(true)
+
+        const node = {
+          nodeId: 'n1',
+          talentName: 'Tough',
+          xpCost: 5,
+          actionable: {
+            primaryAction: 'forget',
+            canForget: true,
+            actionLabel: '[SWERPG.TALENT.SPECIALIZATION_TREE_APP.ACTION.FORGET]',
+            actionRef: { specializationId: 'spec-a', nodeId: 'n1' },
+          },
+        }
+
+        await app.renderer.onNodePointerDown(node)
+
+        expect(confirmSpy).toHaveBeenCalled()
+        const callArgs = confirmSpy.mock.calls[0][0]
+
+        // Button label uses the same actionLabel as the panel CTA would show
+        expect(callArgs.buttons[0].label).toBe('[SWERPG.TALENT.SPECIALIZATION_TREE_APP.ACTION.FORGET]')
+        // Title includes the actionLabel via {action} interpolation
+        expect(callArgs.title).toBe('[SWERPG.TALENT.SPECIALIZATION_TREE_APP.ACTION.FORGET]: Tough')
+      })
+    })
+
+    /* ── Non-regression compact flow ──────────────────────────── */
+
+    describe('non-regression flow (GUX1→GUX5)', () => {
+      it('legend items, detail panel, and purchase action coexist coherently', async () => {
+        const localize = (key) => key
+        const legendItems = buildLegendItems(localize)
+
+        // 1 — Legend exposes all four states with coherent affordance
+        expect(legendItems).toHaveLength(4)
+        const affordanceMap = Object.fromEntries(legendItems.map((i) => [i.state, i.affordance]))
+        expect(affordanceMap).toEqual({
+          purchased: 'informational',
+          available: 'actionable',
+          locked: 'blocked',
+          invalid: 'informational',
+        })
+
+        // 2 — Legend cursor assignment matches affordance intent
+        const cursorMap = Object.fromEntries(legendItems.map((i) => [i.state, i.cursor]))
+        expect(cursorMap).toEqual({
+          purchased: 'default',
+          available: 'pointer',
+          locked: 'not-allowed',
+          invalid: 'help',
+        })
+
+        // 3 — Locked node triggers detail panel (no action) with correct state
+        const { panel: lockedPanel, els: lockedEls } = createPanelMock()
+        const viewportHostLocked = { dataset: {}, firstElementChild: null, replaceChildren: vi.fn() }
+        const appLocked = new SpecializationTreeApp()
+        appLocked.actor = createActor()
+        appLocked.element = createRoot({ viewportHost: viewportHostLocked, panel: lockedPanel })
+        await appLocked._onRender({ currentTreeId: 'spec-a', renderNodes: [], renderConnections: [] }, {})
+
+        await appLocked.renderer.onNodePointerDown({
+          talentName: 'Grit',
+          xpCost: 10,
+          isRanked: true,
+          talentDescription: null,
+          nodeStateLabel: 'Locked',
+          reasonLabel: 'Not enough XP',
+          actionable: { primaryAction: null },
+        })
+
+        expect(lockedPanel.hidden).toBe(false)
+        expect(lockedEls.stateEl.textContent).toBe('Locked')
+        expect(lockedEls.reasonEl.textContent).toBe('Not enough XP')
+        expect(lockedEls.ctaEl.hidden).toBe(true)
+
+        // 4 — Deselected background callback hides panel
+        appLocked.renderer.onBackgroundPointerDown()
+        expect(lockedPanel.hidden).toBe(true)
+
+        // 5 — Available node triggers purchase flow directly (panel stays hidden)
+        const fastPanel = { hidden: true, querySelector: vi.fn(() => null) }
+        const viewportHostAvail = { dataset: {}, firstElementChild: null, replaceChildren: vi.fn() }
+        const appAvail = new SpecializationTreeApp()
+        appAvail.actor = createActor()
+        appAvail.rendered = true
+        appAvail.element = createRoot({ viewportHost: viewportHostAvail, panel: fastPanel })
+        const refreshSpy = vi.spyOn(appAvail, 'refresh').mockResolvedValue(appAvail)
+        await appAvail._onRender({ currentTreeId: 'spec-a', renderNodes: [], renderConnections: [] }, {})
+
+        purchaseTalentNodeMock.mockResolvedValue({ ok: true })
+        const confirmSpy = vi.spyOn(foundry.applications.api.DialogV2, 'confirm')
+        confirmSpy.mockResolvedValue(true)
+        const infoSpy = vi.spyOn(ui.notifications, 'info')
+
+        await appAvail.renderer.onNodePointerDown({
+          nodeId: 'n1',
+          talentName: 'Tough',
+          xpCost: 5,
+          actionable: {
+            primaryAction: 'purchase',
+            canPurchase: true,
+            actionRef: { specializationId: 'spec-a', nodeId: 'n1' },
+          },
+        })
+
+        expect(purchaseTalentNodeMock).toHaveBeenCalledWith(appAvail.actor, 'spec-a', 'n1')
+        expect(infoSpy).toHaveBeenCalled()
+        expect(refreshSpy).toHaveBeenCalled()
+      })
+    })
+  })
 })


### PR DESCRIPTION
Closes #331

## Contexte
Matrice de validation GUX6 pour vérifier la lisibilité et l'affordance des éléments de l'interface de l'arbre de spécialisation, avec tests automatisés formalisant cette validation.

## Résumé des changements
- **documentation/plan/character-sheet/specialization-tree/331-gux6-valider-lisibilite-affordances-et-non-regression-du-flux.md** — plan d'implémentation GUX6 (matrice, scénarios, checklist)
- **tests/applications/specialization-tree-app.test.mjs** (+301 lignes) — 6 nouveaux tests couvrant :
  - locked node : état + raison + pas de CTA
  - invalid node : état + raison + pas de CTA
  - purchased blocked by dependents : raison de blocage + pas de CTA
  - continuité action/microcopy (purchase) : label bouton et titre alignés
  - continuité action/microcopy (forget) : même vérification
  - non-régression flux complet : légende → locked panel → dismiss → purchase

## Tests exécutés
- 27/27 passés (21 existants + 6 nouveaux GUX6)

## Limites
- Tests unitaires uniquement (pas de vérification visuelle PIXI réelle)
- CI à exécuter après merge