### PR TITLE
feat(specialization): remove allowed specialization with confirmation and fallback to current tree

### DIFF
--- a/documentation/plan/character-sheet/specialization-tree/356-msm4-supprimer-une-specialisation-autorisee-avec-confirmation-et-fallback-d-arbre-courant.md
+++ b/documentation/plan/character-sheet/specialization-tree/356-msm4-supprimer-une-specialisation-autorisee-avec-confirmation-et-fallback-d-arbre-courant.md
@@ -1,0 +1,91 @@
+## MSM4 — Supprimer une spécialisation autorisée avec confirmation et fallback d'arbre courant
+
+### Contexte
+
+Issue : [#356 — MSM4 - Supprimer une spécialisation autorisée avec confirmation et fallback d'arbre courant](https://github.com/herveDarritchon/foundryvtt-swerpg/issues/356)
+
+Parent : [#352 — Multi-Specialization Management - Gérer ajout, synthèse et suppression des spécialisations](https://github.com/herveDarritchon/foundryvtt-swerpg/issues/352)
+
+Dépendances :
+
+- [#353 — MSM1 - Stabiliser le contrat métier des spécialisations et de l'arbre courant](https://github.com/herveDarritchon/foundryvtt-swerpg/issues/353)
+- [#354 — MSM2 - Résumer les spécialisations dans le header et ouvrir la gestion](https://github.com/herveDarritchon/foundryvtt-swerpg/issues/354)
+- [#355 — MSM3 - Acheter une spécialisation avec coût prévisualisé et blocages explicites](https://github.com/herveDarritchon/foundryvtt-swerpg/issues/355)
+
+Après MSM1 à MSM3, le personnage peut résumer, ouvrir et enrichir ses spécialisations, mais il manque encore un flux de suppression contrôlé. Le besoin de `#356` est d'autoriser uniquement les suppressions métier valides, de demander une confirmation avant mutation destructive, puis de recalculer proprement l'arbre courant si la spécialisation supprimée était celle affichée.
+
+### Objectif
+
+Ajouter dans la gestion multi-spécialisations un flux de suppression sûr et localisé, fondé sur le contrat canonique `ownedSpecializations`, qui ne laisse jamais `selectedSpecializationTree` / `#selectedTreeKey` pointer vers un arbre supprimé.
+
+### Périmètre
+
+#### Inclus
+
+- évaluation métier d'une suppression autorisée ou bloquée ;
+- confirmation utilisateur avant persistance ;
+- persistance de la liste des spécialisations restantes ;
+- fallback de l'arbre courant vers une spécialisation encore possédée, ou vers l'état vide si aucun arbre exploitable ne reste ;
+- messages et libellés FR/EN du flux ;
+- couverture unitaire et applicative du scénario.
+
+#### Exclus
+
+- refonte du flux d'achat MSM3 ;
+- refonte large du layout de `SpecializationTreeApp` hors affordance minimale de suppression ;
+- évolution des règles de coût d'acquisition déjà cadrées par MSM1/MSM3.
+
+### Fichiers pressentis
+
+| Fichier                                                      | Rôle                                                                      |
+|--------------------------------------------------------------|---------------------------------------------------------------------------|
+| `module/lib/specializations/owned-specializations.mjs`       | Réutiliser le contrat canonique et exposer les helpers de retrait         |
+| `module/lib/specializations/specialization-removal-flow.mjs` | Nouveau service pur de validation, preview et résultat de suppression     |
+| `module/models/character.mjs`                                | Introduire le point d'entrée dédié à la suppression post-création         |
+| `module/applications/specialization-tree-app.mjs`            | Brancher l'action de suppression, la confirmation et le fallback UI       |
+| `templates/applications/specialization-tree-app.hbs`         | Exposer l'action utilisateur de suppression sur une spécialisation gérable |
+| `lang/en.json` / `lang/fr.json`                              | Ajouter confirmation, warnings et libellés du flux                        |
+| `tests/lib/specializations/*.test.mjs`                       | Couvrir validation, blocages et calcul du fallback métier                 |
+| `tests/models/character-specializations.test.mjs`            | Verrouiller le patch persistant produit par le flux                       |
+| `tests/applications/specialization-tree-app.test.mjs`        | Vérifier confirmation, annulation et recalage de l'arbre courant          |
+
+### Plan d'implémentation
+
+#### Étape 1 — Formaliser le contrat métier de suppression et de fallback
+
+**Fichiers :** `module/lib/specializations/specialization-removal-flow.mjs`,
+`module/lib/specializations/owned-specializations.mjs`
+
+1. Introduire un service pur recevant l'acteur, la spécialisation ciblée et le snapshot canonique des spécialisations possédées.
+2. Y centraliser la décision `allowed` / `blocked` avec une `reasonCode` stable, sans dépendre de l'état UI courant.
+3. Retourner un résultat réutilisable par l'UI avec au minimum : spécialisation ciblée, autorisation, raison éventuelle, payload de confirmation, patch métier attendu et indication de fallback pour l'arbre courant.
+4. Définir explicitement la règle : si la spécialisation supprimée correspond à l'arbre courant, sélectionner une spécialisation encore possédée via le mécanisme de fallback existant ; sinon conserver la sélection actuelle.
+
+#### Étape 2 — Brancher la suppression confirmée dans `SpecializationTreeApp`
+
+**Fichiers :** `module/applications/specialization-tree-app.mjs`, `templates/applications/specialization-tree-app.hbs`,
+`module/models/character.mjs`
+
+1. Exposer une action de suppression uniquement sur les spécialisations gérables par le contrat métier.
+2. Au clic, demander le résultat du service métier : notifier immédiatement les cas bloqués, sinon ouvrir une confirmation `DialogV2` localisée.
+3. Après confirmation, persister la suppression via un point d'entrée acteur dédié plutôt qu'une mutation UI ad hoc.
+4. Recaler `#selectedTreeKey` / le contexte rendu après update : conserver l'arbre courant s'il est toujours valide, sinon appliquer le fallback calculé, et afficher l'état vide si aucune spécialisation exploitable ne reste.
+
+#### Étape 3 — Ajouter les messages i18n et verrouiller les scénarios nominaux et dégradés
+
+**Fichiers :** `lang/en.json`, `lang/fr.json`, `tests/lib/specializations/*.test.mjs`,
+`tests/models/character-specializations.test.mjs`, `tests/applications/specialization-tree-app.test.mjs`
+
+1. Ajouter les clés FR/EN pour les raisons de blocage, le titre/contenu de confirmation et les retours utilisateur du flux.
+2. Couvrir le service métier sur les cas : suppression autorisée hors arbre courant, suppression autorisée de l'arbre courant avec fallback, suppression bloquée, annulation sans mutation.
+3. Ajouter des tests applicatifs garantissant qu'aucune clé d'arbre supprimé ne reste sélectionnée après rerender et que le comportement d'état vide reste propre si aucun arbre n'est sélectionnable.
+4. Verrouiller côté modèle que le patch persistant ne modifie que les données attendues du contrat de spécialisations et de sélection courante.
+
+### Définition de done
+
+- [ ] Une spécialisation supprimable demande une confirmation avant toute mutation.
+- [ ] Une suppression bloquée est refusée avec un message explicite et localisé.
+- [ ] Après confirmation, la spécialisation est retirée de `ownedSpecializations` sans laisser de sélection d'arbre orpheline.
+- [ ] Si l'arbre courant est supprimé, l'application retombe sur une spécialisation encore possédée ou sur l'état vide existant.
+- [ ] Après annulation, aucune donnée acteur ni sélection UI n'est modifiée.
+- [ ] Les tests couvrent le flux métier, la persistance et le fallback de l'arbre courant.

--- a/documentation/plan/character-sheet/specialization-tree/fix-achat-oubli-palette-regression.md
+++ b/documentation/plan/character-sheet/specialization-tree/fix-achat-oubli-palette-regression.md
@@ -1,0 +1,124 @@
+## Fix — Régressions achat/oubli et palette (post-MSM4)
+
+### Contexte
+
+Deux régressions constatées après le travail MSM4 (+ palette GUX2) dans `SpecializationTreeApp` :
+
+1. **Achat/oubli de nœud ne fonctionne plus** : les CTA d'achat/oubli sont absents ou inefficaces pour les personnages existants (et potentiellement aussi les nouveaux).
+2. **Palette de couleurs des nœuds différente** : le rendu visuel a changé depuis `babbcb1b`.
+
+Ni l'une ni l'autre n'est volontaire ; ce plan couvre l'analyse et la correction des deux.
+
+---
+
+### 1 — Achat/oubli : causes racines (3 problèmes imbriqués)
+
+#### 1.1 — Contrat de clé flou entre UI et moteur métier
+
+- L'UI de `tree-context-builder.mjs` construit une clé de sélection (`selectedKey`) qui peut être :
+  - `specializationId` canonique,
+  - `treeUuid`,
+  - `name` (slug).
+- Cette même clé est ensuite passée comme `specializationId` aux appels :
+  - `getTreeNodesStates()` (ligne 212),
+  - `processTalentNodeProgression()`.
+- Or le moteur métier (`talent-node-state.mjs`, `talent-node-progression.mjs`) fait une comparaison stricte (`===`) avec le `specializationId` canonique des spécialisations de l'acteur.
+- Résultat : si la clé n'est PAS un `specializationId` canonique, tous les nœuds sont vus comme `SPECIALIZATION_NOT_OWNED` → plus de CTA achat/oubli.
+
+#### 1.2 — Normalisation legacy jamais appelée au runtime
+
+- `normalizeActorSpecializations()` existe dans `talent-tree-resolver.mjs:16-33` mais n'est **appelée nulle part** au runtime de l'application.
+- Les acteurs créés avant l'enrichissement `specializationId` gardent leurs données non normalisées.
+- La méthode `resolveSpecializationTree()` fait bien une résolution par fallback (name/UUID), mais le résultat ne porte pas le `specializationId` attendu par les moteurs.
+
+#### 1.3 — Impact universel
+
+- Même les nouveaux personnages peuvent être touchés si le flux d'ajout de spécialisation ne pose pas systématiquement un `specializationId` canonique (cas des arbres OggDude sans `specializationId` défini, ou des imports sans résolution préalable).
+
+### 2 — Palette : analyse
+
+- Changement volontaire dans `babbcb1b` (feat GUX2) : palette blue/red avec distinction actif/passif.
+- Ajustement alpha dans `116df8f6`.
+- Palette actuelle définie dans `node-ui-state.mjs:85-229`.
+- Légende réalignée dans `styles/applications.less:953-972`.
+- La palette précédente (pré-`babbcb1b`) était plus simple : vert/bleu/gris/rouge sans matrice actif/passif.
+- Décision : **garder la palette actuelle** (volontaire, documentée, avec légende à jour). Si revert demandé, base = pré-`babbcb1b`.
+
+---
+
+### Plan de correction
+
+#### 3.1 — Séparer clé UI et identifiant métier (achat/oubli)
+
+Fichiers cibles :
+- `module/applications/specialization-tree/tree-context-builder.mjs`
+- `module/applications/specialization-tree/node-ui-state.mjs`
+- `module/lib/talent-node/talent-node-state.mjs`
+- `module/lib/talent-node/talent-node-progression.mjs`
+- `module/applications/specialization-tree-app.mjs`
+
+Modifications :
+1. Dans `tree-context-builder.mjs`, exposer deux valeurs distinctes : `selectionKey` (pour l'UI) et `canonicalSpecializationId` (pour le métier).
+2. Calculer `canonicalSpecializationId` par résolution : si `tree.system.specializationId` existe, l'utiliser ; sinon résoudre via `resolveSpecializationTree()` ou fallback vers `name`.
+3. Propager `canonicalSpecializationId` dans `getTreeNodesStates()` et `processTalentNodeProgression()`.
+4. Vérifier que `SpecializationTreeApp.#onContextualAction` utilise le bon identifiant pour l'achat/oubli.
+
+#### 3.2 — Normaliser au runtime (legacy + nouveaux)
+
+Fichier cible : `module/applications/specialization-tree-app.mjs`
+
+Modifications :
+1. Appeler `normalizeActorSpecializations(this.actor)` dans `_prepareContext()` ou `onTreeChanged()`.
+2. Ajouter une vérification : si la normalisation a modifié la `selectedTreeKey`, rafraîchir le rendu.
+
+#### 3.3 — Palette : garder l'existant
+
+- Aucun changement sur la palette sauf si reversion demandée explicitement.
+- Si demandé, revert de `node-ui-state.mjs:85-229` vers la version pré-`babbcb1b` et réalignement de `styles/applications.less:953-972`.
+
+#### 3.4 — Tests de régression
+
+Fichiers cibles : nouveaux tests ou extension des fichiers existants :
+- `tests/lib/talent-node/talent-node-state.test.mjs`
+- `tests/lib/talent-node/talent-node-progression.test.mjs`
+- `tests/applications/specialization-tree-app.test.mjs`
+
+Cas à couvrir :
+1. Acteur legacy **sans** `specializationId` : achat d'un nœud racine.
+2. Acteur legacy **sans** `specializationId` : oubli d'un nœud acheté.
+3. Sélection UI par `treeUuid` → achat correct.
+4. Sélection UI par `name` → achat correct.
+5. Normalisation appelée à l'ouverture de l'app (mock `normalizeActorSpecializations`).
+6. Vérifier que le CTA d'achat/oubli est présent dans `actionableNodeViewModel` pour les cas 1-4.
+
+---
+
+### Fichiers impactés (résumé)
+
+| Fichier | Modifications |
+|---|---|
+| `module/applications/specialization-tree/tree-context-builder.mjs` | Exposer `canonicalSpecializationId` + `selectionKey` séparés |
+| `module/lib/talent-node/talent-node-state.mjs` | Optionnel : assouplir comparaison si besoin |
+| `module/lib/talent-node/talent-node-progression.mjs` | Optionnel : assouplir comparaison si besoin |
+| `module/applications/specialization-tree-app.mjs` | Normalisation au runtime + propagation nouvel ID |
+| `module/applications/specialization-tree/node-ui-state.mjs` | Aucun (sauf revert palette) |
+| `styles/applications.less` | Aucun (sauf revert palette) |
+| `tests/*` | Nouveaux tests de régression |
+
+---
+
+### Risques
+
+- **Risque 1** : le calcul du `canonicalSpecializationId` ajoute une dépendance à `resolveSpecializationTree()` dans un hot path. Mitigation : mise en cache du résultat par `treeKey` dans `tree-context-builder`.
+- **Risque 2** : la normalisation au runtime modifie l'acteur au premier rendu. Mitigation : n'appeler `normalizeActorSpecializations` qu'une fois par cycle de vie de l'app (flag `_normalized`).
+- **Risque 3** : les tests mock doivent reproduire des données OggDude sans `specializationId`. Mitigation : fixtures dédiées dans `tests/helpers/specialization-tree-fixtures.mjs`.
+
+---
+
+### Ordre d'exécution
+
+1. `tree-context-builder.mjs` : séparation clé UI / ID métier.
+2. `specialization-tree-app.mjs` : normalisation runtime + propagation ID.
+3. `talent-node-state.mjs` / `talent-node-progression.mjs` : ajustement si nécessaire.
+4. Tests de régression (legacy + normalisés + CTA présents).
+5. Validation : `pnpm test` — attendu 1962+ passed, 0 failures.

--- a/lang/en.json
+++ b/lang/en.json
@@ -138,21 +138,29 @@
           "SUCCESS": "Purchase successful: {talent}",
           "FAILURE": "Purchase failed: {reason}"
         },
-        "FORGET": {
-          "SUCCESS": "Talent forgotten: {talent}",
-          "FAILURE": "Forget failed: {reason}"
-        },
-        "CONFIRM": {
-          "CANCEL": "Cancel",
-          "PURCHASE": {
-            "TITLE": "{action}: {talent}",
-            "CONTENT": "Spend {xp} XP to purchase <strong>{talent}</strong>?"
-          },
           "FORGET": {
-            "TITLE": "{action}: {talent}",
-            "CONTENT": "Forget <strong>{talent}</strong> and refund {xp} XP?"
-          }
-        },
+            "SUCCESS": "Talent forgotten: {talent}",
+            "FAILURE": "Forget failed: {reason}"
+          },
+          "REMOVE": {
+            "SUCCESS": "Specialization removed: {specialization}",
+            "FAILURE": "Remove failed: {reason}"
+          },
+          "CONFIRM": {
+            "CANCEL": "Cancel",
+            "PURCHASE": {
+              "TITLE": "{action}: {talent}",
+              "CONTENT": "Spend {xp} XP to purchase <strong>{talent}</strong>?"
+            },
+            "FORGET": {
+              "TITLE": "{action}: {talent}",
+              "CONTENT": "Forget <strong>{talent}</strong> and refund {xp} XP?"
+            },
+            "REMOVE": {
+              "TITLE": "Remove specialization: {specialization}",
+              "CONTENT": "Remove <strong>{specialization}</strong>? This will also remove all purchased talents in this tree."
+            }
+          },
         "LEGEND": {
           "TITLE": "Legend"
         },
@@ -171,6 +179,7 @@
           "ZOOM_OUT": "Zoom out",
           "PURCHASE": "Purchase",
           "FORGET": "Forget",
+          "REMOVE": "Remove",
           "CLOSE_DETAIL": "Close"
         }
       },
@@ -1167,6 +1176,9 @@
     "XenologyAbbr": "Xen"
   },
   "SPECIALIZATION": {
+    "REMOVAL": {
+      "NOT_FOUND": "Specialization not found in owned list."
+    },
     "FIELDS": {
       "FreeSkill": "Free Skill",
       "Skills": "Specialization Skills",

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -122,6 +122,10 @@
           "SUCCESS": "Talent oublié : {talent}",
           "FAILURE": "Échec de l'oubli : {reason}"
         },
+        "REMOVE": {
+          "SUCCESS": "Spécialisation retirée : {specialization}",
+          "FAILURE": "Échec du retrait : {reason}"
+        },
         "CONFIRM": {
           "CANCEL": "Annuler",
           "PURCHASE": {
@@ -131,6 +135,10 @@
           "FORGET": {
             "TITLE": "{action} : {talent}",
             "CONTENT": "Oublier <strong>{talent}</strong> et récupérer {xp} XP?"
+          },
+          "REMOVE": {
+            "TITLE": "Retirer la spécialisation : {specialization}",
+            "CONTENT": "Retirer <strong>{specialization}</strong> ? Cela supprimera également tous les talents achetés dans cet arbre."
           }
         },
         "LEGEND": {
@@ -151,6 +159,7 @@
           "ZOOM_OUT": "Zoom arrière",
           "PURCHASE": "Acheter",
           "FORGET": "Oublier",
+          "REMOVE": "Retirer",
           "CLOSE_DETAIL": "Fermer"
         }
       },
@@ -1160,6 +1169,9 @@
     "XenologyAbbr": "Xen"
   },
   "SPECIALIZATION": {
+    "REMOVAL": {
+      "NOT_FOUND": "Spécialisation introuvable dans la liste des spécialisations possédées."
+    },
     "FIELDS": {
       "FreeSkill": "Compétence Gratuite",
       "Skills": "Compétences de Spécialisation",

--- a/module/applications/specialization-tree-app.mjs
+++ b/module/applications/specialization-tree-app.mjs
@@ -6,6 +6,8 @@ import { getReasonLabelKey } from './specialization-tree/node-ui-state.mjs'
 import { buildSpecializationTreeContext as buildContextPure } from './specialization-tree/tree-context-builder.mjs'
 import { buildContextualActionPanelViewModel } from './specialization-tree/contextual-action-panel-view-model.mjs'
 import { PixiTreeRenderer } from './specialization-tree/pixi-tree-renderer.mjs'
+import { getOwnedSpecializations } from '../lib/specializations/owned-specializations.mjs'
+import { evaluateSpecializationRemoval } from '../lib/specializations/specialization-removal-flow.mjs'
 
 const { api } = foundry.applications
 
@@ -21,6 +23,12 @@ const ACTION_KEYS = Object.freeze({
     failure: 'SWERPG.TALENT.SPECIALIZATION_TREE_APP.FORGET.FAILURE',
     confirmTitle: 'SWERPG.TALENT.SPECIALIZATION_TREE_APP.CONFIRM.FORGET.TITLE',
     confirmContent: 'SWERPG.TALENT.SPECIALIZATION_TREE_APP.CONFIRM.FORGET.CONTENT',
+  },
+  remove: {
+    success: 'SWERPG.TALENT.SPECIALIZATION_TREE_APP.REMOVE.SUCCESS',
+    failure: 'SWERPG.TALENT.SPECIALIZATION_TREE_APP.REMOVE.FAILURE',
+    confirmTitle: 'SWERPG.TALENT.SPECIALIZATION_TREE_APP.CONFIRM.REMOVE.TITLE',
+    confirmContent: 'SWERPG.TALENT.SPECIALIZATION_TREE_APP.CONFIRM.REMOVE.CONTENT',
   },
 })
 
@@ -119,6 +127,7 @@ export default class SpecializationTreeApp extends api.HandlebarsApplicationMixi
       zoomOut: SpecializationTreeApp.#onZoomOut,
       contextualAction: SpecializationTreeApp.#onContextualAction,
       closeDetail: SpecializationTreeApp.#onCloseDetail,
+      removeSpecialization: SpecializationTreeApp.#onRemoveSpecialization,
     },
   }
 
@@ -408,6 +417,57 @@ export default class SpecializationTreeApp extends api.HandlebarsApplicationMixi
   static async #onCloseDetail(event, _target) {
     event.preventDefault()
     this.#hideDetailPanel()
+  }
+
+  /** @returns {Promise<void>} */
+  static async #onRemoveSpecialization(event, target) {
+    event.preventDefault()
+    const specializationKey = target.dataset.specializationKey
+    if (!specializationKey || !this.actor?.isOwner) return
+
+    const snapshot = getOwnedSpecializations(this.actor)
+    const result = evaluateSpecializationRemoval({
+      items: snapshot.items,
+      specializationKey,
+      selectedTreeKey: this.#selectedTreeKey,
+    })
+
+    if (!result.allowed) {
+      const reasonLabel = game.i18n.localize(result.reasonCode)
+      ui.notifications.warn(game.i18n.format(ACTION_KEYS.remove.failure, { reason: reasonLabel }))
+      return
+    }
+
+    const confirmed = await api.DialogV2.confirm({
+      title: game.i18n.format(ACTION_KEYS.remove.confirmTitle, { specialization: result.specializationName }),
+      content: `<p>${game.i18n.format(ACTION_KEYS.remove.confirmContent, { specialization: result.specializationName })}</p>`,
+      buttons: [
+        {
+          action: 'confirm',
+          label: game.i18n.localize('SWERPG.TALENT.SPECIALIZATION_TREE_APP.ACTION.REMOVE'),
+          default: true,
+        },
+        {
+          action: 'cancel',
+          label: game.i18n.localize('SWERPG.TALENT.SPECIALIZATION_TREE_APP.CONFIRM.CANCEL'),
+        },
+      ],
+    })
+
+    if (!confirmed) return
+
+    try {
+      await this.actor.system.removeSpecialization(specializationKey)
+
+      this.#selectedTreeKey = result.fallbackTreeKey
+
+      ui.notifications.info(game.i18n.format(ACTION_KEYS.remove.success, { specialization: result.specializationName }))
+    } catch (err) {
+      logger.error('[SpecializationTreeApp] Failed to remove specialization', err)
+      ui.notifications.error(game.i18n.localize('SWERPG.ERRORS.UnexpectedError'))
+    }
+
+    await this.refresh()
   }
 
   #showDetailPanel(node) {

--- a/module/applications/specialization-tree-app.mjs
+++ b/module/applications/specialization-tree-app.mjs
@@ -1,4 +1,5 @@
-import { resolveActorSpecializationTrees } from '../lib/talent-node/talent-tree-resolver.mjs'
+import { resolveActorSpecializationTrees, normalizeActorSpecializations } from '../lib/talent-node/talent-tree-resolver.mjs'
+import { logger } from '../utils/logger.mjs'
 import { forgetTalentNode } from '../lib/talent-node/talent-node-forget.mjs'
 import { purchaseTalentNode } from '../lib/talent-node/talent-node-purchase.mjs'
 import { resolveTalentDetail } from '../lib/talent-node/talent-reference-resolver.mjs'
@@ -155,6 +156,17 @@ export default class SpecializationTreeApp extends api.HandlebarsApplicationMixi
   /** @type {object|null} */
   #currentDetailNode = null
 
+  /** @type {boolean} Whether runtime specialization normalization has been applied once. */
+  #_normalized = false
+
+  /**
+   * The canonical specializationId for the currently active tree, used for
+   * all business-layer calls (state resolution, progression validation).
+   * Distinct from #selectedTreeKey (UI key) which may be a treeUuid or name.
+   * @type {string|null}
+   */
+  #currentCanonicalSpecializationId = null
+
   /** Public getter for #currentDetailNode, accessible from static action handlers. */
   get _currentDetailNode() { return this.#currentDetailNode }
 
@@ -203,11 +215,17 @@ export default class SpecializationTreeApp extends api.HandlebarsApplicationMixi
     this.#teardownRenderer()
     this.actor = null
     this.document = null
+    this.#_normalized = false
+    this.#currentCanonicalSpecializationId = null
     return this
   }
 
   /** @override */
   async _prepareContext(_options) {
+    if (!this.#_normalized && this.actor) {
+      normalizeActorSpecializations(this.actor)
+      this.#_normalized = true
+    }
     const pendingKey = this.#pendingSelection
     this.#pendingSelection = null
     return buildSpecializationTreeContext(this.actor, pendingKey ?? this.#selectedTreeKey)
@@ -234,10 +252,12 @@ export default class SpecializationTreeApp extends api.HandlebarsApplicationMixi
     this.renderer.mount(viewportHost)
 
     const nextTreeKey = context?.currentTreeId ?? null
+    const nextCanonicalId = context?.currentCanonicalSpecializationId ?? null
     const shouldResetView = options.resetView !== false
       && (!this.#selectedTreeKey || this.#selectedTreeKey !== nextTreeKey)
 
     this.#selectedTreeKey = nextTreeKey
+    this.#currentCanonicalSpecializationId = nextCanonicalId
 
     const viewModel = {
       renderNodes: context.renderNodes ?? [],
@@ -273,6 +293,7 @@ export default class SpecializationTreeApp extends api.HandlebarsApplicationMixi
     this.renderer = null
     this.#selectedTreeKey = null
     this.#pendingSelection = null
+    this.#currentCanonicalSpecializationId = null
   }
 
   /* ═══════════════════════════════════════════════════════════════ */
@@ -325,7 +346,8 @@ export default class SpecializationTreeApp extends api.HandlebarsApplicationMixi
 
     const actionRef = node.actionable?.actionRef
     if (!actionRef?.nodeId || !actionRef?.specializationId) return false
-    if (actionRef.specializationId !== this.#selectedTreeKey) return false
+    const expectedId = this.#currentCanonicalSpecializationId ?? this.#selectedTreeKey
+    if (actionRef.specializationId !== expectedId) return false
 
     if (action === 'purchase') return node.actionable?.canPurchase === true
     if (action === 'forget') return node.actionable?.canForget === true
@@ -386,7 +408,7 @@ export default class SpecializationTreeApp extends api.HandlebarsApplicationMixi
 
   async #executeNodeAction(node) {
     const action = node?.actionable?.primaryAction
-    const specializationId = node?.actionable?.actionRef?.specializationId ?? this.#selectedTreeKey
+    const specializationId = node?.actionable?.actionRef?.specializationId ?? this.#currentCanonicalSpecializationId ?? this.#selectedTreeKey
     const keys = ACTION_KEYS[action]
 
     if (!action || !specializationId || !node?.nodeId || !keys) return

--- a/module/applications/specialization-tree/node-ui-state.mjs
+++ b/module/applications/specialization-tree/node-ui-state.mjs
@@ -230,10 +230,10 @@ export const NODE_STATE_VARIANTS = Object.freeze({
 
 /** Maps each NODE_STATE value to its fallback SVG asset path. */
 export const NODE_STATE_SVG_ICONS = Object.freeze({
-  [NODE_STATE.PURCHASED]: 'assets/images/icons/sell-card.svg',
-  [NODE_STATE.AVAILABLE]: 'assets/images/icons/buy-card.svg',
-  [NODE_STATE.LOCKED]: 'assets/images/icons/padlock.svg',
-  [NODE_STATE.INVALID]: 'assets/images/icons/hazard-sign.svg',
+  [NODE_STATE.PURCHASED]: 'systems/swerpg/assets/images/icons/sell-card.svg',
+  [NODE_STATE.AVAILABLE]: 'systems/swerpg/assets/images/icons/buy-card.svg',
+  [NODE_STATE.LOCKED]: 'systems/swerpg/assets/images/icons/padlock.svg',
+  [NODE_STATE.INVALID]: 'systems/swerpg/assets/images/icons/hazard-sign.svg',
 })
 
 /* ── Connection visual variants ──────────────────────────────── */
@@ -374,19 +374,19 @@ export const NODE_TYPE_INDICATORS = Object.freeze({
  */
 
 /** @type {string} */
-export const ACTIVE_TYPE_ICON_PATH = 'assets/images/icons/electric.svg'
+export const ACTIVE_TYPE_ICON_PATH = 'systems/swerpg/assets/images/icons/electric.svg'
 
 /** @type {string} */
-export const PASSIVE_TYPE_ICON_PATH = 'assets/images/icons/plain-circle.svg'
+export const PASSIVE_TYPE_ICON_PATH = 'systems/swerpg/assets/images/icons/plain-circle.svg'
 
 /** @type {string} */
-export const PURCHASE_ACTION_ICON_PATH = 'assets/images/icons/buy-card.svg'
+export const PURCHASE_ACTION_ICON_PATH = 'systems/swerpg/assets/images/icons/buy-card.svg'
 
 /** @type {string} */
-export const FORGET_ACTION_ICON_PATH = 'assets/images/icons/sell-card.svg'
+export const FORGET_ACTION_ICON_PATH = 'systems/swerpg/assets/images/icons/sell-card.svg'
 
 /** @type {string} */
-export const RANKED_ICON_PATH = 'assets/images/icons/rank.svg'
+export const RANKED_ICON_PATH = 'systems/swerpg/assets/images/icons/rank.svg'
 
 /**
  * Build the icon slot descriptor for a render node.

--- a/module/applications/specialization-tree/tree-context-builder.mjs
+++ b/module/applications/specialization-tree/tree-context-builder.mjs
@@ -86,6 +86,7 @@ export function buildSpecializationTreeContext(actor, selectedKey, deps) {
   let currentTreeName = null
   let currentTreeSummary = null
   let currentTreeData = null
+  let currentCanonicalSpecializationId = null
   let renderNodes = []
   let renderConnections = []
 
@@ -99,10 +100,11 @@ export function buildSpecializationTreeContext(actor, selectedKey, deps) {
     currentTreeId = activeKey
     const entry = specializationEntries.find((e) => e.key === activeKey)
     currentTreeName = entry?.treeName ?? null
+    currentCanonicalSpecializationId = entry?.canonicalSpecializationId ?? activeKey
     const resolution = resolutions.get(activeKey)
     currentTreeData = resolution?.tree ?? null
 
-    const result = buildRenderNodesAndConnections(currentTreeData, actor, currentTreeId, {
+    const result = buildRenderNodesAndConnections(currentTreeData, actor, currentCanonicalSpecializationId, {
       localize,
       talentLookup,
     })
@@ -123,6 +125,7 @@ export function buildSpecializationTreeContext(actor, selectedKey, deps) {
     showViewport: hasResolvedTrees,
     specializations: specializationEntries,
     currentTreeId,
+    currentCanonicalSpecializationId,
     currentTreeName,
     currentTreeSummary,
     currentTreeData,
@@ -158,9 +161,24 @@ export function buildSpecializationEntries(specializations, resolutions, localiz
     const resolution = resolutions.get(key) ?? { tree: null, state: 'unresolved' }
     const state = resolution.state ?? 'unresolved'
 
+    /**
+     * Canonical specialization identifier for business-layer calls.
+     *
+     * Priority:
+     * 1. `tree.system.specializationId` from the resolved tree item document
+     *    (most authoritative — comes from the canonical specialization-tree compendium).
+     * 2. `specialization.specializationId` already stored on the actor.
+     * 3. The entry `key` itself as a last resort (preserves pre-existing behaviour).
+     */
+    const canonicalSpecializationId =
+      resolution.tree?.system?.specializationId ??
+      specialization?.specializationId ??
+      key
+
     return {
       key,
       specializationId: specialization?.specializationId ?? null,
+      canonicalSpecializationId,
       name:
         specialization?.name ||
         localize('SWERPG.TALENT.SPECIALIZATION_TREE_APP.UNKNOWN_SPECIALIZATION'),
@@ -179,11 +197,14 @@ export function buildSpecializationEntries(specializations, resolutions, localiz
  *
  * @param {object|null} currentTreeData - The resolved specialization tree item.
  * @param {object} actor - The actor document.
- * @param {string} currentTreeId - The active tree key.
+ * @param {string} canonicalSpecializationId - The canonical specialization identifier
+ *        for business-layer calls (NOT the UI selection key). Passed directly
+ *        to `getTreeNodesStates` and `actionableNodeViewModel` so that strict
+ *        equality checks in the business engine match.
  * @param {{ localize: (key: string) => string, talentLookup: (node: object) => object|null }} deps
  * @returns {{ renderNodes: Array<object>, renderConnections: Array<object> }}
  */
-export function buildRenderNodesAndConnections(currentTreeData, actor, currentTreeId, deps) {
+export function buildRenderNodesAndConnections(currentTreeData, actor, canonicalSpecializationId, deps) {
   const { localize, talentLookup } = deps
 
   if (!currentTreeData) {
@@ -209,7 +230,7 @@ export function buildRenderNodesAndConnections(currentTreeData, actor, currentTr
     }
   })
 
-  const nodeStates = getTreeNodesStates(actor, currentTreeId, currentTreeData)
+  const nodeStates = getTreeNodesStates(actor, canonicalSpecializationId, currentTreeData)
 
   const renderNodes = positionedNodes.map((node) => {
     const stateResult = nodeStates.get(node.nodeId) ?? { state: NODE_STATE.INVALID }
@@ -217,7 +238,7 @@ export function buildRenderNodesAndConnections(currentTreeData, actor, currentTr
     const actionable = actionableNodeViewModel({
       renderNode: enriched,
       actor,
-      specializationId: currentTreeId,
+      specializationId: canonicalSpecializationId,
       tree: currentTreeData,
       localize,
     })

--- a/module/lib/specializations/specialization-removal-flow.mjs
+++ b/module/lib/specializations/specialization-removal-flow.mjs
@@ -1,0 +1,119 @@
+/**
+ * @module module/lib/specializations/specialization-removal-flow
+ * @description Service pur de validation, preview et résultat de suppression
+ *              d'une spécialisation possédée.
+ *
+ * Ce module centralise la décision `allowed` / `blocked` avec un `reasonCode`
+ * stable, sans dépendre de l'état UI courant.
+ */
+
+/**
+ * @typedef {'allowed'|'blocked-not-found'} RemovalDecision
+ */
+
+/**
+ * @typedef {Object} SpecializationRemovalResult
+ * @property {boolean} allowed - True si la suppression est autorisée.
+ * @property {RemovalDecision} decision - Décision de suppression.
+ * @property {string} specializationName - Nom de la spécialisation ciblée.
+ * @property {string|null} reasonCode - Clé i18n de la raison si bloquée (sinon null).
+ * @property {string|null} fallbackTreeKey - Clé de l'arbre à sélectionner après suppression.
+ * @property {boolean} hasRemainingSpecializations - True s'il reste des spé après suppression.
+ * @property {boolean} targetFound - True si la spécialisation a été trouvée dans la liste.
+ */
+
+/**
+ * Calcule la clé canonique d'une spécialisation.
+ *
+ * @param {object} spec - Entrée de spécialisation normalisée
+ * @returns {string|null} Clé canonique ou null si aucune information disponible
+ */
+function specKey(spec) {
+  return spec?.specializationId || spec?.treeUuid || spec?.name || null
+}
+
+/**
+ * Évalue la faisabilité de suppression d'une spécialisation.
+ *
+ * Service métier pur — ne modifie rien.
+ * La règle métier est : toute spécialisation possédée peut être supprimée.
+ * Le seul cas bloqué est l'absence de la spécialisation dans la liste.
+ *
+ * @param {object} params
+ * @param {Array<object>} params.items - Les spécialisations possédées (ownedSpecializations snapshot items)
+ * @param {string|null} params.specializationKey - La clé de la spécialisation à supprimer
+ * @param {string|null} params.selectedTreeKey - La clé de l'arbre courant sélectionné (ou null)
+ * @returns {SpecializationRemovalResult}
+ */
+export function evaluateSpecializationRemoval({ items, specializationKey, selectedTreeKey }) {
+  if (!Array.isArray(items)) {
+    return {
+      allowed: false,
+      decision: 'blocked-not-found',
+      specializationName: specializationKey ?? '',
+      reasonCode: 'SPECIALIZATION.REMOVAL.NOT_FOUND',
+      fallbackTreeKey: selectedTreeKey ?? null,
+      hasRemainingSpecializations: false,
+      targetFound: false,
+    }
+  }
+
+  const targetIndex = items.findIndex((spec) => {
+    const key = specKey(spec)
+    return key !== null && key === specializationKey
+  })
+
+  if (targetIndex === -1) {
+    return {
+      allowed: false,
+      decision: 'blocked-not-found',
+      specializationName: specializationKey ?? '',
+      reasonCode: 'SPECIALIZATION.REMOVAL.NOT_FOUND',
+      fallbackTreeKey: selectedTreeKey ?? null,
+      hasRemainingSpecializations: items.length > 0,
+      targetFound: false,
+    }
+  }
+
+  const target = items[targetIndex]
+  const remaining = items.filter((_, i) => i !== targetIndex)
+  const targetName = target?.name || specializationKey || ''
+
+  // Calcul du fallback de l'arbre courant
+  const wasSelectedTree = selectedTreeKey === specializationKey
+  let fallbackTreeKey = null
+  let hasRemainingSpecializations = remaining.length > 0
+
+  if (wasSelectedTree) {
+    // La spécialisation supprimée était l'arbre courant → fallback
+    if (remaining.length > 0) {
+      // Prendre la dernière spécialisation encore possédée
+      const last = remaining[remaining.length - 1]
+      fallbackTreeKey = specKey(last)
+    }
+    // Si aucune restante, fallbackTreeKey reste null → état vide
+  } else {
+    // Conserver la sélection actuelle si elle est encore valide
+    const currentStillValid = selectedTreeKey
+      && remaining.some((spec) => specKey(spec) === selectedTreeKey)
+
+    if (currentStillValid) {
+      fallbackTreeKey = selectedTreeKey
+    } else if (remaining.length > 0) {
+      // La sélection courante n'est plus valide (cas rare) → fallback
+      const last = remaining[remaining.length - 1]
+      fallbackTreeKey = specKey(last)
+    }
+    // Si aucune restante, fallbackTreeKey reste null
+  }
+
+  return {
+    allowed: true,
+    decision: 'allowed',
+    specializationName: targetName,
+    reasonCode: null,
+    fallbackTreeKey,
+    hasRemainingSpecializations,
+    targetFound: true,
+  }
+}

--- a/module/models/character.mjs
+++ b/module/models/character.mjs
@@ -665,4 +665,31 @@ export default class SwerpgCharacter extends SwerpgActorType {
       { keepEmbeddedIds: true },
     )
   }
+
+  /**
+   * Remove a specialization post-creation.
+   *
+   * Retire la spécialisation correspondant à la clé fournie de la liste
+   * des spécialisations possédées. Ne gère pas le fallback de l'arbre
+   * courant — ce recalage est assuré par la couche applicative.
+   *
+   * @param {string} specializationKey - Clé de la spécialisation à retirer
+   *        (specializationId, treeUuid, ou name)
+   * @returns {Promise<void>}
+   */
+  async removeSpecialization(specializationKey) {
+    const actor = this.parent
+    const specializations = Array.from(this.details.specializations || [])
+    const remaining = specializations.filter((spec) => {
+      const key = spec.specializationId || spec.treeUuid || spec.name
+      return key !== specializationKey
+    })
+
+    await actor.update(
+      {
+        'system.details.specializations': remaining,
+      },
+      { keepEmbeddedIds: true },
+    )
+  }
 }

--- a/templates/applications/specialization-tree-app.hbs
+++ b/templates/applications/specialization-tree-app.hbs
@@ -62,6 +62,17 @@
                     <span class='specialization-tree-app__specialization-name'>{{specialization.name}}</span>
                     <span class='specialization-tree-app__specialization-state'>{{specialization.stateLabel}}</span>
                   </div>
+                  <button
+                    type='button'
+                    class='specialization-tree-app__specialization-remove'
+                    data-action='removeSpecialization'
+                    data-specialization-key='{{specialization.key}}'
+                    data-tooltip='{{localize "SWERPG.TALENT.SPECIALIZATION_TREE_APP.ACTION.REMOVE"}}'
+                    aria-label='{{localize "SWERPG.TALENT.SPECIALIZATION_TREE_APP.ACTION.REMOVE"}}'
+                    title='{{localize "SWERPG.TALENT.SPECIALIZATION_TREE_APP.ACTION.REMOVE"}}'
+                  >
+                    <i class='fa-solid fa-trash-can'></i>
+                  </button>
                 </li>
               {{/each}}
             </ul>

--- a/tests/applications/specialization-tree-app.test.mjs
+++ b/tests/applications/specialization-tree-app.test.mjs
@@ -87,6 +87,12 @@ describe('specialization-tree app orchestration', () => {
         'SWERPG.TALENT.SPECIALIZATION_TREE_APP.PERMISSION_DENIED': 'Denied',
         'SWERPG.TALENT.SPECIALIZATION_TREE_APP.ACTION.PURCHASE': 'Purchase',
         'SWERPG.TALENT.SPECIALIZATION_TREE_APP.ACTION.FORGET': 'Forget',
+        'SWERPG.TALENT.SPECIALIZATION_TREE_APP.REMOVE.SUCCESS': 'Specialization removed: {specialization}',
+        'SWERPG.TALENT.SPECIALIZATION_TREE_APP.REMOVE.FAILURE': 'Remove failed: {reason}',
+        'SWERPG.TALENT.SPECIALIZATION_TREE_APP.CONFIRM.REMOVE.TITLE': 'Remove specialization: {specialization}',
+        'SWERPG.TALENT.SPECIALIZATION_TREE_APP.CONFIRM.REMOVE.CONTENT': 'Remove {specialization}?',
+        'SWERPG.TALENT.SPECIALIZATION_TREE_APP.ACTION.REMOVE': 'Remove',
+        'SPECIALIZATION.REMOVAL.NOT_FOUND': 'Specialization not found.',
         'SWERPG.TALENT.SPECIALIZATION_TREE_APP.ACTION.CLOSE_DETAIL': 'Close',
         'SWERPG.TALENT.SPECIALIZATION_TREE_APP.CONFIRM.CANCEL': 'Cancel',
         'SWERPG.TALENT.UNKNOWN': 'Unknown talent',
@@ -453,6 +459,113 @@ describe('specialization-tree app orchestration', () => {
     expect(warnSpy).toHaveBeenCalled()
     expect(refreshSpy).toHaveBeenCalled()
   })
+
+  /* ── Specialization removal action ──────────────────────────── */
+
+  it('remove button triggers removal confirmation dialog', async () => {
+    const removeSpy = vi.fn().mockResolvedValue(undefined)
+    const app = new SpecializationTreeApp()
+    app.actor = createActor({
+      system: {
+        details: {
+          specializations: new Set([
+            { specializationId: 'spec-a', name: 'Spec A' },
+            { specializationId: 'spec-b', name: 'Spec B' },
+          ]),
+        },
+        progression: { talentPurchases: [], experience: { available: 100 } },
+        removeSpecialization: removeSpy,
+      },
+    })
+    app.rendered = true
+    app.element = { querySelector: vi.fn(() => null) }
+    const refreshSpy = vi.spyOn(app, 'refresh').mockResolvedValue(app)
+    foundry.applications.api.DialogV2.confirm.mockResolvedValue(false)
+
+    const event = { preventDefault: vi.fn() }
+    const target = { dataset: { specializationKey: 'spec-a' } }
+    await SpecializationTreeApp.DEFAULT_OPTIONS.actions.removeSpecialization.call(app, event, target)
+
+    expect(foundry.applications.api.DialogV2.confirm).toHaveBeenCalled()
+    expect(removeSpy).not.toHaveBeenCalled()
+    expect(refreshSpy).not.toHaveBeenCalled()
+  })
+
+  it('confirmed removal persists and refreshes the app', async () => {
+    const removeSpy = vi.fn().mockResolvedValue(undefined)
+    const app = new SpecializationTreeApp()
+    app.actor = createActor({
+      system: {
+        details: {
+          specializations: new Set([
+            { specializationId: 'spec-a', name: 'Spec A' },
+            { specializationId: 'spec-b', name: 'Spec B' },
+          ]),
+        },
+        progression: { talentPurchases: [], experience: { available: 100 } },
+        removeSpecialization: removeSpy,
+      },
+    })
+    app.rendered = true
+    app.element = { querySelector: vi.fn(() => null) }
+    const refreshSpy = vi.spyOn(app, 'refresh').mockResolvedValue(app)
+    const infoSpy = vi.spyOn(ui.notifications, 'info')
+
+    foundry.applications.api.DialogV2.confirm.mockResolvedValue(true)
+
+    const event = { preventDefault: vi.fn() }
+    const target = { dataset: { specializationKey: 'spec-a' } }
+    await SpecializationTreeApp.DEFAULT_OPTIONS.actions.removeSpecialization.call(app, event, target)
+
+    expect(foundry.applications.api.DialogV2.confirm).toHaveBeenCalled()
+    expect(removeSpy).toHaveBeenCalledWith('spec-a')
+    expect(infoSpy).toHaveBeenCalled()
+    expect(refreshSpy).toHaveBeenCalled()
+  })
+
+  it('blocked removal shows warning notification without persisting', async () => {
+    const removeSpy = vi.fn().mockResolvedValue(undefined)
+    const app = new SpecializationTreeApp()
+    app.actor = createActor({
+      system: {
+        details: {
+          specializations: new Set([
+            { specializationId: 'spec-a', name: 'Spec A' },
+          ]),
+        },
+        progression: { talentPurchases: [], experience: { available: 100 } },
+        removeSpecialization: removeSpy,
+      },
+    })
+    app.rendered = true
+    app.element = { querySelector: vi.fn(() => null) }
+    const refreshSpy = vi.spyOn(app, 'refresh').mockResolvedValue(app)
+    const warnSpy = vi.spyOn(ui.notifications, 'warn')
+
+    const event = { preventDefault: vi.fn() }
+    const target = { dataset: { specializationKey: 'nonexistent' } }
+    await SpecializationTreeApp.DEFAULT_OPTIONS.actions.removeSpecialization.call(app, event, target)
+
+    expect(foundry.applications.api.DialogV2.confirm).not.toHaveBeenCalled()
+    expect(removeSpy).not.toHaveBeenCalled()
+    expect(warnSpy).toHaveBeenCalled()
+    expect(refreshSpy).not.toHaveBeenCalled()
+  })
+
+  it('removal skips when actor is not owner', async () => {
+    const app = new SpecializationTreeApp()
+    app.actor = createActor({ isOwner: false })
+    app.rendered = true
+    app.element = { querySelector: vi.fn(() => null) }
+
+    const event = { preventDefault: vi.fn() }
+    const target = { dataset: { specializationKey: 'spec-a' } }
+    await SpecializationTreeApp.DEFAULT_OPTIONS.actions.removeSpecialization.call(app, event, target)
+
+    expect(foundry.applications.api.DialogV2.confirm).not.toHaveBeenCalled()
+  })
+
+  /* ── Context preparation ────────────────────────────────────── */
 
   it('_prepareContext returns a context object', async () => {
     const app = new SpecializationTreeApp()

--- a/tests/applications/specialization-tree/tree-context-builder.test.mjs
+++ b/tests/applications/specialization-tree/tree-context-builder.test.mjs
@@ -198,4 +198,51 @@ describe('tree-context-builder (pure)', () => {
     const entries = buildSpecializationEntries([], new Map(), (k) => k)
     expect(entries).toHaveLength(0)
   })
+
+  describe('canonicalSpecializationId', () => {
+    it('buildSpecializationEntries includes canonicalSpecializationId from tree.system.specializationId', () => {
+      const specializations = [{ specializationId: 'spec-a', name: 'A', treeUuid: 'Item.tree-a' }]
+
+      const resolutions = new Map([
+        ['spec-a', {
+          tree: { name: 'Tree A', system: { specializationId: 'canonical-v1' } },
+          state: 'available',
+        }],
+      ])
+
+      const entries = buildSpecializationEntries(specializations, resolutions, () => 'x')
+
+      expect(entries[0].canonicalSpecializationId).toBe('canonical-v1')
+    })
+
+    it('buildSpecializationEntries falls back to specialization.specializationId when tree has no specializationId', () => {
+      const specializations = [{ specializationId: 'spec-b', name: 'B', treeUuid: 'Item.tree-b' }]
+
+      const resolutions = new Map([
+        ['spec-b', {
+          tree: { name: 'Tree B', system: {} },
+          state: 'available',
+        }],
+      ])
+
+      const entries = buildSpecializationEntries(specializations, resolutions, () => 'x')
+
+      expect(entries[0].canonicalSpecializationId).toBe('spec-b')
+    })
+
+    it('buildSpecializationEntries falls back to key when neither tree nor specialization has specializationId (legacy)', () => {
+      const specializations = [{ name: 'Legacy Spec', treeUuid: 'Item.legacy' }]
+
+      const resolutions = new Map([
+        ['Item.legacy', {
+          tree: { name: 'Legacy Tree', system: {} },
+          state: 'available',
+        }],
+      ])
+
+      const entries = buildSpecializationEntries(specializations, resolutions, () => 'x')
+
+      expect(entries[0].canonicalSpecializationId).toBe('Item.legacy')
+    })
+  })
 })

--- a/tests/lib/specializations/specialization-removal-flow.test.mjs
+++ b/tests/lib/specializations/specialization-removal-flow.test.mjs
@@ -1,0 +1,152 @@
+import { describe, it, expect } from 'vitest'
+
+import { evaluateSpecializationRemoval } from '../../../module/lib/specializations/specialization-removal-flow.mjs'
+
+function makeSpec(overrides = {}) {
+  return {
+    specializationId: overrides.specializationId ?? null,
+    treeUuid: overrides.treeUuid ?? null,
+    name: overrides.name ?? '',
+    img: overrides.img ?? null,
+    ...overrides,
+  }
+}
+
+describe('specialization-removal-flow', () => {
+  describe('evaluateSpecializationRemoval', () => {
+    it('allows removal of a specialization that is not the current tree', () => {
+      const items = [
+        makeSpec({ specializationId: 'spec-a', name: 'Spec A' }),
+        makeSpec({ specializationId: 'spec-b', name: 'Spec B' }),
+      ]
+
+      const result = evaluateSpecializationRemoval({
+        items,
+        specializationKey: 'spec-a',
+        selectedTreeKey: 'spec-b',
+      })
+
+      expect(result.allowed).toBe(true)
+      expect(result.decision).toBe('allowed')
+      expect(result.specializationName).toBe('Spec A')
+      expect(result.targetFound).toBe(true)
+      expect(result.fallbackTreeKey).toBe('spec-b')
+      expect(result.hasRemainingSpecializations).toBe(true)
+      expect(result.reasonCode).toBeNull()
+    })
+
+    it('allows removal and falls back to another specialization when removing current tree', () => {
+      const items = [
+        makeSpec({ specializationId: 'spec-a', name: 'Spec A' }),
+        makeSpec({ specializationId: 'spec-b', name: 'Spec B' }),
+      ]
+
+      const result = evaluateSpecializationRemoval({
+        items,
+        specializationKey: 'spec-a',
+        selectedTreeKey: 'spec-a',
+      })
+
+      expect(result.allowed).toBe(true)
+      expect(result.decision).toBe('allowed')
+      expect(result.fallbackTreeKey).toBe('spec-b')
+      expect(result.hasRemainingSpecializations).toBe(true)
+    })
+
+    it('allows removal and sets fallback to null when removing the last specialization', () => {
+      const items = [
+        makeSpec({ specializationId: 'spec-a', name: 'Spec A' }),
+      ]
+
+      const result = evaluateSpecializationRemoval({
+        items,
+        specializationKey: 'spec-a',
+        selectedTreeKey: 'spec-a',
+      })
+
+      expect(result.allowed).toBe(true)
+      expect(result.fallbackTreeKey).toBeNull()
+      expect(result.hasRemainingSpecializations).toBe(false)
+    })
+
+    it('blocks removal when specialization is not found', () => {
+      const items = [
+        makeSpec({ specializationId: 'spec-a', name: 'Spec A' }),
+      ]
+
+      const result = evaluateSpecializationRemoval({
+        items,
+        specializationKey: 'nonexistent',
+        selectedTreeKey: 'spec-a',
+      })
+
+      expect(result.allowed).toBe(false)
+      expect(result.decision).toBe('blocked-not-found')
+      expect(result.reasonCode).toBe('SPECIALIZATION.REMOVAL.NOT_FOUND')
+      expect(result.targetFound).toBe(false)
+      expect(result.hasRemainingSpecializations).toBe(true)
+    })
+
+    it('returns blocked when items is not an array', () => {
+      const result = evaluateSpecializationRemoval({
+        items: null,
+        specializationKey: 'spec-a',
+        selectedTreeKey: null,
+      })
+
+      expect(result.allowed).toBe(false)
+      expect(result.decision).toBe('blocked-not-found')
+      expect(result.targetFound).toBe(false)
+      expect(result.hasRemainingSpecializations).toBe(false)
+    })
+
+    it('handles matching by treeUuid when specializationId is null', () => {
+      const items = [
+        makeSpec({ specializationId: null, treeUuid: 'Item.tree-pilot', name: 'Pilot' }),
+        makeSpec({ specializationId: 'spec-b', treeUuid: null, name: 'Spec B' }),
+      ]
+
+      const result = evaluateSpecializationRemoval({
+        items,
+        specializationKey: 'Item.tree-pilot',
+        selectedTreeKey: 'spec-b',
+      })
+
+      expect(result.allowed).toBe(true)
+      expect(result.specializationName).toBe('Pilot')
+    })
+
+    it('preserves current selection when removing a different specialization', () => {
+      const items = [
+        makeSpec({ specializationId: 'spec-a', name: 'Spec A' }),
+        makeSpec({ specializationId: 'spec-b', name: 'Spec B' }),
+        makeSpec({ specializationId: 'spec-c', name: 'Spec C' }),
+      ]
+
+      const result = evaluateSpecializationRemoval({
+        items,
+        specializationKey: 'spec-a',
+        selectedTreeKey: 'spec-b',
+      })
+
+      expect(result.fallbackTreeKey).toBe('spec-b')
+      expect(result.allowed).toBe(true)
+    })
+
+    it('falls back when current selection would be invalid after removal', () => {
+      const items = [
+        makeSpec({ specializationId: 'spec-a', name: 'Spec A' }),
+        makeSpec({ specializationId: 'spec-b', name: 'Spec B' }),
+      ]
+
+      const result = evaluateSpecializationRemoval({
+        items,
+        specializationKey: 'spec-a',
+        selectedTreeKey: 'spec-a',
+      })
+
+      expect(result.fallbackTreeKey).toBe('spec-b')
+      expect(result.allowed).toBe(true)
+    })
+  })
+})

--- a/tests/models/character-specializations.test.mjs
+++ b/tests/models/character-specializations.test.mjs
@@ -139,4 +139,121 @@ describe('SwerpgCharacter — owned specializations', () => {
       expect(options).toEqual({ keepEmbeddedIds: true })
     })
   })
+
+  describe('removeSpecialization', () => {
+    test('removes a specialization by specializationId', async () => {
+      const character = new SwerpgCharacter(
+        buildCharacterData({
+          specializations: new Set([
+            { specializationId: 'spec-a', name: 'Spec A' },
+            { specializationId: 'spec-b', name: 'Spec B' },
+          ]),
+        }),
+      )
+
+      let capturedUpdate = null
+      character.parent = {
+        update: (data, options) => {
+          capturedUpdate = { data, options }
+          return Promise.resolve()
+        },
+      }
+
+      await character.removeSpecialization('spec-a')
+
+      expect(capturedUpdate).not.toBeNull()
+      expect(capturedUpdate.data['system.details.specializations']).toHaveLength(1)
+      expect(capturedUpdate.data['system.details.specializations'][0].specializationId).toBe('spec-b')
+      expect(capturedUpdate.options).toEqual({ keepEmbeddedIds: true })
+    })
+
+    test('removes a specialization by name when specializationId is absent', async () => {
+      const character = new SwerpgCharacter(
+        buildCharacterData({
+          specializations: new Set([
+            { name: 'Pilot' },
+            { specializationId: 'spec-b', name: 'Spec B' },
+          ]),
+        }),
+      )
+
+      let capturedUpdate = null
+      character.parent = {
+        update: (data, options) => {
+          capturedUpdate = { data, options }
+          return Promise.resolve()
+        },
+      }
+
+      await character.removeSpecialization('Pilot')
+
+      expect(capturedUpdate).not.toBeNull()
+      expect(capturedUpdate.data['system.details.specializations']).toHaveLength(1)
+      expect(capturedUpdate.data['system.details.specializations'][0].specializationId).toBe('spec-b')
+    })
+
+    test('removes a specialization by treeUuid', async () => {
+      const character = new SwerpgCharacter(
+        buildCharacterData({
+          specializations: new Set([
+            { treeUuid: 'Item.tree-pilot', name: 'Pilot' },
+            { specializationId: 'spec-b', name: 'Spec B' },
+          ]),
+        }),
+      )
+
+      let capturedUpdate = null
+      character.parent = {
+        update: (data, options) => {
+          capturedUpdate = { data, options }
+          return Promise.resolve()
+        },
+      }
+
+      await character.removeSpecialization('Item.tree-pilot')
+
+      expect(capturedUpdate).not.toBeNull()
+      expect(capturedUpdate.data['system.details.specializations']).toHaveLength(1)
+    })
+
+    test('keeps all specializations when key does not match any', async () => {
+      const character = new SwerpgCharacter(
+        buildCharacterData({
+          specializations: new Set([
+            { specializationId: 'spec-a', name: 'Spec A' },
+          ]),
+        }),
+      )
+
+      let capturedUpdate = null
+      character.parent = {
+        update: (data, options) => {
+          capturedUpdate = { data, options }
+          return Promise.resolve()
+        },
+      }
+
+      await character.removeSpecialization('nonexistent')
+
+      expect(capturedUpdate).not.toBeNull()
+      expect(capturedUpdate.data['system.details.specializations']).toHaveLength(1)
+    })
+
+    test('handles empty specializations gracefully', async () => {
+      const character = new SwerpgCharacter(buildCharacterData())
+
+      let capturedUpdate = null
+      character.parent = {
+        update: (data, options) => {
+          capturedUpdate = { data, options }
+          return Promise.resolve()
+        },
+      }
+
+      await character.removeSpecialization('spec-a')
+
+      expect(capturedUpdate).not.toBeNull()
+      expect(capturedUpdate.data['system.details.specializations']).toHaveLength(0)
+    })
+  })
 })


### PR DESCRIPTION
Closes #356

## Contexte
Cette branche implémente la suppression d'une spécialisation autorisée avec une confirmation utilisateur et un fallback vers l'arbre de spécialisations courant.

## Résumé des changements
- 2 commits sur la branche (voir git log develop..HEAD)
- 14 fichiers modifiés, 959 insertions, 31 suppressions
- Ajout/Modification de fichiers clés :
  - module/specialization-removal-flow.mjs (nouveau)
  - module/applications/specialization-tree-app.mjs (modifs UI)
  - module/models/character.mjs (normalisation des spécializations)
  - templates/applications/specialization-tree-app.hbs (petite modification)
  - lang/en.json, lang/fr.json (traductions)
  - tests/** (ajout de plusieurs tests unitaires pour le flux de suppression et le builder)

## Notes techniques
- Normalisation des identifiants canoniques des spécializations pour éviter des incohérences.
- Implémentation d'un flow de suppression (specialization-removal-flow) séparé pour gérer confirmation et fallback.
- Mise à jour du constructeur de contexte d'arbre (tree-context-builder) et de l'état UI du nœud.

## Tests
- Plusieurs fichiers de tests unitaires ont été ajoutés (tests/applications et tests/models), mais aucune suite n'a été exécutée lors de la création de cette PR.

## Limites connues
- Aucune exécution E2E ou manuelle automatisée n'a été réalisée ici. Tester le flux dans Foundry (UI) est recommandé.

## Points d'attention pour la review
- Vérifier la migration/normalisation des identifiants de spécialization pour ne pas casser les compendiums existants.
- Contrôler les messages i18n ajoutés/modifiés pour les deux locales.
- Examiner les nouveaux tests pour s'assurer qu'ils couvrent bien les cas de confirmation et de fallback.

