### PR TITLE
chore(specialization-tree): add PXP1 plans and tests

### DIFF
--- a/documentation/plan/character-sheet/specialization-tree/341-pxp1-clarifier-contraste-et-etats-des-noeuds-actifs-inactifs.md
+++ b/documentation/plan/character-sheet/specialization-tree/341-pxp1-clarifier-contraste-et-etats-des-noeuds-actifs-inactifs.md
@@ -1,0 +1,104 @@
+# PXP1 — Plan d'implémentation : Clarifier contraste et états des nœuds actifs/inactifs
+
+## Contexte
+
+Issue : [#341 — PXP1 - Clarifier contraste et etats des noeuds actifs/inactifs](https://github.com/herveDarritchon/foundryvtt-swerpg/issues/341)
+
+Références :
+
+- `documentation/ways-of-work/plan/specialization-tree-v1/pixi-tree-polish/project-plan.md`
+- `documentation/ways-of-work/plan/specialization-tree-v1/pixi-tree-polish/issues-checklist.md`
+- `documentation/cadrage/character-sheet/specialization-tree/cadrage-refonte-graphique.md`
+- `documentation/plan/character-sheet/specialization-tree/327-gux2-clarifier-les-etats-des-noeuds-avec-couleurs-contraste-et-pictogrammes.md`
+
+`#341` ouvre la passe de base du chantier `Pixi Tree Polish` : rendre immédiatement lisibles le type métier du nœud (actif/inactif) et son état observable (acheté, disponible, verrouillé), sans retoucher les règles domaine.
+
+## Objectif
+
+Établir un contrat visuel court, stable et testable pour les nœuds de `SpecializationTreeApp`, avec une base rouge pour les talents actifs, une base bleue pour les talents inactifs, des variantes d'état distinguables, un badge XP réservé aux cas `available`, et un coût XP présenté de manière uniforme.
+
+## Périmètre
+
+### Inclus
+
+- palette actif/inactif portée par la couleur de base du nœud ;
+- différenciation visible entre `purchased`, `available` et `locked` à l'intérieur de chaque famille ;
+- indice non chromatique minimal pour éviter une lecture dépendante de la seule couleur ;
+- harmonisation du rendu du coût XP ;
+- définition explicite des couleurs `fill`, `border`, `text`, `xpCost` et `xpBadge` pour les 6 cas ;
+- couverture de test ciblée sur les 6 cas prioritaires.
+
+### Exclus
+
+- ouverture du détail au clic et icônes d'action dédiées (`PXP2`) ;
+- renforcement des connexions et compaction de la fenêtre de détail (`PXP3`) ;
+- correction de netteté du zoom PIXI (`PXP4`) ;
+- toute modification des règles métier de calcul d'état, d'achat ou d'oubli.
+
+## Matrice visuelle cible
+
+| Type talent      | État        | Fill       | Border     | Texte                | Coût XP    | Badge XP                        |
+| ---------------- | ----------- | ---------- | ---------- | -------------------- | ---------- | ------------------------------- |
+| Actif            | `purchased` | `0x7A2323` | `0xFFA2A2` | `0xFFF7F7`           | `0xFFC7C7` | aucun                           |
+| Actif            | `available` | `0x4D2525` | `0xB87676` | `0xFFF5F5`           | `0xFFFFFF` | `0x7A3E3E` / border `0xD9A0A0`  |
+| Actif            | `locked`    | `0x302020` | `0x7A7A7A` | `0xE2D7D7` a `0.68`  | `0x999999` | aucun                           |
+| Passif / inactif | `purchased` | `0x1F4F8C` | `0x95C9FF` | `0xFFFFFF`           | `0xB9D9FF` | aucun                           |
+| Passif / inactif | `available` | `0x21344D` | `0x5F85AD` | `0xF5F9FF`           | `0xFFFFFF` | `0x355A84` / border `0x8CB8E8`  |
+| Passif / inactif | `locked`    | `0x1F2630` | `0x7A7A7A` | `0xD7DBE2` a `0.68`  | `0x999999` | aucun                           |
+
+Contraintes de lecture derivees :
+
+- le rouge/bleu porte exclusivement le type de talent ;
+- la distinction `purchased` / `available` / `locked` repose sur la combinaison fill + border + contraste texte + presence/absence du badge XP ;
+- le badge XP n'apparait que pour les noeuds `available`.
+
+## Fichiers pressentis
+
+| Fichier                                                         | Rôle                                                              |
+| --------------------------------------------------------------- | ----------------------------------------------------------------- |
+| `module/applications/specialization-tree/node-ui-state.mjs`     | Centraliser la matrice visuelle état × type                       |
+| `module/applications/specialization-tree-app.mjs`               | Appliquer le contrat visuel au rendu PIXI des nœuds               |
+| `tests/applications/specialization-tree/node-ui-state.test.mjs` | Verrouiller le mapping pur des variantes                          |
+| `tests/applications/specialization-tree-app.test.mjs`           | Vérifier l'exposition applicative du contrat de rendu             |
+| `lang/fr.json` / `lang/en.json`                                 | Compléter les libellés uniquement si un nouvel indice l'exige     |
+
+## Plan d'implémentation
+
+### Étape 1 — Figer la matrice visuelle des nœuds
+
+**Fichiers :** `module/applications/specialization-tree/node-ui-state.mjs`
+
+1. Définir un contrat unique combinant `isActive` et `nodeState` pour produire `fill`, `border`, `text`, `xpCost` et `xpBadge` selon la matrice ci-dessus.
+2. Séparer clairement le signal de type (rouge actif / bleu inactif) du signal d'état (acheté, disponible, verrouillé) sans recalcul métier côté UI.
+3. Encadrer explicitement les cas `available` comme seuls noeuds portant un badge XP dédié, avec ses couleurs de fond et de bordure.
+
+**Validation visée :** les 6 combinaisons prioritaires sont distinguables sans ambiguïté majeure et sans recalcul métier côté UI.
+
+### Étape 2 — Appliquer ce contrat au rendu PIXI et stabiliser le coût XP
+
+**Fichiers :** `module/applications/specialization-tree-app.mjs`
+
+1. Remplacer tout style inline disperse par la consommation du mapper UI centralisé.
+2. Appliquer strictement les valeurs de `fill`, `border`, contraste texte et couleur du coût XP pour chacun des 6 cas définis.
+3. Afficher le badge XP uniquement pour les noeuds `available`, avec la palette specifique active/inactive fournie.
+
+**Validation visée :** le rendu final raconte clairement actif/inactif et acheté/disponible/verrouillé au premier regard.
+
+### Étape 3 — Verrouiller les tests du contrat observable
+
+**Fichiers :** `tests/applications/specialization-tree/node-ui-state.test.mjs`, `tests/applications/specialization-tree-app.test.mjs`
+
+1. Couvrir la matrice minimale : actif acheté, actif disponible, actif verrouillé, inactif acheté, inactif disponible, inactif verrouillé.
+2. Vérifier que la lisibilite ne depend pas uniquement de la teinte : bordure, contraste texte et presence/absence du badge XP doivent rester coherents.
+3. Verifier que le cout XP suit le contrat attendu pour chaque etat et que l'application consomme bien le mapper dedie.
+
+**Validation visée :** le langage visuel de base de `PXP1` devient stable avant d'ouvrir `PXP2` et `PXP3`.
+
+## Définition de done
+
+- [ ] Les nœuds actifs utilisent une base rouge et les nœuds inactifs une base bleue.
+- [ ] `purchased`, `available` et `locked` restent lisibles dans chaque famille actif/inactif.
+- [ ] Le badge XP n'apparait que sur les noeuds `available`, avec la palette definie.
+- [ ] La lecture d'etat ne depend pas uniquement de la couleur.
+- [ ] Le cout XP est presente de facon uniforme et conforme a la matrice cible.
+- [ ] Les tests couvrent les 6 cas prioritaires du ticket.

--- a/documentation/ways-of-work/plan/specialization-tree-v1/pixi-tree-polish/issues-checklist.md
+++ b/documentation/ways-of-work/plan/specialization-tree-v1/pixi-tree-polish/issues-checklist.md
@@ -1,0 +1,103 @@
+# Issues Checklist — Specialization Tree V1 / Pixi Tree Polish
+
+## Préparation
+
+- [ ] Relire les cadrages `cadrage-refonte-graphique.md` et `spec-cadrage-canvas-specialization-tree-ergonomie.md`
+- [ ] Confirmer le rattachement à l'epic `Specialization Tree V1`
+- [ ] Noter que la feature prolonge `Graphical UX Refresh` sans la remplacer
+- [ ] Préparer les labels `feature`, `user-story`, `enabler`, `test`, `priority-*`, `value-high`, `specialization-tree`, `pixi`, `ux`
+
+## Création Epic / Feature
+
+- [ ] Réutiliser l'epic `Specialization Tree V1`
+- [ ] Créer la feature `Pixi Tree Polish - Renforcer lisibilité et netteté de l'arbre de spécialisation`
+- [ ] Renseigner `Priority = P1`, `Value = High`, `Component = Character Sheet / Specialization Tree / PIXI`
+- [ ] Poser la relation de continuité avec `Graphical UX Refresh`
+
+## Stories / Enabler / Test à créer
+
+### PXP1 — États visuels des nœuds
+
+- [ ] Titre : `PXP1 - Clarifier contraste et états des nœuds actifs/inactifs`
+- [ ] AC : base rouge pour actif, base bleue pour inactif, variantes visibles pour `available` / `locked` / `purchased`
+- [ ] AC : lecture claire des 6 cas prioritaires sans dépendre uniquement de la couleur
+- [ ] AC : coût XP uniformisé
+- [ ] Estimate : `3`
+- [ ] Priority : `P1`
+- [ ] Bloquée par : Feature
+
+### PXP2 — Clic nœud et icônes
+
+- [ ] Titre : `PXP2 - Ouvrir le détail au clic et ajouter les icônes d'action des nœuds`
+- [ ] AC : clic sur nœud ouvre la fenêtre de détail
+- [ ] AC : `assets/images/icons/electricity.svg` en haut à gauche pour actif
+- [ ] AC : `assets/images/icons/plain-circle.svg` en haut à gauche pour inactif
+- [ ] AC : `assets/images/icons/buy-card.svg` / `sell-card.svg` en haut à droite selon l'action
+- [ ] AC : `assets/images/icons/rank.svg` en bas à droite pour talent ranked
+- [ ] Estimate : `3`
+- [ ] Priority : `P1`
+- [ ] Bloquée par : `PXP1`
+
+### PXP3 — Connexions et détail
+
+- [ ] Titre : `PXP3 - Renforcer connexions et compacter la fenêtre de détail`
+- [ ] AC : connexions élargies et plus visibles
+- [ ] AC : header de détail compacté
+- [ ] AC : croix explicite pour fermer la fenêtre de détail
+- [ ] Estimate : `2`
+- [ ] Priority : `P1`
+- [ ] Bloquée par : `PXP1`
+
+### PXP4 — Enabler zoom PIXI
+
+- [ ] Titre : `PXP4 - Corriger le flou du zoom PIXI dans le viewport`
+- [ ] AC : le zoom reste lisible dans la plage supportée
+- [ ] AC : la correction ne réintroduit pas de glissement ou de perte de contrôle du viewport
+- [ ] AC : la netteté des nœuds, icônes et connexions reste acceptable après zoom in/out
+- [ ] Estimate : `3`
+- [ ] Priority : `P0`
+- [ ] Bloquée par : Feature
+
+### PXP5 — Validation ciblée
+
+- [ ] Titre : `PXP5 - Valider lisibilité, affordances et netteté du canvas`
+- [ ] Cas : actif disponible, actif indisponible, actif acheté, inactif disponible, inactif indisponible, inactif acheté
+- [ ] Cas : ouverture détail au clic, fermeture par croix, visibilité des connexions, cohérence des icônes, netteté au zoom
+- [ ] Estimate : `2`
+- [ ] Priority : `P1`
+- [ ] Bloquée par : `PXP1`, `PXP2`, `PXP3`, `PXP4`
+
+## Sous-tâches recommandées
+
+- [ ] Ajouter une task de mapping des emplacements d'icônes par coin du nœud
+- [ ] Ajouter une task de normalisation visuelle du badge/coût XP
+- [ ] Ajouter une task de différenciation fine acheté vs disponible vs indisponible dans chaque famille actif/inactif
+- [ ] Ajouter une task de réglage d'épaisseur et contraste des connexions
+- [ ] Ajouter une task dédiée à la netteté du rendu pendant le zoom
+
+## Dépendances GitHub à poser
+
+- [ ] Feature **blocked by** Epic `Specialization Tree V1`
+- [ ] Feature **related to** `Graphical UX Refresh`
+- [ ] `PXP1` **blocked by** Feature
+- [ ] `PXP2` **blocked by** `PXP1`
+- [ ] `PXP3` **blocked by** `PXP1`
+- [ ] `PXP4` **blocked by** Feature
+- [ ] `PXP5` **blocked by** `PXP1`, `PXP2`, `PXP3`, `PXP4`
+
+## Board / pilotage
+
+- [ ] Ajouter toutes les issues au board Kanban
+- [ ] Mettre `PXP1` et `PXP4` en `Sprint Ready` en premier
+- [ ] Lancer `PXP2` et `PXP3` après validation du langage visuel de base
+- [ ] Garder `PXP5` comme verrou final de la feature
+
+## Checklist de clôture
+
+- [ ] Les nœuds et connexions sont plus lisibles au premier regard
+- [ ] Le joueur comprend actif/inactif et acheté/disponible/indisponible sans effort excessif
+- [ ] Le détail s'ouvre directement au clic sur nœud
+- [ ] Les icônes de statut et d'action sont cohérentes avec le métier
+- [ ] Le coût XP est uniforme
+- [ ] Le header de détail est compact et la fermeture est explicite
+- [ ] Le zoom n'introduit plus de flou gênant

--- a/documentation/ways-of-work/plan/specialization-tree-v1/pixi-tree-polish/project-plan.md
+++ b/documentation/ways-of-work/plan/specialization-tree-v1/pixi-tree-polish/project-plan.md
@@ -1,0 +1,127 @@
+# Project Plan — Specialization Tree V1 / Pixi Tree Polish
+
+## Contexte source
+
+- Input utilisateur: TODO `Specialization Tree (Pixi)`
+- `documentation/cadrage/character-sheet/specialization-tree/cadrage-refonte-graphique.md`
+- `documentation/cadrage/character-sheet/specialization-tree/spec-cadrage-canvas-specialization-tree-ergonomie.md`
+- `documentation/ways-of-work/plan/specialization-tree-v1/graphical-ux-refresh/project-plan.md`
+
+## 1. Vue d'ensemble
+
+- **Epic**: `Specialization Tree V1`
+- **Feature**: `Pixi Tree Polish`
+- **Positionnement**: passe courte de polish visuel et ergonomique sur la fenêtre PIXI des arbres de spécialisation.
+
+### Résumé
+
+Renforcer la lisibilité immédiate des nœuds et des connexions, rendre le panneau de détail plus actionnable, et corriger la perte de netteté au zoom sans changer la logique métier des arbres.
+
+### Valeur métier
+
+- distinguer en un coup d'œil actif/inactif, disponible/indisponible/acheté ;
+- rendre le clic sur nœud plus évident et plus utile ;
+- fiabiliser la lecture des connexions et du coût XP ;
+- éviter qu'un zoom utile dégrade la qualité visuelle du canvas.
+
+## 2. Critères de succès
+
+- les nœuds actifs utilisent une base rouge, les nœuds inactifs une base bleue ;
+- chaque état `available` / `locked` / `purchased` reste lisible à l'intérieur de cette base couleur ;
+- le clic sur un nœud ouvre la fenêtre de détail ;
+- les icônes métier sont cohérentes et stables: actif/inactif en haut à gauche, acheter/vendre en haut à droite, rang en bas à droite ;
+- le coût XP est affiché de façon uniforme ;
+- les connexions sont plus visibles ;
+- la fenêtre de détail a un header compact et une action de fermeture explicite ;
+- le zoom garde une image nette et exploitable.
+
+## 3. Jalons
+
+1. **Langage visuel des nœuds** — contraste, variantes d'état, icônes, coût XP.
+2. **Affordances d'interaction** — clic nœud → détail, achat/vente explicites, ranked visible.
+3. **Lisibilité de l'écran** — connexions renforcées, détail compact, fermeture claire.
+4. **Qualité viewport** — correction du flou au zoom et validation finale.
+
+## 4. Risques
+
+| Risque | Impact | Mitigation |
+| --- | --- | --- |
+| Trop d'icônes sur un nœud | surcharge visuelle | garder des marqueurs discrets et positions stables |
+| Couleur métier et état d'achat mélangés | ambiguïté utilisateur | séparer couleur de base et variation d'état |
+| Connexions plus épaisses mais trop dominantes | bruit visuel | augmenter la visibilité sans concurrencer les nœuds |
+| Correction du zoom qui casse le rendu courant | régression UX | isoler l'issue zoom comme enabler technique avec validation dédiée |
+
+## 5. Hiérarchie des work items
+
+```mermaid
+graph TD
+    A[Epic: Specialization Tree V1] --> B[Feature: Pixi Tree Polish]
+    B --> C[Story: Clarifier les états visuels des nœuds]
+    B --> D[Story: Rendre le nœud actionnable et informatif]
+    B --> E[Story: Améliorer connexions et fenêtre de détail]
+    B --> F[Enabler: Stabiliser la netteté du zoom PIXI]
+    B --> G[Test: Valider lisibilité, actions et zoom]
+
+    C --> C1[Task: base rouge/bleue + variantes d'état]
+    C --> C2[Task: uniformiser coût XP]
+    D --> D1[Task: clic nœud ouvre le détail]
+    D --> D2[Task: ajouter icônes actif/inactif, achat/vente, ranked]
+    E --> E1[Task: élargir les connexions]
+    E --> E2[Task: compacter header + ajouter croix de fermeture]
+    F --> F1[Task: corriger le flou au zoom]
+    G --> G1[Task: couvrir contraste, icônes, détail, connexions, zoom]
+```
+
+## 6. Découpage GitHub recommandé
+
+| Type | Titre | Priorité | Estimate | Dépendances |
+| --- | --- | --- | --- | --- |
+| Feature | `Pixi Tree Polish - Renforcer lisibilité et netteté de l'arbre de spécialisation` | P1 | 8 | Epic `Specialization Tree V1`, continuité `Graphical UX Refresh` |
+| Story | `PXP1 - Clarifier contraste et états des nœuds actifs/inactifs` | P1 | 3 | Feature |
+| Story | `PXP2 - Ouvrir le détail au clic et ajouter les icônes d'action des nœuds` | P1 | 3 | PXP1 |
+| Story | `PXP3 - Renforcer connexions et compacter la fenêtre de détail` | P1 | 2 | PXP1 |
+| Enabler | `PXP4 - Corriger le flou du zoom PIXI dans le viewport` | P0 | 3 | Feature |
+| Test | `PXP5 - Valider lisibilité, affordances et netteté du canvas` | P1 | 2 | PXP1, PXP2, PXP3, PXP4 |
+
+## 7. Dépendances et ordre recommandé
+
+1. **PXP1** — établir le contrat visuel de base.
+2. **PXP2** et **PXP3** — parallélisables après stabilisation des états visuels.
+3. **PXP4** — peut avancer en parallèle, mais doit être validé avant clôture feature.
+4. **PXP5** — verrouiller la non-régression observable.
+
+## 8. Board Kanban
+
+- **Backlog**: feature et sous-issues créées
+- **Sprint Ready**: AC détaillés, assets confirmés, dépendances posées
+- **In Progress**: une story UX + l'enabler zoom au maximum en parallèle
+- **In Review**: relecture UX + rendu PIXI
+- **Testing**: validation sur cas actif/inactif, acheté/disponible/indisponible, zoom
+- **Done**: lisibilité, action et netteté validées
+
+### Champs recommandés
+
+- `Priority`: `P0` / `P1`
+- `Value`: `High`
+- `Component`: `Character Sheet / Specialization Tree / PIXI`
+- `Estimate`: `2`, `3`, `8`
+- `Epic`: `Specialization Tree V1`
+- `Track`: `Pixi Tree Polish`
+
+## 9. Définition de done
+
+- les 6 variantes visuelles demandées sont distinguables sans ambiguïté majeure ;
+- le détail s'ouvre au clic sur nœud ;
+- les icônes `electricity.svg`, `plain-circle.svg`, `buy-card.svg`, `sell-card.svg`, `rank.svg` sont mappées aux bons cas ;
+- le coût XP est présenté de façon uniforme ;
+- les connexions sont plus visibles sans dominer les nœuds ;
+- la fenêtre de détail peut se fermer explicitement et prend moins d'espace ;
+- le zoom reste net dans la plage supportée par le viewport ;
+- la feature et ses sous-issues sont traçables sur le board.
+
+## 10. Métriques de pilotage
+
+- **Predictibilité sprint**: >80 % des sous-issues livrées dans le sprint prévu
+- **Cycle time cible**: <5 jours ouvrés par story/enabler
+- **Couverture AC**: 100 % des critères de chaque issue relus en review/testing
+- **Défauts UX post-livraison**: 0 défaut bloquant sur contraste, clic nœud, zoom flou

--- a/tests/applications/specialization-tree/node-ui-state.test.mjs
+++ b/tests/applications/specialization-tree/node-ui-state.test.mjs
@@ -475,4 +475,170 @@ describe('node-ui-state', () => {
       expect(result.nodeStateSvgIconPath).toBe(NODE_STATE_SVG_ICONS[NODE_STATE.INVALID])
     })
   })
+
+  /**
+   * PXP1 - Visual contract tests for the 6 priority cases from issue #341
+   * These tests lock in the exact visual matrix defined in the implementation plan.
+   *
+   * Matrix:
+   * - Active talents: red-based fill colors
+   * - Passive talents: blue-based fill colors
+   * - purchased: bright, costDisplay='secondary' (no badge)
+   * - available: medium, costDisplay='badge' (only state with XP badge)
+   * - locked: dark, textAlpha=0.68, costDisplay='plain'
+   */
+  describe('PXP1 visual contract - 6 priority cases', () => {
+    it('ACTIVE PURCHASED: red base, bright border, no XP badge', () => {
+      const v = NODE_STATE_VARIANTS[NODE_STATE.PURCHASED][NODE_TYPE.ACTIVE]
+
+      // Red-based fill for active
+      expect(v.fillColor).toBe(0x7a2323)
+      expect(v.borderColor).toBe(0xffa2a2)
+      expect(v.textColor).toBe(0xfff7f7)
+      expect(v.textAlpha).toBe(1)
+      expect(v.costColor).toBe(0xffc7c7)
+      // Purchased has no badge
+      expect(v.costDisplay).toBe('secondary')
+      expect(v.costBadgeFillColor).toBeNull()
+      expect(v.costBadgeBorderColor).toBeNull()
+    })
+
+    it('ACTIVE AVAILABLE: darker red, medium border, XP badge present', () => {
+      const v = NODE_STATE_VARIANTS[NODE_STATE.AVAILABLE][NODE_TYPE.ACTIVE]
+
+      // Darker red fill for available active
+      expect(v.fillColor).toBe(0x4d2525)
+      expect(v.borderColor).toBe(0xb87676)
+      expect(v.textColor).toBe(0xfff5f5)
+      expect(v.textAlpha).toBe(1)
+      expect(v.costColor).toBe(0xffffff)
+      // Available is the ONLY state with XP badge
+      expect(v.costDisplay).toBe('badge')
+      expect(v.costBadgeFillColor).toBe(0x7a3e3e)
+      expect(v.costBadgeBorderColor).toBe(0xd9a0a0)
+    })
+
+    it('ACTIVE LOCKED: darkest red, gray border, reduced text alpha, no badge', () => {
+      const v = NODE_STATE_VARIANTS[NODE_STATE.LOCKED][NODE_TYPE.ACTIVE]
+
+      // Darkest red fill for locked active
+      expect(v.fillColor).toBe(0x302020)
+      expect(v.borderColor).toBe(0x7a7a7a)
+      expect(v.textColor).toBe(0xe2d7d7)
+      expect(v.textAlpha).toBe(0.68) // Reduced alpha for locked
+      expect(v.costColor).toBe(0x999999)
+      // Locked has no badge
+      expect(v.costDisplay).toBe('plain')
+      expect(v.costBadgeFillColor).toBeNull()
+      expect(v.costBadgeBorderColor).toBeNull()
+    })
+
+    it('PASSIVE PURCHASED: blue base, bright border, no XP badge', () => {
+      const v = NODE_STATE_VARIANTS[NODE_STATE.PURCHASED][NODE_TYPE.PASSIVE]
+
+      // Blue-based fill for passive
+      expect(v.fillColor).toBe(0x1f4f8c)
+      expect(v.borderColor).toBe(0x95c9ff)
+      expect(v.textColor).toBe(0xffffff)
+      expect(v.textAlpha).toBe(1)
+      expect(v.costColor).toBe(0xb9d9ff)
+      // Purchased has no badge
+      expect(v.costDisplay).toBe('secondary')
+      expect(v.costBadgeFillColor).toBeNull()
+      expect(v.costBadgeBorderColor).toBeNull()
+    })
+
+    it('PASSIVE AVAILABLE: darker blue, medium border, XP badge present', () => {
+      const v = NODE_STATE_VARIANTS[NODE_STATE.AVAILABLE][NODE_TYPE.PASSIVE]
+
+      // Darker blue fill for available passive
+      expect(v.fillColor).toBe(0x21344d)
+      expect(v.borderColor).toBe(0x5f85ad)
+      expect(v.textColor).toBe(0xf5f9ff)
+      expect(v.textAlpha).toBe(1)
+      expect(v.costColor).toBe(0xffffff)
+      // Available is the ONLY state with XP badge
+      expect(v.costDisplay).toBe('badge')
+      expect(v.costBadgeFillColor).toBe(0x355a84)
+      expect(v.costBadgeBorderColor).toBe(0x8cb8e8)
+    })
+
+    it('PASSIVE LOCKED: darkest blue-gray, gray border, reduced text alpha, no badge', () => {
+      const v = NODE_STATE_VARIANTS[NODE_STATE.LOCKED][NODE_TYPE.PASSIVE]
+
+      // Darkest blue-gray fill for locked passive
+      expect(v.fillColor).toBe(0x1f2630)
+      expect(v.borderColor).toBe(0x7a7a7a)
+      expect(v.textColor).toBe(0xd7dbe2)
+      expect(v.textAlpha).toBe(0.68) // Reduced alpha for locked
+      expect(v.costColor).toBe(0x999999)
+      // Locked has no badge
+      expect(v.costDisplay).toBe('plain')
+      expect(v.costBadgeFillColor).toBeNull()
+      expect(v.costBadgeBorderColor).toBeNull()
+    })
+
+    it('Active/Passive distinction: red vs blue fill colors', () => {
+      const activePurchased = NODE_STATE_VARIANTS[NODE_STATE.PURCHASED][NODE_TYPE.ACTIVE]
+      const passivePurchased = NODE_STATE_VARIANTS[NODE_STATE.PURCHASED][NODE_TYPE.PASSIVE]
+      const activeAvailable = NODE_STATE_VARIANTS[NODE_STATE.AVAILABLE][NODE_TYPE.ACTIVE]
+      const passiveAvailable = NODE_STATE_VARIANTS[NODE_STATE.AVAILABLE][NODE_TYPE.PASSIVE]
+      const activeLocked = NODE_STATE_VARIANTS[NODE_STATE.LOCKED][NODE_TYPE.ACTIVE]
+      const passiveLocked = NODE_STATE_VARIANTS[NODE_STATE.LOCKED][NODE_TYPE.PASSIVE]
+
+      // Active = red-based (higher red channel)
+      expect(activePurchased.fillColor).toBeGreaterThan(0x700000)
+      expect(activeAvailable.fillColor).toBeGreaterThan(0x400000)
+      expect(activeLocked.fillColor).toBeGreaterThan(0x300000)
+
+      // Passive = blue-based (higher blue channel)
+      expect(passivePurchased.fillColor).toBeLessThan(0x200000)
+      expect(passiveAvailable.fillColor).toBeLessThan(0x300000)
+      expect(passiveLocked.fillColor).toBeLessThan(0x200000)
+    })
+
+    it('State distinction: purchased vs available vs locked have distinguishable properties', () => {
+      const activePurchased = NODE_STATE_VARIANTS[NODE_STATE.PURCHASED][NODE_TYPE.ACTIVE]
+      const activeAvailable = NODE_STATE_VARIANTS[NODE_STATE.AVAILABLE][NODE_TYPE.ACTIVE]
+      const activeLocked = NODE_STATE_VARIANTS[NODE_STATE.LOCKED][NODE_TYPE.ACTIVE]
+
+      // Fill colors are distinct (brightest → darkest)
+      expect(activePurchased.fillColor).not.toBe(activeAvailable.fillColor)
+      expect(activeAvailable.fillColor).not.toBe(activeLocked.fillColor)
+
+      // Border colors are distinct
+      expect(activePurchased.borderColor).not.toBe(activeAvailable.borderColor)
+      expect(activeAvailable.borderColor).not.toBe(activeLocked.borderColor)
+
+      // Only available has badge
+      expect(activePurchased.costDisplay).not.toBe('badge')
+      expect(activeAvailable.costDisplay).toBe('badge')
+      expect(activeLocked.costDisplay).not.toBe('badge')
+
+      // Only locked has reduced text alpha
+      expect(activePurchased.textAlpha).toBe(1)
+      expect(activeAvailable.textAlpha).toBe(1)
+      expect(activeLocked.textAlpha).toBe(0.68)
+    })
+
+    it('Only AVAILABLE nodes have XP badge - non-color state signal', () => {
+      const states = [NODE_STATE.PURCHASED, NODE_STATE.AVAILABLE, NODE_STATE.LOCKED, NODE_STATE.INVALID]
+      const types = [NODE_TYPE.ACTIVE, NODE_TYPE.PASSIVE]
+
+      for (const state of states) {
+        for (const type of types) {
+          const v = NODE_STATE_VARIANTS[state][type]
+          if (state === NODE_STATE.AVAILABLE) {
+            expect(v.costDisplay).toBe('badge')
+            expect(v.costBadgeFillColor).not.toBeNull()
+            expect(v.costBadgeBorderColor).not.toBeNull()
+          } else {
+            expect(v.costDisplay).not.toBe('badge')
+            expect(v.costBadgeFillColor).toBeNull()
+            expect(v.costBadgeBorderColor).toBeNull()
+          }
+        }
+      }
+    })
+  })
 })


### PR DESCRIPTION
## Summary
- add the PXP1 implementation plan for issue #341, including the node visual matrix
- add the Pixi Tree Polish project plan and issue checklist under documentation/ways-of-work
- add explicit node UI state tests covering the six PXP1 priority visual cases

## Issue
Refs #341

## Technical Notes
- this PR adds documentation and tests only
- no runtime production code changes are included
- the test updates lock the current node state visual contract in `tests/applications/specialization-tree/node-ui-state.test.mjs`
- implementation plan: `documentation/plan/character-sheet/specialization-tree/341-pxp1-clarifier-contraste-et-etats-des-noeuds-actifs-inactifs.md`

## Tests
- `pnpm vitest run tests/applications/specialization-tree/node-ui-state.test.mjs`

## Known Limits
- this PR does not change the specialization tree runtime or PIXI rendering code

## Points of Attention
- verify the added planning docs stay aligned with the existing specialization tree visual matrix
- review the new PXP1 assertions as the contract for active/passive and purchased/available/locked variants