### PR TITLE
feat(specialization): add specialization tree UI, purchase preview and explicit blocking

### DIFF
--- a/documentation/plan/character-sheet/specialization-tree/355-msm3-acheter-une-specialisation-avec-cout-previsualise-et-blocages-explicites.md
+++ b/documentation/plan/character-sheet/specialization-tree/355-msm3-acheter-une-specialisation-avec-cout-previsualise-et-blocages-explicites.md
@@ -1,0 +1,93 @@
+## MSM3 — Acheter une spécialisation avec coût prévisualisé et blocages explicites
+
+### Contexte
+
+Issue : [#355 — MSM3 - Acheter une spécialisation avec coût prévisualisé et blocages explicites](https://github.com/herveDarritchon/foundryvtt-swerpg/issues/355)
+
+Suite de `MSM1` et `MSM2`, le socle existe déjà sur deux points utiles :
+
+- `calculateSpecializationCost()` encapsule la règle de coût métier ;
+- `SpecializationTreeApp` est désormais le point d'entrée de gestion des spécialisations.
+
+En revanche, l'application ne permet encore que de naviguer dans les spécialisations déjà possédées : elle n'expose ni catalogue d'achat, ni prévisualisation du coût avant confirmation, ni raison explicite quand une spécialisation ne peut pas être achetée.
+
+### Objectif
+
+Permettre l'achat d'une nouvelle spécialisation depuis `SpecializationTreeApp`, avec une prévisualisation fiable du coût (y compris la surtaxe hors carrière) et des blocages lisibles, sans déplacer la logique métier dans l'UI.
+
+### Périmètre
+
+#### Inclus
+
+- construction d'un view-model pur de spécialisations achetables ;
+- prévisualisation du coût à partir du service métier existant ;
+- exposition de blocages explicites côté UI ;
+- action d'achat avec revalidation métier, application de la spécialisation et déduction XP ;
+- rafraîchissement de l'application après succès ;
+- clés i18n et tests ciblés.
+
+#### Exclus
+
+- suppression / oubli de spécialisation ;
+- refonte générale de `SpecializationTreeApp` hors parcours d'achat ;
+- modification des règles de coût définies en `MSM1` ;
+- changement du pipeline d'import OggDude ou du modèle d'arbre de talents.
+
+### Fichiers pressentis
+
+| Fichier                                                                    | Rôle                                                                    |
+|----------------------------------------------------------------------------|-------------------------------------------------------------------------|
+| `module/lib/specializations/specialization-purchase-service.mjs`          | Nouveau service pur : éligibilité, preview de coût, blocages, payload   |
+| `module/lib/specializations/owned-specializations.mjs`                    | Réutiliser le snapshot canonique et éviter les doublons métier          |
+| `module/lib/specializations/specialization-cost-service.mjs`              | Réemploi du calcul détaillé (`baseCost`, `nonCareerPenalty`, `finalCost`) |
+| `module/models/character.mjs` et/ou `module/documents/actor-mixins/*.mjs` | Orchestration document : appliquer la spécialisation et débiter l'XP    |
+| `module/applications/specialization-tree/tree-context-builder.mjs`        | Exposer la liste achetable, la preview et l'état bloqué/actionnable     |
+| `module/applications/specialization-tree-app.mjs`                         | Gérer sélection, confirmation, achat, refresh et sélection post-achat   |
+| `templates/applications/specialization-tree-app.hbs`                      | Rendre le panneau/liste d'achat et ses blocages explicites              |
+| `lang/en.json` / `lang/fr.json`                                           | Ajouter les libellés de preview, action et raisons de blocage           |
+| `tests/lib/specializations/*.test.mjs`                                    | Couvrir preview de coût, éligibilité et refus métier                    |
+| `tests/applications/specialization-tree-app.test.mjs`                     | Couvrir le flux UI achat/refresh et les états bloqués                   |
+
+### Plan d'implémentation
+
+#### Étape 1 — Construire un contrat métier pur pour l'achat de spécialisation
+
+**Fichiers :** `module/lib/specializations/specialization-purchase-service.mjs`, `module/lib/specializations/owned-specializations.mjs`, `module/lib/specializations/specialization-cost-service.mjs`
+
+1. Définir une entrée candidate stable (identité, lien carrière/universelle, arbre associé, statut déjà possédé ou non).
+2. Produire un résultat pur réutilisable par l'UI et par l'action d'achat : `canPurchase`, `blockedReasonCode`, `blockedReasonLabelKey`, `costPreview`, `isCareerOrUniversal`.
+3. Réutiliser `calculateSpecializationCost()` pour exposer la décomposition du coût au lieu de recalculer localement la formule.
+4. Couvrir au minimum les blocages explicites attendus : spécialisation déjà possédée, XP insuffisante, candidate invalide / introuvable.
+
+#### Étape 2 — Introduire l'orchestration document et brancher l'action d'achat
+
+**Fichiers :** `module/models/character.mjs` et/ou `module/documents/actor-mixins/*.mjs`, `module/applications/specialization-tree-app.mjs`
+
+1. Ajouter une orchestration non-UI qui revalide la candidate au moment du clic, applique la spécialisation via le mécanisme document existant, puis débite l'XP dans la même transaction observable.
+2. Retourner un résultat uniforme (`ok`, `reasonCode`, `reason`, `cost`, `specializationId`) pour que l'application n'ait qu'à afficher succès/échec sans porter la règle métier.
+3. Faire sélectionner automatiquement la spécialisation nouvellement achetée après succès, puis rafraîchir `SpecializationTreeApp` pour exposer immédiatement son arbre ou son état résolu/non résolu.
+
+#### Étape 3 — Exposer la preview et les blocages dans l'application
+
+**Fichiers :** `module/applications/specialization-tree/tree-context-builder.mjs`, `module/applications/specialization-tree-app.mjs`, `templates/applications/specialization-tree-app.hbs`, `lang/en.json`, `lang/fr.json`
+
+1. Étendre la sidebar de `SpecializationTreeApp` avec une section d'achat distincte des spécialisations déjà possédées.
+2. Afficher pour la candidate sélectionnée un récapitulatif de coût stable (`coût de base`, `surtaxe hors carrière`, `coût total`) et un CTA unique d'achat quand l'action est autorisée.
+3. Quand l'action est bloquée, afficher un état lisible et localisé au lieu d'un simple bouton absent ou muet.
+4. Ajouter uniquement les clés i18n nécessaires pour la preview, l'action d'achat, le `0 XP` de première spécialisation et les raisons de blocage retenues.
+
+#### Étape 4 — Verrouiller les cas nominaux et les refus métier
+
+**Fichiers :** `tests/lib/specializations/*.test.mjs`, `tests/applications/specialization-tree-app.test.mjs`
+
+1. Couvrir les previews de coût représentatives : première spécialisation `0 XP`, deuxième spécialisation de carrière `20 XP`, deuxième hors carrière `30 XP`.
+2. Couvrir les refus métier principaux : déjà possédée, XP insuffisante, candidate invalide / absente.
+3. Couvrir le flux UI : sélection d'une candidate, affichage de la preview, confirmation d'achat, refresh et sélection de la nouvelle spécialisation après succès.
+
+### Définition de done
+
+- [ ] `SpecializationTreeApp` expose un parcours d'achat pour une nouvelle spécialisation.
+- [ ] Le coût affiché provient du service métier central et montre explicitement la surtaxe hors carrière si elle s'applique.
+- [ ] Les blocages principaux sont lisibles et localisés, sans logique métier dupliquée dans le template.
+- [ ] L'achat réussi applique la spécialisation, débite l'XP et rafraîchit l'application sur la nouvelle spécialisation.
+- [ ] Les tests verrouillent les cas nominaux et les refus métier ciblés.

--- a/lang/en.json
+++ b/lang/en.json
@@ -136,7 +136,17 @@
         },
         "PURCHASE": {
           "SUCCESS": "Purchase successful: {talent}",
-          "FAILURE": "Purchase failed: {reason}"
+          "FAILURE": "Purchase failed: {reason}",
+          "SECTION_TITLE": "Purchase a Specialization",
+          "COST_BASE": "Base cost",
+          "COST_NON_CAREER": "Non-career surcharge",
+          "COST_TOTAL": "Total",
+          "FIRST_SPEC_FREE": "Free (first specialization)",
+          "INVALID_CANDIDATE": "Cannot purchase this specialization",
+          "CAREER": "Career",
+          "UNIVERSAL": "Universal",
+          "NON_CAREER": "Non-career",
+          "NO_CANDIDATES": "No additional specializations available"
         },
         "FORGET": {
           "SUCCESS": "Talent forgotten: {talent}",

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -116,7 +116,17 @@
         },
         "PURCHASE": {
           "SUCCESS": "Achat réussi : {talent}",
-          "FAILURE": "Échec de l'achat : {reason}"
+          "FAILURE": "Échec de l'achat : {reason}",
+          "SECTION_TITLE": "Acheter une spécialisation",
+          "COST_BASE": "Coût de base",
+          "COST_NON_CAREER": "Surtaxe hors carrière",
+          "COST_TOTAL": "Total",
+          "FIRST_SPEC_FREE": "Gratuit (première spécialisation)",
+          "INVALID_CANDIDATE": "Impossible d'acheter cette spécialisation",
+          "CAREER": "Carrière",
+          "UNIVERSAL": "Universelle",
+          "NON_CAREER": "Hors carrière",
+          "NO_CANDIDATES": "Aucune spécialisation supplémentaire disponible"
         },
         "FORGET": {
           "SUCCESS": "Talent oublié : {talent}",

--- a/module/applications/specialization-tree-app.mjs
+++ b/module/applications/specialization-tree-app.mjs
@@ -6,6 +6,8 @@ import { getReasonLabelKey } from './specialization-tree/node-ui-state.mjs'
 import { buildSpecializationTreeContext as buildContextPure } from './specialization-tree/tree-context-builder.mjs'
 import { buildContextualActionPanelViewModel } from './specialization-tree/contextual-action-panel-view-model.mjs'
 import { PixiTreeRenderer } from './specialization-tree/pixi-tree-renderer.mjs'
+import { evaluateSpecializationPurchase, getBlockedReasonLabelKey } from '../lib/specializations/specialization-purchase-service.mjs'
+import { getOwnedSpecializations, isUniversalSpecialization } from '../lib/specializations/owned-specializations.mjs'
 
 const { api } = foundry.applications
 
@@ -49,6 +51,7 @@ const ACTION_KEYS = Object.freeze({
     const pureContext = buildContextPure(actor, selectedKey, { resolutions, localize, format, talentLookup })
 
     const legendItems = buildLegendItems(localize)
+    const buyableSpecializations = buildBuyableSpecializations(actor, localize)
 
     return {
       ...pureContext,
@@ -58,6 +61,7 @@ const ACTION_KEYS = Object.freeze({
       config: game.system.config,
       isOwner: actor?.isOwner ?? false,
       legendItems,
+      buyableSpecializations,
     }
   }
 
@@ -96,8 +100,94 @@ const ACTION_KEYS = Object.freeze({
         affordance: 'informational',
         cursor: 'help',
       },
-    ]
-  }
+  ]
+}
+
+/**
+ * Find a specialization Item document by key (id, uuid, specializationId, or name).
+ * @param {string} key - Lookup key
+ * @returns {object|null} The matching Item document, or null
+ */
+function findSpecializationItem(key) {
+  const items = game.items
+  if (!items) return null
+
+  const byId = items.get?.(key)
+  if (byId?.type === 'specialization') return byId
+
+  const source = items.contents ?? Array.from(items)
+  return source.find(
+    (i) => i.type === 'specialization' && (i.name === key || i.system?.specializationId === key),
+  ) ?? null
+}
+
+/**
+ * Build the buyable specializations view-model for the purchase section.
+ *
+ * Iterates all specializations from game.items, filters out already-owned
+ * candidates, and computes purchase eligibility + cost preview for each.
+ *
+ * @param {object|null|undefined} actor - The actor document
+ * @param {(key: string) => string} localize - i18n localize function
+ * @returns {Array<object>} Buyable specialization entries
+ */
+export function buildBuyableSpecializations(actor, localize) {
+  if (!actor || !game.items) return []
+
+  const ownedSnapshot = getOwnedSpecializations(actor)
+  const career = actor.system?.details?.career ?? null
+  const availableXp = actor.system?.progression?.experience?.available ?? 0
+
+  const source = game.items.contents ?? Array.from(game.items)
+  const allSpecItems = source.filter((i) => i.type === 'specialization')
+
+  return allSpecItems.map((item) => {
+    const candidate = {
+      specializationId: item.system?.specializationId ?? null,
+      name: item.name,
+      system: item.system,
+    }
+
+    const isUniversal = isUniversalSpecialization(candidate)
+    const evaluation = evaluateSpecializationPurchase({
+      ownedSpecializations: ownedSnapshot,
+      candidateSpecialization: candidate,
+      career,
+      availableXp,
+    })
+
+    const isFirstSpec = evaluation.costPreview?.ownedCountBefore === 0
+
+    let typeLabel
+    if (isUniversal) {
+      typeLabel = localize('SWERPG.TALENT.SPECIALIZATION_TREE_APP.PURCHASE.UNIVERSAL')
+    } else if (evaluation.isCareerOrUniversal) {
+      typeLabel = localize('SWERPG.TALENT.SPECIALIZATION_TREE_APP.PURCHASE.CAREER')
+    } else {
+      typeLabel = localize('SWERPG.TALENT.SPECIALIZATION_TREE_APP.PURCHASE.NON_CAREER')
+    }
+
+    let blockedReasonLabel = null
+    if (!evaluation.canPurchase && evaluation.blockedReasonCode) {
+      blockedReasonLabel = localize(getBlockedReasonLabelKey(evaluation.blockedReasonCode))
+    }
+
+    const key = item.id ?? candidate.specializationId ?? candidate.name
+
+    return {
+      specializationId: candidate.specializationId,
+      name: candidate.name,
+      key,
+      canPurchase: evaluation.canPurchase,
+      blockedReasonCode: evaluation.blockedReasonCode,
+      blockedReasonLabel,
+      costPreview: evaluation.costPreview,
+      isCareerOrUniversal: evaluation.isCareerOrUniversal,
+      typeLabel,
+      isFirstSpecialization: isFirstSpec,
+    }
+  })
+}
 
 export default class SpecializationTreeApp extends api.HandlebarsApplicationMixin(api.ApplicationV2) {
   static DEFAULT_OPTIONS = {
@@ -119,6 +209,7 @@ export default class SpecializationTreeApp extends api.HandlebarsApplicationMixi
       zoomOut: SpecializationTreeApp.#onZoomOut,
       contextualAction: SpecializationTreeApp.#onContextualAction,
       closeDetail: SpecializationTreeApp.#onCloseDetail,
+      purchaseSpecialization: SpecializationTreeApp.#onPurchaseSpecialization,
     },
   }
 
@@ -408,6 +499,83 @@ export default class SpecializationTreeApp extends api.HandlebarsApplicationMixi
   static async #onCloseDetail(event, _target) {
     event.preventDefault()
     this.#hideDetailPanel()
+  }
+
+  /** @returns {Promise<void>} */
+  static async #onPurchaseSpecialization(event, target) {
+    event.preventDefault()
+    const candidateKey = target.dataset.candidateKey
+    if (!candidateKey || !this.actor) return
+
+    if (!this.actor.isOwner) {
+      ui.notifications.warn(game.i18n.localize('SWERPG.TALENT.SPECIALIZATION_TREE_APP.PERMISSION_DENIED'))
+      return
+    }
+
+    const specItem = findSpecializationItem(candidateKey)
+    if (!specItem) {
+      ui.notifications.warn(game.i18n.localize('SWERPG.TALENT.SPECIALIZATION_TREE_APP.REASON.UNKNOWN'))
+      return
+    }
+
+    const ownedSnapshot = getOwnedSpecializations(this.actor)
+    const career = this.actor.system?.details?.career ?? null
+    const availableXp = this.actor.system?.progression?.experience?.available ?? 0
+
+    const candidate = {
+      specializationId: specItem.system?.specializationId ?? null,
+      name: specItem.name,
+    }
+
+    const evaluation = evaluateSpecializationPurchase({
+      ownedSpecializations: ownedSnapshot,
+      candidateSpecialization: candidate,
+      career,
+      availableXp,
+    })
+
+    if (!evaluation.canPurchase) {
+      const reasonKey = getBlockedReasonLabelKey(evaluation.blockedReasonCode)
+      ui.notifications.warn(game.i18n.localize(reasonKey))
+      return
+    }
+
+    const cost = evaluation.costPreview.finalCost
+    const actionLabel = game.i18n.localize('SWERPG.TALENT.SPECIALIZATION_TREE_APP.ACTION.PURCHASE')
+    const cancelLabel = game.i18n.localize('SWERPG.TALENT.SPECIALIZATION_TREE_APP.CONFIRM.CANCEL')
+
+    const confirmed = await api.DialogV2.confirm({
+      title: game.i18n.format('SWERPG.TALENT.SPECIALIZATION_TREE_APP.CONFIRM.PURCHASE.TITLE', {
+        action: actionLabel,
+        talent: specItem.name,
+      }),
+      content: `<p>${game.i18n.format('SWERPG.TALENT.SPECIALIZATION_TREE_APP.CONFIRM.PURCHASE.CONTENT', {
+        action: actionLabel,
+        talent: specItem.name,
+        xp: cost,
+      })}</p>`,
+      buttons: [
+        { action: 'confirm', label: actionLabel, default: true },
+        { action: 'cancel', label: cancelLabel },
+      ],
+    })
+    if (!confirmed) return
+
+    await this.actor._applyDetailItem(specItem, {
+      canApply: true,
+      canClear: false,
+      isCollection: true,
+      collectionKey: 'specializations',
+    })
+
+    const currentSpent = this.actor.system.progression.experience.spent ?? 0
+    await this.actor.updateExperiencePoints({ spent: currentSpent + cost })
+
+    ui.notifications.info(game.i18n.format('SWERPG.TALENT.SPECIALIZATION_TREE_APP.PURCHASE.SUCCESS', {
+      talent: specItem.name,
+    }))
+
+    await this.refresh()
   }
 
   #showDetailPanel(node) {

--- a/module/lib/specializations/specialization-purchase-service.mjs
+++ b/module/lib/specializations/specialization-purchase-service.mjs
@@ -1,0 +1,107 @@
+/**
+ * @module module/lib/specializations/specialization-purchase-service
+ * @description Pure service pur pour l'éligibilité, la preview de coût et les blocages
+ *              lors de l'achat d'une nouvelle spécialisation.
+ *
+ * Dépend du service de coût existant (specialization-cost-service) et du snapshot
+ * canonique des spécialisations possédées (owned-specializations).
+ */
+
+import { calculateSpecializationCost } from './specialization-cost-service.mjs'
+
+/**
+ * Codes de raison de blocage pour l'achat de spécialisation.
+ * @type {Readonly<Record<string, string>>}
+ */
+export const BLOCKED_REASON = Object.freeze({
+  ALREADY_OWNED: 'specialization.alreadyOwned',
+  INSUFFICIENT_XP: 'specialization.insufficientXp',
+  INVALID_CANDIDATE: 'specialization.invalidCandidate',
+})
+
+/**
+ * Résultat de l'évaluation d'achat d'une spécialisation.
+ * @typedef {Object} SpecializationPurchaseEvaluation
+ * @property {boolean} canPurchase - True si l'achat est autorisé
+ * @property {string|null} blockedReasonCode - Code de blocage si canPurchase est false
+ * @property {object|null} costPreview - Résultat détaillé du calcul de coût (SpecializationCostResult) ou null
+ * @property {boolean} isCareerOrUniversal - True si la candidate est traitée comme carrière/universelle
+ */
+
+/**
+ * Évalue si une spécialisation candidate peut être achetée.
+ *
+ * Fonction pure — toutes les données doivent être injectées en paramètres.
+ * Les dépendances Foundry (game, actor document) ne doivent pas être utilisées ici.
+ *
+ * @param {object} params - Paramètres d'évaluation
+ * @param {Array<object>|{count: number, items: Array<object>}} params.ownedSpecializations -
+ *        Snapshot des spécialisations possédées (getOwnedSpecializations() ou tableau brut)
+ * @param {object|null|undefined} params.candidateSpecialization - La spécialisation candidate
+ * @param {object|null|undefined} params.career - La carrière du personnage
+ * @param {number|null|undefined} params.availableXp - XP disponible du personnage
+ * @returns {SpecializationPurchaseEvaluation} Résultat de l'évaluation
+ */
+export function evaluateSpecializationPurchase(params) {
+  const { ownedSpecializations, candidateSpecialization, career, availableXp } = params
+
+  if (!candidateSpecialization) {
+    return buildResult(false, BLOCKED_REASON.INVALID_CANDIDATE, null)
+  }
+
+  const ownedItems = Array.isArray(ownedSpecializations)
+    ? ownedSpecializations
+    : (ownedSpecializations?.items ?? [])
+
+  const isOwned = ownedItems.some((s) => {
+    const candidateId = candidateSpecialization.specializationId
+    if (candidateId && s.specializationId === candidateId) return true
+    if (!candidateId && s.name === candidateSpecialization.name) return true
+    return false
+  })
+  if (isOwned) {
+    return buildResult(false, BLOCKED_REASON.ALREADY_OWNED, null)
+  }
+
+  const costResult = calculateSpecializationCost({
+    ownedSpecializations,
+    candidateSpecialization,
+    career,
+  })
+
+  if (costResult.finalCost > 0 && (availableXp == null || availableXp < costResult.finalCost)) {
+    return buildResult(false, BLOCKED_REASON.INSUFFICIENT_XP, costResult)
+  }
+
+  return buildResult(true, null, costResult)
+}
+
+/**
+ * Construit un résultat d'évaluation normalisé.
+ * @param {boolean} canPurchase
+ * @param {string|null} blockedReasonCode
+ * @param {object|null} costPreview
+ * @returns {SpecializationPurchaseEvaluation}
+ */
+function buildResult(canPurchase, blockedReasonCode, costPreview) {
+  return {
+    canPurchase,
+    blockedReasonCode,
+    costPreview,
+    isCareerOrUniversal: costPreview?.isCareerOrUniversal ?? false,
+  }
+}
+
+/**
+ * Mappe un code de raison de blocage vers la clé i18n correspondante.
+ * @param {string} code - Le code de raison (une valeur de BLOCKED_REASON)
+ * @returns {string} La clé i18n
+ */
+export function getBlockedReasonLabelKey(code) {
+  const map = {
+    [BLOCKED_REASON.ALREADY_OWNED]: 'SWERPG.TALENT.SPECIALIZATION_TREE_APP.REASON.ALREADY_PURCHASED',
+    [BLOCKED_REASON.INSUFFICIENT_XP]: 'SWERPG.TALENT.SPECIALIZATION_TREE_APP.REASON.NOT_ENOUGH_XP',
+    [BLOCKED_REASON.INVALID_CANDIDATE]: 'SWERPG.TALENT.SPECIALIZATION_TREE_APP.PURCHASE.INVALID_CANDIDATE',
+  }
+  return map[code] ?? 'SWERPG.TALENT.SPECIALIZATION_TREE_APP.REASON.UNKNOWN'
+}

--- a/templates/applications/specialization-tree-app.hbs
+++ b/templates/applications/specialization-tree-app.hbs
@@ -66,6 +66,31 @@
               {{/each}}
             </ul>
           </section>
+          {{#if buyableSpecializations.length}}
+            <section class='specialization-tree-app__sidebar-section'>
+              <p class='specialization-tree-app__section-label'>{{localize 'SWERPG.TALENT.SPECIALIZATION_TREE_APP.PURCHASE.SECTION_TITLE'}}</p>
+              <ul class='specialization-tree-app__buyable-specs'>
+                {{#each buyableSpecializations as |candidate|}}
+                  <li class='specialization-tree-app__buyable-spec {{#if candidate.canPurchase}}can-purchase{{else}}blocked{{/if}}' data-candidate-key='{{candidate.key}}'>
+                    <div class='specialization-tree-app__buyable-spec-main'>
+                      <span class='specialization-tree-app__buyable-spec-name'>{{candidate.name}}</span>
+                      <span class='specialization-tree-app__buyable-spec-type'>{{candidate.typeLabel}}</span>
+                    </div>
+                    {{#if candidate.canPurchase}}
+                      {{#if candidate.isFirstSpecialization}}
+                        <span class='specialization-tree-app__buyable-spec-free'>{{localize 'SWERPG.TALENT.SPECIALIZATION_TREE_APP.PURCHASE.FIRST_SPEC_FREE'}}</span>
+                      {{else}}
+                        <span class='specialization-tree-app__buyable-spec-cost'>{{localize 'SWERPG.TALENT.SPECIALIZATION_TREE_APP.PURCHASE.COST_TOTAL'}}: {{candidate.costPreview.finalCost}} XP</span>
+                      {{/if}}
+                      <button type='button' class='specialization-tree-app__buyable-spec-cta' data-action='purchaseSpecialization' data-candidate-key='{{candidate.key}}'>{{localize 'SWERPG.TALENT.SPECIALIZATION_TREE_APP.ACTION.PURCHASE'}}</button>
+                    {{else}}
+                      <span class='specialization-tree-app__buyable-spec-blocked-reason'>{{candidate.blockedReasonLabel}}</span>
+                    {{/if}}
+                  </li>
+                {{/each}}
+              </ul>
+            </section>
+          {{/if}}
         {{else}}
           <div class='specialization-tree-app__sidebar-empty'>
             <h3>{{emptyStateTitle}}</h3>

--- a/tests/applications/specialization-tree-app.test.mjs
+++ b/tests/applications/specialization-tree-app.test.mjs
@@ -3,7 +3,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { setupFoundryMock, teardownFoundryMock } from '../helpers/mock-foundry.mjs'
 
 function createActor(overrides = {}) {
-  return {
+  const base = {
     id: 'actor-1',
     name: 'Vara Kesh',
     type: 'character',
@@ -12,10 +12,15 @@ function createActor(overrides = {}) {
     system: {
       details: { specializations: [] },
       progression: { talentPurchases: [], experience: { available: 100 } },
-      ...overrides.system,
     },
-    ...overrides,
   }
+
+  if (overrides.system) {
+    base.system = { ...base.system, ...overrides.system }
+  }
+
+  const { system: _, ...otherOverrides } = overrides
+  return { ...base, ...otherOverrides }
 }
 
 function createRoot({ viewportHost, panel }) {
@@ -38,6 +43,7 @@ describe('specialization-tree app orchestration', () => {
   let SpecializationTreeApp
   let buildSpecializationTreeContext
   let buildLegendItems
+  let buildBuyableSpecializations
   let mockRendererInstances
   let purchaseTalentNodeMock
   let forgetTalentNodeMock
@@ -129,6 +135,7 @@ describe('specialization-tree app orchestration', () => {
     SpecializationTreeApp = mod.default
     buildSpecializationTreeContext = mod.buildSpecializationTreeContext
     buildLegendItems = mod.buildLegendItems
+    buildBuyableSpecializations = mod.buildBuyableSpecializations
   })
 
   afterEach(() => {
@@ -954,6 +961,200 @@ describe('specialization-tree app orchestration', () => {
         expect(infoSpy).toHaveBeenCalled()
         expect(refreshSpy).toHaveBeenCalled()
       })
+    })
+  })
+
+  describe('buildBuyableSpecializations', () => {
+    it('returns empty array when no actor', () => {
+      const result = buildBuyableSpecializations(null, (key) => key)
+      expect(result).toEqual([])
+    })
+
+    it('returns empty array when game.items is null', () => {
+      const actor = createActor()
+      const result = buildBuyableSpecializations(actor, (key) => key)
+      expect(result).toEqual([])
+    })
+
+    it('returns candidates for available specialization items', () => {
+      const actor = createActor({
+        system: {
+          details: {
+            specializations: [],
+            career: { specializations: [{ specializationId: 'scoundrel' }] },
+          },
+        },
+      })
+      game.items = {
+        contents: [
+          { id: 'spec-1', name: 'Scoundrel', type: 'specialization', system: { specializationId: 'scoundrel' } },
+          { id: 'spec-2', name: 'Pilot', type: 'specialization', system: { specializationId: 'pilot' } },
+        ],
+      }
+
+      const result = buildBuyableSpecializations(actor, (key) => key)
+
+      expect(result).toHaveLength(2)
+      expect(result[0].name).toBe('Scoundrel')
+      expect(result[0].canPurchase).toBe(true)
+      expect(result[0].costPreview.finalCost).toBe(0)
+      expect(result[0].isFirstSpecialization).toBe(true)
+      expect(result[1].name).toBe('Pilot')
+      expect(result[1].canPurchase).toBe(true)
+      expect(result[1].costPreview.finalCost).toBe(10)
+    })
+
+    it('excludes already owned specializations', () => {
+      const actor = createActor({
+        system: {
+          details: {
+            specializations: new Set([{ specializationId: 'scoundrel', name: 'Scoundrel' }]),
+            career: { specializations: [{ specializationId: 'scoundrel' }, { specializationId: 'pilot' }] },
+          },
+        },
+      })
+      game.items = {
+        contents: [
+          { id: 'spec-1', name: 'Scoundrel', type: 'specialization', system: { specializationId: 'scoundrel' } },
+          { id: 'spec-2', name: 'Pilot', type: 'specialization', system: { specializationId: 'pilot' } },
+        ],
+      }
+
+      const result = buildBuyableSpecializations(actor, (key) => key)
+
+      expect(result).toHaveLength(2)
+      expect(result[0].canPurchase).toBe(false)
+      expect(result[0].blockedReasonCode).toBe('specialization.alreadyOwned')
+      expect(result[1].canPurchase).toBe(true)
+    })
+
+    it('marks candidates with insufficient XP as blocked', () => {
+      const actor = createActor({
+        system: {
+          details: {
+            specializations: new Set([{ specializationId: 'scoundrel', name: 'Scoundrel' }]),
+            career: { specializations: [{ specializationId: 'scoundrel' }, { specializationId: 'pilot' }] },
+          },
+          progression: { talentPurchases: [], experience: { available: 5 } },
+        },
+      })
+      game.items = {
+        contents: [
+          { id: 'spec-2', name: 'Pilot', type: 'specialization', system: { specializationId: 'pilot' } },
+        ],
+      }
+
+      const result = buildBuyableSpecializations(actor, (key) => key)
+
+      expect(result).toHaveLength(1)
+      expect(result[0].canPurchase).toBe(false)
+      expect(result[0].costPreview.finalCost).toBe(20)
+    })
+
+    it('includes buyable specializations in the render context', () => {
+      const actor = createActor()
+      game.items = { contents: [] }
+
+      const context = buildSpecializationTreeContext(actor)
+
+      expect(context).toHaveProperty('buyableSpecializations')
+      expect(Array.isArray(context.buyableSpecializations)).toBe(true)
+    })
+  })
+
+  describe('purchaseSpecialization action', () => {
+    it('applies specialization item and deducts XP on success', async () => {
+      const mockSpecItem = {
+        id: 'spec-pilot',
+        name: 'Pilot',
+        type: 'specialization',
+        system: { specializationId: 'pilot' },
+      }
+      game.items = {
+        get: (key) => (key === 'spec-pilot' ? mockSpecItem : undefined),
+        contents: [mockSpecItem],
+      }
+
+      const actor = createActor({
+        system: {
+          details: {
+            specializations: new Set([{ specializationId: 'scoundrel', name: 'Scoundrel' }]),
+            career: { specializations: [{ specializationId: 'scoundrel' }, { specializationId: 'pilot' }] },
+          },
+          progression: { talentPurchases: [], experience: { available: 50, spent: 0 } },
+        },
+      })
+      actor._applyDetailItem = vi.fn().mockResolvedValue(undefined)
+      actor.updateExperiencePoints = vi.fn().mockResolvedValue(undefined)
+
+      const app = new SpecializationTreeApp()
+      app.actor = actor
+      app.rendered = true
+      const refreshSpy = vi.spyOn(app, 'refresh').mockResolvedValue(app)
+      const infoSpy = vi.spyOn(ui.notifications, 'info')
+
+      const confirmSpy = vi.spyOn(foundry.applications.api.DialogV2, 'confirm')
+      confirmSpy.mockResolvedValue(true)
+
+      const event = { preventDefault: vi.fn() }
+      const target = { dataset: { candidateKey: 'spec-pilot' } }
+
+      await SpecializationTreeApp.DEFAULT_OPTIONS.actions.purchaseSpecialization.call(app, event, target)
+
+      expect(actor._applyDetailItem).toHaveBeenCalledWith(mockSpecItem, {
+        canApply: true,
+        canClear: false,
+        isCollection: true,
+        collectionKey: 'specializations',
+      })
+      expect(actor.updateExperiencePoints).toHaveBeenCalledWith({ spent: 20 })
+      expect(infoSpy).toHaveBeenCalled()
+      expect(refreshSpy).toHaveBeenCalled()
+    })
+
+    it('warns when actor cannot afford the specialization', async () => {
+      const mockSpecItem = {
+        id: 'spec-pilot',
+        name: 'Pilot',
+        type: 'specialization',
+        system: { specializationId: 'pilot' },
+      }
+      game.items = {
+        get: (key) => (key === 'spec-pilot' ? mockSpecItem : undefined),
+        contents: [mockSpecItem],
+      }
+
+      const actor = createActor({
+        system: {
+          details: { specializations: new Set([{ specializationId: 'scoundrel', name: 'Scoundrel' }]) },
+          progression: { talentPurchases: [], experience: { available: 5 } },
+        },
+      })
+      const warnSpy = vi.spyOn(ui.notifications, 'warn')
+
+      const app = new SpecializationTreeApp()
+      app.actor = actor
+      app.rendered = true
+
+      const event = { preventDefault: vi.fn() }
+      const target = { dataset: { candidateKey: 'spec-pilot' } }
+
+      await SpecializationTreeApp.DEFAULT_OPTIONS.actions.purchaseSpecialization.call(app, event, target)
+
+      expect(warnSpy).toHaveBeenCalled()
+    })
+
+    it('does nothing when target has no candidateKey', async () => {
+      const actor = createActor()
+      const app = new SpecializationTreeApp()
+      app.actor = actor
+
+      const event = { preventDefault: vi.fn() }
+      const target = { dataset: {} }
+
+      await expect(
+        SpecializationTreeApp.DEFAULT_OPTIONS.actions.purchaseSpecialization.call(app, event, target),
+      ).resolves.toBeUndefined()
     })
   })
 })

--- a/tests/lib/specializations/specialization-purchase-service.test.mjs
+++ b/tests/lib/specializations/specialization-purchase-service.test.mjs
@@ -1,0 +1,195 @@
+import { describe, it, expect } from 'vitest'
+
+import {
+  evaluateSpecializationPurchase,
+  BLOCKED_REASON,
+  getBlockedReasonLabelKey,
+} from '../../../module/lib/specializations/specialization-purchase-service.mjs'
+
+describe('specialization-purchase-service', () => {
+  describe('evaluateSpecializationPurchase', () => {
+    it('allows purchase of 1st career specialization at 0 XP', () => {
+      const result = evaluateSpecializationPurchase({
+        ownedSpecializations: { items: [], count: 0 },
+        candidateSpecialization: { specializationId: 'scoundrel', name: 'Scoundrel' },
+        career: { specializations: [{ specializationId: 'scoundrel' }] },
+        availableXp: 0,
+      })
+
+      expect(result.canPurchase).toBe(true)
+      expect(result.blockedReasonCode).toBeNull()
+      expect(result.costPreview).toMatchObject({
+        finalCost: 0,
+        baseCost: 0,
+        nonCareerPenalty: 0,
+        isCareerOrUniversal: true,
+      })
+      expect(result.isCareerOrUniversal).toBe(true)
+    })
+
+    it('allows purchase of 2nd career specialization with enough XP', () => {
+      const result = evaluateSpecializationPurchase({
+        ownedSpecializations: { items: [{ specializationId: 'scoundrel' }], count: 1 },
+        candidateSpecialization: { specializationId: 'pilot', name: 'Pilot' },
+        career: { specializations: [{ specializationId: 'scoundrel' }, { specializationId: 'pilot' }] },
+        availableXp: 20,
+      })
+
+      expect(result.canPurchase).toBe(true)
+      expect(result.blockedReasonCode).toBeNull()
+      expect(result.costPreview.finalCost).toBe(20)
+      expect(result.isCareerOrUniversal).toBe(true)
+    })
+
+    it('allows purchase of 2nd non-career specialization with enough XP', () => {
+      const result = evaluateSpecializationPurchase({
+        ownedSpecializations: { items: [{ specializationId: 'scoundrel' }], count: 1 },
+        candidateSpecialization: { specializationId: 'mercenary-soldier', name: 'Mercenary Soldier' },
+        career: { specializations: [{ specializationId: 'scoundrel' }] },
+        availableXp: 30,
+      })
+
+      expect(result.canPurchase).toBe(true)
+      expect(result.costPreview.finalCost).toBe(30)
+      expect(result.isCareerOrUniversal).toBe(false)
+    })
+
+    it('rejects already owned specialization', () => {
+      const result = evaluateSpecializationPurchase({
+        ownedSpecializations: { items: [{ specializationId: 'scoundrel', name: 'Scoundrel' }], count: 1 },
+        candidateSpecialization: { specializationId: 'scoundrel', name: 'Scoundrel' },
+        career: { specializations: [{ specializationId: 'scoundrel' }] },
+        availableXp: 100,
+      })
+
+      expect(result.canPurchase).toBe(false)
+      expect(result.blockedReasonCode).toBe(BLOCKED_REASON.ALREADY_OWNED)
+      expect(result.costPreview).toBeNull()
+    })
+
+    it('rejects owned specialization matched by name when no id', () => {
+      const result = evaluateSpecializationPurchase({
+        ownedSpecializations: { items: [{ name: 'Scoundrel' }], count: 1 },
+        candidateSpecialization: { name: 'Scoundrel' },
+        career: { specializations: [] },
+        availableXp: 100,
+      })
+
+      expect(result.canPurchase).toBe(false)
+      expect(result.blockedReasonCode).toBe(BLOCKED_REASON.ALREADY_OWNED)
+    })
+
+    it('rejects specialization when XP is insufficient', () => {
+      const result = evaluateSpecializationPurchase({
+        ownedSpecializations: { items: [{ specializationId: 'scoundrel' }], count: 1 },
+        candidateSpecialization: { specializationId: 'pilot', name: 'Pilot' },
+        career: { specializations: [{ specializationId: 'scoundrel' }, { specializationId: 'pilot' }] },
+        availableXp: 5,
+      })
+
+      expect(result.canPurchase).toBe(false)
+      expect(result.blockedReasonCode).toBe(BLOCKED_REASON.INSUFFICIENT_XP)
+      expect(result.costPreview.finalCost).toBe(20)
+    })
+
+    it('rejects null candidate', () => {
+      const result = evaluateSpecializationPurchase({
+        ownedSpecializations: { items: [], count: 0 },
+        candidateSpecialization: null,
+        career: null,
+        availableXp: 0,
+      })
+
+      expect(result.canPurchase).toBe(false)
+      expect(result.blockedReasonCode).toBe(BLOCKED_REASON.INVALID_CANDIDATE)
+      expect(result.costPreview).toBeNull()
+    })
+
+    it('rejects undefined candidate', () => {
+      const result = evaluateSpecializationPurchase({
+        ownedSpecializations: { items: [], count: 0 },
+        candidateSpecialization: undefined,
+        career: null,
+        availableXp: 0,
+      })
+
+      expect(result.canPurchase).toBe(false)
+      expect(result.blockedReasonCode).toBe(BLOCKED_REASON.INVALID_CANDIDATE)
+    })
+
+    it('treats universal specialization as career for purchase', () => {
+      const result = evaluateSpecializationPurchase({
+        ownedSpecializations: { items: [{ specializationId: 'scoundrel' }], count: 1 },
+        candidateSpecialization: { specializationId: 'universal-sharpshooter', name: 'Sharpshooter' },
+        career: { specializations: [{ specializationId: 'scoundrel' }] },
+        availableXp: 20,
+      })
+
+      expect(result.canPurchase).toBe(true)
+      expect(result.costPreview.finalCost).toBe(20)
+      expect(result.isCareerOrUniversal).toBe(true)
+    })
+
+    it('handles missing availableXp as unable to afford non-free specs', () => {
+      const result = evaluateSpecializationPurchase({
+        ownedSpecializations: { items: [{ specializationId: 'scoundrel' }], count: 1 },
+        candidateSpecialization: { specializationId: 'pilot', name: 'Pilot' },
+        career: { specializations: [{ specializationId: 'scoundrel' }, { specializationId: 'pilot' }] },
+        availableXp: undefined,
+      })
+
+      expect(result.canPurchase).toBe(false)
+      expect(result.blockedReasonCode).toBe(BLOCKED_REASON.INSUFFICIENT_XP)
+    })
+
+    it('accepts a plain array as ownedSpecializations', () => {
+      const result = evaluateSpecializationPurchase({
+        ownedSpecializations: [{ specializationId: 'scoundrel' }],
+        candidateSpecialization: { specializationId: 'pilot', name: 'Pilot' },
+        career: { specializations: [{ specializationId: 'scoundrel' }, { specializationId: 'pilot' }] },
+        availableXp: 40,
+      })
+
+      expect(result.canPurchase).toBe(true)
+      expect(result.costPreview.finalCost).toBe(20)
+    })
+
+    it('allows purchase of 1st spec even with 0 XP', () => {
+      const result = evaluateSpecializationPurchase({
+        ownedSpecializations: { items: [], count: 0 },
+        candidateSpecialization: { specializationId: 'scoundrel', name: 'Scoundrel' },
+        career: { specializations: [{ specializationId: 'scoundrel' }] },
+        availableXp: 0,
+      })
+
+      expect(result.canPurchase).toBe(true)
+      expect(result.costPreview.finalCost).toBe(0)
+    })
+  })
+
+  describe('getBlockedReasonLabelKey', () => {
+    it('returns i18n key for ALREADY_OWNED', () => {
+      expect(getBlockedReasonLabelKey(BLOCKED_REASON.ALREADY_OWNED)).toBe(
+        'SWERPG.TALENT.SPECIALIZATION_TREE_APP.REASON.ALREADY_PURCHASED',
+      )
+    })
+
+    it('returns i18n key for INSUFFICIENT_XP', () => {
+      expect(getBlockedReasonLabelKey(BLOCKED_REASON.INSUFFICIENT_XP)).toBe(
+        'SWERPG.TALENT.SPECIALIZATION_TREE_APP.REASON.NOT_ENOUGH_XP',
+      )
+    })
+
+    it('returns i18n key for INVALID_CANDIDATE', () => {
+      expect(getBlockedReasonLabelKey(BLOCKED_REASON.INVALID_CANDIDATE)).toBe(
+        'SWERPG.TALENT.SPECIALIZATION_TREE_APP.PURCHASE.INVALID_CANDIDATE',
+      )
+    })
+
+    it('falls back to UNKNOWN for unrecognized code', () => {
+      expect(getBlockedReasonLabelKey('unknown.code')).toBe(
+        'SWERPG.TALENT.SPECIALIZATION_TREE_APP.REASON.UNKNOWN',
+      )
+    })
+  })
+})


### PR DESCRIPTION
Closes #355

## Contexte
Ajoute une UI de visualisation/achat des spécialisations avec prévisualisation des coûts et blocages explicites. Travaille côté client (ApplicationV2) et apporte un service de gestion d'achat, des templates et des tests unitaires.

## Résumé des changements
- Ajout du bouton d'ouverture de l'arbre de spécialisations dans le header.
- Nouvelle application : module/applications/specialization-tree-app.mjs et template correspondant.
- Nouveau service : module/lib/specialization-purchase-service.mjs pour gérer la prévisualisation du coût et les règles de blocage.
- Ajout/maj d'entrées i18n dans lang/en.json et lang/fr.json.
- Tests unitaires ajoutés/actualisés : tests/...specialization-tree-app.test.mjs, specialization-purchase-service.test.mjs.

## Notes techniques
- Fichiers principaux modifiés/ajoutés :
  - module/applications/specialization-tree-app.mjs
  - module/lib/specialization-purchase-service.mjs
  - templates/applications/specialization-tree-app.hbs
  - tests/*specialization-tree-app.test.mjs, *specialization-purchase-service.test.mjs
  - lang/en.json, lang/fr.json
- Commit(s) inclus sur cette branche :
  - 77cc80fb feat(header): add specialization tree button and enhance badge visibility
- Aucune modification de configuration CI/build.

## Tests exécutés
Aucun test n'a été exécuté localement lors de la création de cette PR.

## Limites connues
- Les interactions UI nécessitent une instance Foundry pour vérifier l'intégration runtime.
- Les tests unitaires sont présents mais n'ont pas été lancés ici.

## Points d'attention pour la review
- Vérifier la conformité aux conventions ApplicationV2 (PARTS/TABS) et usages i18n.
- Valider les règles métier du service de prévisualisation/achat (blocages et calculs de coût).
- S'assurer qu'aucun fichier généré ou secret n'ait été accidentellement committé.

Branch source: feat/355-msm3-acheter-une-specialisation-avec-cout-previsualise-et-blocages-explicites
Base: develop
