### PR TITLE
feat(specialization): implement specialization purchase flow with validation

### DIFF
--- a/documentation/plan/character-sheet/specialization-tree/355-msm3-acheter-une-specialisation-avec-cout-previsualise-et-blocages-explicites.md
+++ b/documentation/plan/character-sheet/specialization-tree/355-msm3-acheter-une-specialisation-avec-cout-previsualise-et-blocages-explicites.md
@@ -1,0 +1,101 @@
+## MSM3 — Acheter une spécialisation avec coût prévisualisé et blocages explicites
+
+### Contexte
+
+Issue : [#355 — MSM3 - Acheter une spécialisation avec coût prévisualisé et blocages explicites](https://github.com/herveDarritchon/foundryvtt-swerpg/issues/355)
+
+Parent : [#352 — Multi-Specialization Management - Gérer ajout, synthèse et suppression des spécialisations](https://github.com/herveDarritchon/foundryvtt-swerpg/issues/352)
+
+Dépendance : [#353 — MSM1 - Stabiliser le contrat métier des spécialisations et de l'arbre courant](https://github.com/herveDarritchon/foundryvtt-swerpg/issues/353)
+
+L'existant route le drop d'une spécialisation dans `CharacterSheet` vers `actor.system.applySpecialization(item)`, qui
+délègue ensuite au flux générique `_applyDetailItem(...)`. Ce chemin ne couvre ni le refus de doublon, ni le contrôle
+d'XP, ni la confirmation avec prévisualisation, et il risque de rejouer des effets de création incompatibles avec
+l'ajout post-création.
+
+### Objectif
+
+Brancher sur la feuille personnage un flux d'ajout de spécialisation par drag'n drop qui applique les règles MSM1,
+refuse explicitement les cas bloquants, confirme les achats payants avec aperçu du coût, et persiste l'ajout sans
+attribuer de rangs gratuits de compétences.
+
+### Périmètre
+
+#### Inclus
+
+- validation métier du drop de spécialisation sur la fiche personnage ;
+- détection de doublon, calcul du coût et contrôle d'XP disponible ;
+- confirmation utilisateur pour les achats `1 -> 2+` avec coût et XP restante ;
+- persistance de la spécialisation et décrément d'XP après confirmation ;
+- messages `ui.notifications.warn` localisés FR/EN ;
+- couverture unitaire du service et du flux principal de drop.
+
+#### Exclus
+
+- implémentation dans `SpecializationTreeApp` ;
+- ajout/suppression depuis la sidebar ou un autre point d'entrée UI ;
+- attribution de rangs gratuits de compétences de spécialisation ;
+- refonte générale du modèle de carrière ou de l'arbre de spécialisation au-delà du strict support du flux.
+
+### Fichiers pressentis
+
+| Fichier                                                       | Rôle                                                                              |
+|---------------------------------------------------------------|-----------------------------------------------------------------------------------|
+| `module/lib/specializations/owned-specializations.mjs`        | Réutiliser/compléter la détection de spécialisation déjà possédée                 |
+| `module/lib/specializations/specialization-cost-service.mjs`  | Réutiliser le calcul de coût MSM1 pour la prévisualisation                        |
+| `module/lib/specializations/specialization-purchase-flow.mjs` | Nouveau service métier pur de validation, preview et résultat d'achat             |
+| `module/models/character.mjs`                                 | Introduire un point d'entrée dédié à l'acquisition post-création                  |
+| `module/applications/sheets/character-sheet.mjs`              | Brancher le drop `specialization` sur le nouveau flux au lieu du raccourci actuel |
+| `lang/en.json` / `lang/fr.json`                               | Ajouter les messages de refus et de confirmation                                  |
+| `tests/lib/specializations/*.test.mjs`                        | Couvrir calcul, blocages et preview métier                                        |
+| `tests/applications/sheets/character-sheet-talents.test.mjs`  | Vérifier le flux de drop, les warnings et la confirmation                         |
+| `tests/models/character-specializations.test.mjs`             | Verrouiller l'absence de rangs gratuits dans ce flux                              |
+
+### Plan d'implémentation
+
+#### Étape 1 — Formaliser un contrat métier de validation et de prévisualisation
+
+**Fichiers :** `module/lib/specializations/specialization-purchase-flow.mjs`,
+`module/lib/specializations/owned-specializations.mjs`, `module/lib/specializations/specialization-cost-service.mjs`
+
+1. Introduire un service pur qui reçoit l'acteur, la spécialisation candidate et le snapshot métier des spécialisations
+   possédées.
+2. Y centraliser les décisions : `free-add`, `confirm-required`, `blocked-duplicate`, `blocked-insufficient-xp`.
+3. Retourner un résultat stable avec au minimum : spécialisation ciblée, type carrière/hors carrière, coût XP, XP
+   disponible, XP restante, raison de blocage éventuelle et patch métier attendu.
+4. Fiabiliser la détection de doublon à partir de `specializationId`, `treeUuid`, puis du nom en fallback contrôlé.
+
+#### Étape 2 — Brancher le flux de drop et persister l'achat sans rejouer la création
+
+**Fichiers :** `module/applications/sheets/character-sheet.mjs`, `module/models/character.mjs`
+
+1. Remplacer le `applySpecialization(item)` direct du drop par un point d'entrée dédié au flux d'acquisition
+   post-création.
+2. Pour `0 -> 1`, ajouter immédiatement la spécialisation sans dialogue ni dépense d'XP.
+3. Pour `1 -> 2+`, afficher une confirmation `DialogV2` avec le nom, le statut carrière/hors carrière, le coût, l'XP
+   disponible et l'XP restante ; après validation, appliquer l'ajout et la dépense d'XP via `actor.update()` /
+   `document.update()`.
+4. Refuser les doublons et l'XP insuffisante via `ui.notifications.warn` localisés.
+5. Isoler ce flux du comportement de création afin que l'ajout n'accorde aucun rang gratuit de compétence de
+   spécialisation.
+
+#### Étape 3 — Ajouter les messages i18n et verrouiller les cas nominaux et bloquants
+
+**Fichiers :** `lang/en.json`, `lang/fr.json`, `tests/lib/specializations/*.test.mjs`,
+`tests/applications/sheets/character-sheet-talents.test.mjs`, `tests/models/character-specializations.test.mjs`
+
+1. Ajouter les clés FR/EN pour les warnings de doublon, d'XP insuffisante et pour le contenu/titre de confirmation.
+2. Couvrir le service métier sur les cas : `0 -> 1` gratuit, doublon refusé, XP insuffisante refusée, achat carrière
+   confirmé, achat hors carrière confirmé.
+3. Ajouter des tests du flux feuille personnage garantissant : pas de dialogue sur `0 -> 1`, dialogue sur `1 -> 2+`,
+   aucune mutation après annulation, décrément XP après confirmation.
+4. Verrouiller explicitement qu'aucun rang gratuit de compétence n'est attribué lors de ce chemin d'ajout.
+
+### Définition de done
+
+- [ ] Un drop de première spécialisation ajoute la spécialisation gratuitement sans confirmation.
+- [ ] Un doublon est refusé avec un message utilisateur explicite et localisé.
+- [ ] Une spécialisation supplémentaire sans XP suffisante est refusée avec un message explicite et localisé.
+- [ ] Une spécialisation supplémentaire avec XP suffisante affiche une confirmation avec coût et XP restante.
+- [ ] Après confirmation, la spécialisation est ajoutée et l'XP est décrémentée ; après annulation, rien n'est modifié.
+- [ ] Ce flux n'accorde aucun rang gratuit de compétence de spécialisation.

--- a/lang/en.json
+++ b/lang/en.json
@@ -1175,6 +1175,16 @@
         "hint": "Select number of free ranks from specialization."
       }
     },
+    "PURCHASE": {
+      "DUPLICATE": "This specialization is already owned.",
+      "INSUFFICIENT_XP": "Not enough XP to purchase this specialization ({cost} XP needed, {available} XP available).",
+      "CAREER": "Career",
+      "NON_CAREER": "Non-Career",
+      "CONFIRM_TITLE": "Purchase Specialization: {name}",
+      "CONFIRM_CONTENT": "Purchase <strong>{name}</strong> ({careerStatus}) for <strong>{cost} XP</strong>?<br>Available: {available} XP — Remaining after purchase: {remaining} XP.",
+      "CONFIRM_BUTTON": "Spend {cost} XP",
+      "CANCEL_BUTTON": "Cancel"
+    },
     "SHEET": {
       "CHOOSE": "Choose Specialization",
       "CLEAR": "Clear Specialization",

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -1168,6 +1168,16 @@
         "hint": "Sélectionnez le nombre de rangs gratuits de la spécialisation."
       }
     },
+    "PURCHASE": {
+      "DUPLICATE": "Cette spécialisation est déjà possédée.",
+      "INSUFFICIENT_XP": "XP insuffisante pour acheter cette spécialisation ({cost} XP requis, {available} XP disponible).",
+      "CAREER": "Carrière",
+      "NON_CAREER": "Hors carrière",
+      "CONFIRM_TITLE": "Achat de spécialisation : {name}",
+      "CONFIRM_CONTENT": "Acheter <strong>{name}</strong> ({careerStatus}) pour <strong>{cost} XP</strong> ?<br>Disponible : {available} XP — Restant après achat : {remaining} XP.",
+      "CONFIRM_BUTTON": "Dépenser {cost} XP",
+      "CANCEL_BUTTON": "Annuler"
+    },
     "SHEET": {
       "CHOOSE": "Choisir une Spécialisation",
       "CLEAR": "Effacer la Spécialisation",

--- a/module/applications/sheets/character-sheet.mjs
+++ b/module/applications/sheets/character-sheet.mjs
@@ -10,6 +10,7 @@ import { buildTalentDefinitionsMap } from '../../lib/talent-node/talent-referenc
 import { logger } from '../../utils/logger.mjs'
 import { getPositiveDicePoolPreview } from '../../utils/skill-costs.mjs'
 import SkillCostCalculator from '../../lib/skills/skill-cost-calculator.mjs'
+import { evaluateSpecializationPurchase } from '../../lib/specializations/specialization-purchase-flow.mjs'
 
 /**
  * @typedef {Object} DefenseDisplayData
@@ -680,7 +681,7 @@ export default class CharacterSheet extends SwerpgBaseActorSheet {
         await this.actor.system.applyCareer(item)
         return
       case 'specialization':
-        await this.actor.system.applySpecialization(item)
+        await this.#handleSpecializationDrop(item)
         return
       case 'talent':
         // Build the skill class depending on the context
@@ -733,6 +734,84 @@ export default class CharacterSheet extends SwerpgBaseActorSheet {
         return
     }
     return super._onDropItem(event, item)
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Handle drop of a specialization item with purchase flow.
+   * @param {object} item - The dropped Item document (specialization)
+   */
+  async #handleSpecializationDrop(item) {
+    const actor = this.actor
+    const career = actor.system.details.career
+    const xpAvailable = actor.system.progression.experience.available
+
+    const result = evaluateSpecializationPurchase({ actor, candidateItem: item, career, xpAvailable })
+
+    switch (result.decision) {
+      case 'free-add':
+        await actor.system.acquireSpecialization(item)
+        return
+
+      case 'blocked-duplicate':
+        ui.notifications.warn(game.i18n.localize(result.messageKey))
+        return
+
+      case 'blocked-insufficient-xp': {
+        const msg = game.i18n.format(result.messageKey, {
+          cost: result.cost.finalCost,
+          available: result.xpAvailable,
+        })
+        ui.notifications.warn(msg)
+        return
+      }
+
+      case 'confirm-required': {
+        const confirmed = await this.#confirmSpecializationPurchase(result)
+        if (!confirmed) return
+        await actor.system.acquireSpecialization(item)
+        const newSpent = (actor.system.progression.experience.spent || 0) + result.cost.finalCost
+        await actor.update({ 'system.progression.experience.spent': newSpent })
+      }
+    }
+  }
+
+  /**
+   * Show a DialogV2 confirmation for a paid specialization purchase.
+   * @param {object} result - Purchase evaluation result with decision 'confirm-required'
+   * @returns {Promise<boolean>} True if the user confirmed
+   */
+  async #confirmSpecializationPurchase(result) {
+    const { specializationName, cost, xpAvailable, xpRemaining } = result
+    const i18n = game.i18n
+
+    const careerLabel = cost.isCareerOrUniversal ? i18n.localize('SPECIALIZATION.PURCHASE.CAREER') : i18n.localize('SPECIALIZATION.PURCHASE.NON_CAREER')
+
+    return foundry.applications.api.DialogV2.confirm({
+      window: {
+        title: i18n.format('SPECIALIZATION.PURCHASE.CONFIRM_TITLE', {
+          name: specializationName,
+        }),
+      },
+      content: `<p>${i18n.format('SPECIALIZATION.PURCHASE.CONFIRM_CONTENT', {
+        name: specializationName,
+        careerStatus: careerLabel,
+        cost: cost.finalCost,
+        available: xpAvailable,
+        remaining: xpRemaining,
+      })}</p>`,
+      yes: {
+        label: i18n.format('SPECIALIZATION.PURCHASE.CONFIRM_BUTTON', {
+          cost: cost.finalCost,
+        }),
+        icon: 'fa-solid fa-check',
+      },
+      no: {
+        label: i18n.localize('SPECIALIZATION.PURCHASE.CANCEL_BUTTON'),
+        icon: 'fa-solid fa-xmark',
+      },
+    })
   }
 
   /* -------------------------------------------- */

--- a/module/lib/specializations/specialization-purchase-flow.mjs
+++ b/module/lib/specializations/specialization-purchase-flow.mjs
@@ -1,0 +1,111 @@
+import { calculateSpecializationCost } from './specialization-cost-service.mjs'
+import { getOwnedSpecializations } from './owned-specializations.mjs'
+
+/**
+ * @typedef {'free-add'|'confirm-required'|'blocked-duplicate'|'blocked-insufficient-xp'} PurchaseDecision
+ */
+
+/**
+ * @typedef {Object} SpecializationPurchaseResult
+ * @property {PurchaseDecision} decision - The purchase decision
+ * @property {string} specializationName - Name of the specialization
+ * @property {Object} [cost] - Cost breakdown (absent on blocked decisions)
+ * @property {number} [xpAvailable] - XP available before purchase
+ * @property {number} [xpRemaining] - XP remaining after purchase
+ * @property {string} [messageKey] - i18n key for blocked reasons
+ */
+
+/**
+ * Évalue la faisabilité d'achat d'une spécialisation post-création.
+ *
+ * Retourne un résultat stable avec la décision, le coût et l'état XP.
+ * Ne modifie rien — service métier pur sans effet de bord.
+ *
+ * @param {object} params
+ * @param {object} params.actor L'acteur Foundry (pour ownedSpecializations via getOwnedSpecializations)
+ * @param {object} params.candidateItem L'item spécialisation candidate (Foundry Item document)
+ * @param {object|null|undefined} params.career La carrière du personnage (actor.system.details.career)
+ * @param {number} params.xpAvailable XP disponible (actor.system.progression.experience.available)
+ * @returns {SpecializationPurchaseResult}
+ */
+export function evaluateSpecializationPurchase({ actor, candidateItem, career, xpAvailable }) {
+  const owned = getOwnedSpecializations(actor)
+
+  const candidateId = candidateItem?.system?.specializationId ?? null
+  const candidateName = candidateItem?.name ?? ''
+  const isUniversal = candidateItem?.system?.isUniversal === true
+
+  // 1. Détection de doublon
+  const isDuplicate = owned.items.some((spec) => {
+    if (candidateId && spec.specializationId && spec.specializationId === candidateId) return true
+    if (candidateName && spec.name && spec.name === candidateName) return true
+    return false
+  })
+
+  if (isDuplicate) {
+    return {
+      decision: 'blocked-duplicate',
+      specializationName: candidateName,
+      messageKey: 'SPECIALIZATION.PURCHASE.DUPLICATE',
+    }
+  }
+
+  // 2. Calcul du coût
+  const candidateForCost = { specializationId: candidateId, name: candidateName, system: { isUniversal } }
+  const cost = calculateSpecializationCost({
+    ownedSpecializations: owned,
+    candidateSpecialization: candidateForCost,
+    career,
+  })
+
+  // 3. Première spécialisation gratuite
+  if (owned.count === 0 || cost.finalCost === 0) {
+    return {
+      decision: 'free-add',
+      specializationName: candidateName,
+      cost: {
+        baseCost: cost.baseCost,
+        nonCareerPenalty: cost.nonCareerPenalty,
+        finalCost: 0,
+        isCareerOrUniversal: cost.isCareerOrUniversal,
+        ownedCountBefore: cost.ownedCountBefore,
+        ownedCountAfter: cost.ownedCountAfter,
+      },
+    }
+  }
+
+  // 4. XP insuffisante
+  if (xpAvailable < cost.finalCost) {
+    return {
+      decision: 'blocked-insufficient-xp',
+      specializationName: candidateName,
+      cost: {
+        baseCost: cost.baseCost,
+        nonCareerPenalty: cost.nonCareerPenalty,
+        finalCost: cost.finalCost,
+        isCareerOrUniversal: cost.isCareerOrUniversal,
+        ownedCountBefore: cost.ownedCountBefore,
+        ownedCountAfter: cost.ownedCountAfter,
+      },
+      xpAvailable,
+      xpRemaining: xpAvailable,
+      messageKey: 'SPECIALIZATION.PURCHASE.INSUFFICIENT_XP',
+    }
+  }
+
+  // 5. Achat payant avec confirmation
+  return {
+    decision: 'confirm-required',
+    specializationName: candidateName,
+    cost: {
+      baseCost: cost.baseCost,
+      nonCareerPenalty: cost.nonCareerPenalty,
+      finalCost: cost.finalCost,
+      isCareerOrUniversal: cost.isCareerOrUniversal,
+      ownedCountBefore: cost.ownedCountBefore,
+      ownedCountAfter: cost.ownedCountAfter,
+    },
+    xpAvailable,
+    xpRemaining: xpAvailable - cost.finalCost,
+  }
+}

--- a/module/models/character.mjs
+++ b/module/models/character.mjs
@@ -634,4 +634,35 @@ export default class SwerpgCharacter extends SwerpgActorType {
       collectionKey: 'specializations',
     })
   }
+
+  /**
+   * Acquire a specialization post-creation without granting free skill ranks.
+   * Used by the specialization purchase flow (drop on character sheet).
+   *
+   * Differs from applySpecialization by zeroing freeSkillRank to prevent
+   * free skill rank attribution during prepareBaseData.
+   *
+   * @param {object} specialization The specialization Item to acquire
+   * @returns {Promise<void>}
+   */
+  async acquireSpecialization(specialization) {
+    const actor = this.parent
+    const itemData = specialization.toObject()
+
+    const acquiredSpecialization = {
+      ...itemData.system,
+      name: itemData.name,
+      img: itemData.img,
+      freeSkillRank: 0,
+    }
+
+    const specializations = Array.from(this.details.specializations || [])
+
+    await actor.update(
+      {
+        'system.details.specializations': [...specializations, acquiredSpecialization],
+      },
+      { keepEmbeddedIds: true },
+    )
+  }
 }

--- a/tests/lib/specializations/specialization-purchase-flow.test.mjs
+++ b/tests/lib/specializations/specialization-purchase-flow.test.mjs
@@ -1,0 +1,126 @@
+import { describe, it, expect } from 'vitest'
+
+import { evaluateSpecializationPurchase } from '../../../module/lib/specializations/specialization-purchase-flow.mjs'
+
+function buildActor(specializations = []) {
+  return {
+    system: {
+      details: {
+        specializations: new Set(specializations),
+      },
+    },
+  }
+}
+
+function buildCandidateItem({ specializationId, name, isUniversal } = {}) {
+  return {
+    name: name ?? 'Test Spec',
+    system: {
+      specializationId: specializationId ?? null,
+      isUniversal: isUniversal ?? false,
+    },
+  }
+}
+
+describe('specialization-purchase-flow', () => {
+  describe('evaluateSpecializationPurchase', () => {
+    it('returns free-add when moving from 0 to 1 specialization', () => {
+      const actor = buildActor([])
+      const item = buildCandidateItem({ name: 'Scoundrel' })
+      const career = { specializations: [] }
+
+      const result = evaluateSpecializationPurchase({ actor, candidateItem: item, career, xpAvailable: 0 })
+
+      expect(result.decision).toBe('free-add')
+      expect(result.cost.finalCost).toBe(0)
+      expect(result.cost.ownedCountBefore).toBe(0)
+      expect(result.cost.ownedCountAfter).toBe(1)
+    })
+
+    it('returns blocked-duplicate when specializationId matches', () => {
+      const actor = buildActor([{ specializationId: 'scoundrel', name: 'Scoundrel' }])
+      const item = buildCandidateItem({ specializationId: 'scoundrel', name: 'Scoundrel' })
+      const career = { specializations: [] }
+
+      const result = evaluateSpecializationPurchase({ actor, candidateItem: item, career, xpAvailable: 100 })
+
+      expect(result.decision).toBe('blocked-duplicate')
+      expect(result.messageKey).toBe('SPECIALIZATION.PURCHASE.DUPLICATE')
+    })
+
+    it('returns blocked-duplicate when name matches without specializationId', () => {
+      const actor = buildActor([{ name: 'Scoundrel' }])
+      const item = buildCandidateItem({ name: 'Scoundrel' })
+      const career = { specializations: [] }
+
+      const result = evaluateSpecializationPurchase({ actor, candidateItem: item, career, xpAvailable: 100 })
+
+      expect(result.decision).toBe('blocked-duplicate')
+    })
+
+    it('returns blocked-insufficient-xp when XP is not enough for paid specialization', () => {
+      const actor = buildActor([{ specializationId: 'scoundrel', name: 'Scoundrel' }])
+      const item = buildCandidateItem({ specializationId: 'pilot', name: 'Pilot' })
+      const career = { specializations: [{ specializationId: 'pilot' }] }
+
+      const result = evaluateSpecializationPurchase({ actor, candidateItem: item, career, xpAvailable: 5 })
+
+      expect(result.decision).toBe('blocked-insufficient-xp')
+      expect(result.cost.finalCost).toBe(20)
+      expect(result.xpAvailable).toBe(5)
+      expect(result.messageKey).toBe('SPECIALIZATION.PURCHASE.INSUFFICIENT_XP')
+    })
+
+    it('returns confirm-required when XP is sufficient for paid career specialization', () => {
+      const actor = buildActor([{ specializationId: 'scoundrel', name: 'Scoundrel' }])
+      const item = buildCandidateItem({ specializationId: 'pilot', name: 'Pilot' })
+      const career = { specializations: [{ specializationId: 'scoundrel' }, { specializationId: 'pilot' }] }
+
+      const result = evaluateSpecializationPurchase({ actor, candidateItem: item, career, xpAvailable: 50 })
+
+      expect(result.decision).toBe('confirm-required')
+      expect(result.cost.finalCost).toBe(20)
+      expect(result.cost.isCareerOrUniversal).toBe(true)
+      expect(result.xpAvailable).toBe(50)
+      expect(result.xpRemaining).toBe(30)
+    })
+
+    it('returns confirm-required with correct cost for non-career specialization', () => {
+      const actor = buildActor([{ specializationId: 'scoundrel', name: 'Scoundrel' }])
+      const item = buildCandidateItem({ name: 'Mercenary Soldier' })
+      const career = { specializations: [{ specializationId: 'scoundrel' }] }
+
+      const result = evaluateSpecializationPurchase({ actor, candidateItem: item, career, xpAvailable: 50 })
+
+      expect(result.decision).toBe('confirm-required')
+      expect(result.cost.finalCost).toBe(30)
+      expect(result.cost.isCareerOrUniversal).toBe(false)
+      expect(result.cost.nonCareerPenalty).toBe(10)
+      expect(result.xpRemaining).toBe(20)
+    })
+
+    it('treats universal specializations as career for cost', () => {
+      const actor = buildActor([{ specializationId: 'scoundrel', name: 'Scoundrel' }])
+      const item = buildCandidateItem({ name: 'Sharpshooter', isUniversal: true })
+      const career = { specializations: [{ specializationId: 'scoundrel' }] }
+
+      const result = evaluateSpecializationPurchase({ actor, candidateItem: item, career, xpAvailable: 50 })
+
+      expect(result.decision).toBe('confirm-required')
+      expect(result.cost.finalCost).toBe(20)
+      expect(result.cost.isCareerOrUniversal).toBe(true)
+      expect(result.cost.nonCareerPenalty).toBe(0)
+    })
+
+    it('accepts candidateItem without system.specializationId', () => {
+      const actor = buildActor([])
+      const item = { name: 'No Id Spec', system: {} }
+      const career = { specializations: [] }
+
+      const result = evaluateSpecializationPurchase({ actor, candidateItem: item, career, xpAvailable: 0 })
+
+      expect(result.decision).toBe('free-add')
+      expect(result.specializationName).toBe('No Id Spec')
+    })
+  })
+})

--- a/tests/models/character-specializations.test.mjs
+++ b/tests/models/character-specializations.test.mjs
@@ -95,4 +95,48 @@ describe('SwerpgCharacter — owned specializations', () => {
       expect(character.progression.freeSkillRanks.specialization.gained).toBe(0)
     })
   })
+
+  describe('acquireSpecialization', () => {
+    test('should zero out freeSkillRank before persisting', async () => {
+      const character = new SwerpgCharacter(buildCharacterData())
+
+      const mockUpdate = { args: null }
+
+      const mockParent = {
+        update: (...args) => {
+          mockUpdate.args = args
+          return Promise.resolve()
+        },
+      }
+
+      character.parent = mockParent
+
+      character.details.specializations = new Set()
+
+      const fakeItem = {
+        toObject: () => ({
+          name: 'Pilot',
+          img: 'systems/swerpg/assets/pilot.png',
+          system: {
+            specializationId: 'pilot',
+            freeSkillRank: 4,
+            specializationSkills: [],
+          },
+        }),
+      }
+
+      await character.acquireSpecialization(fakeItem)
+
+      const [payload, options] = mockUpdate.args
+      const specs = payload['system.details.specializations']
+
+      expect(specs).toHaveLength(1)
+      expect(specs[0].name).toBe('Pilot')
+      expect(specs[0].img).toBe('systems/swerpg/assets/pilot.png')
+      expect(specs[0].specializationId).toBe('pilot')
+      expect(specs[0].freeSkillRank).toBe(0)
+
+      expect(options).toEqual({ keepEmbeddedIds: true })
+    })
+  })
 })


### PR DESCRIPTION
Closes #355 (inferred from branch name)

## Contexte
Implémente le flux d'achat d'une spécialisation pour les personnages : prévisualisation du coût en XP, vérifications et blocages explicites (doublon, XP insuffisant), et confirmation utilisateur pour les spécialisations payantes.

## Résumé des changements
- Ajout de la logique d'achat de spécialisation : module/lib/specializations/specialization-purchase-flow.mjs
- Intégration dans la fiche personnage : module/applications/sheets/character-sheet.mjs
- Mise à jour du modèle Character pour supporter l'opération : module/models/character.mjs
- Ajout de tests unitaires pour le flux : tests/lib/specializations/specialization-purchase-flow.test.mjs
- Mise à jour des tests existants : tests/models/character-specializations.test.mjs
- Internationalisation : lang/en.json, lang/fr.json
- Documentation du plan d'implémentation : documentation/plan/character-sheet/specialization-tree/355-msm3-acheter-une-specialisation-avec-cout-previsualise-et-blocages-explicites.md

## Notes techniques
- Le flux prévisualise le coût en XP et empêche l'achat si le personnage n'a pas suffisamment d'XP ou possède déjà la spécialisation.
- Les spécialisations payantes exigent une confirmation explicite de l'utilisateur ; aucune attribution automatique de ranks gratuits n'est effectuée pendant l'opération.
- Les changements sont encapsulés dans module/lib/specializations/* et appelés depuis la sheet; respecter l'API publique du modèle Character.

## Tests
- Aucun test n'a été exécuté lors de la création de cette PR.
- Des tests unitaires ont été ajoutés au dépôt (tests/lib/specializations/specialization-purchase-flow.test.mjs). La CI/mainteneur devra lancer pnpm test pour valider.

## Limites connues
- Aucune validation runtime n'a été exécutée localement par mes soins.
- Scénarios d'intégration UI (E2E) non couverts ici.

## Points d'attention pour la review
- Vérifier les modifications de la fiche personnage pour ne pas casser d'autres interactions de sheet.
- Examiner la logique de confirmation pour s'assurer qu'elle respecte les conventions UX (messages i18n disponibles dans lang/*.json).
- Les tests ajoutés couvrent le flux principal ; des cas limites peuvent rester à couvrir.
