### PR TITLE
feat(e2e): add two-tier E2E strategy — regression + smoke prod

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -27,7 +27,8 @@
       "Bash(/Users/hervedarritchon/Workspace/Perso/FoundryVTT/foundryvtt-swerpg/node_modules/.bin/playwright *)",
       "Bash(git -C /Users/hervedarritchon/Workspace/Perso/FoundryVTT/foundryvtt-swerpg diff --stat HEAD)",
       "Bash(git *)",
-      "Bash(echo \"exit: $?\")"
+      "Bash(echo \"exit: $?\")",
+      "Bash(pnpm add *)"
     ]
   }
 }

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -23,7 +23,11 @@
       "mcp__plugin_chrome-devtools-mcp_chrome-devtools__navigate_page",
       "Bash(cp /tmp/inspect-foundry.mjs /Users/hervedarritchon/Workspace/Perso/FoundryVTT/foundryvtt-swerpg/inspect-foundry.mjs)",
       "Bash(node inspect-foundry.mjs)",
-      "Skill(git-commit)"
+      "Skill(git-commit)",
+      "Bash(/Users/hervedarritchon/Workspace/Perso/FoundryVTT/foundryvtt-swerpg/node_modules/.bin/playwright *)",
+      "Bash(git -C /Users/hervedarritchon/Workspace/Perso/FoundryVTT/foundryvtt-swerpg diff --stat HEAD)",
+      "Bash(git *)",
+      "Bash(echo \"exit: $?\")"
     ]
   }
 }

--- a/.env.e2e.smoke.prod.example
+++ b/.env.e2e.smoke.prod.example
@@ -1,0 +1,25 @@
+# Configuration smoke prod — instance Foundry de production sur port 30000
+# Copier ce fichier en .env.e2e.smoke.prod et remplir les valeurs.
+# Ce fichier ne doit JAMAIS être commité.
+#
+# Usage :
+#   cp .env.e2e.smoke.prod.example .env.e2e.smoke.prod
+#   pnpm e2e:smoke
+#
+# IMPORTANT : la suite smoke prod est en LECTURE SEULE.
+# Aucune création, édition, suppression ou import n'est autorisé dans ces tests.
+# Utiliser un compte de lecture seule ou un compte dédié avec discipline stricte de non-mutation.
+
+# URL de l'instance Foundry de production
+E2E_FOUNDRY_BASE_URL=http://localhost:30000
+
+# Mot de passe administrateur Foundry (page /auth)
+E2E_FOUNDRY_ADMIN_PASSWORD=your_admin_password_here
+
+# Identifiants du compte utilisé pour les smoke tests (lecture seule de préférence)
+E2E_FOUNDRY_USERNAME=Gamemaster
+E2E_FOUNDRY_PASSWORD=
+
+# Monde de production à tester (monde stable, ne pas utiliser le monde de régression)
+# Laisser vide si les smoke tests n'ont pas besoin d'entrer dans un monde.
+E2E_FOUNDRY_WORLD=test-v14-309

--- a/.gitignore
+++ b/.gitignore
@@ -213,6 +213,9 @@ dist
 
 # E2E Playwright env files
 .env.e2e*
+!.env.e2e.example
+!.env.e2e.regression.example
+!.env.e2e.smoke.prod.example
 
 # Playwright outputs
 playwright-report/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,9 +22,11 @@ pnpm vitest run --grep "pattern"        # Filter by name
 pnpm exec eslint <targets>              # Lint (no npm script exists)
 pnpm fmt:check                          # Prettier check (no --write)
 pnpm run build                         # fmt → rollup → less
-pnpm e2e                               # Playwright E2E (requires Docker Foundry)
-pnpm e2e:headed                        # E2E with visible browser
+pnpm e2e                               # E2E regression (requires Docker Foundry, port 31001)
+pnpm e2e:headed                        # E2E regression with visible browser
 pnpm e2e:ci                            # Chromium only, tag [ci]
+pnpm e2e:smoke                         # E2E smoke prod headless (read-only, port 30000)
+pnpm e2e:smoke:headed                  # E2E smoke prod with visible browser
 pnpm compile                           # YAML _source/ → LevelDB packs/
 pnpm extract                           # LevelDB packs/ → YAML _source/
 ```
@@ -82,8 +84,10 @@ lang/              # en.json, fr.json
 - Setup: `tests/setup.mjs` (default) or `tests/vitest-setup.js` (full mock-foundry)
 - Mock helpers: `tests/helpers/mock-foundry.mjs`
 - Use `setupFoundryMock()` / `teardownFoundryMock()` in beforeEach/afterEach for Foundry-dependent tests
-- E2E requires Docker Foundry instance, configured via `.env.e2e.local`
-- CI runs `pnpm test` (Vitest) + `pnpm e2e:ci` (Playwright Chromium, tag `[ci]`)
+- **E2E two-tier strategy**:
+  - Tier 1 `e2e/regression/` — mutating specs, requires Docker Foundry (port 31001), env `.env.e2e.local`, config `playwright.config.ts`
+  - Tier 2 `e2e/smoke/` — read-only surface checks, targets any live Foundry (port 30000), env `.env.e2e.smoke.prod`, config `playwright.smoke.config.ts`
+- CI runs `pnpm test` (Vitest) + `pnpm e2e:ci` (Playwright Chromium, tag `[ci]`); smoke suite is local-only
 
 ## ApplicationV2 sheets
 
@@ -151,5 +155,5 @@ For failures:
 
 - `.github/copilot-instructions.md` — references Foundry v13/Crucible/Tenebris (outdated), wrong npm commands (use
   `pnpm`)
-- `README.md` — E2E script names may be stale (real ones: `pnpm e2e*`)
+- `README.md` — E2E sections updated; two-tier strategy now documented inline
 - No `lint` npm script in `package.json` — use `pnpm exec eslint <targets>` directly

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,12 +35,16 @@ pnpm fmt:check                                         # Prettier check only
 pnpm run compile        # YAML _source/ → LevelDB packs/
 pnpm run extract        # LevelDB packs/ → YAML _source/
 
-# E2E (requires Docker Foundry)
-pnpm e2e                # Playwright headless
+# E2E — Tier 1: regression (requires Docker Foundry on port 31001)
+pnpm e2e                # Playwright headless (regression suite)
 pnpm e2e:headed         # Playwright with browser
 pnpm e2e:ci             # Chromium only, [ci]-tagged specs
 pnpm foundry:e2e:start  # start Docker Foundry instance
 pnpm foundry:e2e:stop   # stop Docker Foundry instance
+
+# E2E — Tier 2: smoke prod (read-only, targets port 30000, no Docker needed)
+pnpm e2e:smoke          # smoke suite headless
+pnpm e2e:smoke:headed   # smoke suite with browser
 ```
 
 ## Architecture

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,10 +1,16 @@
 # CLAUDE.md
 
-This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+## Règles agent (toujours)
+
+- Si ambigu : demande. Ne choisis pas en silence.
+- Diff minimal. Touche uniquement ce qui est demandé.
+- Définis « done » avant de commencer (1 ligne suffit).
+- Vérifie dans le code latest. Jamais d'hypothèse.
+- Code minimum. Pas de feature spéculative.
 
 ## Project
 
-**Swerpg** is a Foundry VTT v13+ game system for Star Wars Edge RPG. It targets `foundry.applications.api` (ApplicationV2) and `foundry.abstract.TypeDataModel`. The codebase is ES2022 modules only — no TypeScript, no `require`.
+**Swerpg** is a Foundry VTT v14+ game system for Star Wars Edge RPG. It targets `foundry.applications.api` (ApplicationV2) and `foundry.abstract.TypeDataModel`. The codebase is ES2022 modules only — no TypeScript, no `require`.
 
 - **Entry point**: `swerpg.mjs` → bundled to `dist/swerpg.bundle.js` via Rollup
 - **System ID**: `swerpg` (in `module/config/system.mjs`)

--- a/README.md
+++ b/README.md
@@ -97,62 +97,54 @@ pnpm test
 pnpm vitest run tests/integration/species-import.integration.spec.mjs # ex. tester un fichier d'intégration
 ```
 
-## Tests E2E (Playwright)
+## Tests E2E (Playwright) — stratégie à deux étages
 
-Le projet inclut une suite de tests end-to-end basée sur Playwright, séparée des tests unitaires (Vitest).
+Les tests end-to-end sont séparés en deux étages indépendants.
 
-- Tests unitaires : `pnpm test`
-- Tests E2E : `pnpm test:e2e` (ou `pnpm test:e2e:headed`)
+### Étage 1 — Régression (port 31001, Docker, CI)
 
-Voir `documentation/tests/playwright-e2e-guide.md` pour la configuration détaillée et les bonnes pratiques.
+Specs dans `e2e/regression/`. Instance Foundry éphémère créée automatiquement par Docker.
+Config : `playwright.config.ts`. Env : `.env.e2e.local`.
 
-## Tests E2E Playwright – Environnement Foundry local
+```bash
+pnpm foundry:e2e:start   # démarrer l’instance Docker (port 31001)
+pnpm e2e                 # lancer la suite headless
+pnpm e2e:headed          # lancer avec navigateur visible
+pnpm e2e:ci              # Chromium uniquement, specs taggées [ci] (pour la CI)
+pnpm foundry:e2e:stop    # arrêter l’instance Docker
+```
 
-Pour exécuter les tests end‑to‑end Playwright contre une instance Foundry locale, un script Docker est fourni.
-
-- Script: `scripts/e2e-foundry-start.sh`
-- Guide détaillé: `scripts/README-e2e-foundry-start.md`
-
-### Pré‑requis
-
-- Docker installé
-- Licence Foundry VTT valide (ne pas commiter la clé)
-- Fichier `.env.e2e.local` pour les variables E2E (ignoré par Git)
-
-Exemple minimal de `.env.e2e.local`:
+Exemple minimal `.env.e2e.local` :
 
 ```dotenv
-E2E_FOUNDRY_BASE_URL=http://localhost:30000
+E2E_FOUNDRY_BASE_URL=http://localhost:31001
 E2E_FOUNDRY_ADMIN_PASSWORD=admin
 E2E_FOUNDRY_USERNAME=Gamemaster
 E2E_FOUNDRY_PASSWORD=changeme
 E2E_FOUNDRY_WORLD=Swerpg-E2E-World
 ```
 
-### Démarrer/arrêter Foundry E2E
+### Étage 2 — Smoke prod (port 30000, lecture seule, hors CI)
+
+Specs dans `e2e/smoke/`. Cible une instance Foundry déjà active — aucune mutation du monde.
+Config : `playwright.smoke.config.ts`. Env : `.env.e2e.smoke.prod` (voir `.env.e2e.smoke.prod.example`).
 
 ```bash
-pnpm foundry:e2e:start
-pnpm foundry:e2e:stop
-# ou
-pnpm foundry:e2e:restart
+pnpm e2e:smoke           # suite smoke headless
+pnpm e2e:smoke:headed    # suite smoke avec navigateur visible
 ```
 
-Le script crée un répertoire éphémère `.e2e-foundry-data` pour les données et le nettoie à l’arrêt (sauf si `KEEP_DATA=1`).
+Vérifie : présence de `body.system-swerpg`, absence d’erreurs console critiques, assets non-404, sidebar sans clés i18n brutes ni `undefined`.
 
-### Lancer un test E2E de base
+> Ne commitez jamais les fichiers `.env.e2e.*` contenant des secrets.
 
-```bash
-pnpm e2e:headed e2e/specs/bootstrap.spec.ts
-```
-
-En cas d’échec, utilisez la trace Playwright pour diagnostiquer:
+En cas d’échec, diagnostiquer avec la trace Playwright :
 
 ```bash
 pnpm exec playwright show-trace test-results/**/trace.zip
 ```
 
-> Sécurité: fournissez `FOUNDRY_LICENSE_KEY`, `FOUNDRY_USERNAME`, `FOUNDRY_PASSWORD`, `FOUNDRY_ADMIN_KEY` via l’environnement. Ne commitez jamais vos secrets.
+Voir `e2e/README.md` et `documentation/tests/e2e/playwright-e2e-guide.md` pour les détails.
 
 ## Règles de contribution (rapide)
 

--- a/documentation/plan/tests/366-playwright-local-foundry-smoke-tests-securiser-les-parcours-mj-essentiels-en-local.md
+++ b/documentation/plan/tests/366-playwright-local-foundry-smoke-tests-securiser-les-parcours-mj-essentiels-en-local.md
@@ -1,0 +1,137 @@
+# Plan d'implémentation — Issue #366
+
+**Issue** : [#366 — Playwright Local Foundry Smoke Tests - Securiser les parcours MJ essentiels en local](https://github.com/herveDarritchon/foundryvtt-swerpg/issues/366)
+**Dépendance** : [#365 — Tests E2E](https://github.com/herveDarritchon/foundryvtt-swerpg/issues/365)
+**Domaine métier** : `tests`
+**Source de cadrage** :
+
+- `documentation/ways-of-work/plan/tests-e2e/playwright-local-foundry-smoke-tests/project-plan.md`
+- `documentation/ways-of-work/plan/tests-e2e/playwright-local-foundry-smoke-tests/issues-checklist.md`
+- `documentation/tests/e2e/playwright-e2e-guide.md`
+
+---
+
+## 1. Objectif
+
+Mettre en place une suite Playwright locale courte, fiable et maintenable pour sécuriser les parcours MJ essentiels dans Foundry : démarrage du monde, création de personnage, dépense simple d'XP, ouverture de l'arbre de spécialisation, avec détection des erreurs console et une frontière locale-first / CI explicitée.
+
+---
+
+## 2. Périmètre
+
+### Inclus
+
+- baseline locale E2E reproductible ;
+- contrats d'interaction stables pour Foundry et SWERPG ;
+- 3 à 5 smoke tests prioritaires ;
+- hygiène du monde de test et stratégie de reset ;
+- documentation de validation locale et de la frontière CI.
+
+### Exclu
+
+- couverture E2E exhaustive de toutes les règles métier ;
+- dépendance à des sélecteurs CSS décoratifs ;
+- exécution CI élargie au-delà des parcours explicitement retenus ;
+- refonte générale de l'outillage E2E hors besoin direct du smoke scope.
+
+---
+
+## 3. Plan de travail proposé
+
+### Étape 1 — Stabiliser la baseline locale Playwright et le monde E2E
+
+**But** : verrouiller un environnement local reproductible avant d'ajouter de nouveaux scénarios.
+
+**Fichiers cibles** : `playwright.config.ts`, `.env.e2e.example`, `e2e/README.md`, `documentation/tests/e2e/playwright-e2e-guide.md`
+
+**Actions** :
+
+- confirmer les variables d'environnement minimales et le monde cible ;
+- expliciter le mode local-first, `workers: 1`, les artefacts à conserver uniquement à l'échec ;
+- documenter clairement les prérequis de démarrage et les conventions d'exécution locale.
+
+### Étape 2 — Fiabiliser les contrats d'interaction et la capture d'erreurs navigateur
+
+**But** : rendre les scénarios robustes face à l'UI Foundry et visibles en cas de régression navigateur.
+
+**Fichiers cibles** : `e2e/utils/foundrySession.ts`, `e2e/utils/foundryUI.ts`, `e2e/utils/playwrightTest.ts`, `e2e/fixtures/index.ts`
+
+**Actions** :
+
+- centraliser les helpers de session et de navigation réellement nécessaires aux smoke tests ;
+- privilégier `getByRole`, `getByLabel` et `data-testid` seulement quand l'accessibilité ne suffit pas ;
+- brancher une capture systématique des erreurs `console` et `pageerror` non autorisées dans les scénarios.
+
+### Étape 3 — Couvrir le démarrage du monde et la création de personnage
+
+**But** : sécuriser le premier parcours MJ à forte valeur.
+
+**Fichiers cibles** : `e2e/specs/bootstrap.spec.ts`, `e2e/specs/*.spec.ts` dédiés aux smoke tests personnage, helpers partagés sous `e2e/utils/`
+
+**Actions** :
+
+- vérifier que le monde SWERPG se charge correctement et que l'interface MJ critique est disponible ;
+- ajouter un smoke test focalisé sur la création d'un personnage et l'ouverture de sa fiche ;
+- faire échouer le scénario en cas d'erreur console inattendue.
+
+### Étape 4 — Couvrir la dépense simple d'XP et l'ouverture de l'arbre de spécialisation
+
+**But** : sécuriser un flux métier central sans transformer la suite locale en test d'intégration exhaustif.
+
+**Fichiers cibles** : `e2e/specs/*.spec.ts` dédiés aux flux XP/spécialisation, helpers partagés sous `e2e/utils/`
+
+**Actions** :
+
+- couvrir une augmentation simple à impact visible sur l'XP disponible ;
+- vérifier la persistance minimale après réouverture du document concerné ;
+- ouvrir l'arbre de spécialisation et contrôler l'absence d'erreur bloquante et la présence du conteneur attendu.
+
+### Étape 5 — Formaliser l'hygiène du monde de test et la stratégie de reset
+
+**But** : éviter la dérive de données et la flakiness entre exécutions locales.
+
+**Fichiers cibles** : `documentation/tests/e2e/playwright-e2e-guide.md`, `e2e/README.md`, éventuels helpers de cleanup sous `e2e/utils/` ou `e2e/fixtures/`
+
+**Actions** :
+
+- définir la politique de données jetables, noms uniques et nettoyage ;
+- documenter le niveau minimal de reset requis entre scénarios ;
+- garder la stratégie compatible avec une exécution locale simple et déterministe.
+
+### Étape 6 — Valider la non-régression locale et documenter la frontière CI
+
+**But** : fermer le scope avec des critères de validation clairs et maintenables.
+
+**Fichiers cibles** : `documentation/tests/e2e/playwright-e2e-guide.md`, `e2e/README.md`, `playwright.config.ts`
+
+**Actions** :
+
+- documenter la liste des smoke tests retenus pour la validation locale ;
+- expliciter quels scénarios peuvent être taggés `[ci]` et pourquoi ;
+- confirmer que les artefacts lourds restent limités aux échecs et que les erreurs console sont traitées comme des régressions.
+
+---
+
+## 4. Ordre recommandé
+
+1. Baseline locale
+2. Contrats d'interaction
+3. Smoke test monde + création personnage
+4. Hygiène / reset du monde de test
+5. Smoke test XP + arbre de spécialisation
+6. Validation finale et frontière CI
+
+---
+
+## 5. Validation prévue (à exécuter pendant l'implémentation, non exécutée dans ce plan)
+
+- `pnpm e2e -- --project=chromium`
+- `pnpm e2e -- --project=firefox`
+- `pnpm e2e -- e2e/specs/bootstrap.spec.ts`
+- exécution ciblée des nouvelles specs smoke locales
+
+---
+
+## 6. Résultat attendu
+
+Une suite Playwright locale courte et fiable couvre les parcours MJ essentiels, remonte les erreurs console inattendues, reste compatible avec l'outillage E2E existant, et distingue explicitement ce qui relève de la validation locale complète de ce qui mérite une exécution CI ciblée.

--- a/documentation/plan/tests/e2e/strategie-e2e-deux-etages-regression-et-smoke-prod.md
+++ b/documentation/plan/tests/e2e/strategie-e2e-deux-etages-regression-et-smoke-prod.md
@@ -1,0 +1,299 @@
+# Strategie E2E a deux etages
+
+**Contexte** : besoin de separer clairement les tests E2E de non-regression fonctionnelle profonde et les tests E2E de surface sur instance de production.
+
+**Decision structurante** :
+
+- les tests `smoke prod` tournent uniquement en manuel, post-deploiement (pnpm run e2e:smoke) ;
+- ils ne tournent pas en pipeline GitHub car l'execution Foundry VTT requiert une machine locale adaptee, notamment cote GPU et performances navigateur ;
+- les tests `regression` tournent sur une instance E2E dediee, avec monde controle et mutations autorisees (pnpm run e2e:regression).
+
+---
+
+## 1. Objectif
+
+Mettre en place une strategie Playwright a deux etages :
+
+- un etage `regression` pour valider en profondeur les parcours fonctionnels, la persistance et les regressions UI/metier sur une instance E2E dediee ;
+- un etage `smoke prod` pour verifier rapidement, manuellement et sans mutation, que l'instance de production deployee est saine et exploitable.
+
+---
+
+## 2. Perimetre
+
+### Inclus
+
+- separation explicite entre suites `regression` et `smoke prod` ;
+- conventions d'execution, de structure de fichiers et de variables d'environnement ;
+- criteres de couverture initiaux pour chaque etage ;
+- documentation de la frontiere CI / execution manuelle ;
+- garde-fous pour garantir que le `smoke prod` reste strictement non destructif.
+
+### Exclu
+
+- execution automatique des `smoke prod` dans GitHub Actions ;
+- transformation du `smoke prod` en suite fonctionnelle profonde ;
+- couverture exhaustive de toute la logique metier par Playwright quand Vitest est plus adapte ;
+- refonte globale des tests non liee a cette separation de strategie.
+
+---
+
+## 3. Architecture cible
+
+### Etage 1 - `regression`
+
+**Cible** : instance Foundry E2E dediee (e2e: port 31001), monde controle, donnees jetables ou regenerables.
+
+**Usage** : non-regression fonctionnelle profonde avant merge important, avant release, ou en campagne locale dediee.
+
+**Proprietes** :
+
+- mutations autorisees ;
+- persistance verifiee ;
+- workflows complets autorises ;
+- couverture large par domaine fonctionnel ;
+- duree plus longue acceptable ;
+- priorite a Chromium, extension eventuelle a Firefox pour un sous-ensemble stable.
+
+### Etage 2 - `smoke prod`
+
+**Cible** : instance Foundry actuellement deployee (port 30000). Monde standant de test (test-v14-309).
+
+**Usage** : verification manuelle post-deploiement, depuis une machine locale adaptee.
+
+**Proprietes** :
+
+- lecture seule ;
+- aucune creation, edition, suppression ou import ;
+- duree tres courte ;
+- focus sur la sante de l'instance et la disponibilite des surfaces critiques ;
+- diagnostic rapide en cas de regression visible ou de crash navigateur (ouverture de feuille de personnage démo, check du i18n, ...).
+
+---
+
+## 4. Arborescence cible
+
+Conserver l'intention deja visible dans le repository et la rendre explicite :
+
+- `e2e/regression/**` : suite de non-regression profonde sur instance dediee ;
+- `e2e/specs/**` ou `e2e/smoke/**` : suite de smoke tests de surface pour l'instance de production.
+
+Decision recommandee :
+
+- conserver `e2e/regression/**` pour l'etage profond ;
+- converger progressivement vers `e2e/smoke/**` pour rendre la destination des tests de surface explicite ;
+- garder les helpers partages dans `e2e/utils/**` uniquement s'ils restent compatibles avec les deux etages ;
+- isoler les helpers destructifs ou relies au monde jetable dans `e2e/regression/**` quand necessaire.
+
+---
+
+## 5. Variables d'environnement et scripts
+
+### Variables d'environnement
+
+Prevoir deux configurations separees :
+
+- `.env.e2e.regression` ;
+- `.env.e2e.smoke.prod`.
+
+Variables minimales attendues selon la suite :
+
+- `E2E_FOUNDRY_BASE_URL` ;
+- `E2E_FOUNDRY_ADMIN_PASSWORD` si necessaire pour la suite cible ;
+- `E2E_FOUNDRY_USERNAME` ;
+- `E2E_FOUNDRY_PASSWORD` si necessaire ;
+- `E2E_FOUNDRY_WORLD` uniquement pour la suite `regression` ou pour un compte/monde de lecture controle si le `smoke prod` en a besoin.
+
+### Scripts npm cibles
+
+- conserver `pnpm e2e:regression` pour la suite profonde ;
+- ajouter `pnpm e2e:smoke:prod` pour l'execution manuelle post-deploiement ;
+- ajouter si utile `pnpm e2e:smoke:prod:headed` pour le debug visuel local ;
+- ne pas brancher `e2e:smoke:prod` dans GitHub Actions.
+
+---
+
+## 6. Contrat de couverture - suite `regression`
+
+La suite `regression` doit couvrir des parcours metier et techniques profonds, avec verification de persistance et d'absence de regression observable.
+
+### Couverture initiale attendue
+
+- bootstrap monde, login, session MJ ;
+- creation et ouverture de personnage ;
+- edition de champs critiques et verification apres reouverture ;
+- depense simple d'XP et recalcul observable ;
+- ouverture et usage des surfaces de progression critiques ;
+- arbre de specialisation et interactions centrales ;
+- import OggDude ;
+- settings systeme critiques ;
+- workflows UI centraux necessaires a la sante fonctionnelle du systeme.
+
+### Regles de conception
+
+- une spec par domaine fonctionnel, pas une megaspec transversale ;
+- des donnees deterministes et jetables ;
+- des assertions de persistance apres fermeture/reouverture quand le flux le justifie ;
+- capture des `console error`, `pageerror` et erreurs reseau critiques comme causes d'echec ;
+- zero verification decorative sans valeur de contrat.
+
+### Matrice de couverture attendue
+
+Maintenir une matrice qui relie :
+
+- domaine fonctionnel ;
+- feature ;
+- champs critiques ;
+- spec Playwright de regression associee ;
+- statut de couverture.
+
+Cette matrice evite de transformer l'objectif "tous les champs / toutes les features" en scenario monolithique fragile.
+
+---
+
+## 7. Contrat de couverture - suite `smoke prod`
+
+La suite `smoke prod` doit rester courte, non destructive et operationnelle.
+
+### Couverture initiale attendue
+
+- l'instance repond et charge correctement ;
+- la surface Foundry cible s'ouvre sans crash ;
+- `body.system-swerpg` est present quand le systeme est charge ;
+- les surfaces UI critiques sont visibles ;
+- quelques ecrans racine peuvent etre ouverts sans erreur bloquante ;
+- aucune erreur `console` ou `pageerror` inattendue n'apparait ;
+- aucune cle i18n brute visible du type `SWERPG.*` ;
+- absence de `undefined`, `null` ou placeholders casses dans les zones critiques ;
+- absence de 404 sur les assets systeme critiques.
+
+### Interdictions absolues
+
+- aucune creation de document ;
+- aucune edition de champ ;
+- aucun import ;
+- aucune suppression ;
+- aucun test qui depend d'un monde jetable ou d'un reset de donnees.
+
+### Mode operatoire
+
+- execution manuelle uniquement ;
+- post-deploiement ;
+- depuis une machine locale adaptee GPU/performance ;
+- compte de lecture seule si possible, sinon compte dedie avec discipline stricte de non-mutation.
+
+---
+
+## 8. Frontiere CI / local manuel
+
+### Ce qui reste en CI GitHub
+
+- `pnpm run build` ;
+- `pnpm test` ;
+- lint et format checks selon l'usage du repository ;
+- eventuellement d'autres validations non GPU et non Foundry-live.
+
+### Ce qui reste hors CI GitHub
+
+- `smoke prod` Playwright (`pnpm run e2e:smoke`);
+- `non regression` Playwright (`pnpm run e2e:regression`) ;
+- toute verification post-deploiement demandant une machine locale adaptee ;
+- toute execution dont la fiabilite depend du rendu navigateur GPU et des performances reelles de l'instance.
+
+---
+
+## 9. Plan de travail propose
+
+### Etape 1 - Formaliser la frontiere documentaire
+
+**But** : documenter noir sur blanc la difference entre `regression` et `smoke prod`.
+
+**Fichiers cibles** : `documentation/tests/e2e/playwright-e2e-guide.md`, `e2e/README.md`
+
+**Actions** :
+
+- decrire les deux etages, leurs objectifs et leurs interdictions ;
+- documenter que `smoke prod` est manuel et post-deploiement uniquement ;
+- corriger les references de doc desynchronisees si besoin.
+
+### Etape 2 - Clarifier la structure des suites
+
+**But** : rendre la separation visible dans l'arborescence et les conventions de nommage.
+
+**Fichiers cibles** : `e2e/regression/**`, `e2e/specs/**` ou `e2e/smoke/**`
+
+**Actions** :
+
+- figer la destination des specs profondes ;
+- figer la destination des specs de surface ;
+- identifier les helpers communs et ceux a isoler.
+
+### Etape 3 - Stabiliser la suite `regression`
+
+**But** : faire de `e2e/regression/**` la suite de non-regression profonde de reference.
+
+**Fichiers cibles** : `playwright.regression.config.ts`, `e2e/regression/specs/**`, `e2e/regression/utils/**`
+
+**Actions** :
+
+- consolider la baseline monde dedie ;
+- ajouter les specs par domaine prioritaire ;
+- brancher la surveillance systematique des erreurs navigateur ;
+- verifier la persistance sur les parcours qui mutent l'etat.
+
+### Etape 4 - Creer la suite `smoke prod`
+
+**But** : disposer d'une suite courte et non destructive pour valider la sante de la prod.
+
+**Fichiers cibles** : config Playwright dediee si necessaire, specs sous `e2e/specs/**` ou `e2e/smoke/**`, helpers non destructifs associes.
+
+**Actions** :
+
+- definir les checks de surface obligatoires ;
+- ajouter la capture d'erreurs navigateur et des assets critiques ;
+- garantir l'absence de mutation dans les helpers et les specs.
+
+### Etape 5 - Ajouter les scripts et env dedies
+
+**But** : rendre l'execution explicite et sans ambiguite.
+
+**Fichiers cibles** : `package.json`, `.env.e2e.example` ou fichiers d'exemple dedies, documentation associee.
+
+**Actions** :
+
+- ajouter les commandes `smoke prod` ;
+- documenter les fichiers d'environnement attendus ;
+- eviter toute confusion entre instance dediee et instance live.
+
+### Etape 6 - Etablir la matrice de couverture
+
+**But** : suivre proprement l'objectif "toutes les features / tous les champs critiques" cote regression.
+
+**Fichiers cibles** : documentation de test dediee a definir.
+
+**Actions** :
+
+- lister les domaines fonctionnels ;
+- lister les champs et parcours critiques par domaine ;
+- relier chaque element a une spec Playwright de regression ou a un test Vitest quand Playwright n'est pas la bonne couche.
+
+---
+
+## 10. Ordre recommande
+
+1. Documenter la strategie et la frontiere CI / manuel
+2. Clarifier la structure des suites et des helpers
+3. Stabiliser la baseline `regression`
+4. Mettre en place la suite `smoke prod`
+5. Ajouter scripts et fichiers d'environnement dedies
+6. Construire la matrice de couverture profonde
+
+---
+
+## 11. Resultat attendu
+
+Le projet dispose d'une strategie E2E claire, lisible et exploitable :
+
+- une suite `regression` profonde, executee sur instance E2E dediee pour securiser les features et la persistance ;
+- une suite `smoke prod` courte, strictement non destructive, executee manuellement post-deploiement pour verifier la sante de l'instance live ;
+- une frontiere explicite entre ce qui releve de la CI GitHub et ce qui releve d'une validation locale Foundry GPU-compatible.

--- a/documentation/tests/e2e/playwright-e2e-guide.md
+++ b/documentation/tests/e2e/playwright-e2e-guide.md
@@ -1,12 +1,43 @@
 # Guide Playwright E2E pour Swerpg
 
-Ce guide décrit comment exécuter et étendre la suite de tests end-to-end Playwright pour le système **Swerpg** sous Foundry VTT v13.
+Ce guide décrit comment exécuter et étendre la suite de tests end-to-end Playwright pour le système **Swerpg** sous Foundry VTT v14.
 
 Il s’adresse à des développeurs déjà à l’aise avec Foundry VTT, TypeScript et Playwright.
 
 > Pour un modèle de spec prêt à l’emploi et un guide détaillé sur la création de nouveaux scénarios E2E, voir également :
 >
 > - `documentation/tests/e2e/playwright-spec-squelette-mon-parcours.md`
+
+---
+
+## Stratégie à deux étages
+
+La suite E2E est organisée en deux étages distincts :
+
+### Étage 1 — `regression` (non-régression profonde)
+
+- **Instance** : Foundry E2E dédiée, port 31001
+- **Monde** : monde contrôlé et jetable (`Swerpg-Regression-World`)
+- **Usage** : avant merge important, avant release, en campagne locale dédiée
+- **Mutations** : autorisées, persistance vérifiée
+- **Config** : `.env.e2e.regression` (copier depuis `.env.e2e.regression.example`)
+- **Commandes** : `pnpm e2e:regression`, `pnpm e2e:regression:headed`
+
+### Étage 2 — `smoke` (vérification post-déploiement)
+
+- **Instance** : instance de production, port 30000
+- **Monde** : monde stable (`test-v14-309` ou équivalent)
+- **Usage** : vérification manuelle post-déploiement uniquement
+- **Mutations** : interdites — lecture seule stricte
+- **Config** : `.env.e2e.smoke.prod` (copier depuis `.env.e2e.smoke.prod.example`)
+- **Commandes** : `pnpm e2e:smoke`, `pnpm e2e:smoke:headed`
+
+### Frontière CI / local manuel
+
+Les suites `regression` et `smoke` ne tournent **jamais** en CI GitHub Actions.
+Elles nécessitent une machine locale adaptée (GPU, performances navigateur, instance Foundry live).
+
+Seuls les tests marqués `[ci]` dans leur titre (via `pnpm e2e:ci`) tournent en CI.
 
 ---
 
@@ -73,11 +104,19 @@ Les scripts E2E sont déclarés dans `package.json` :
 
 ```jsonc
 "scripts": {
-  ...
+  // Suite générale (instance dev, port 30000)
   "e2e": "playwright test",
   "e2e:headed": "playwright test --headed",
   "e2e:ci": "playwright test --project=chromium --grep \"\\[ci\\]\"",
   "e2e:ui": "playwright test --ui",
+  // Non-régression profonde (instance dédiée, port 31001)
+  "e2e:regression": "playwright test --config playwright.regression.config.ts",
+  "e2e:regression:headed": "playwright test --config playwright.regression.config.ts --headed",
+  "e2e:regression:ui": "playwright test --config playwright.regression.config.ts --ui",
+  // Smoke post-déploiement (instance prod, port 30000 — manuel uniquement)
+  "e2e:smoke": "playwright test --config playwright.smoke.config.ts",
+  "e2e:smoke:headed": "playwright test --config playwright.smoke.config.ts --headed",
+  // Instance Foundry dédiée E2E
   "foundry:e2e:start": "bash ./scripts/e2e-foundry-start.sh start",
   "foundry:e2e:stop": "bash ./scripts/e2e-foundry-start.sh stop",
   "foundry:e2e:restart": "bash ./scripts/e2e-foundry-start.sh restart"
@@ -188,19 +227,47 @@ Ces ajustements résolvent les problèmes de redirection vers `/join` observés 
 
 ## 5. Structure des tests E2E
 
-Le dossier `e2e/` est organisé ainsi :
+Le dossier `e2e/` est organisé selon la stratégie à deux étages :
 
-- `e2e/specs/` – fichiers de tests (scénarios métiers)
-  - `bootstrap.spec.ts` – test minimal qui vérifie que le monde Swerpg se charge correctement
-  - `oggdude-import.spec.ts` – test UI de l’importeur OggDude
-- `e2e/utils/` – utilitaires de session Foundry et helpers de setup/teardown
-  - `foundrySession.ts` – primitives pour naviguer dans les écrans `/license`, `/auth`, `/setup`, `/join`, `/game`
-  - `e2eTest.ts` – `setUp` / `tearDown` haut niveau, basés sur `FoundrySessionOptions`
-  - `foundryUI.ts` – helpers pour interactions UI récurrentes (Game Settings, navigation système)
-- `e2e/helper/`
-  - `overlay.ts` – helpers pour fermer les overlays Foundry (tour, partage de données, etc.)
-- `e2e/fixtures.ts` (si présent) – fixtures Playwright projet, notamment `worldReady`
-- `e2e/README.md` – résumé rapide et renvoi vers ce guide détaillé
+```
+e2e/
+  smoke/                  # Étage 2 — smoke post-déploiement (lecture seule)
+    fixtures.ts           # Fixture smokeReady — navigation sans mutation
+    01-health.spec.ts     # Santé de l'instance, erreurs console, 404 système
+    02-surfaces.spec.ts   # Surfaces UI critiques, i18n, placeholders
+  regression/             # Étage 1 — non-régression profonde (mutations autorisées)
+    fixtures/
+      global-setup.ts     # Bootstrap monde de régression
+    specs/
+      01-smoke.spec.ts
+      02-oggdude-import.spec.ts
+    utils/
+      oggdude-importer.ts
+      world-manager.ts
+  specs/                  # Specs générales / tests [ci] pour la CI
+    bootstrap.spec.ts
+    oggdude-import.spec.ts
+  fixtures/               # Fixtures partagées (worldReady)
+    index.ts
+    global-setup.ts
+  helper/
+    overlay.ts            # Fermeture des overlays Foundry
+  utils/                  # Helpers de session communs aux deux étages
+    foundrySession.ts
+    foundryUI.ts
+    playwrightTest.ts
+  README.md
+  tsconfig.json
+```
+
+### 5.1. Fichiers de configuration Playwright
+
+| Config | Suite | Instance | Env file |
+|---|---|---|---|
+| `playwright.config.ts` | générale + `[ci]` | port 30000 | `.env.e2e.local` |
+| `playwright.regression.config.ts` | non-régression | port 31001 | `.env.e2e.regression` |
+| `playwright.smoke.config.ts` | smoke prod | port 30000 | `.env.e2e.smoke.prod` |
+
 
 ### 5.1. Fixtures et session Foundry
 

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -1,24 +1,121 @@
 # Tests E2E Playwright pour Swerpg
 
 Ce dossier contient la suite de tests end-to-end Playwright pour le système Swerpg.
+Les tests E2E sont séparés des tests unitaires (Vitest) : `pnpm test` n'exécute **que** Vitest.
 
-- Les tests E2E sont séparés des tests unitaires (Vitest).
-- Utiliser `pnpm e2e` (ou `pnpm e2e:headed` pour le mode headed) pour exécuter les tests E2E.
-- Configurer l’URL de Foundry et les identifiants dans un fichier `.env.e2e.local` basé sur `.env.e2e.example`.
+Pour tous les détails (prérequis, configuration, structure des specs, bonnes pratiques et troubleshooting),
+se référer au guide complet :
 
-Pour tous les détails (prérequis, configuration Playwright, structure des specs, bonnes pratiques et troubleshooting),
-se référer au guide complet:
+- `documentation/tests/e2e/playwright-e2e-guide.md`
 
-- `documentation/tests/e2e/playwright-e2e-guide.md`.
+---
 
-- Utiliser les hooks Playwright:
-  - `beforeAll`: pour initialiser le contexte du fichier de test.
-  - `beforeEach`: pour initialiser le contexte de .
-  - `afterEach`:
-  - `afterAll`: pour fermer le contexte de fichier de test.
+## Stratégie à deux étages
 
-## Conseils:
+La suite E2E est organisée en deux étages distincts avec des objectifs et des contraintes différentes.
 
-Plutôt utilisé les `beforeEach` et `beforeAll` plutôt que les `afterEach` et `afterAll` pour se mettre dans un état
-initial plutôt que de le faire en post-testing car potentiellement il est possible que le test crash et que le contexte
-ne soit pas remis en état initial.
+### Étage 1 — `regression` (non-régression profonde)
+
+**Instance cible** : Foundry E2E dédiée sur port 31001 (`E2E_FOUNDRY_BASE_URL=http://localhost:31001`).
+
+**Monde** : monde contrôlé et jetable (`Swerpg-Regression-World`).
+
+**Propriétés** :
+
+- mutations autorisées ;
+- persistance vérifiée ;
+- workflows complets autorisés ;
+- durée plus longue acceptable.
+
+**Commandes** :
+
+```bash
+pnpm e2e:regression
+pnpm e2e:regression:headed
+pnpm e2e:regression:ui
+```
+
+**Configuration** : `.env.e2e.regression` (copier depuis `.env.e2e.regression.example`)
+
+**Specs** : `e2e/regression/specs/`
+
+### Étage 2 — `smoke` (vérification post-déploiement)
+
+**Instance cible** : instance Foundry de production sur port 30000 (`E2E_FOUNDRY_BASE_URL=http://localhost:30000`).
+
+**Monde** : monde stable de production (`test-v14-309` ou équivalent).
+
+**Propriétés** :
+
+- lecture seule stricte ;
+- aucune création, édition, suppression ou import ;
+- durée très courte ;
+- exécution manuelle uniquement, post-déploiement.
+
+**Commandes** :
+
+```bash
+pnpm e2e:smoke
+pnpm e2e:smoke:headed
+```
+
+**Configuration** : `.env.e2e.smoke.prod` (copier depuis `.env.e2e.smoke.prod.example`)
+
+**Specs** : `e2e/smoke/`
+
+---
+
+## Frontière CI / local manuel
+
+| Suite | CI GitHub Actions | Local manuel |
+|---|---|---|
+| `pnpm test` (Vitest) | oui | oui |
+| `pnpm e2e:regression` | non | oui |
+| `pnpm e2e:smoke` | non | oui |
+| `pnpm e2e:ci` (tests `[ci]`) | oui | oui |
+
+Les suites `regression` et `smoke` ne tournent pas en CI car elles nécessitent une machine locale
+adaptée (GPU, performances navigateur, instance Foundry live).
+
+---
+
+## Structure du dossier
+
+```
+e2e/
+  smoke/               # Smoke tests post-déploiement (lecture seule)
+    fixtures.ts        # Fixture smokeReady — navigation sans mutation
+    01-health.spec.ts  # Santé de l'instance, erreurs console, 404 système
+    02-surfaces.spec.ts # Surfaces UI critiques, i18n, placeholders
+  regression/          # Non-régression profonde sur instance dédiée
+    fixtures/
+      global-setup.ts  # Bootstrap monde de régression
+    specs/
+      01-smoke.spec.ts
+      02-oggdude-import.spec.ts
+    utils/
+      oggdude-importer.ts
+      world-manager.ts
+  specs/               # Specs legacy / [ci] sur instance de dev
+    bootstrap.spec.ts
+    oggdude-import.spec.ts
+  fixtures/            # Fixtures partagées (worldReady)
+    index.ts
+    global-setup.ts
+  helper/
+    overlay.ts         # Fermeture des overlays Foundry (tour, usage data)
+  utils/               # Helpers de session communs aux deux étages
+    foundrySession.ts  # Primitives /license → /auth → /setup → /join → /game
+    foundryUI.ts       # Interactions UI récurrentes (Settings, system settings)
+    playwrightTest.ts  # setUp / tearDown haut niveau
+  README.md
+  tsconfig.json
+```
+
+---
+
+## Conseils
+
+Préférer `beforeEach` et `beforeAll` pour se mettre dans un état initial plutôt que
+`afterEach` / `afterAll` en post-testing : en cas de crash, le contexte reste propre
+pour la prochaine exécution.

--- a/e2e/smoke/01-health.spec.ts
+++ b/e2e/smoke/01-health.spec.ts
@@ -1,0 +1,85 @@
+import { expect, test } from './fixtures'
+
+/**
+ * 01 — Smoke prod : santé de l'instance
+ *
+ * Vérifie que l'instance Foundry de production répond correctement
+ * et que le système swerpg est chargé sans erreur critique.
+ *
+ * LECTURE SEULE — aucune mutation du monde.
+ * Exécution manuelle uniquement, post-déploiement.
+ */
+test.describe('[smoke] 01 — health', () => {
+  test("l'instance répond et charge le système swerpg", async ({ page }) => {
+    await expect(page).toHaveURL(/.*\/(game|setup|join)/)
+  })
+
+  test('body.system-swerpg est présent quand le système est chargé', async ({ page }) => {
+    // Ce test ne s'exécute que si E2E_FOUNDRY_WORLD est configuré et /game est atteint
+    const url = page.url()
+    if (!url.includes('/game')) {
+      test.skip()
+      return
+    }
+
+    await expect(page.locator('body.system-swerpg')).toHaveCount(1)
+    await expect(page.locator('#sidebar')).toBeVisible()
+  })
+
+  test('aucune erreur console critique sur /game', async ({ page }) => {
+    const url = page.url()
+    if (!url.includes('/game')) {
+      test.skip()
+      return
+    }
+
+    const errors: string[] = []
+
+    page.on('console', (msg) => {
+      if (msg.type() === 'error') {
+        errors.push(msg.text())
+      }
+    })
+
+    page.on('pageerror', (err) => {
+      errors.push(err.message)
+    })
+
+    // Recharger la page pour capturer les erreurs au démarrage
+    await page.reload({ waitUntil: 'domcontentloaded' })
+    await expect(page.locator('body.system-swerpg')).toHaveCount(1)
+
+    const criticalErrors = errors.filter(
+      (e) =>
+        // Exclure les erreurs connues non bloquantes (ex: extensions navigateur)
+        !e.includes('favicon') &&
+        !e.includes('chrome-extension'),
+    )
+
+    expect(criticalErrors, `Erreurs console critiques détectées : ${criticalErrors.join('\n')}`).toHaveLength(0)
+  })
+
+  test('aucun asset système critique en 404', async ({ page }) => {
+    const url = page.url()
+    if (!url.includes('/game')) {
+      test.skip()
+      return
+    }
+
+    const failed404s: string[] = []
+
+    page.on('response', (response) => {
+      if (response.status() === 404) {
+        const reqUrl = response.url()
+        // Surveiller les assets système swerpg uniquement
+        if (reqUrl.includes('/systems/swerpg/') || reqUrl.includes('/swerpg.bundle.js') || reqUrl.includes('/swerpg.css')) {
+          failed404s.push(reqUrl)
+        }
+      }
+    })
+
+    await page.reload({ waitUntil: 'networkidle' })
+
+    expect(failed404s, `Assets système swerpg manquants (404) : ${failed404s.join('\n')}`).toHaveLength(0)
+  })
+})

--- a/e2e/smoke/02-surfaces.spec.ts
+++ b/e2e/smoke/02-surfaces.spec.ts
@@ -1,0 +1,104 @@
+import { expect, test } from './fixtures'
+
+/**
+ * 02 — Smoke prod : surfaces UI critiques
+ *
+ * Vérifie que les surfaces UI principales sont visibles et exploitables
+ * sans crash ni clé i18n brute.
+ *
+ * LECTURE SEULE — aucune création, édition, suppression ou import.
+ * Exécution manuelle uniquement, post-déploiement.
+ */
+test.describe('[smoke] 02 — surfaces', () => {
+  /**
+   * Vérifie que ce test tourne bien en /game.
+   * Si le monde n'est pas configuré (E2E_FOUNDRY_WORLD vide), on skip.
+   */
+  async function requireGame(page: import('@playwright/test').Page): Promise<boolean> {
+    if (!page.url().includes('/game')) {
+      test.skip()
+      return false
+    }
+    return true
+  }
+
+  test('sidebar affiche les onglets principaux sans clé i18n brute', async ({ page }) => {
+    if (!(await requireGame(page))) return
+
+    const sidebar = page.locator('#sidebar')
+    await expect(sidebar).toBeVisible()
+
+    // Vérifier qu'aucune clé SWERPG.* brute n'est visible dans la sidebar
+    const sidebarText = await sidebar.textContent()
+    const rawKeys = (sidebarText ?? '').match(/SWERPG\.[A-Z][A-Za-z.]+/g) ?? []
+    expect(rawKeys, `Clés i18n brutes dans la sidebar : ${rawKeys.join(', ')}`).toHaveLength(0)
+  })
+
+  test('aucun placeholder cassé visible dans la sidebar (undefined, null)', async ({ page }) => {
+    if (!(await requireGame(page))) return
+
+    const sidebar = page.locator('#sidebar')
+    await expect(sidebar).toBeVisible()
+
+    const sidebarText = await sidebar.textContent()
+    // Détecter les valeurs "undefined" ou "null" visibles comme du texte utilisateur
+    expect(sidebarText).not.toMatch(/\bundefined\b/)
+    expect(sidebarText).not.toMatch(/\bnull\b/)
+  })
+
+  test('onglet Actors visible et accessible en lecture', async ({ page }) => {
+    if (!(await requireGame(page))) return
+
+    const sidebar = page.locator('#sidebar')
+    await expect(sidebar).toBeVisible()
+
+    // Ouvrir l'onglet Actors sans mutation
+    const actorsTab = sidebar
+      .locator('[role="tab"][data-tab="actors"]')
+      .or(sidebar.getByRole('tab', { name: /Actors/i }))
+      .first()
+
+    await actorsTab.waitFor({ state: 'visible', timeout: 10000 })
+    await actorsTab.click()
+
+    // Vérifier que la section Actors s'affiche
+    const actorsSection = page.locator('#sidebar #actors')
+    await expect(actorsSection).toBeVisible()
+  })
+
+  test('onglet Items visible et accessible en lecture', async ({ page }) => {
+    if (!(await requireGame(page))) return
+
+    const sidebar = page.locator('#sidebar')
+    await expect(sidebar).toBeVisible()
+
+    const itemsTab = sidebar
+      .locator('[role="tab"][data-tab="items"]')
+      .or(sidebar.getByRole('tab', { name: /Items/i }))
+      .first()
+
+    await itemsTab.waitFor({ state: 'visible', timeout: 10000 })
+    await itemsTab.click()
+
+    const itemsSection = page.locator('#sidebar #items')
+    await expect(itemsSection).toBeVisible()
+  })
+
+  test('onglet Settings visible et accessible en lecture', async ({ page }) => {
+    if (!(await requireGame(page))) return
+
+    const sidebar = page.locator('#sidebar')
+    await expect(sidebar).toBeVisible()
+
+    const settingsTab = sidebar
+      .locator('[role="tab"][data-tab="settings"]')
+      .or(sidebar.getByRole('tab', { name: /Settings/i }))
+      .first()
+
+    await settingsTab.waitFor({ state: 'visible', timeout: 10000 })
+    await settingsTab.click()
+
+    const settingsSection = page.locator('#sidebar #settings')
+    await expect(settingsSection).toBeVisible()
+  })
+})

--- a/e2e/smoke/fixtures.ts
+++ b/e2e/smoke/fixtures.ts
@@ -1,0 +1,91 @@
+import { expect, test as base } from '@playwright/test'
+import { accepteLicense, enterGameAsGamemaster, enterWorld, FoundrySessionOptions, loginIntoInstance } from '../utils/foundrySession'
+import { dismissOverlayIfPresent } from '../helper/overlay'
+
+/**
+ * Fixtures pour la suite smoke prod.
+ *
+ * La fixture `smokeReady` navigue jusqu'à /game en lecture seule.
+ * Aucune création, édition, suppression ou import n'est effectuée.
+ *
+ * Utiliser `E2E_FOUNDRY_WORLD` pour cibler le monde de production standant.
+ * Si la variable est absente, la fixture s'arrête après /setup sans entrer dans un monde.
+ */
+
+export const test = base.extend<{ smokeReady: void }>({
+  smokeReady: [
+    async ({ page }, use) => {
+      const options: FoundrySessionOptions = {
+        baseURL: process.env.E2E_FOUNDRY_BASE_URL ?? 'http://localhost:30000',
+        adminPassword: process.env.E2E_FOUNDRY_ADMIN_PASSWORD ?? '',
+        username: process.env.E2E_FOUNDRY_USERNAME ?? 'Gamemaster',
+        password: process.env.E2E_FOUNDRY_PASSWORD ?? '',
+        world: process.env.E2E_FOUNDRY_WORLD ?? '',
+      }
+
+      await setUpSmoke(page, options)
+
+      await use()
+
+      // Smoke prod : pas de tearDown destructif — retour soft à /setup seulement
+      await tearDownSmoke(page, options)
+    },
+    { auto: true },
+  ],
+})
+
+export { expect }
+
+/**
+ * Navigation légère jusqu'à /game pour les smoke tests.
+ * Gère /license → /auth → /setup → /join → /game.
+ * Ne crée ni ne supprime aucune donnée.
+ */
+async function setUpSmoke(page: import('@playwright/test').Page, options: FoundrySessionOptions): Promise<void> {
+  let url = page.url()
+
+  if (url.includes('about:blank')) {
+    await page.goto(`${options.baseURL}/auth`, { waitUntil: 'domcontentloaded' })
+    url = page.url()
+  }
+
+  if (url.includes('/game')) {
+    return
+  }
+
+  if (url.includes('/license')) {
+    url = await accepteLicense(page, options)
+  }
+
+  if (url.includes('/auth')) {
+    url = await loginIntoInstance(page, options)
+  }
+
+  if (url.includes('/setup') && options.world) {
+    url = await enterWorld(page, options)
+  }
+
+  if (url.includes('/join') && options.world) {
+    await dismissOverlayIfPresent(page)
+    url = await enterGameAsGamemaster(page, options)
+  }
+
+  if (options.world && !url.includes('/game')) {
+    throw new Error(`[smokeSetUp] Expected /game but got ${url}`)
+  }
+}
+
+/**
+ * Retour doux à /setup sans fermer le monde via shutDown().
+ * Les smoke tests ne doivent pas altérer l'état de l'instance de production.
+ */
+async function tearDownSmoke(page: import('@playwright/test').Page, options: FoundrySessionOptions): Promise<void> {
+  try {
+    const url = page.url()
+    if (!url.includes('/setup') && !url.includes('/auth')) {
+      await page.goto(`${options.baseURL}/setup`, { waitUntil: 'domcontentloaded', timeout: 10000 }).catch(() => {})
+    }
+  } catch {
+    // Cleanup best-effort : ne pas faire échouer le test
+  }
+}

--- a/e2e/smoke/global-setup.ts
+++ b/e2e/smoke/global-setup.ts
@@ -1,0 +1,52 @@
+import { chromium, FullConfig } from '@playwright/test'
+import dotenv from 'dotenv'
+
+dotenv.config({ path: process.env.E2E_ENV_FILE || '.env.e2e.smoke.prod' })
+
+/**
+ * Global setup des smoke tests.
+ *
+ * Vérifie que l'instance Foundry est accessible et que les variables
+ * d'environnement sont chargées avant de lancer les 9 specs.
+ *
+ * Fail-fast : si l'instance est inaccessible ou les vars manquantes,
+ * on échoue immédiatement avec un message clair au lieu de laisser
+ * les 9 tests pendre jusqu'au timeout de 60 s chacun.
+ *
+ * Exécuté une seule fois avant tous les smoke tests.
+ */
+export default async function globalSetup(_config: FullConfig): Promise<void> {
+  const baseURL = process.env.E2E_FOUNDRY_BASE_URL || 'http://localhost:30000'
+  const adminPassword = process.env.E2E_FOUNDRY_ADMIN_PASSWORD || ''
+
+  if (!adminPassword) {
+    throw new Error(
+      '[smokeSetup] E2E_FOUNDRY_ADMIN_PASSWORD non défini.\n' +
+        "  → Copier .env.e2e.smoke.prod.example en .env.e2e.smoke.prod et remplir les valeurs.",
+    )
+  }
+
+  console.log(`[smokeSetup] Instance: ${baseURL}`)
+  console.log(`[smokeSetup] Monde cible: "${process.env.E2E_FOUNDRY_WORLD || '(non défini — smoke sur /setup uniquement)'}"`)
+
+  // Vérification de connectivité légère — pas de création ni mutation
+  const browser = await chromium.launch({ headless: true })
+  const page = await browser.newPage()
+
+  try {
+    const response = await page
+      .goto(`${baseURL}/auth`, { waitUntil: 'domcontentloaded', timeout: 15000 })
+      .catch(() => null)
+
+    if (!response || (!response.ok() && response.status() !== 302)) {
+      throw new Error(
+        `[smokeSetup] Instance inaccessible sur ${baseURL}/auth (statut: ${response?.status() ?? 'aucun'}).\n` +
+          `  → Vérifier que Foundry tourne sur ce port.`,
+      )
+    }
+
+    console.log('[smokeSetup] ✅ Instance accessible — prêt pour les smoke tests')
+  } finally {
+    await browser.close()
+  }
+}

--- a/package.json
+++ b/package.json
@@ -22,6 +22,8 @@
     "e2e:regression": "playwright test --config playwright.regression.config.ts",
     "e2e:regression:headed": "playwright test --config playwright.regression.config.ts --headed",
     "e2e:regression:ui": "playwright test --config playwright.regression.config.ts --ui",
+    "e2e:smoke": "playwright test --config playwright.smoke.config.ts",
+    "e2e:smoke:headed": "playwright test --config playwright.smoke.config.ts --headed",
     "fmt": "prettier --write .",
     "fmt:check": "prettier --check .",
     "foundry:e2e:start": "bash ./scripts/e2e-foundry-start.sh start",

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "@semantic-release/git": "^10.0.1",
     "@semantic-release/github": "^11.0.3",
     "@semantic-release/release-notes-generator": "^14.0.3",
+    "@types/node": "^25.9.1",
     "@vitest/coverage-v8": "^3.1.1",
     "commander": "^11.1.0",
     "dotenv": "^17.2.3",
@@ -63,6 +64,7 @@
     "prettier-plugin-handlebars": "^0.0.1",
     "rollup": "^4.41.1",
     "semantic-release": "^24.2.5",
+    "typescript": "^6.0.3",
     "vitest": "^3.1.1"
   },
   "author": "Behaska",

--- a/playwright.smoke.config.ts
+++ b/playwright.smoke.config.ts
@@ -10,6 +10,7 @@ const baseURL = process.env.E2E_FOUNDRY_BASE_URL || 'http://localhost:30000'
 
 export default defineConfig({
   testDir: './e2e/smoke',
+  globalSetup: './e2e/smoke/global-setup.ts',
   workers: 1,
   // Délais courts : les smoke tests doivent rester rapides et non-destructifs
   timeout: process.env.PLAYWRIGHT_TEST_TIMEOUT ? parseInt(process.env.PLAYWRIGHT_TEST_TIMEOUT) : 60000,

--- a/playwright.smoke.config.ts
+++ b/playwright.smoke.config.ts
@@ -1,0 +1,43 @@
+import { defineConfig, devices } from '@playwright/test'
+import * as dotenv from 'dotenv'
+
+// Configuration smoke prod : instance de production sur port 30000
+// Exécution manuelle uniquement, post-déploiement, depuis une machine locale adaptée.
+// Aucune mutation du monde — lecture seule stricte.
+dotenv.config({ path: process.env.E2E_ENV_FILE || '.env.e2e.smoke.prod' })
+
+const baseURL = process.env.E2E_FOUNDRY_BASE_URL || 'http://localhost:30000'
+
+export default defineConfig({
+  testDir: './e2e/smoke',
+  workers: 1,
+  // Délais courts : les smoke tests doivent rester rapides et non-destructifs
+  timeout: process.env.PLAYWRIGHT_TEST_TIMEOUT ? parseInt(process.env.PLAYWRIGHT_TEST_TIMEOUT) : 60000,
+  expect: {
+    timeout: process.env.PLAYWRIGHT_EXPECT_TIMEOUT ? parseInt(process.env.PLAYWRIGHT_EXPECT_TIMEOUT) : 15000,
+  },
+  use: {
+    baseURL,
+    trace: 'retain-on-failure',
+    screenshot: 'only-on-failure',
+    video: 'retain-on-failure',
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: {
+        ...devices['Desktop Chrome'],
+        viewport: { width: 1920, height: 1080 },
+        actionTimeout: 15000,
+        launchOptions: {
+          args: ['--disable-blink-features=AutomationControlled', '--disable-features=IsolateOrigins,site-per-process'],
+        },
+        contextOptions: {
+          acceptDownloads: false,
+        },
+      },
+    },
+  ],
+  reporter: 'list',
+  retries: 0,
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -31,25 +31,28 @@ importers:
         version: 6.0.2(rollup@4.41.1)
       '@semantic-release/changelog':
         specifier: ^6.0.3
-        version: 6.0.3(semantic-release@24.2.5)
+        version: 6.0.3(semantic-release@24.2.5(typescript@6.0.3))
       '@semantic-release/commit-analyzer':
         specifier: ^13.0.1
-        version: 13.0.1(semantic-release@24.2.5)
+        version: 13.0.1(semantic-release@24.2.5(typescript@6.0.3))
       '@semantic-release/exec':
         specifier: ^7.1.0
-        version: 7.1.0(semantic-release@24.2.5)
+        version: 7.1.0(semantic-release@24.2.5(typescript@6.0.3))
       '@semantic-release/git':
         specifier: ^10.0.1
-        version: 10.0.1(semantic-release@24.2.5)
+        version: 10.0.1(semantic-release@24.2.5(typescript@6.0.3))
       '@semantic-release/github':
         specifier: ^11.0.3
-        version: 11.0.3(semantic-release@24.2.5)
+        version: 11.0.3(semantic-release@24.2.5(typescript@6.0.3))
       '@semantic-release/release-notes-generator':
         specifier: ^14.0.3
-        version: 14.0.3(semantic-release@24.2.5)
+        version: 14.0.3(semantic-release@24.2.5(typescript@6.0.3))
+      '@types/node':
+        specifier: ^25.9.1
+        version: 25.9.1
       '@vitest/coverage-v8':
         specifier: ^3.1.1
-        version: 3.1.1(vitest@3.1.1(less@4.4.2))
+        version: 3.1.1(vitest@3.1.1(@types/node@25.9.1)(less@4.4.2))
       commander:
         specifier: ^11.1.0
         version: 11.1.0
@@ -103,10 +106,13 @@ importers:
         version: 4.41.1
       semantic-release:
         specifier: ^24.2.5
-        version: 24.2.5
+        version: 24.2.5(typescript@6.0.3)
+      typescript:
+        specifier: ^6.0.3
+        version: 6.0.3
       vitest:
         specifier: ^3.1.1
-        version: 3.1.1(less@4.4.2)
+        version: 3.1.1(@types/node@25.9.1)(less@4.4.2)
 
 packages:
 
@@ -735,6 +741,9 @@ packages:
 
   '@types/json5@0.0.29':
     resolution: {integrity: sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==}
+
+  '@types/node@25.9.1':
+    resolution: {integrity: sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg==}
 
   '@types/normalize-package-data@2.4.4':
     resolution: {integrity: sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==}
@@ -3272,6 +3281,11 @@ packages:
     resolution: {integrity: sha512-3KS2b+kL7fsuk/eJZ7EQdnEmQoaho/r6KUef7hxvltNA5DR8NAUM+8wJMbJyZ4G9/7i3v5zPBIMN5aybAh2/Jg==}
     engines: {node: '>= 0.4'}
 
+  typescript@6.0.3:
+    resolution: {integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
   uglify-js@3.19.3:
     resolution: {integrity: sha512-v3Xu+yuwBXisp6QYTcH4UbH+xYJXqnq2m/LtQVWKWzYc1iehYnLixoQDN9FH6/j9/oybfd6W9Ghwkl8+UMKTKQ==}
     engines: {node: '>=0.8.0'}
@@ -3292,6 +3306,9 @@ packages:
   undertaker@2.0.0:
     resolution: {integrity: sha512-tO/bf30wBbTsJ7go80j0RzA2rcwX6o7XPBpeFcb+jzoeb4pfMM2zUeSDIkY1AWqeZabWxaQZ/h8N9t35QKDLPQ==}
     engines: {node: '>=10.13.0'}
+
+  undici-types@7.24.6:
+    resolution: {integrity: sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==}
 
   unicode-emoji-modifier-base@1.0.0:
     resolution: {integrity: sha512-yLSH4py7oFH3oG/9K+XWrz1pSi3dfUrWEnInbxMfArOfc1+33BlGPQtLsOYwvdMy11AwUBetYuaRxSPqgkq+8g==}
@@ -3961,15 +3978,15 @@ snapshots:
 
   '@sec-ant/readable-stream@0.4.1': {}
 
-  '@semantic-release/changelog@6.0.3(semantic-release@24.2.5)':
+  '@semantic-release/changelog@6.0.3(semantic-release@24.2.5(typescript@6.0.3))':
     dependencies:
       '@semantic-release/error': 3.0.0
       aggregate-error: 3.1.0
       fs-extra: 11.3.0
       lodash: 4.17.21
-      semantic-release: 24.2.5
+      semantic-release: 24.2.5(typescript@6.0.3)
 
-  '@semantic-release/commit-analyzer@13.0.1(semantic-release@24.2.5)':
+  '@semantic-release/commit-analyzer@13.0.1(semantic-release@24.2.5(typescript@6.0.3))':
     dependencies:
       conventional-changelog-angular: 8.0.0
       conventional-changelog-writer: 8.1.0
@@ -3979,7 +3996,7 @@ snapshots:
       import-from-esm: 2.0.0
       lodash-es: 4.17.21
       micromatch: 4.0.8
-      semantic-release: 24.2.5
+      semantic-release: 24.2.5(typescript@6.0.3)
     transitivePeerDependencies:
       - supports-color
 
@@ -3987,7 +4004,7 @@ snapshots:
 
   '@semantic-release/error@4.0.0': {}
 
-  '@semantic-release/exec@7.1.0(semantic-release@24.2.5)':
+  '@semantic-release/exec@7.1.0(semantic-release@24.2.5(typescript@6.0.3))':
     dependencies:
       '@semantic-release/error': 4.0.0
       aggregate-error: 3.1.0
@@ -3995,11 +4012,11 @@ snapshots:
       execa: 9.6.0
       lodash-es: 4.17.21
       parse-json: 8.3.0
-      semantic-release: 24.2.5
+      semantic-release: 24.2.5(typescript@6.0.3)
     transitivePeerDependencies:
       - supports-color
 
-  '@semantic-release/git@10.0.1(semantic-release@24.2.5)':
+  '@semantic-release/git@10.0.1(semantic-release@24.2.5(typescript@6.0.3))':
     dependencies:
       '@semantic-release/error': 3.0.0
       aggregate-error: 3.1.0
@@ -4009,11 +4026,11 @@ snapshots:
       lodash: 4.17.21
       micromatch: 4.0.8
       p-reduce: 2.1.0
-      semantic-release: 24.2.5
+      semantic-release: 24.2.5(typescript@6.0.3)
     transitivePeerDependencies:
       - supports-color
 
-  '@semantic-release/github@11.0.3(semantic-release@24.2.5)':
+  '@semantic-release/github@11.0.3(semantic-release@24.2.5(typescript@6.0.3))':
     dependencies:
       '@octokit/core': 7.0.2
       '@octokit/plugin-paginate-rest': 13.0.1(@octokit/core@7.0.2)
@@ -4030,12 +4047,12 @@ snapshots:
       lodash-es: 4.17.21
       mime: 4.0.7
       p-filter: 4.1.0
-      semantic-release: 24.2.5
+      semantic-release: 24.2.5(typescript@6.0.3)
       url-join: 5.0.0
     transitivePeerDependencies:
       - supports-color
 
-  '@semantic-release/npm@12.0.1(semantic-release@24.2.5)':
+  '@semantic-release/npm@12.0.1(semantic-release@24.2.5(typescript@6.0.3))':
     dependencies:
       '@semantic-release/error': 4.0.0
       aggregate-error: 5.0.0
@@ -4048,11 +4065,11 @@ snapshots:
       rc: 1.2.8
       read-pkg: 9.0.1
       registry-auth-token: 5.1.0
-      semantic-release: 24.2.5
+      semantic-release: 24.2.5(typescript@6.0.3)
       semver: 7.7.1
       tempy: 3.1.0
 
-  '@semantic-release/release-notes-generator@14.0.3(semantic-release@24.2.5)':
+  '@semantic-release/release-notes-generator@14.0.3(semantic-release@24.2.5(typescript@6.0.3))':
     dependencies:
       conventional-changelog-angular: 8.0.0
       conventional-changelog-writer: 8.1.0
@@ -4064,7 +4081,7 @@ snapshots:
       into-stream: 7.0.0
       lodash-es: 4.17.21
       read-package-up: 11.0.0
-      semantic-release: 24.2.5
+      semantic-release: 24.2.5(typescript@6.0.3)
     transitivePeerDependencies:
       - supports-color
 
@@ -4082,11 +4099,15 @@ snapshots:
 
   '@types/json5@0.0.29': {}
 
+  '@types/node@25.9.1':
+    dependencies:
+      undici-types: 7.24.6
+
   '@types/normalize-package-data@2.4.4': {}
 
   '@types/resolve@1.20.2': {}
 
-  '@vitest/coverage-v8@3.1.1(vitest@3.1.1(less@4.4.2))':
+  '@vitest/coverage-v8@3.1.1(vitest@3.1.1(@types/node@25.9.1)(less@4.4.2))':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@bcoe/v8-coverage': 1.0.2
@@ -4100,7 +4121,7 @@ snapshots:
       std-env: 3.9.0
       test-exclude: 7.0.1
       tinyrainbow: 2.0.0
-      vitest: 3.1.1(less@4.4.2)
+      vitest: 3.1.1(@types/node@25.9.1)(less@4.4.2)
     transitivePeerDependencies:
       - supports-color
 
@@ -4111,13 +4132,13 @@ snapshots:
       chai: 5.2.0
       tinyrainbow: 2.0.0
 
-  '@vitest/mocker@3.1.1(vite@6.0.11(less@4.4.2))':
+  '@vitest/mocker@3.1.1(vite@6.0.11(@types/node@25.9.1)(less@4.4.2))':
     dependencies:
       '@vitest/spy': 3.1.1
       estree-walker: 3.0.3
       magic-string: 0.30.17
     optionalDependencies:
-      vite: 6.0.11(less@4.4.2)
+      vite: 6.0.11(@types/node@25.9.1)(less@4.4.2)
 
   '@vitest/pretty-format@3.1.1':
     dependencies:
@@ -4555,12 +4576,14 @@ snapshots:
 
   core-util-is@1.0.3: {}
 
-  cosmiconfig@9.0.0:
+  cosmiconfig@9.0.0(typescript@6.0.3):
     dependencies:
       env-paths: 2.2.1
       import-fresh: 3.3.1
       js-yaml: 4.1.0
       parse-json: 5.2.0
+    optionalDependencies:
+      typescript: 6.0.3
 
   cross-spawn@7.0.6:
     dependencies:
@@ -6374,15 +6397,15 @@ snapshots:
   sax@1.4.1:
     optional: true
 
-  semantic-release@24.2.5:
+  semantic-release@24.2.5(typescript@6.0.3):
     dependencies:
-      '@semantic-release/commit-analyzer': 13.0.1(semantic-release@24.2.5)
+      '@semantic-release/commit-analyzer': 13.0.1(semantic-release@24.2.5(typescript@6.0.3))
       '@semantic-release/error': 4.0.0
-      '@semantic-release/github': 11.0.3(semantic-release@24.2.5)
-      '@semantic-release/npm': 12.0.1(semantic-release@24.2.5)
-      '@semantic-release/release-notes-generator': 14.0.3(semantic-release@24.2.5)
+      '@semantic-release/github': 11.0.3(semantic-release@24.2.5(typescript@6.0.3))
+      '@semantic-release/npm': 12.0.1(semantic-release@24.2.5(typescript@6.0.3))
+      '@semantic-release/release-notes-generator': 14.0.3(semantic-release@24.2.5(typescript@6.0.3))
       aggregate-error: 5.0.0
-      cosmiconfig: 9.0.0
+      cosmiconfig: 9.0.0(typescript@6.0.3)
       debug: 4.4.0
       env-ci: 11.1.1
       execa: 9.6.0
@@ -6787,6 +6810,8 @@ snapshots:
       possible-typed-array-names: 1.0.0
       reflect.getprototypeof: 1.0.10
 
+  typescript@6.0.3: {}
+
   uglify-js@3.19.3:
     optional: true
 
@@ -6807,6 +6832,8 @@ snapshots:
       fast-levenshtein: 3.0.0
       last-run: 2.0.0
       undertaker-registry: 2.0.0
+
+  undici-types@7.24.6: {}
 
   unicode-emoji-modifier-base@1.0.0: {}
 
@@ -6890,13 +6917,13 @@ snapshots:
       replace-ext: 2.0.0
       teex: 1.0.1
 
-  vite-node@3.1.1(less@4.4.2):
+  vite-node@3.1.1(@types/node@25.9.1)(less@4.4.2):
     dependencies:
       cac: 6.7.14
       debug: 4.4.0
       es-module-lexer: 1.6.0
       pathe: 2.0.3
-      vite: 6.0.11(less@4.4.2)
+      vite: 6.0.11(@types/node@25.9.1)(less@4.4.2)
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -6911,19 +6938,20 @@ snapshots:
       - tsx
       - yaml
 
-  vite@6.0.11(less@4.4.2):
+  vite@6.0.11(@types/node@25.9.1)(less@4.4.2):
     dependencies:
       esbuild: 0.24.2
       postcss: 8.5.1
       rollup: 4.41.1
     optionalDependencies:
+      '@types/node': 25.9.1
       fsevents: 2.3.3
       less: 4.4.2
 
-  vitest@3.1.1(less@4.4.2):
+  vitest@3.1.1(@types/node@25.9.1)(less@4.4.2):
     dependencies:
       '@vitest/expect': 3.1.1
-      '@vitest/mocker': 3.1.1(vite@6.0.11(less@4.4.2))
+      '@vitest/mocker': 3.1.1(vite@6.0.11(@types/node@25.9.1)(less@4.4.2))
       '@vitest/pretty-format': 3.1.1
       '@vitest/runner': 3.1.1
       '@vitest/snapshot': 3.1.1
@@ -6939,9 +6967,11 @@ snapshots:
       tinyexec: 0.3.2
       tinypool: 1.0.2
       tinyrainbow: 2.0.0
-      vite: 6.0.11(less@4.4.2)
-      vite-node: 3.1.1(less@4.4.2)
+      vite: 6.0.11(@types/node@25.9.1)(less@4.4.2)
+      vite-node: 3.1.1(@types/node@25.9.1)(less@4.4.2)
       why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 25.9.1
     transitivePeerDependencies:
       - jiti
       - less

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,14 +1,14 @@
 {
   "compilerOptions": {
-    "target": "ES2020", // ou ES2019 / ESNext, mais > ES2015
+    "target": "ES2020",
     "module": "commonjs",
     "moduleResolution": "node10",
     "ignoreDeprecations": "6.0",
-    "lib": ["ES2020", "DOM"], // apporte Promise, etc.
+    "lib": ["ES2020"],
     "strict": true,
     "esModuleInterop": true,
     "skipLibCheck": true,
-    "noEmit": true // on ne build pas les tests
+    "noEmit": true
   },
-  "include": ["**/*.ts"]
+  "include": ["*.config.ts"]
 }


### PR DESCRIPTION
Closes: none linked

## Contexte

- Ajoute une stratégie E2E à deux niveaux pour couvrir :
  - les tests de régression : suite complète, locale/Docker ;
  - une suite smoke en production : lecture seule, destinée à vérifier rapidement les surfaces critiques sur un Foundry live.

## Résumé des changements

- Ajout d'une nouvelle suite smoke :
  - `e2e/smoke/*.spec.ts`
  - fixtures associées
- Nouveau fichier de configuration Playwright :
  - `playwright.smoke.config.ts`
- Nouveaux scripts npm dans `package.json` :
  - `e2e:smoke`
  - `e2e:smoke:headed`
- Documentation :
  - plusieurs fichiers sous `documentation/` et `e2e/` expliquant la stratégie et le guide Playwright smoke/régression
- Ajout d'un exemple d'environnement :
  - `.env.e2e.smoke.prod.example`
- Petits ajustements liés à la documentation :
  - `.gitignore`
  - `AGENTS.md`
  - `CLAUDE.md`
  - `README.md`

## Notes techniques

- La suite smoke est conçue pour être **read-only**.
- Elle cible un Foundry distant, production ou staging, via les variables d'environnement décrites dans `.env.e2e.smoke.prod.example`.
- Aucune modification au code runtime dans `module/` n'est effectuée.
- Les changements sont centrés sur :
  - les tests ;
  - la documentation ;
  - les scripts d'exécution E2E.

## Tests exécutés

Aucune validation `lint`, `test` ou `build` n'a été exécutée lors de la création de cette PR.

Les deux commits inclus sont :

- `feat(e2e): add two-tier E2E strategy — regression + smoke prod`
- `docs(e2e): update E2E testing strategy to include two-tier approach`

## Known limits / Points d'attention

- La suite smoke dépend :
  - d'un Foundry accessible ;
  - de variables d'environnement configurées.
- La configuration doit être fournie par l'équipe d'infra avant utilisation.
- Vérifier que les nouveaux scripts n'entrent pas en conflit avec les workflows CI existants.
- `.env.e2e.smoke.prod.example` ne contient pas de secrets.
- Ne pas committer de vrais secrets dans le repo.

## Recommandation

Lancer la suite smoke manuellement contre un environnement de staging avant d'ajouter un job CI automatisé pointant vers la production.

## Fichiers clés modifiés — extrait

- `e2e/smoke/01-health.spec.ts`
- `e2e/smoke/02-surfaces.spec.ts`
- `e2e/smoke/fixtures.ts`
- `playwright.smoke.config.ts`
- `package.json` — scripts
- `.env.e2e.smoke.prod.example`
- `documentation/tests/e2e/playwright-e2e-guide.md`