### PR TITLE
feat(specialization-tree): open detail panel on node click and add action icons

### DIFF
--- a/documentation/plan/character-sheet/specialization-tree/342-pxp2-ouvrir-le-detail-au-clic-et-ajouter-les-icones-d-action-des-noeuds.md
+++ b/documentation/plan/character-sheet/specialization-tree/342-pxp2-ouvrir-le-detail-au-clic-et-ajouter-les-icones-d-action-des-noeuds.md
@@ -1,0 +1,91 @@
+# PXP2 — Plan d'implémentation : Ouvrir le détail au clic et ajouter les icônes d'action des nœuds
+
+## Contexte
+
+Issue : [#342 — PXP2 - Ouvrir le detail au clic et ajouter les icones d action des noeuds](https://github.com/herveDarritchon/foundryvtt-swerpg/issues/342)
+
+Références principales :
+
+- `documentation/plan/character-sheet/specialization-tree/341-pxp1-clarifier-contraste-et-etats-des-noeuds-actifs-inactifs.md`
+- `documentation/plan/character-sheet/specialization-tree/329-gux4-transformer-le-panneau-de-detail-en-panneau-daction-contextuelle.md`
+- `module/applications/specialization-tree/node-ui-state.mjs`
+- `module/applications/specialization-tree/pixi-tree-renderer.mjs`
+- `module/applications/specialization-tree-app.mjs`
+
+`#342` prolonge `PXP1` en rendant chaque nœud immédiatement lisible et consultable : le clic ne doit plus déclencher directement l'action métier, mais ouvrir le détail, tandis que les coins du nœud exposent des icônes stables pour le type actif/inactif, l'action disponible et le caractère ranked.
+
+## Objectif
+
+Faire du clic sur nœud le point d'entrée unique de consultation/action, puis rendre le langage visuel des nœuds plus explicite via trois emplacements d'icônes stables : état actif/inactif en haut à gauche, action en haut à droite, rang en bas à droite.
+
+## Périmètre
+
+### Inclus
+
+- ouverture systématique du panneau de détail au clic sur n'importe quel nœud ;
+- conservation de l'action métier via le CTA du panneau contextuel ;
+- mapping explicite des icônes par coin du nœud ;
+- affichage de `electricity.svg` / `plain-circle.svg` pour actif / inactif ;
+- affichage de `buy-card.svg` / `sell-card.svg` selon `primaryAction` ;
+- affichage de `rank.svg` pour les talents ranked.
+
+### Exclus
+
+- modification des règles métier d'achat, d'oubli, de blocage ou de remboursement ;
+- refonte large du panneau de détail hors ajustements nécessaires au nouveau flux de clic ;
+- nouvelles interactions secondaires (double-clic, menu contextuel, raccourcis clavier) ;
+- reprise du contraste global des nœuds déjà traité par `PXP1`.
+
+## Fichiers pressentis
+
+| Fichier                                                           | Rôle                                                                    |
+| ----------------------------------------------------------------- | ----------------------------------------------------------------------- |
+| `module/applications/specialization-tree/node-ui-state.mjs`       | Centraliser le contrat d'icônes par coin selon type, action et rang     |
+| `module/applications/specialization-tree/pixi-tree-renderer.mjs`  | Rendre les sprites/icônes aux bons emplacements sur chaque nœud         |
+| `module/applications/specialization-tree-app.mjs`                 | Faire du clic un ouvre-détail et réserver l'exécution au CTA du panneau |
+| `tests/applications/specialization-tree/node-ui-state.test.mjs`   | Verrouiller le mapping des slots d'icônes                               |
+| `tests/applications/specialization-tree-app.test.mjs`             | Vérifier le nouveau flux clic → détail → action                         |
+| `tests/integration/specialization-tree-pixi-render.test.mjs`      | Vérifier la présence et la stabilité des icônes rendues                 |
+
+## Plan d'implémentation
+
+### Étape 1 — Formaliser le contrat d'icônes par coin
+
+**Fichiers :** `module/applications/specialization-tree/node-ui-state.mjs`, `tests/applications/specialization-tree/node-ui-state.test.mjs`
+
+1. Remplacer le pictogramme d'état unique par un contrat explicite de slots visuels (`topLeft`, `topRight`, `bottomRight`) consommable par le renderer.
+2. Mapper le coin haut gauche sur le type du talent : `electricity.svg` pour actif, `plain-circle.svg` pour inactif.
+3. Mapper le coin haut droit sur `primaryAction` quand elle existe : `buy-card.svg` pour `purchase`, `sell-card.svg` pour `forget`, et aucune icône sinon.
+4. Mapper le coin bas droit sur `rank.svg` quand `isRanked === true`.
+
+**Validation visée :** la source de vérité du langage d'icônes devient pure, stable et testable sans dépendre du rendu PIXI.
+
+### Étape 2 — Recentrer l'interaction utilisateur sur le panneau de détail
+
+**Fichiers :** `module/applications/specialization-tree-app.mjs`, `tests/applications/specialization-tree-app.test.mjs`
+
+1. Faire en sorte que le clic sur nœud ouvre toujours le détail, y compris pour les nœuds actuellement actionnables.
+2. Conserver l'exécution d'achat/oubli uniquement derrière le CTA du panneau contextuel déjà existant.
+3. Vérifier que les cas bloqués, informatifs et actionnables restent cohérents avec le panneau et qu'aucune action métier ne part directement du clic initial.
+
+**Validation visée :** le flux utilisateur devient systématiquement `clic sur nœud → lecture du détail → CTA éventuel`, sans perte des comportements d'achat/oubli existants.
+
+### Étape 3 — Rendre les icônes PIXI et verrouiller le contrat observable
+
+**Fichiers :** `module/applications/specialization-tree/pixi-tree-renderer.mjs`, `tests/integration/specialization-tree-pixi-render.test.mjs`, `tests/applications/specialization-tree-app.test.mjs`
+
+1. Rendre les icônes par coin avec des positions stables et lisibles à petite taille, sans collision avec le nom, le coût XP et le badge éventuel.
+2. Remplacer l'indicateur textuel ranked actuel par `rank.svg` au coin bas droit.
+3. Vérifier en tests d'intégration que les icônes attendues apparaissent pour les combinaisons clés (actif/inactif, achat/oubli, ranked/non-ranked).
+4. Vérifier en tests applicatifs que le clic ouvre le détail avant toute action et que le CTA reste le seul déclencheur du flux métier.
+
+**Validation visée :** les nœuds deviennent consultables au clic et immédiatement compréhensibles visuellement, avec des affordances stables par coin.
+
+## Définition de done
+
+- [ ] Le clic sur un nœud ouvre toujours le panneau de détail.
+- [ ] Une action `purchase` ou `forget` n'est plus exécutée directement au clic sur le nœud.
+- [ ] `electricity.svg` et `plain-circle.svg` distinguent clairement actif / inactif en haut à gauche.
+- [ ] `buy-card.svg` et `sell-card.svg` exposent l'action disponible en haut à droite.
+- [ ] `rank.svg` remplace l'indicateur textuel de rang en bas à droite.
+- [ ] Les tests couvrent le mapping d'icônes, le rendu PIXI et le flux clic → détail → action.

--- a/module/applications/specialization-tree-app.mjs
+++ b/module/applications/specialization-tree-app.mjs
@@ -302,15 +302,10 @@ export default class SpecializationTreeApp extends api.HandlebarsApplicationMixi
 
   /**
    * Handle a node pointer down event from the renderer.
-   * Dispatches purchase/forget or shows tooltip.
+   * Opens the detail panel for the clicked node.
    * @param {object} node - The enriched render node.
    */
   async #handleNodePointerDown(node) {
-    if (node?.actionable?.primaryAction) {
-      await this.#handleNodePrimaryAction(node)
-      return
-    }
-
     this.#showDetailPanel(node)
   }
 

--- a/module/applications/specialization-tree/node-ui-state.mjs
+++ b/module/applications/specialization-tree/node-ui-state.mjs
@@ -87,7 +87,7 @@ const PASSIVE_NODE_VARIANTS = Object.freeze({
     fillColor: 0x1f4f8c,
     borderColor: 0x95c9ff,
     borderWidth: 2,
-    alpha: 1,
+    alpha: 0.6,
     textColor: 0xffffff,
     textAlpha: 1,
     costColor: 0xb9d9ff,
@@ -117,7 +117,7 @@ const PASSIVE_NODE_VARIANTS = Object.freeze({
     fillColor: 0x1f2630,
     borderColor: 0x7a7a7a,
     borderWidth: 2,
-    alpha: 1,
+    alpha: 0.6,
     textColor: 0xd7dbe2,
     textAlpha: 0.68,
     costColor: 0x999999,
@@ -132,7 +132,7 @@ const PASSIVE_NODE_VARIANTS = Object.freeze({
     fillColor: 0x2b1f28,
     borderColor: 0x7c4e5a,
     borderWidth: 2,
-    alpha: 1,
+    alpha: 0.6,
     textColor: 0xf1dfe4,
     textAlpha: 1,
     costColor: 0xf1dfe4,
@@ -180,7 +180,7 @@ const ACTIVE_NODE_VARIANTS = Object.freeze({
     fillColor: 0x302020,
     borderColor: 0x7a7a7a,
     borderWidth: 2,
-    alpha: 1,
+    alpha: 0.6,
     textColor: 0xe2d7d7,
     textAlpha: 0.68,
     costColor: 0x999999,
@@ -195,7 +195,7 @@ const ACTIVE_NODE_VARIANTS = Object.freeze({
     fillColor: 0x3c1d1d,
     borderColor: 0x8f4a4a,
     borderWidth: 2,
-    alpha: 1,
+    alpha: 0.6,
     textColor: 0xffe8e8,
     textAlpha: 1,
     costColor: 0xffe8e8,
@@ -357,6 +357,67 @@ export const NODE_TYPE_INDICATORS = Object.freeze({
     label: 'Passive',
   }),
 })
+
+/* ── Icon slot paths (PXP2) ─────────────────────────────────────── */
+
+/**
+ * Icon slot paths for the three stable corner positions on each node card.
+ *
+ * - `topLeft`    — Active/inactive type icon (electric.svg / plain-circle.svg).
+ * - `topRight`   — Primary action icon (buy-card.svg for purchase, sell-card.svg for forget).
+ * - `bottomRight`— Ranked indicator icon (rank.svg when isRanked === true).
+ *
+ * @typedef {Object} NodeIconSlots
+ * @property {string|null} topLeft    - SVG icon path for the active/passive type indicator.
+ * @property {string|null} topRight   - SVG icon path for the primary action (or null).
+ * @property {string|null} bottomRight - SVG icon path for the ranked indicator (or null).
+ */
+
+/** @type {string} */
+export const ACTIVE_TYPE_ICON_PATH = 'assets/images/icons/electric.svg'
+
+/** @type {string} */
+export const PASSIVE_TYPE_ICON_PATH = 'assets/images/icons/plain-circle.svg'
+
+/** @type {string} */
+export const PURCHASE_ACTION_ICON_PATH = 'assets/images/icons/buy-card.svg'
+
+/** @type {string} */
+export const FORGET_ACTION_ICON_PATH = 'assets/images/icons/sell-card.svg'
+
+/** @type {string} */
+export const RANKED_ICON_PATH = 'assets/images/icons/rank.svg'
+
+/**
+ * Build the icon slot descriptor for a render node.
+ *
+ * Pure function — no Foundry dependencies.
+ * Consumes the node's enriched properties (nodeType, isRanked) and the
+ * actionable sub-view-model (primaryAction) to produce the stable three-corner
+ * icon contract consumed by the PIXI renderer.
+ *
+ * @param {object} node - Enriched render node with `nodeType`, `isRanked`,
+ *        and `actionable` (which must carry `primaryAction` if set).
+ * @returns {NodeIconSlots} Icon paths for the three corner slots.
+ */
+export function buildIconSlots(node) {
+  const nodeType = node?.nodeType ?? resolveNodeType(node?.isActive)
+
+  const topLeft = nodeType === NODE_TYPE.ACTIVE
+    ? ACTIVE_TYPE_ICON_PATH
+    : PASSIVE_TYPE_ICON_PATH
+
+  let topRight = null
+  if (node.actionable?.primaryAction === 'purchase') {
+    topRight = PURCHASE_ACTION_ICON_PATH
+  } else if (node.actionable?.primaryAction === 'forget') {
+    topRight = FORGET_ACTION_ICON_PATH
+  }
+
+  const bottomRight = node.isRanked ? RANKED_ICON_PATH : null
+
+  return { topLeft, topRight, bottomRight }
+}
 
 /* ── Pure UI mapping functions ──────────────────────────────────── */
 

--- a/module/applications/specialization-tree/pixi-tree-renderer.mjs
+++ b/module/applications/specialization-tree/pixi-tree-renderer.mjs
@@ -34,6 +34,53 @@ function setPixiDebugLabel(displayObject, label) {
 }
 
 const MIN_VIEWPORT_SIZE = 320
+const NODE_CORNER_ICON_SIZE = 16
+const NODE_CORNER_ICON_MARGIN = 4
+
+const ICON_SLOT_POSITIONS = Object.freeze({
+  topLeft: Object.freeze({ x: NODE_CORNER_ICON_MARGIN, y: NODE_CORNER_ICON_MARGIN }),
+  topRight: Object.freeze({ x: NODE_WIDTH - NODE_CORNER_ICON_SIZE - NODE_CORNER_ICON_MARGIN, y: NODE_CORNER_ICON_MARGIN }),
+  bottomRight: Object.freeze({
+    x: NODE_WIDTH - NODE_CORNER_ICON_SIZE - NODE_CORNER_ICON_MARGIN,
+    y: NODE_HEIGHT - NODE_CORNER_ICON_SIZE - NODE_CORNER_ICON_MARGIN,
+  }),
+})
+
+const ICON_SLOT_FALLBACKS = Object.freeze({
+  topLeft: Object.freeze({
+    label: 'type-icon-fallback',
+    text: (node) => node?.nodeTypeIcon ?? '',
+    style: (node) => ({
+      fontFamily: 'Arial',
+      fontSize: 9,
+      fill: node?.variant?.textColor ?? 0xffffff,
+    }),
+  }),
+  topRight: Object.freeze({
+    label: 'action-icon-fallback',
+    text: (node) => {
+      if (node?.actionable?.primaryAction === 'purchase') return '+'
+      if (node?.actionable?.primaryAction === 'forget') return '-'
+      return ''
+    },
+    style: (node) => ({
+      fontFamily: 'Arial',
+      fontSize: 10,
+      fill: node?.variant?.pictogramColor ?? 0xffffff,
+      fontWeight: 'bold',
+    }),
+  }),
+  bottomRight: Object.freeze({
+    label: 'ranked-indicator-fallback',
+    text: (node) => (node?.isRanked ? '(R)' : ''),
+    style: (node) => ({
+      fontFamily: 'Arial',
+      fontSize: 9,
+      fill: node?.variant?.costColor ?? 0xffffff,
+      fontStyle: 'italic',
+    }),
+  }),
+})
 
 /**
  * Compute the viewport size from a host element.
@@ -87,9 +134,10 @@ export function computeCenteredOffset(bbox, viewportWidth, viewportHeight) {
   }
 }
 
-/* ── Texture cache ────────────────────────────────────────────── */
+/* ── Texture caches ───────────────────────────────────────────── */
 
 const STATE_PICTOGRAM_TEXTURE_CACHE = new Map()
+const ICON_TEXTURE_CACHE = new Map()
 
 /**
  * Load the SVG pictogram texture for a node state.
@@ -120,6 +168,38 @@ export async function loadStatePictogram(state) {
     return await texturePromise
   } catch (error) {
     STATE_PICTOGRAM_TEXTURE_CACHE.delete(iconPath)
+    throw error
+  }
+}
+
+/**
+ * Load an SVG texture from any icon path, with caching.
+ * @param {string|null|undefined} iconPath - Direct file path to the SVG.
+ * @returns {Promise<PIXI.Texture|null>}
+ */
+export async function loadIconTexture(iconPath) {
+  if (!iconPath) return null
+
+  if (ICON_TEXTURE_CACHE.has(iconPath)) {
+    return ICON_TEXTURE_CACHE.get(iconPath)
+  }
+
+  let texturePromise
+
+  if (PIXI.Assets?.load) {
+    texturePromise = PIXI.Assets.load(iconPath)
+  } else if (PIXI.Texture?.from) {
+    texturePromise = Promise.resolve(PIXI.Texture.from(iconPath))
+  } else {
+    texturePromise = Promise.resolve(null)
+  }
+
+  ICON_TEXTURE_CACHE.set(iconPath, texturePromise)
+
+  try {
+    return await texturePromise
+  } catch (error) {
+    ICON_TEXTURE_CACHE.delete(iconPath)
     throw error
   }
 }
@@ -603,21 +683,10 @@ export class PixiTreeRenderer {
       background.endFill()
       nodeContainer.addChild(background)
 
-      // Type indicator (active/passive icon) — top-left corner
-      const typeIcon = node.nodeTypeIcon ?? ''
-      const nameOffsetX = typeIcon ? 14 : 4
-      let typeText = null
-      if (typeIcon) {
-        typeText = new PIXI.Text(typeIcon, {
-          fontFamily: 'Arial',
-          fontSize: 9,
-          fill: v.textColor,
-        })
-        setPixiDebugLabel(typeText, `${nodeLabel}:type-icon`)
-        typeText.x = 4
-        typeText.y = 5
-        nodeContainer.addChild(typeText)
-      }
+      const hasTopLeftIcon = Boolean(node.iconSlots?.topLeft)
+      const hasTopRightIcon = Boolean(node.iconSlots?.topRight)
+      const nameOffsetX = hasTopLeftIcon ? 24 : 4
+      const nameRightPadding = hasTopRightIcon ? 24 : 4
 
       // Talent name — local coords
       const nameText = new PIXI.Text(node.talentName, {
@@ -625,7 +694,7 @@ export class PixiTreeRenderer {
         fontSize: 10,
         fill: v.textColor,
         wordWrap: true,
-        wordWrapWidth: this.nodeWidth - nameOffsetX - 4,
+        wordWrapWidth: this.nodeWidth - nameOffsetX - nameRightPadding,
       })
       setPixiDebugLabel(nameText, `${nodeLabel}:title`)
       nameText.alpha = v.textAlpha ?? 1
@@ -667,37 +736,7 @@ export class PixiTreeRenderer {
       }
       nodeContainer.addChild(costText)
 
-      // State pictogram sprite — local coords
-      const hasRenderedSvgPictogram = await this.#drawStatePictogramSprite(node, nodeContainer, nodeLabel)
-
-      // Fallback Unicode pictogram — local coords
-      let pictogramText = null
-      if (!hasRenderedSvgPictogram && v.pictogram) {
-        pictogramText = new PIXI.Text(v.pictogram, {
-          fontFamily: 'Arial',
-          fontSize: 10,
-          fill: v.pictogramColor,
-        })
-        setPixiDebugLabel(pictogramText, `${nodeLabel}:state-pictogram-text`)
-        pictogramText.x = this.nodeWidth - pictogramText.width - 6
-        pictogramText.y = 4
-        nodeContainer.addChild(pictogramText)
-      }
-
-      // Ranked indicator — local coords
-      let rankedText = null
-      if (node.isRanked) {
-        rankedText = new PIXI.Text('(R)', {
-          fontFamily: 'Arial',
-          fontSize: 9,
-          fill: v.costColor,
-          fontStyle: 'italic',
-        })
-        setPixiDebugLabel(rankedText, `${nodeLabel}:ranked-indicator`)
-        rankedText.x = this.nodeWidth - rankedText.width - 4
-        rankedText.y = 4
-        nodeContainer.addChild(rankedText)
-      }
+      const iconSlotSprites = await this.#drawNodeIconSlots(node, nodeContainer, nodeLabel)
 
       // Hit area — local coords, transparent overlay
       const hitArea = new PIXI.Graphics()
@@ -723,9 +762,7 @@ export class PixiTreeRenderer {
         nameText,
         costText,
         badge,
-        typeText,
-        pictogramText,
-        rankedText,
+        iconSlotSprites,
         hitArea,
       })
     }
@@ -756,5 +793,67 @@ export class PixiTreeRenderer {
       })
       return false
     }
+  }
+
+  async #drawNodeIconSlots(node, parent, nodeLabel = 'node:unknown') {
+    const iconSlots = node?.iconSlots ?? {}
+    const renderedSlots = {}
+
+    for (const slotName of Object.keys(ICON_SLOT_POSITIONS)) {
+      renderedSlots[slotName] = await this.#drawNodeIconSlot(node, parent, nodeLabel, slotName, iconSlots[slotName] ?? null)
+    }
+
+    return renderedSlots
+  }
+
+  async #drawNodeIconSlot(node, parent, nodeLabel, slotName, iconPath) {
+    if (!parent) return null
+
+    const position = ICON_SLOT_POSITIONS[slotName]
+    if (!position) return null
+
+    if (!iconPath) {
+      return null
+    }
+
+    try {
+      const texture = await loadIconTexture(iconPath)
+      if (texture && PIXI.Sprite) {
+        const sprite = new PIXI.Sprite(texture)
+        setPixiDebugLabel(sprite, `${nodeLabel}:icon-slot:${slotName}`)
+        sprite.x = position.x
+        sprite.y = position.y
+        sprite.width = NODE_CORNER_ICON_SIZE
+        sprite.height = NODE_CORNER_ICON_SIZE
+        sprite.tint = 0xffffff
+        parent.addChild(sprite)
+        return sprite
+      }
+    } catch (error) {
+      logger.warn('[PixiTreeRenderer] Failed to load node corner icon, falling back to text', {
+        slotName,
+        iconPath,
+        nodeId: node?.nodeId,
+        error,
+      })
+    }
+
+    return this.#drawNodeIconSlotFallback(node, parent, nodeLabel, slotName)
+  }
+
+  #drawNodeIconSlotFallback(node, parent, nodeLabel, slotName) {
+    if (!PIXI.Text) return null
+
+    const fallback = ICON_SLOT_FALLBACKS[slotName]
+    const position = ICON_SLOT_POSITIONS[slotName]
+    const text = fallback?.text?.(node) ?? ''
+    if (!text) return null
+
+    const textNode = new PIXI.Text(text, fallback.style?.(node) ?? {})
+    setPixiDebugLabel(textNode, `${nodeLabel}:${fallback.label}`)
+    textNode.x = position.x
+    textNode.y = position.y
+    parent.addChild(textNode)
+    return textNode
   }
 }

--- a/module/applications/specialization-tree/tree-context-builder.mjs
+++ b/module/applications/specialization-tree/tree-context-builder.mjs
@@ -12,7 +12,7 @@
  */
 
 import { buildRenderViewModel } from './render-view-model.mjs'
-import { enrichNode, NODE_STATE } from './node-ui-state.mjs'
+import { buildIconSlots, enrichNode, NODE_STATE } from './node-ui-state.mjs'
 import { actionableNodeViewModel } from './actionable-node-view-model.mjs'
 import { buildConnectionAnchors, computeNodePosition } from './layout.mjs'
 import { selectDefaultTreeKey } from '../../lib/specialization-tree/default-tree-selector.mjs'
@@ -214,15 +214,17 @@ export function buildRenderNodesAndConnections(currentTreeData, actor, currentTr
   const renderNodes = positionedNodes.map((node) => {
     const stateResult = nodeStates.get(node.nodeId) ?? { state: NODE_STATE.INVALID }
     const enriched = enrichNode(node, stateResult, localize)
+    const actionable = actionableNodeViewModel({
+      renderNode: enriched,
+      actor,
+      specializationId: currentTreeId,
+      tree: currentTreeData,
+      localize,
+    })
     return {
       ...enriched,
-      actionable: actionableNodeViewModel({
-        renderNode: enriched,
-        actor,
-        specializationId: currentTreeId,
-        tree: currentTreeData,
-        localize,
-      }),
+      actionable,
+      iconSlots: buildIconSlots({ ...enriched, actionable }),
     }
   })
 

--- a/tests/applications/specialization-tree-app.test.mjs
+++ b/tests/applications/specialization-tree-app.test.mjs
@@ -28,6 +28,12 @@ function createRoot({ viewportHost, panel }) {
   }
 }
 
+async function triggerContextualAction(app, SpecializationTreeApp) {
+  const event = { preventDefault: vi.fn() }
+  await SpecializationTreeApp.DEFAULT_OPTIONS.actions.contextualAction.call(app, event, null)
+  return event
+}
+
 describe('specialization-tree app orchestration', () => {
   let SpecializationTreeApp
   let buildSpecializationTreeContext
@@ -358,7 +364,7 @@ describe('specialization-tree app orchestration', () => {
     expect(panel.hidden).toBe(true)
   })
 
-  it('renderer node callback executes purchase flow and refreshes on success', async () => {
+  it('renderer node callback opens detail first, then contextual CTA executes purchase flow', async () => {
     const app = new SpecializationTreeApp()
     app.actor = createActor()
     app.rendered = true
@@ -384,12 +390,17 @@ describe('specialization-tree app orchestration', () => {
 
     await app.renderer.onNodePointerDown(node)
 
+    expect(purchaseTalentNodeMock).not.toHaveBeenCalled()
+    expect(app._currentDetailNode).toBe(node)
+
+    await triggerContextualAction(app, SpecializationTreeApp)
+
     expect(purchaseTalentNodeMock).toHaveBeenCalledWith(app.actor, 'spec-a', 'n1')
     expect(infoSpy).toHaveBeenCalled()
     expect(refreshSpy).toHaveBeenCalled()
   })
 
-  it('renderer node callback executes forget flow and warns on failure', async () => {
+  it('renderer node callback opens detail first, then contextual CTA executes forget flow', async () => {
     forgetTalentNodeMock.mockResolvedValue({ ok: false, reasonCode: 'node-has-dependents' })
     const app = new SpecializationTreeApp()
     app.actor = createActor()
@@ -415,6 +426,11 @@ describe('specialization-tree app orchestration', () => {
     }
 
     await app.renderer.onNodePointerDown(node)
+
+    expect(forgetTalentNodeMock).not.toHaveBeenCalled()
+    expect(app._currentDetailNode).toBe(node)
+
+    await triggerContextualAction(app, SpecializationTreeApp)
 
     expect(forgetTalentNodeMock).toHaveBeenCalledWith(app.actor, 'spec-a', 'n1')
     expect(warnSpy).toHaveBeenCalled()
@@ -526,6 +542,7 @@ describe('specialization-tree app orchestration', () => {
     }
 
     await app.renderer.onNodePointerDown(node)
+    await triggerContextualAction(app, SpecializationTreeApp)
 
     expect(confirmSpy).toHaveBeenCalled()
     const callArgs = confirmSpy.mock.calls[0][0]
@@ -703,6 +720,7 @@ describe('specialization-tree app orchestration', () => {
         }
 
         await app.renderer.onNodePointerDown(node)
+        await triggerContextualAction(app, SpecializationTreeApp)
 
         expect(confirmSpy).toHaveBeenCalled()
         const callArgs = confirmSpy.mock.calls[0][0]
@@ -740,6 +758,7 @@ describe('specialization-tree app orchestration', () => {
         }
 
         await app.renderer.onNodePointerDown(node)
+        await triggerContextualAction(app, SpecializationTreeApp)
 
         expect(confirmSpy).toHaveBeenCalled()
         const callArgs = confirmSpy.mock.calls[0][0]
@@ -804,8 +823,11 @@ describe('specialization-tree app orchestration', () => {
         appLocked.renderer.onBackgroundPointerDown()
         expect(lockedPanel.hidden).toBe(true)
 
-        // 5 — Available node triggers purchase flow directly (panel stays hidden)
-        const fastPanel = { hidden: true, querySelector: vi.fn(() => null) }
+        // 5 — Available node opens detail first, CTA triggers purchase flow
+        const fastPanel = {
+          hidden: true,
+          querySelector: vi.fn(() => null),
+        }
         const viewportHostAvail = { dataset: {}, firstElementChild: null, replaceChildren: vi.fn() }
         const appAvail = new SpecializationTreeApp()
         appAvail.actor = createActor()
@@ -829,6 +851,11 @@ describe('specialization-tree app orchestration', () => {
             actionRef: { specializationId: 'spec-a', nodeId: 'n1' },
           },
         })
+
+        expect(purchaseTalentNodeMock).not.toHaveBeenCalled()
+        expect(appAvail._currentDetailNode?.nodeId).toBe('n1')
+
+        await triggerContextualAction(appAvail, SpecializationTreeApp)
 
         expect(purchaseTalentNodeMock).toHaveBeenCalledWith(appAvail.actor, 'spec-a', 'n1')
         expect(infoSpy).toHaveBeenCalled()

--- a/tests/applications/specialization-tree/node-ui-state.test.mjs
+++ b/tests/applications/specialization-tree/node-ui-state.test.mjs
@@ -1,6 +1,9 @@
 import { describe, expect, it } from 'vitest'
 
 import {
+  ACTIVE_TYPE_ICON_PATH,
+  buildIconSlots,
+  FORGET_ACTION_ICON_PATH,
   enrichNode,
   getNodeVariant,
   getReasonLabelKey,
@@ -10,9 +13,12 @@ import {
   NODE_STATE_VARIANTS,
   NODE_TYPE,
   NODE_TYPE_INDICATORS,
+  PASSIVE_TYPE_ICON_PATH,
+  PURCHASE_ACTION_ICON_PATH,
   REASON_CODE,
   REASON_LABEL_DEFAULT,
   REASON_LABEL_KEYS,
+  RANKED_ICON_PATH,
   resolveNodeType,
 } from '../../../module/applications/specialization-tree/node-ui-state.mjs'
 
@@ -219,6 +225,44 @@ describe('node-ui-state', () => {
 
     it('returns REASON_LABEL_DEFAULT for unknown reason code', () => {
       expect(getReasonLabelKey('no-such-reason')).toBe(REASON_LABEL_DEFAULT)
+    })
+  })
+
+  describe('buildIconSlots', () => {
+    it('maps passive purchase ranked nodes to the three expected slots', () => {
+      const iconSlots = buildIconSlots({
+        isActive: false,
+        isRanked: true,
+        actionable: { primaryAction: 'purchase' },
+      })
+
+      expect(iconSlots.topLeft).toBe(PASSIVE_TYPE_ICON_PATH)
+      expect(iconSlots.topRight).toBe(PURCHASE_ACTION_ICON_PATH)
+      expect(iconSlots.bottomRight).toBe(RANKED_ICON_PATH)
+    })
+
+    it('maps active forget nodes to active type and forget action slots', () => {
+      const iconSlots = buildIconSlots({
+        nodeType: NODE_TYPE.ACTIVE,
+        isRanked: false,
+        actionable: { primaryAction: 'forget' },
+      })
+
+      expect(iconSlots.topLeft).toBe(ACTIVE_TYPE_ICON_PATH)
+      expect(iconSlots.topRight).toBe(FORGET_ACTION_ICON_PATH)
+      expect(iconSlots.bottomRight).toBeNull()
+    })
+
+    it('omits action and rank slots when the node has no CTA and is not ranked', () => {
+      const iconSlots = buildIconSlots({
+        nodeType: NODE_TYPE.PASSIVE,
+        isRanked: false,
+        actionable: { primaryAction: null },
+      })
+
+      expect(iconSlots.topLeft).toBe(PASSIVE_TYPE_ICON_PATH)
+      expect(iconSlots.topRight).toBeNull()
+      expect(iconSlots.bottomRight).toBeNull()
     })
   })
 

--- a/tests/integration/specialization-tree-pixi-render.test.mjs
+++ b/tests/integration/specialization-tree-pixi-render.test.mjs
@@ -7,7 +7,14 @@ import {
   PixiTreeRenderer,
 } from '../../module/applications/specialization-tree/pixi-tree-renderer.mjs'
 import { CONNECTION_VISUAL_STYLES } from '../../module/applications/specialization-tree/connection-ui-state.mjs'
-import { NODE_STATE, NODE_STATE_VARIANTS } from '../../module/applications/specialization-tree/node-ui-state.mjs'
+import {
+  ACTIVE_TYPE_ICON_PATH,
+  NODE_STATE,
+  NODE_STATE_VARIANTS,
+  PASSIVE_TYPE_ICON_PATH,
+  PURCHASE_ACTION_ICON_PATH,
+  RANKED_ICON_PATH,
+} from '../../module/applications/specialization-tree/node-ui-state.mjs'
 
 function createMockCanvas() {
   const listeners = {}
@@ -74,6 +81,12 @@ function createViewModel() {
         nodeTypeIcon: 'P',
         nodeState: NODE_STATE.AVAILABLE,
         variant: NODE_STATE_VARIANTS[NODE_STATE.AVAILABLE].passive,
+        iconSlots: {
+          topLeft: PASSIVE_TYPE_ICON_PATH,
+          topRight: PURCHASE_ACTION_ICON_PATH,
+          bottomRight: RANKED_ICON_PATH,
+        },
+        actionable: { primaryAction: 'purchase' },
       },
       {
         nodeId: 'n2',
@@ -85,6 +98,12 @@ function createViewModel() {
         nodeTypeIcon: 'A',
         nodeState: NODE_STATE.LOCKED,
         variant: NODE_STATE_VARIANTS[NODE_STATE.LOCKED].active,
+        iconSlots: {
+          topLeft: ACTIVE_TYPE_ICON_PATH,
+          topRight: null,
+          bottomRight: null,
+        },
+        actionable: { primaryAction: null },
       },
     ],
     renderConnections: [
@@ -152,7 +171,8 @@ describe('PixiTreeRenderer integration', () => {
         }
       },
       Sprite: class MockSprite {
-        constructor() {
+        constructor(texture) {
+          this.texture = texture
           this.x = 0
           this.y = 0
           this.width = 0
@@ -160,7 +180,7 @@ describe('PixiTreeRenderer integration', () => {
           this.tint = 0
         }
       },
-      Assets: { load: vi.fn().mockResolvedValue(null) },
+      Assets: { load: vi.fn().mockImplementation(async (path) => ({ path })) },
       Texture: { from: vi.fn().mockReturnValue(null) },
     }
 
@@ -251,7 +271,7 @@ describe('PixiTreeRenderer integration', () => {
     ])
   })
 
-  it('renders type icons, title texts, cost texts and ranked indicator', async () => {
+  it('renders title texts, cost texts, and corner icon sprites from icon slots', async () => {
     const host = createMockHost()
     const renderer = new PixiTreeRenderer()
     renderer.mount(host)
@@ -261,23 +281,32 @@ describe('PixiTreeRenderer integration', () => {
     const descendants = flattenChildren(renderer.treeContainer)
     expect(descendants.some((child) => child.text === 'Tough')).toBe(true)
     expect(descendants.some((child) => child.text === 'Grit')).toBe(true)
-    expect(descendants.some((child) => child.text === '(R)')).toBe(true)
-    expect(descendants.some((child) => child.text === 'P')).toBe(true)
-    expect(descendants.some((child) => child.text === 'A')).toBe(true)
+    expect(descendants.some((child) => child.text === '5 XP')).toBe(true)
+    expect(descendants.some((child) => child.label === 'node:n1:Tough:icon-slot:topLeft')).toBe(true)
+    expect(descendants.some((child) => child.label === 'node:n1:Tough:icon-slot:topRight')).toBe(true)
+    expect(descendants.some((child) => child.label === 'node:n1:Tough:icon-slot:bottomRight')).toBe(true)
+    expect(descendants.some((child) => child.label === 'node:n2:Grit:icon-slot:topLeft')).toBe(true)
+    expect(descendants.some((child) => child.label === 'node:n2:Grit:icon-slot:topRight')).toBe(false)
+    expect(descendants.some((child) => child.label === 'node:n2:Grit:icon-slot:bottomRight')).toBe(false)
   })
 
-  it('renders fallback pictograms from node variants when svg is unavailable', async () => {
+  it('attaches the expected textures to rendered icon slot sprites', async () => {
     const host = createMockHost()
     const renderer = new PixiTreeRenderer()
     renderer.mount(host)
-    const viewModel = createViewModel()
 
-    await renderer.update(viewModel, {})
+    await renderer.update(createViewModel(), {})
 
-    const expectedPictograms = new Set(viewModel.renderNodes.map((node) => node.variant.pictogram))
     const descendants = flattenChildren(renderer.treeContainer)
-    const found = descendants.filter((child) => expectedPictograms.has(child.text))
-    expect(found).toHaveLength(2)
+    const topLeft = descendants.find((child) => child.label === 'node:n1:Tough:icon-slot:topLeft')
+    const topRight = descendants.find((child) => child.label === 'node:n1:Tough:icon-slot:topRight')
+    const bottomRight = descendants.find((child) => child.label === 'node:n1:Tough:icon-slot:bottomRight')
+    const activeTopLeft = descendants.find((child) => child.label === 'node:n2:Grit:icon-slot:topLeft')
+
+    expect(topLeft?.texture?.path).toBe(PASSIVE_TYPE_ICON_PATH)
+    expect(topRight?.texture?.path).toBe(PURCHASE_ACTION_ICON_PATH)
+    expect(bottomRight?.texture?.path).toBe(RANKED_ICON_PATH)
+    expect(activeTopLeft?.texture?.path).toBe(ACTIVE_TYPE_ICON_PATH)
   })
 
   it('rebuilds the tree container on subsequent updates', async () => {


### PR DESCRIPTION
Closes #342

## Context
Issue #342 extends the specialization tree interaction so node clicks always open the detail panel, while node corners expose stable visual action cues.

## Summary of Changes
- route node clicks through the detail panel instead of executing purchase or forget directly
- add a pure icon slot contract for node corners in the specialization tree UI state
- render top-left, top-right, and bottom-right PIXI corner icons with text fallbacks when icon loading is unavailable
- pass icon slot data through the tree context builder
- update unit, app, and PIXI integration tests for the new click flow and icon rendering contract

## Technical Notes
- no persisted schema or public data model was changed
- the renderer keeps a cached icon texture loader and falls back to text markers when SVG textures cannot be loaded
- the node title layout now reserves space for left and right corner icons to avoid overlap

## Tests Run
- `pnpm vitest run tests/applications/specialization-tree/node-ui-state.test.mjs tests/applications/specialization-tree-app.test.mjs tests/integration/specialization-tree-pixi-render.test.mjs`

## Known Limits
- no broad build, lint, or E2E validation was run in this workflow

## Points of Attention
- verify the corner icon readability on dense specialization trees in Foundry runtime
- verify the detail-panel-first flow remains comfortable for frequent purchase and forget actions in live UI usage