### PR TITLE
feat(specialization): establish business contract for specializations and current tree

### DIFF
--- a/documentation/cadrage/character-sheet/specializations/cadrage-gestion-multi-specialisations-feuille-personnage.md
+++ b/documentation/cadrage/character-sheet/specializations/cadrage-gestion-multi-specialisations-feuille-personnage.md
@@ -1,0 +1,626 @@
+# Document de cadrage — Gestion multi-spécialisation dans la feuille personnage
+
+## 1. Objectif
+
+Ce cadrage définit les règles métier et les règles UI/UX associées à la gestion des spécialisations d’un personnage dans le système SWERPG.
+
+Le besoin couvre trois zones fonctionnelles :
+
+1. l’affichage synthétique des spécialisations dans le header de la fiche personnage ;
+2. l’ajout d’une spécialisation avec calcul de coût XP et contrôle de disponibilité ;
+3. la suppression conditionnelle d’une spécialisation depuis la vue des arbres de spécialisation.
+
+La règle de coût retenue est celle de Star Wars FFG : une spécialisation supplémentaire coûte `10 × le nombre total de spécialisations après achat`, avec `+10 XP` si elle est hors carrière. Les spécialisations universelles sont généralement traitées comme des spécialisations de carrière pour le coût. ([sw-eote-srd.vercel.app][1])
+
+---
+
+## 2. Principes métier
+
+### 2.1. Carrière, spécialisation et arbre actif
+
+La **carrière** du personnage est définie à la création et ne doit pas être modifiée par cette fonctionnalité.
+
+Une **spécialisation possédée** est une spécialisation initiale ou achetée par le personnage. Elle donne accès à son arbre de talents et à ses compétences de spécialisation.
+
+L’**arbre courant** ou **spécialisation sélectionnée** dans l’interface n’a qu’un sens UI. Il ne doit pas être interprété comme une spécialisation mécaniquement active ou exclusive.
+
+Décision métier :
+
+```txt
+career = identité métier stable du personnage
+ownedSpecializations = spécialisations possédées
+selectedSpecializationTree = contexte d’affichage uniquement
+```
+
+Cette distinction est importante pour éviter une confusion entre progression métier et simple navigation dans l’interface.
+
+---
+
+## 3. Règles métier d’ajout d’une spécialisation
+
+### 3.1. Calcul du coût
+
+Le coût d’ajout d’une spécialisation est calculé à partir du nombre de spécialisations que le personnage possédera après achat.
+
+```js
+baseCost = 10 * (ownedSpecializationsCount + 1)
+```
+
+Si la spécialisation ajoutée n’appartient pas à la carrière du personnage, un surcoût est appliqué :
+
+```js
+finalCost = baseCost + 10
+```
+
+Si la spécialisation appartient à la carrière du personnage :
+
+```js
+finalCost = baseCost
+```
+
+Si la spécialisation est universelle, elle doit être traitée comme une spécialisation de carrière pour le coût, sauf décision contraire explicite dans les règles du système ou dans une future ADR.
+
+### 3.2. Exemples
+
+| Situation                                                                             |  Coût |
+| ------------------------------------------------------------------------------------- | ----: |
+| Le personnage possède 1 spécialisation et achète une 2e spécialisation de carrière    | 20 XP |
+| Le personnage possède 1 spécialisation et achète une 2e spécialisation hors carrière  | 30 XP |
+| Le personnage possède 2 spécialisations et achète une 3e spécialisation de carrière   | 30 XP |
+| Le personnage possède 2 spécialisations et achète une 3e spécialisation hors carrière | 40 XP |
+
+Source de règle : table de progression XP reprise du système Star Wars FFG / Edge of the Empire. ([sw-eote-srd.vercel.app][1])
+
+---
+
+## 4. Contrôles métier à l’ajout
+
+### 4.1. Contrôle d’XP disponible
+
+L’ajout est autorisé uniquement si le personnage dispose d’assez d’XP disponible.
+
+```js
+canPurchaseSpecialization =
+  actor.system.experience.available >= specializationPurchaseCost
+```
+
+Si l’XP disponible est insuffisante, l’action doit être bloquée.
+
+Exemple :
+
+```txt
+XP disponible : 25
+Coût de la spécialisation : 30
+Résultat : ajout interdit
+```
+
+### 4.2. Contrôle de doublon
+
+Une spécialisation déjà possédée ne doit pas pouvoir être ajoutée une seconde fois.
+
+```js
+canPurchaseSpecialization =
+  !ownedSpecializations.includes(candidateSpecializationId)
+```
+
+La vue d’ajout doit donc exclure les spécialisations déjà possédées ou les afficher en état désactivé avec un message clair.
+
+### 4.3. Contrôle de résolution de l’arbre
+
+L’ajout d’une spécialisation doit idéalement vérifier qu’un arbre associé est disponible ou résoluble.
+
+Trois cas sont possibles :
+
+| Cas                                          | Comportement recommandé           |
+| -------------------------------------------- | --------------------------------- |
+| Arbre disponible                             | Achat autorisé                    |
+| Arbre introuvable mais spécialisation valide | Achat possible avec avertissement |
+| Spécialisation non résolue ou invalide       | Achat bloqué                      |
+
+Décision recommandée : pour la V1, bloquer l’achat si la spécialisation ne peut pas être résolue proprement. Cela évite d’ajouter à l’acteur une spécialisation impossible à afficher ou à exploiter.
+
+---
+
+## 5. Effets métier de l’ajout
+
+Lorsqu’une spécialisation est ajoutée avec succès, le système doit :
+
+1. ajouter la spécialisation à la liste des spécialisations possédées par l’acteur ;
+2. décrémenter l’XP disponible du coût calculé ;
+3. rendre l’arbre de talents accessible dans la vue des arbres ;
+4. recalculer les compétences de carrière dérivées si le système les déduit depuis les spécialisations ;
+5. journaliser l’opération si l’audit log est déjà disponible.
+
+Une spécialisation achetée après la création ne doit pas attribuer automatiquement de rangs gratuits de compétences. À la création, la spécialisation initiale donne des compétences de spécialisation et permet de choisir deux rangs gratuits ; ce comportement ne doit pas être rejoué lors d’un achat ultérieur. ([sw-eote-srd.vercel.app][2])
+
+---
+
+## 6. Règles métier de suppression d’une spécialisation
+
+### 6.1. Principe général
+
+Une spécialisation peut être supprimée uniquement si aucun talent n’a été acheté dans son arbre.
+
+```js
+canRemoveSpecialization =
+  purchasedTalentsInSpecialization.length === 0
+```
+
+Cette règle protège l’intégrité de la progression du personnage.
+
+### 6.2. Spécialisation initiale
+
+La spécialisation initiale du personnage ne devrait pas être supprimable en V1.
+
+Raison : elle peut avoir participé à la création du personnage, notamment via les compétences de spécialisation et les rangs gratuits initiaux. La supprimer proprement demanderait une logique de rollback plus complexe.
+
+Règle recommandée :
+
+```js
+canRemoveSpecialization =
+  !isInitialSpecialization
+  && purchasedTalentsInSpecialization.length === 0
+```
+
+### 6.3. Suppression et remboursement XP
+
+Pour la V1, la suppression d’une spécialisation ne doit pas rembourser automatiquement l’XP.
+
+Deux raisons :
+
+1. le remboursement automatique impose de reconstruire l’historique exact de dépense ;
+2. une suppression pourrait être utilisée pour optimiser artificiellement les coûts de progression.
+
+Décision recommandée :
+
+```txt
+Suppression autorisée = retrait technique d’une spécialisation sans talent acheté.
+Remboursement XP = hors scope V1.
+```
+
+Si le remboursement devient nécessaire plus tard, il doit passer par une logique d’audit log explicite.
+
+---
+
+## 7. Effets métier de la suppression
+
+Lorsqu’une spécialisation est supprimée, le système doit :
+
+1. retirer la spécialisation de la liste des spécialisations possédées ;
+2. retirer l’accès à son arbre dans la vue des arbres ;
+3. recalculer les compétences de carrière dérivées ;
+4. changer l’arbre courant si la spécialisation supprimée était sélectionnée ;
+5. journaliser l’opération si l’audit log est disponible.
+
+Si la spécialisation supprimée était l’arbre courant, la vue doit sélectionner automatiquement une autre spécialisation disponible.
+
+Règle recommandée :
+
+```txt
+Après suppression, sélectionner la dernière spécialisation possédée encore disponible.
+```
+
+Cette règle reste cohérente avec l’idée actuelle de sélectionner le dernier arbre disponible comme contexte actif d’interface.
+
+---
+
+# 8. Règles UI/UX — Header de la fiche personnage
+
+## 8.1. Affichage compact des spécialisations
+
+Dans le header de la fiche personnage, l’objectif est d’afficher une information courte, lisible et stable.
+
+Structure cible :
+
+```html
+<h2 class="specialization flexrow" data-action="editSpecializations">
+  <a>
+    <span class="specialization__primary">Scoundrel</span>
+    <span class="specialization__count-badge">+1</span>
+  </a>
+</h2>
+```
+
+Règle d’affichage :
+
+| Nombre de spécialisations | Affichage                                      |
+| ------------------------: | ---------------------------------------------- |
+|                         0 | `No specialization` ou valeur i18n équivalente |
+|                         1 | `Scoundrel`                                    |
+|                         2 | `Scoundrel +1`                                 |
+|                         3 | `Scoundrel +2`                                 |
+
+Il vaut mieux éviter `Scoundrel, Pilot, ...` dans le header. Cette forme devient vite illisible et casse la stabilité visuelle de la fiche.
+
+## 8.2. Tooltip de la pastille
+
+La pastille doit afficher la liste des spécialisations supplémentaires au survol.
+
+Exemple :
+
+```txt
++2
+Tooltip: Pilot, Charmer
+```
+
+La spécialisation principale reste visible en permanence ; les spécialisations supplémentaires sont accessibles au survol ou au clic.
+
+## 8.3. Action au clic
+
+Le clic sur le bloc spécialisation doit ouvrir l’interface de gestion des spécialisations, idéalement la fenêtre existante des arbres de spécialisation.
+
+Comportement :
+
+```txt
+Click sur le bloc specialization
+→ ouvre SpecializationTreeApp
+→ affiche l’arbre courant ou le dernier arbre disponible
+```
+
+---
+
+# 9. Règles UI/UX — Specialization Tree View App
+
+## 9.1. Rôle de la fenêtre
+
+La fenêtre des arbres de spécialisation devient le centre de gestion des spécialisations possédées.
+
+Elle doit permettre :
+
+1. de consulter les spécialisations possédées ;
+2. de sélectionner l’arbre affiché ;
+3. de voir la progression par arbre ;
+4. d’ajouter une spécialisation ;
+5. de supprimer une spécialisation lorsque la règle métier l’autorise.
+
+L’écran actuel dispose déjà d’une sidebar listant les spécialisations et d’une zone centrale dédiée à l’arbre graphique, ce qui correspond bien au besoin.
+
+---
+
+## 9.2. Sidebar des spécialisations
+
+Chaque spécialisation affichée dans la sidebar doit présenter au minimum :
+
+```txt
+Nom de la spécialisation
+État de résolution de l’arbre
+Progression talents achetés / talents totaux
+Action de sélection
+Action de suppression si autorisée
+```
+
+Exemple :
+
+```txt
+Scoundrel
+Available tree
+0/20
+```
+
+Pour l’arbre courant :
+
+```txt
+Pilot
+Current tree
+0/20
+```
+
+Pour une spécialisation avec talents achetés :
+
+```txt
+Pilot
+3/20 talents
+Removal locked
+```
+
+## 9.3. Suppression dans la sidebar
+
+La suppression doit être une action secondaire, jamais une action principale.
+
+Recommandation UI :
+
+```txt
+[Nom de la spé]        [icône corbeille]
+Available tree
+0/20
+```
+
+L’icône de suppression est affichée uniquement si :
+
+```txt
+spécialisation non initiale
+ET aucun talent acheté dans cette spécialisation
+```
+
+Si le choix UX est de garder l’icône visible mais désactivée, il faut un tooltip explicite :
+
+```txt
+Cannot remove this specialization because talents have already been purchased.
+```
+
+ou en français :
+
+```txt
+Impossible de supprimer cette spécialisation : des talents ont déjà été achetés dans cet arbre.
+```
+
+---
+
+## 9.4. Confirmation de suppression
+
+Une confirmation est obligatoire avant suppression.
+
+Texte recommandé :
+
+```txt
+Remove specialization “Pilot”?
+
+This specialization has no purchased talents.
+Removing it will remove access to its specialization tree.
+No XP refund will be applied.
+
+[Cancel] [Remove specialization]
+```
+
+Version française :
+
+```txt
+Supprimer la spécialisation « Pilot » ?
+
+Aucun talent n’a été acheté dans cet arbre.
+La suppression retirera l’accès à cet arbre de spécialisation.
+Aucun remboursement d’XP ne sera appliqué.
+
+[Annuler] [Supprimer la spécialisation]
+```
+
+---
+
+# 10. Règles UI/UX — Ajout d’une spécialisation
+
+## 10.1. Emplacement de l’ajout
+
+L’ajout peut rester là où il existe actuellement, mais il doit afficher clairement le coût avant validation.
+
+Dans la fenêtre de gestion, l’action d’ajout doit être accessible depuis la sidebar ou depuis un bouton dédié :
+
+```txt
++ Add specialization
+```
+
+ou :
+
+```txt
++ Ajouter une spécialisation
+```
+
+## 10.2. Prévisualisation du coût
+
+Avant achat, l’utilisateur doit voir :
+
+```txt
+Specialization: Charmer
+Type: Career specialization
+Current specializations: 2
+Cost: 30 XP
+Available XP: 100
+```
+
+Si la spécialisation est hors carrière :
+
+```txt
+Specialization: Mercenary Soldier
+Type: Non-career specialization
+Current specializations: 2
+Cost: 40 XP
+Available XP: 100
+```
+
+## 10.3. État XP insuffisante
+
+Si l’XP disponible est insuffisante, le bouton d’achat doit être désactivé.
+
+Message recommandé :
+
+```txt
+Insufficient XP — cost: 40 XP, available: 25 XP.
+```
+
+Version française :
+
+```txt
+XP insuffisante — coût : 40 XP, disponible : 25 XP.
+```
+
+Ne pas masquer l’option. Il vaut mieux afficher l’action bloquée avec une raison claire.
+
+---
+
+# 11. États UI recommandés
+
+## 11.1. Spécialisation possédée
+
+```txt
+Owned
+Selectable
+Tree available
+```
+
+## 11.2. Spécialisation sélectionnée
+
+```txt
+Current tree
+Highlighted
+Not mechanically exclusive
+```
+
+## 11.3. Spécialisation supprimable
+
+```txt
+Owned
+No purchased talents
+Not initial specialization
+Remove action available
+```
+
+## 11.4. Spécialisation non supprimable
+
+```txt
+Owned
+Purchased talents exist
+Remove action unavailable
+Reason displayed in tooltip
+```
+
+## 11.5. Spécialisation achetable
+
+```txt
+Not owned
+Cost computable
+Enough XP
+Purchase action enabled
+```
+
+## 11.6. Spécialisation non achetable
+
+```txt
+Not owned
+Cost computable
+Not enough XP
+Purchase action disabled
+Reason displayed
+```
+
+---
+
+# 12. Critères d’acceptation
+
+## 12.1. Header fiche personnage
+
+```gherkin
+Given un personnage avec une seule spécialisation
+When la fiche personnage est affichée
+Then le header affiche le nom de cette spécialisation sans pastille
+```
+
+```gherkin
+Given un personnage avec deux spécialisations
+When la fiche personnage est affichée
+Then le header affiche la première spécialisation
+And une pastille "+1" est affichée
+```
+
+```gherkin
+Given un personnage avec trois spécialisations
+When la fiche personnage est affichée
+Then le header affiche la première spécialisation
+And une pastille "+2" est affichée
+And le tooltip de la pastille liste les spécialisations supplémentaires
+```
+
+## 12.2. Ajout d’une spécialisation
+
+```gherkin
+Given un personnage avec une spécialisation possédée
+And 100 XP disponibles
+When il sélectionne une deuxième spécialisation de carrière
+Then le coût affiché est 20 XP
+And l’action d’achat est disponible
+```
+
+```gherkin
+Given un personnage avec une spécialisation possédée
+And 100 XP disponibles
+When il sélectionne une deuxième spécialisation hors carrière
+Then le coût affiché est 30 XP
+And l’action d’achat est disponible
+```
+
+```gherkin
+Given un personnage avec deux spécialisations possédées
+And 25 XP disponibles
+When il sélectionne une troisième spécialisation de carrière
+Then le coût affiché est 30 XP
+And l’action d’achat est désactivée
+And un message indique que l’XP est insuffisante
+```
+
+```gherkin
+Given un personnage possède déjà la spécialisation Pilot
+When il ouvre l’ajout de spécialisation
+Then Pilot ne peut pas être achetée une seconde fois
+```
+
+## 12.3. Suppression d’une spécialisation
+
+```gherkin
+Given une spécialisation non initiale
+And aucun talent acheté dans son arbre
+When l’utilisateur consulte la sidebar des spécialisations
+Then une action de suppression est disponible
+```
+
+```gherkin
+Given une spécialisation non initiale
+And au moins un talent acheté dans son arbre
+When l’utilisateur consulte la sidebar des spécialisations
+Then l’action de suppression est absente ou désactivée
+And la raison est affichée
+```
+
+```gherkin
+Given une spécialisation supprimable
+When l’utilisateur clique sur supprimer
+Then une confirmation est affichée
+```
+
+```gherkin
+Given une spécialisation supprimable
+When l’utilisateur confirme la suppression
+Then la spécialisation est retirée de l’acteur
+And l’arbre n’est plus disponible dans la sidebar
+And aucun remboursement d’XP n’est appliqué
+```
+
+---
+
+# 13. Hors scope V1
+
+Sont explicitement hors scope :
+
+```txt
+- changement de carrière ;
+- suppression de la spécialisation initiale ;
+- remboursement automatique d’XP ;
+- oubli de talents achetés ;
+- reconstruction automatique d’un arbre supprimé ;
+- réparation de liens cassés vers des arbres ou talents supprimés ;
+- gestion avancée par audit log.
+```
+
+Ces sujets relèvent plutôt d’une V2 de résilience et de maintenance des référentiels.
+
+---
+
+# 14. Recommandation finale
+
+La bonne séparation est la suivante :
+
+```txt
+Header personnage
+→ affichage compact de l’identité de spécialisation
+
+Specialization Tree View App
+→ gestion complète des spécialisations possédées
+
+Service métier
+→ calcul du coût, contrôle XP, contrôle suppression
+
+Audit log
+→ traçabilité future, pas bloquant pour la V1
+```
+
+Le point à ne pas rater : **ne pas transformer la spécialisation sélectionnée dans l’UI en état métier exclusif**. Un personnage peut posséder plusieurs spécialisations et continuer à progresser dans chacune. L’interface doit donc parler de **current tree** ou **selected tree**, pas de spécialisation active au sens mécanique.
+
+[1]: https://sw-eote-srd.vercel.app/experience-points?utm_source=chatgpt.com "Experience Points"
+[2]: https://sw-eote-srd.vercel.app/careers-specializations?utm_source=chatgpt.com "Careers & Specs"

--- a/documentation/plan/character-sheet/specialization-tree/353-msm1-stabiliser-le-contrat-metier-des-specialisations-et-de-l-arbre-courant.md
+++ b/documentation/plan/character-sheet/specialization-tree/353-msm1-stabiliser-le-contrat-metier-des-specialisations-et-de-l-arbre-courant.md
@@ -1,0 +1,93 @@
+## MSM1 — Stabiliser le contrat métier des spécialisations et de l'arbre courant
+
+### Contexte
+
+Issue : [#353 — MSM1 - Stabiliser le contrat métier des spécialisations et de l'arbre courant](https://github.com/herveDarritchon/foundryvtt-swerpg/issues/353)
+
+Le flux multi-spécialisations doit cesser de mélanger :
+
+- `career` : identité métier stable ;
+- `ownedSpecializations` : source canonique des spécialisations possédées ;
+- `selectedSpecializationTree` : contexte d'affichage uniquement.
+
+L'issue demande aussi un service de coût pur, réutilisable par la prévisualisation UI et par le futur flux d'achat, avec
+la règle :
+
+Le service de coût MSM1 calcule le coût d’obtention d’une spécialisation dans tous les cas.
+
+Règle :
+
+- si le personnage ne possède aucune spécialisation, la première spécialisation coûte 0 XP ;
+- à partir de la deuxième spécialisation, le coût est 10 × le nombre total de spécialisations après achat ;
+- si la spécialisation ajoutée n’est pas une spécialisation de carrière, ajouter +10 XP ;
+- en V1, une spécialisation universelle est traitée comme une spécialisation de carrière pour le coût.
+
+### Objectif
+
+Poser un contrat métier explicite pour les spécialisations possédées et fournir un calculateur de coût pur, sans
+dépendance UI, afin que l'arbre courant ne puisse plus influencer les décisions métier.
+
+### Fichiers pressentis
+
+| Fichier                                                            | Rôle                                                                           |
+|--------------------------------------------------------------------|--------------------------------------------------------------------------------|
+| `module/lib/specializations/owned-specializations.mjs`             | Nouveau module pur : contrat canonique, lecture/normalisation, helpers métier  |
+| `module/lib/specializations/specialization-cost-service.mjs`       | Nouveau service pur de calcul de coût                                          |
+| `module/models/character.mjs`                                      | Documenter l'alignement entre le modèle acteur et le contrat métier            |
+| `module/lib/talent-node/talent-tree-resolver.mjs`                  | Réutiliser le contrat canonique côté résolution, sans dépendre d'un état UI    |
+| `module/applications/specialization-tree/tree-context-builder.mjs` | Consommer le contrat métier sans faire de `selected tree` une source de vérité |
+| `module/applications/specialization-tree-app.mjs`                  | Garder `#selectedTreeKey` strictement dans le rôle de sélection d'affichage    |
+| `tests/lib/specializations/*.test.mjs`                             | Couvrir contrat, helpers de typage et calcul de coût                           |
+| `tests/applications/specialization-tree/*.test.mjs`                | Verrouiller la séparation métier vs contexte UI                                |
+
+### Plan d'implémentation
+
+#### Étape 1 — Formaliser le contrat canonique des spécialisations
+
+**Fichiers :** `module/lib/specializations/owned-specializations.mjs`, `module/models/character.mjs`
+
+1. Définir un contrat pur qui expose explicitement `career`, `ownedSpecializations` et interdit d'y inclure la notion d'
+   arbre courant.
+2. Aligner ce contrat sur la persistance actuelle (`system.details.career`, `system.details.specializations`) avec JSDoc
+   et helpers de lecture/normalisation.
+3. Ajouter les helpers de typage demandés (`isCareerSpecialization`, `isUniversalSpecialization`) pour éviter les
+   heuristiques dispersées.
+
+#### Étape 2 — Créer le service métier de calcul de coût
+
+**Fichiers :** `module/lib/specializations/specialization-cost-service.mjs`,
+`module/lib/specializations/owned-specializations.mjs`
+
+1. Implémenter un service pur qui reçoit la spécialisation candidate et le snapshot `ownedSpecializations` canonique.
+2. Encapsuler la formule complète (`baseCost`, `finalCost`) et la règle V1 « universelle = carrière ».
+3. Retourner un résultat stable, réutilisable tel quel par la prévisualisation UI et le futur flux d'achat.
+
+#### Étape 3 — Réaligner les adaptateurs application/UI sur ce contrat
+
+**Fichiers :** `module/lib/talent-node/talent-tree-resolver.mjs`,
+`module/applications/specialization-tree/tree-context-builder.mjs`, `module/applications/specialization-tree-app.mjs`
+
+1. Faire consommer le contrat canonique par les adaptateurs existants au lieu de reconstruire localement la sémantique
+   métier.
+2. Conserver `selectedSpecializationTree` / `#selectedTreeKey` comme simple sélection d'affichage, jamais comme
+   spécialisation « active » métier.
+3. Vérifier que les usages de prévisualisation et de résolution passent toujours la spécialisation ciblée explicitement
+   au service métier.
+
+#### Étape 4 — Verrouiller les non-régressions par tests
+
+**Fichiers :** `tests/lib/specializations/*.test.mjs`, `tests/lib/talent-node/talent-tree-resolver.test.mjs`,
+`tests/applications/specialization-tree/*.test.mjs`
+
+1. Couvrir les cas de coût : `0→1 = 0 XP`, `1→2 carrière = 20 XP`, `1→2 hors carrière = 30 XP`, `2→3 carrière = 30 XP`, `2→3 hors carrière = 40 XP`.
+2. Couvrir explicitement le cas universel et les helpers `isCareerSpecialization` / `isUniversalSpecialization`.
+3. Vérifier qu'un changement d'arbre courant ne change que le contexte de rendu, jamais le contrat métier ni le calcul
+   de coût.
+
+### Définition de done
+
+- [ ] `ownedSpecializations` est la source canonique des spécialisations possédées.
+- [ ] `selectedSpecializationTree` n'est utilisé que comme contexte UI.
+- [ ] Le calcul de coût vit dans `module/lib/specializations/` et ne dépend pas de `game`/`ui`.
+- [ ] Les spécialisations universelles suivent bien la règle V1 de coût carrière.
+- [ ] Les tests couvrent le contrat métier et la séparation avec le contexte d'affichage.

--- a/documentation/ways-of-work/plan/specialization-tree-v1/multi-specialization-management/issues-checklist.md
+++ b/documentation/ways-of-work/plan/specialization-tree-v1/multi-specialization-management/issues-checklist.md
@@ -1,0 +1,95 @@
+# Issues Checklist — Specialization Tree V1 / Multi-Specialization Management
+
+## Préparation
+
+- [ ] Relire `documentation/cadrage/character-sheet/specializations/cadrage-gestion-multi-specialisations-feuille-personnage.md`
+- [ ] Confirmer le rattachement à l'epic `Specialization Tree V1`
+- [ ] Vérifier les prérequis fonctionnels issus de US16 / US17 et de la fenêtre `SpecializationTreeApp`
+- [ ] Préparer les labels `feature`, `user-story`, `enabler`, `test`, `priority-*`, `value-*`, `character-sheet`, `specializations`, `specialization-tree`
+
+## Création Epic / Feature
+
+- [ ] Réutiliser l'epic `Specialization Tree V1`
+- [ ] Créer la feature `Multi-Specialization Management - Gérer ajout, synthèse et suppression des spécialisations`
+- [ ] Renseigner `Priority = P1`, `Value = High`, `Component = Character Sheet / Specializations / Specialization Tree`
+- [ ] Poser la dépendance de feature vers l'epic et la continuité US16 / US17
+
+## Stories / Enabler / Test à créer
+
+### MSM1 — Contrat métier et arbre courant
+
+- [ ] Titre : `MSM1 - Stabiliser le contrat métier des spécialisations et de l'arbre courant`
+- [ ] AC : `career` inchangé, `ownedSpecializations` canonique, `selectedSpecializationTree` purement UI, coût carrière / hors carrière / universelle défini
+- [ ] Estimate : `2`
+- [ ] Priority : `P1`
+- [ ] Bloquée par : Feature
+
+### MSM2 — Header multi-spécialisation
+
+- [ ] Titre : `MSM2 - Résumer les spécialisations dans le header et ouvrir la gestion`
+- [ ] AC : affichage `No specialization` / nom principal / `+N`, tooltip des spécialisations supplémentaires, clic ouvrant la gestion
+- [ ] Estimate : `2`
+- [ ] Priority : `P1`
+- [ ] Bloquée par : `MSM1`
+
+### MSM3 — Achat de spécialisation
+
+- [ ] Titre : `MSM3 - Acheter une spécialisation avec coût prévisualisé et blocages explicites`
+- [ ] AC : coût visible avant validation, distinction carrière / hors carrière, doublons bloqués, XP insuffisante bloquante avec message, arbre non résolu bloqué
+- [ ] Estimate : `3`
+- [ ] Priority : `P1`
+- [ ] Bloquée par : `MSM1`
+
+### MSM4 — Suppression contrôlée
+
+- [ ] Titre : `MSM4 - Supprimer une spécialisation autorisée avec confirmation et fallback d'arbre courant`
+- [ ] AC : suppression seulement si non initiale et sans talent acheté, confirmation obligatoire, pas de remboursement XP, nouvel arbre courant sélectionné après retrait
+- [ ] Estimate : `3`
+- [ ] Priority : `P1`
+- [ ] Bloquée par : `MSM1`
+
+### MSM5 — Validation ciblée
+
+- [ ] Titre : `MSM5 - Valider coûts, états UI et non-régression multi-spécialisation`
+- [ ] Cas : header `0/1/N`, achat carrière / hors carrière, XP insuffisante, doublon, suppression autorisée, suppression verrouillée, absence de remboursement XP
+- [ ] Estimate : `2`
+- [ ] Priority : `P1`
+- [ ] Bloquée par : `MSM2`, `MSM3`, `MSM4`
+
+## Sous-tâches recommandées
+
+- [ ] Ajouter une task de badge `+N` et tooltip des spécialisations supplémentaires
+- [ ] Ajouter une task de microcopy explicite pour `XP insuffisante` et `suppression impossible`
+- [ ] Ajouter une task de traitement des spécialisations universelles comme spécialisations de carrière pour le coût V1
+- [ ] Ajouter une task de blocage achat si l'arbre n'est pas résoluble proprement
+- [ ] Ajouter une task de confirmation de suppression sans remboursement XP
+- [ ] Ajouter une task de fallback vers la dernière spécialisation encore disponible après suppression
+
+## Dépendances GitHub à poser
+
+- [ ] Feature **blocked by** Epic `Specialization Tree V1`
+- [ ] Feature **related to** continuité US16 / US17
+- [ ] `MSM1` **blocked by** Feature
+- [ ] `MSM2` **blocked by** `MSM1`
+- [ ] `MSM3` **blocked by** `MSM1`
+- [ ] `MSM4` **blocked by** `MSM1`
+- [ ] `MSM5` **blocked by** `MSM2`, `MSM3`, `MSM4`
+
+## Board / pilotage
+
+- [ ] Ajouter toutes les issues au board Kanban
+- [ ] Mettre `MSM1` en `Sprint Ready` en premier
+- [ ] Lancer `MSM2` juste après stabilisation du contrat de données
+- [ ] Paralléliser `MSM3` et `MSM4` si le centre de gestion est stable
+- [ ] Réserver `MSM5` comme verrou de fin de flux, pas comme ticket fourre-tout
+
+## Checklist de clôture
+
+- [ ] Le header reste compact et informatif quel que soit le nombre de spécialisations
+- [ ] L'utilisateur comprend que `current tree` est un contexte d'affichage et non un état métier exclusif
+- [ ] Le coût d'achat respecte les exemples métier du cadrage
+- [ ] Les achats bloqués restent visibles avec raison explicite
+- [ ] Une spécialisation déjà possédée ne peut jamais être rachetée
+- [ ] La spécialisation initiale n'est pas supprimable en V1
+- [ ] Aucun remboursement XP n'est appliqué lors d'une suppression
+- [ ] La suppression d'une spécialisation courante laisse toujours l'interface sur un arbre valide

--- a/documentation/ways-of-work/plan/specialization-tree-v1/multi-specialization-management/project-plan.md
+++ b/documentation/ways-of-work/plan/specialization-tree-v1/multi-specialization-management/project-plan.md
@@ -1,0 +1,138 @@
+# Project Plan — Specialization Tree V1 / Multi-Specialization Management
+
+## Contexte source
+
+- `documentation/cadrage/character-sheet/specializations/cadrage-gestion-multi-specialisations-feuille-personnage.md`
+- `documentation/ways-of-work/plan/specialization-tree-v1/us16-graphical-tree-rendering/project-plan.md`
+- `documentation/ways-of-work/plan/specialization-tree-v1/us17-talent-node-purchase-and-forget/project-plan.md`
+- `documentation/ways-of-work/plan/specialization-tree-v1/graphical-ux-refresh/project-plan.md`
+
+## 1. Vue d'ensemble
+
+- **Epic**: `Specialization Tree V1`
+- **Feature**: `Multi-Specialization Management`
+- **Positionnement**: étendre la fiche personnage et `SpecializationTreeApp` pour gérer plusieurs spécialisations sans
+  confondre arbre courant UI et état métier.
+
+### Résumé
+
+Introduire une gestion V1 des spécialisations possédées avec trois capacités visibles : synthèse compacte dans le
+header, achat cadré par les règles XP / doublon / résolution d'arbre, et suppression contrôlée d'une spécialisation non
+initiale sans talents achetés.
+
+### Valeur métier
+
+- rendre lisible l'identité de spécialisation d'un personnage multi-spécialisé ;
+- fiabiliser l'achat de spécialisation selon les règles Star Wars FFG ;
+- éviter les états incohérents entre liste possédée, arbre courant et progression talents ;
+- centraliser la gestion dans la fenêtre des arbres déjà connue par l'utilisateur.
+
+## 2. Critères de succès
+
+- le header affiche une spécialisation principale et une pastille `+N` avec tooltip sur les spécialisations
+  supplémentaires ;
+- le clic header ouvre la gestion des spécialisations dans `SpecializationTreeApp` ;
+- `selectedSpecializationTree` reste un contexte UI et n'est jamais traité comme une spécialisation mécaniquement
+  active ;
+- l'achat affiche le coût calculé, le type carrière / hors carrière, et les raisons de blocage (`XP insuffisante`,
+  doublon, arbre introuvable) ;
+- un achat réussi ajoute la spécialisation, retire l'XP, ouvre l'accès à l'arbre et déclenche les recalculs dérivés
+  nécessaires ;
+- la suppression n'est possible que pour une spécialisation non initiale sans talent acheté, avec confirmation et sans
+  remboursement XP ;
+- après suppression, l'arbre courant bascule automatiquement vers une spécialisation encore disponible.
+
+## 3. Jalons
+
+1. **Contrat métier** — stabiliser `ownedSpecializations`, le calcul de coût et la sémantique de l'arbre courant.
+2. **Synthèse header** — exposer l'information compacte et le point d'entrée de gestion.
+3. **Achat guidé** — permettre l'ajout avec prévisualisation du coût et blocages explicites.
+4. **Suppression contrôlée** — permettre le retrait autorisé avec confirmation et fallback de sélection.
+5. **Validation ciblée** — verrouiller règles métier, états UI et non-régression V1.
+
+## 4. Risques
+
+| Risque                                                        | Impact                                | Mitigation                                                                                  |
+|---------------------------------------------------------------|---------------------------------------|---------------------------------------------------------------------------------------------|
+| Confondre arbre courant UI et spécialisation active métier    | bugs de progression ou d'affichage    | figer explicitement le contrat `career / ownedSpecializations / selectedSpecializationTree` |
+| Autoriser l'achat d'une spécialisation non résoluble          | acteur incohérent, arbre inutilisable | bloquer la V1 si la spécialisation ne résout pas proprement son arbre                       |
+| Supprimer une spécialisation avec talents achetés ou initiale | corruption de progression             | verrouiller la suppression par règles métier et message explicite                           |
+| Oublier les effets dérivés après achat / suppression          | compétences ou vues désynchronisées   | traiter mise à jour acteur, recalculs et refresh UI dans le même flux                       |
+
+## 5. Hiérarchie des work items
+
+```mermaid
+graph TD
+    A[Epic: Specialization Tree V1] --> B[Feature: Multi-Specialization Management]
+    B --> C[Enabler: Stabiliser les règles métier et le contrat UI]
+    B --> D[Story: Résumer les spécialisations dans le header]
+    B --> E[Story: Acheter une spécialisation depuis l'app]
+    B --> F[Story: Supprimer une spécialisation autorisée]
+    B --> G[Test: Valider règles métier et états UI]
+
+    C --> C1[Task: formaliser career ownedSpecializations selectedTree]
+    C --> C2[Task: calculer coût carrière hors carrière universelle]
+    D --> D1[Task: afficher primaire + badge + tooltip]
+    D --> D2[Task: ouvrir la fenêtre de gestion au clic]
+    E --> E1[Task: prévisualiser coût et disponibilité]
+    E --> E2[Task: bloquer doublon XP insuffisante arbre introuvable]
+    F --> F1[Task: afficher suppression conditionnelle + confirmation]
+    F --> F2[Task: sélectionner un nouvel arbre courant après retrait]
+    G --> G1[Task: couvrir header achat suppression hors scope]
+```
+
+## 6. Découpage GitHub recommandé
+
+| Type    | Titre                                                                                         | Priorité | Estimate | Dépendances                                           |
+|---------|-----------------------------------------------------------------------------------------------|----------|----------|-------------------------------------------------------|
+| Feature | `Multi-Specialization Management - Gérer ajout, synthèse et suppression des spécialisations`  | P1       | 8        | Epic `Specialization Tree V1`, continuité US16 + US17 |
+| Enabler | `MSM1 - Stabiliser le contrat métier des spécialisations et de l'arbre courant`               | P1       | 2        | Feature                                               |
+| Story   | `MSM2 - Résumer les spécialisations dans le header et ouvrir la gestion`                      | P1       | 2        | MSM1                                                  |
+| Story   | `MSM3 - Acheter une spécialisation avec coût prévisualisé et blocages explicites`             | P1       | 3        | MSM1                                                  |
+| Story   | `MSM4 - Supprimer une spécialisation autorisée avec confirmation et fallback d'arbre courant` | P1       | 3        | MSM1                                                  |
+| Test    | `MSM5 - Valider coûts, états UI et non-régression multi-spécialisation`                       | P1       | 2        | MSM2, MSM3, MSM4                                      |
+
+## 7. Dépendances et ordre recommandé
+
+1. **MSM1** — verrouiller la distinction métier / UI et les règles de coût.
+2. **MSM2** — rendre visible la synthèse et le point d'entrée utilisateur.
+3. **MSM3** et **MSM4** — parallélisables après MSM1, avec partage du même centre de gestion.
+4. **MSM5** — valider le flux complet sur cas nominaux et bloqués.
+
+## 8. Board Kanban
+
+- **Backlog**: feature et sous-issues documentées
+- **Sprint Ready**: critères d'acceptation relus, dépendances posées
+- **In Progress**: une story flux utilisateur active à la fois
+- **In Review**: revue métier + revue UI
+- **Testing**: validation des cas carrière / hors carrière / doublon / XP insuffisante / suppression verrouillée
+- **Done**: règles V1 tenues et wording cohérent FR/EN
+
+### Champs recommandés
+
+- `Priority`: `P1`
+- `Value`: `High`
+- `Component`: `Character Sheet / Specializations / Specialization Tree`
+- `Estimate`: `2`, `3`, `8`
+- `Epic`: `Specialization Tree V1`
+- `Track`: `Multi-Specialization Management`
+
+## 9. Définition de done
+
+- le header synthétise correctement 0, 1, 2+ spécialisations ;
+- l'app distingue clairement spécialisation possédée et arbre courant ;
+- le coût affiché respecte la règle `10 x (n + 1)` avec `+10` hors carrière ;
+- les spécialisations déjà possédées ne peuvent pas être rachetées ;
+- l'achat bloqué expose une raison claire au lieu de masquer l'action ;
+- la suppression de la spécialisation initiale ou d'une spécialisation avec talents achetés est impossible ;
+- aucune suppression V1 ne rembourse d'XP ;
+- après retrait, l'arbre courant reste valide et visible.
+
+## 10. Métriques projet
+
+- **Lisibilité header**: 100% des cas `0 / 1 / N` ont un rendu déterministe ;
+- **Règles de coût**: couverture des cas 2e et 3e spécialisation carrière / hors carrière ;
+- **Blocages explicites**: 100% des achats refusés affichent une raison compréhensible ;
+- **Intégrité suppression**: 0 cas où une spécialisation initiale ou avec talents achetés peut être retirée ;
+- **Cohérence UI**: 100% des suppressions réassignent un arbre courant valide si un autre arbre existe ;
+- **Scope V1**: 0 remboursement XP et 0 confusion entre arbre courant et état métier exclusif.

--- a/module/lib/specializations/owned-specializations.mjs
+++ b/module/lib/specializations/owned-specializations.mjs
@@ -1,0 +1,136 @@
+/**
+ * @module module/lib/specializations/owned-specializations
+ * @description Contrat canonique pour les spécialisations possédées par un personnage.
+ *
+ * Ce module définit :
+ * - Le type des spécialisations possédées
+ * - Des helpers pour normaliser et lire les spécialisations depuis un acteur
+ * - Des helpers de typage : isCareerSpecialization, isUniversalSpecialization
+ */
+
+/**
+ * @typedef {Object} OwnedSpecialization
+ * @property {string|null} specializationId - Identifiant stable de la spécialisation
+ * @property {string|null} treeUuid - UUID de l'arbre de talents associé (Item)
+ * @property {string} name - Nom de la spécialisation
+ * @property {string|null} img - Image de la spécialisation
+ * @property {Object} [system] - Données système de la spécialisation (skills, freeSkillRank, etc.)
+ */
+
+/**
+ * @typedef {Object} OwnedSpecializationsSnapshot
+ * @property {Array<OwnedSpecialization>} items - Liste des spécialisations possédées
+ * @property {number} count - Nombre de spécialisations possédées
+ */
+
+/**
+ * Extrait et normalise les spécialisations possédées depuis un acteur.
+ *
+ * @param {object|null|undefined} actor - L'acteur (document Foundry ou objet plain)
+ * @returns {OwnedSpecializationsSnapshot} Snapshot normalisé des spécialisations
+ */
+export function getOwnedSpecializations(actor) {
+  const raw = Array.from(actor?.system?.details?.specializations || [])
+  const items = raw.map((spec) => normalizeSpecialization(spec)).filter(Boolean)
+  return {
+    items,
+    count: items.length,
+  }
+}
+
+/**
+ * Normalise une entrée de spécialisation brute en un OwnedSpecialization stable.
+ *
+ * @param {object|null|undefined} raw - Entrée brute depuis actor.system.details.specializations
+ * @returns {OwnedSpecialization|null} Spécialisation normalisée, ou null si invalide
+ */
+export function normalizeSpecialization(raw) {
+  if (!raw) return null
+
+  return {
+    specializationId: raw.specializationId ?? null,
+    treeUuid: raw.treeUuid ?? null,
+    name: raw.name ?? '',
+    img: raw.img ?? null,
+    system: raw.system ?? undefined,
+  }
+}
+
+/**
+ * Détermine si une spécialisation est une spécialisation de carrière.
+ *
+ * V1 : vérifie si la spécialisation est explicitement associée à la carrière du personnage.
+ *
+ * @param {OwnedSpecialization|object|null} specialization - La spécialisation à évaluer
+ * @param {object|null|undefined} career - La carrière du personnage (actor.system.details.career)
+ * @returns {boolean} True si c'est une spécialisation de carrière
+ */
+export function isCareerSpecialization(specialization, career) {
+  if (!specialization || !career) return false
+
+  // V1 : vérification par association explicite si la carrière a une liste de spécialisations
+  const careerSpecializations = Array.from(career.specializations || [])
+  const specId = specialization.specializationId
+  const specName = specialization.name
+
+  if (specId) {
+    const hasMatchingId = careerSpecializations.some((cs) => cs.specializationId === specId || cs.id === specId)
+    if (hasMatchingId) return true
+  }
+
+  if (specName) {
+    const hasMatchingName = careerSpecializations.some((cs) => cs.name === specName)
+    if (hasMatchingName) return true
+  }
+
+  // Fallback V1 : si pas d'association explicite, on retourne false
+  // TODO: à affiner quand le modèle de carrière inclura explicitement ses spécialisations
+  return false
+}
+
+/**
+ * Détermine si une spécialisation est une spécialisation universelle.
+ *
+ * V1 : les spécialisations universelles sont traitées comme des spécialisations de carrière pour le coût.
+ *
+ * @param {OwnedSpecialization|object|null} specialization - La spécialisation à évaluer
+ * @returns {boolean} True si c'est une spécialisation universelle
+ */
+export function isUniversalSpecialization(specialization) {
+  if (!specialization) return false
+
+  // V1 : vérification par champ explicite ou par convention de nommage/ID
+  const system = specialization.system ?? {}
+
+  // Cas 1 : champ isUniversal explicite
+  if (system.isUniversal === true || specialization.isUniversal === true) {
+    return true
+  }
+
+  // Cas 2 : convention d'ID "universal-" ou nom contenant "universal"
+  const specId = specialization.specializationId ?? ''
+  const specName = specialization.name ?? ''
+
+  if (specId.toLowerCase().startsWith('universal-')) {
+    return true
+  }
+
+  if (specName.toLowerCase().includes('universal')) {
+    return true
+  }
+
+  return false
+}
+
+/**
+ * Détermine si une spécialisation doit être traitée comme une spécialisation de carrière pour le coût.
+ *
+ * Combine : isCareerSpecialization OU isUniversalSpecialization
+ *
+ * @param {OwnedSpecialization|object|null} specialization - La spécialisation à évaluer
+ * @param {object|null|undefined} career - La carrière du personnage
+ * @returns {boolean} True si traité comme carrière pour le coût
+ */
+export function isTreatedAsCareerForCost(specialization, career) {
+  return isCareerSpecialization(specialization, career) || isUniversalSpecialization(specialization)
+}

--- a/module/lib/specializations/specialization-cost-service.mjs
+++ b/module/lib/specializations/specialization-cost-service.mjs
@@ -1,0 +1,72 @@
+/**
+ * @module module/lib/specializations/specialization-cost-service
+ * @description Service pur de calcul de coût pour l'achat de spécialisations.
+ *
+ * Règles V1 :
+ * - 1ère spécialisation : 0 XP
+ * - N-ième spécialisation (n≥2) : 10 × n XP
+ * - +10 XP si ce n'est pas une spécialisation de carrière ou universelle
+ * - Spécialisation universelle = spécialisation de carrière pour le coût
+ */
+
+import { isTreatedAsCareerForCost } from './owned-specializations.mjs'
+
+/**
+ * @typedef {Object} SpecializationCostResult
+ * @property {number} baseCost - Coût de base selon le nombre de spécialisations
+ * @property {number} nonCareerPenalty - Pénalité si ce n'est pas une spécialisation de carrière/universelle (0 ou 10)
+ * @property {number} finalCost - Coût total final
+ * @property {boolean} isCareerOrUniversal - True si traité comme carrière pour le coût
+ * @property {number} ownedCountBefore - Nombre de spécialisations possédées avant achat
+ * @property {number} ownedCountAfter - Nombre de spécialisations après achat
+ */
+
+/**
+ * Calcule le coût d'obtention d'une nouvelle spécialisation.
+ *
+ * @param {object} params - Paramètres d'entrée
+ * @param {Array<object>|{count: number, items: Array<object>}} params.ownedSpecializations -
+ *        Soit un snapshot de getOwnedSpecializations(), soit un tableau brut de spécialisations
+ * @param {object|null|undefined} params.candidateSpecialization - La spécialisation candidate à acheter
+ * @param {object|null|undefined} params.career - La carrière du personnage (actor.system.details.career)
+ * @returns {SpecializationCostResult} Résultat détaillé du calcul de coût
+ */
+export function calculateSpecializationCost(params) {
+  const { ownedSpecializations, candidateSpecialization, career } = params
+
+  // Calculer le nombre de spécialisations possédées
+  let ownedCountBefore
+  if (Array.isArray(ownedSpecializations)) {
+    ownedCountBefore = ownedSpecializations.length
+  } else if (ownedSpecializations && typeof ownedSpecializations === 'object' && 'count' in ownedSpecializations) {
+    ownedCountBefore = ownedSpecializations.count
+  } else {
+    ownedCountBefore = 0
+  }
+
+  const ownedCountAfter = ownedCountBefore + 1
+
+  // Coût de base
+  let baseCost
+  if (ownedCountBefore === 0) {
+    baseCost = 0
+  } else {
+    baseCost = 10 * ownedCountAfter
+  }
+
+  // Pénalité hors carrière
+  const isCareerOrUniversal = isTreatedAsCareerForCost(candidateSpecialization, career)
+  const nonCareerPenalty = isCareerOrUniversal ? 0 : 10
+
+  // Coût final
+  const finalCost = baseCost + nonCareerPenalty
+
+  return {
+    baseCost,
+    nonCareerPenalty,
+    finalCost,
+    isCareerOrUniversal,
+    ownedCountBefore,
+    ownedCountAfter,
+  }
+}

--- a/tests/lib/specializations/owned-specializations.test.mjs
+++ b/tests/lib/specializations/owned-specializations.test.mjs
@@ -1,0 +1,197 @@
+import { describe, it, expect } from 'vitest'
+
+import {
+  getOwnedSpecializations,
+  normalizeSpecialization,
+  isCareerSpecialization,
+  isUniversalSpecialization,
+  isTreatedAsCareerForCost,
+} from '../../../module/lib/specializations/owned-specializations.mjs'
+
+describe('owned-specializations', () => {
+  describe('normalizeSpecialization', () => {
+    it('normalizes a complete specialization entry', () => {
+      const raw = {
+        specializationId: 'pilot',
+        treeUuid: 'Item.tree-pilot',
+        name: 'Pilot',
+        img: 'systems/swerpg/assets/icons/pilot.png',
+        system: { specializationSkills: [{ id: 'piloting' }], freeSkillRank: 4 },
+      }
+
+      const result = normalizeSpecialization(raw)
+
+      expect(result).toMatchObject({
+        specializationId: 'pilot',
+        treeUuid: 'Item.tree-pilot',
+        name: 'Pilot',
+        img: 'systems/swerpg/assets/icons/pilot.png',
+        system: expect.objectContaining({ freeSkillRank: 4 }),
+      })
+    })
+
+    it('handles partial specialization entries with defaults', () => {
+      const raw = { name: 'Gunner' }
+
+      const result = normalizeSpecialization(raw)
+
+      expect(result).toMatchObject({
+        specializationId: null,
+        treeUuid: null,
+        name: 'Gunner',
+        img: null,
+      })
+    })
+
+    it('returns null for null/undefined input', () => {
+      expect(normalizeSpecialization(null)).toBeNull()
+      expect(normalizeSpecialization(undefined)).toBeNull()
+    })
+  })
+
+  describe('getOwnedSpecializations', () => {
+    it('extracts specializations from actor structure', () => {
+      const actor = {
+        system: {
+          details: {
+            specializations: new Set([
+              { specializationId: 'spec-1', name: 'Spec 1' },
+              { specializationId: 'spec-2', name: 'Spec 2' },
+            ]),
+          },
+        },
+      }
+
+      const snapshot = getOwnedSpecializations(actor)
+
+      expect(snapshot.count).toBe(2)
+      expect(snapshot.items).toHaveLength(2)
+      expect(snapshot.items[0].specializationId).toBe('spec-1')
+    })
+
+    it('handles missing specializations gracefully', () => {
+      const actor1 = { system: { details: {} } }
+      const actor2 = { system: {} }
+      const actor3 = {}
+      const actor4 = null
+
+      expect(getOwnedSpecializations(actor1).count).toBe(0)
+      expect(getOwnedSpecializations(actor2).count).toBe(0)
+      expect(getOwnedSpecializations(actor3).count).toBe(0)
+      expect(getOwnedSpecializations(actor4).count).toBe(0)
+    })
+  })
+
+  describe('isCareerSpecialization', () => {
+    it('returns false when either parameter is null/undefined', () => {
+      const spec = { specializationId: 'pilot', name: 'Pilot' }
+      const career = { name: 'Ace', specializations: [{ specializationId: 'pilot' }] }
+
+      expect(isCareerSpecialization(null, career)).toBe(false)
+      expect(isCareerSpecialization(undefined, career)).toBe(false)
+      expect(isCareerSpecialization(spec, null)).toBe(false)
+      expect(isCareerSpecialization(spec, undefined)).toBe(false)
+    })
+
+    it('returns true when specializationId matches career specialization', () => {
+      const spec = { specializationId: 'pilot', name: 'Pilot' }
+      const career = {
+        name: 'Ace',
+        specializations: [{ specializationId: 'pilot' }, { specializationId: 'gunner' }],
+      }
+
+      expect(isCareerSpecialization(spec, career)).toBe(true)
+    })
+
+    it('returns true when name matches career specialization', () => {
+      const spec = { name: 'Pilot' } // no specializationId
+      const career = {
+        name: 'Ace',
+        specializations: [{ name: 'Pilot' }, { name: 'Gunner' }],
+      }
+
+      expect(isCareerSpecialization(spec, career)).toBe(true)
+    })
+
+    it('returns false when no match found', () => {
+      const spec = { specializationId: 'medic', name: 'Medic' }
+      const career = {
+        name: 'Ace',
+        specializations: [{ specializationId: 'pilot' }],
+      }
+
+      expect(isCareerSpecialization(spec, career)).toBe(false)
+    })
+
+    it('returns false when career has no specializations list', () => {
+      const spec = { specializationId: 'pilot', name: 'Pilot' }
+      const career = { name: 'Ace' } // no specializations field
+
+      expect(isCareerSpecialization(spec, career)).toBe(false)
+    })
+  })
+
+  describe('isUniversalSpecialization', () => {
+    it('returns false for null/undefined input', () => {
+      expect(isUniversalSpecialization(null)).toBe(false)
+      expect(isUniversalSpecialization(undefined)).toBe(false)
+    })
+
+    it('returns true when system.isUniversal is true', () => {
+      const spec1 = { system: { isUniversal: true } }
+      const spec2 = { isUniversal: true } // top-level
+
+      expect(isUniversalSpecialization(spec1)).toBe(true)
+      expect(isUniversalSpecialization(spec2)).toBe(true)
+    })
+
+    it('returns true when specializationId starts with "universal-"', () => {
+      const spec = { specializationId: 'universal-sharpshooter', name: 'Sharpshooter' }
+
+      expect(isUniversalSpecialization(spec)).toBe(true)
+    })
+
+    it('returns true when name contains "universal" (case insensitive)', () => {
+      const spec1 = { name: 'Universal Tech' }
+      const spec2 = { name: 'UNIVERSAL Leader' }
+      const spec3 = { name: 'universal' }
+
+      expect(isUniversalSpecialization(spec1)).toBe(true)
+      expect(isUniversalSpecialization(spec2)).toBe(true)
+      expect(isUniversalSpecialization(spec3)).toBe(true)
+    })
+
+    it('returns false for regular specializations', () => {
+      const spec1 = { specializationId: 'pilot', name: 'Pilot' }
+      const spec2 = { specializationId: 'gunner', name: 'Gunner' }
+      const spec3 = { name: 'Medic' }
+
+      expect(isUniversalSpecialization(spec1)).toBe(false)
+      expect(isUniversalSpecialization(spec2)).toBe(false)
+      expect(isUniversalSpecialization(spec3)).toBe(false)
+    })
+  })
+
+  describe('isTreatedAsCareerForCost', () => {
+    it('returns true for career specializations', () => {
+      const spec = { specializationId: 'pilot', name: 'Pilot' }
+      const career = { specializations: [{ specializationId: 'pilot' }] }
+
+      expect(isTreatedAsCareerForCost(spec, career)).toBe(true)
+    })
+
+    it('returns true for universal specializations (even without career match)', () => {
+      const spec = { specializationId: 'universal-tech', name: 'Universal Tech' }
+      const career = { specializations: [{ specializationId: 'pilot' }] } // no match in career
+
+      expect(isTreatedAsCareerForCost(spec, career)).toBe(true)
+    })
+
+    it('returns false for non-career, non-universal specializations', () => {
+      const spec = { specializationId: 'medic', name: 'Medic' }
+      const career = { specializations: [{ specializationId: 'pilot' }] }
+
+      expect(isTreatedAsCareerForCost(spec, career)).toBe(false)
+    })
+  })
+})

--- a/tests/lib/specializations/specialization-cost-service.test.mjs
+++ b/tests/lib/specializations/specialization-cost-service.test.mjs
@@ -1,0 +1,154 @@
+import { describe, it, expect } from 'vitest'
+
+import { calculateSpecializationCost } from '../../../module/lib/specializations/specialization-cost-service.mjs'
+
+describe('specialization-cost-service', () => {
+  describe('calculateSpecializationCost', () => {
+    it('returns 0 XP when moving from 0 to 1 specialization', () => {
+      const result = calculateSpecializationCost({
+        ownedSpecializations: { items: [], count: 0 },
+        candidateSpecialization: { specializationId: 'scoundrel', name: 'Scoundrel' },
+        career: { specializations: [{ specializationId: 'scoundrel' }] },
+      })
+
+      expect(result).toMatchObject({
+        baseCost: 0,
+        nonCareerPenalty: 0,
+        finalCost: 0,
+        isCareerOrUniversal: true,
+        ownedCountBefore: 0,
+        ownedCountAfter: 1,
+      })
+    })
+
+    it('returns 20 XP for 2nd career specialization (1→2 career)', () => {
+      const result = calculateSpecializationCost({
+        ownedSpecializations: { items: [{ specializationId: 'scoundrel' }], count: 1 },
+        candidateSpecialization: { specializationId: 'pilot', name: 'Pilot' },
+        career: { specializations: [{ specializationId: 'scoundrel' }, { specializationId: 'pilot' }] },
+      })
+
+      expect(result).toMatchObject({
+        baseCost: 20,
+        nonCareerPenalty: 0,
+        finalCost: 20,
+        isCareerOrUniversal: true,
+        ownedCountBefore: 1,
+        ownedCountAfter: 2,
+      })
+    })
+
+    it('returns 30 XP for 2nd non-career specialization (1→2 non-career)', () => {
+      const result = calculateSpecializationCost({
+        ownedSpecializations: { items: [{ specializationId: 'scoundrel' }], count: 1 },
+        candidateSpecialization: { specializationId: 'mercenary-soldier', name: 'Mercenary Soldier' },
+        career: { specializations: [{ specializationId: 'scoundrel' }] },
+      })
+
+      expect(result).toMatchObject({
+        baseCost: 20,
+        nonCareerPenalty: 10,
+        finalCost: 30,
+        isCareerOrUniversal: false,
+        ownedCountBefore: 1,
+        ownedCountAfter: 2,
+      })
+    })
+
+    it('returns 30 XP for 3rd career specialization (2→3 career)', () => {
+      const result = calculateSpecializationCost({
+        ownedSpecializations: { items: [{ specializationId: 'scoundrel' }, { specializationId: 'pilot' }], count: 2 },
+        candidateSpecialization: { specializationId: 'gunner', name: 'Gunner' },
+        career: { specializations: [{ specializationId: 'scoundrel' }, { specializationId: 'pilot' }, { specializationId: 'gunner' }] },
+      })
+
+      expect(result).toMatchObject({
+        baseCost: 30,
+        nonCareerPenalty: 0,
+        finalCost: 30,
+        isCareerOrUniversal: true,
+        ownedCountBefore: 2,
+        ownedCountAfter: 3,
+      })
+    })
+
+    it('returns 40 XP for 3rd non-career specialization (2→3 non-career)', () => {
+      const result = calculateSpecializationCost({
+        ownedSpecializations: { items: [{ specializationId: 'scoundrel' }, { specializationId: 'pilot' }], count: 2 },
+        candidateSpecialization: { specializationId: 'medic', name: 'Medic' },
+        career: { specializations: [{ specializationId: 'scoundrel' }, { specializationId: 'pilot' }] },
+      })
+
+      expect(result).toMatchObject({
+        baseCost: 30,
+        nonCareerPenalty: 10,
+        finalCost: 40,
+        isCareerOrUniversal: false,
+        ownedCountBefore: 2,
+        ownedCountAfter: 3,
+      })
+    })
+
+    it('treats universal specializations as career for cost', () => {
+      const result = calculateSpecializationCost({
+        ownedSpecializations: { items: [{ specializationId: 'scoundrel' }], count: 1 },
+        candidateSpecialization: { specializationId: 'universal-sharpshooter', name: 'Sharpshooter' },
+        career: { specializations: [{ specializationId: 'scoundrel' }] },
+      })
+
+      expect(result).toMatchObject({
+        baseCost: 20,
+        nonCareerPenalty: 0,
+        finalCost: 20,
+        isCareerOrUniversal: true,
+      })
+    })
+
+    it('accepts a plain array as ownedSpecializations', () => {
+      const result = calculateSpecializationCost({
+        ownedSpecializations: [{ specializationId: 'scoundrel' }, { specializationId: 'pilot' }],
+        candidateSpecialization: { specializationId: 'gunner', name: 'Gunner' },
+        career: { specializations: [] },
+      })
+
+      expect(result.ownedCountBefore).toBe(2)
+      expect(result.ownedCountAfter).toBe(3)
+    })
+
+    it('defaults count to 0 when ownedSpecializations is missing', () => {
+      const result = calculateSpecializationCost({
+        ownedSpecializations: null,
+        candidateSpecialization: { specializationId: 'scoundrel', name: 'Scoundrel' },
+        career: { specializations: [] },
+      })
+
+      expect(result.ownedCountBefore).toBe(0)
+      expect(result.ownedCountAfter).toBe(1)
+      expect(result.finalCost).toBe(10)
+      expect(result.isCareerOrUniversal).toBe(false)
+    })
+
+    it('returns nonCareerPenalty=10 when candidate is null', () => {
+      const result = calculateSpecializationCost({
+        ownedSpecializations: { items: [{ specializationId: 'scoundrel' }], count: 1 },
+        candidateSpecialization: null,
+        career: { specializations: [{ specializationId: 'scoundrel' }] },
+      })
+
+      expect(result.isCareerOrUniversal).toBe(false)
+      expect(result.nonCareerPenalty).toBe(10)
+      expect(result.finalCost).toBe(30)
+    })
+
+    it('returns nonCareerPenalty=10 when candidate is undefined', () => {
+      const result = calculateSpecializationCost({
+        ownedSpecializations: { items: [{ specializationId: 'scoundrel' }], count: 1 },
+        candidateSpecialization: undefined,
+        career: { specializations: [{ specializationId: 'scoundrel' }] },
+      })
+
+      expect(result.isCareerOrUniversal).toBe(false)
+      expect(result.nonCareerPenalty).toBe(10)
+    })
+  })
+})


### PR DESCRIPTION
Closes #353

## Context
Stabilisation du contrat métier des spécialisations et de l'arbre courant. Ajout de owned-specializations comme source canonique, service de coût pur, helpers de typage (career/universal), et tests unitaires.

## Changes
- `module/lib/specializations/owned-specializations.mjs` — contrat canonique, normalisation, helpers métier
- `module/lib/specializations/specialization-cost-service.mjs` — calcul de coût pur (10×n, +10 hors carrière, universelle = carrière)
- `tests/lib/specializations/owned-specializations.test.mjs` — 18 tests
- `tests/lib/specializations/specialization-cost-service.test.mjs` — 10 tests

## Tests
`pnpm vitest run` — 157 files, 1930 passed, 2 skipped. No regressions.

## Notes
- Pure domain logic in `module/lib/` — no game/ui/canvas dependencies
- selectedSpecializationTree remains UI-only context (never business state)
- Docs in `documentation/ways-of-work/plan/` and `documentation/plan/` updated
