### PR TITLE
feat(e2e): add interaction contract ADR and centralized browser error capture

### DIFF
--- a/documentation/INDEX.md
+++ b/documentation/INDEX.md
@@ -13,7 +13,7 @@ Cette documentation technique couvre l'architecture, les modules, les exigences,
 | [OVERVIEW.md](./architecture/OVERVIEW.md)                  | Architecture globale du système swerpg                |
 | [MODELS.md](./architecture/MODELS.md)                      | Modèles de données (TypeDataModel, acteurs, etc.)     |
 | Dossiers détaillés                                         |                                                       |
-| [`architecture/adr/`](./architecture/adr/)                 | Architecture Decision Records (ADR-0001 → 0008)       |
+| [`architecture/adr/`](./architecture/adr/)                 | Architecture Decision Records (ADR-0001 → 0017)       |
 | [`architecture/core/`](./architecture/core/)               | Cœur système, entrypoints, configuration              |
 | [`architecture/data/`](./architecture/data/)               | Modèles de données, schémas et persistance            |
 | [`architecture/integration/`](./architecture/integration/) | Intégrations Foundry, hooks, API externes             |
@@ -87,6 +87,15 @@ Cette documentation technique couvre l'architecture, les modules, les exigences,
 | [TESTING_GUIDE_specialization_ui_fix.md](./TESTING_GUIDE_specialization_ui_fix.md) | Guide de tests pour la correction UI des spécialisations |
 | [TESTS_COVERAGE_IMPROVEMENT.md](./TESTS_COVERAGE_IMPROVEMENT.md)                   | Stratégie d'amélioration de la couverture de tests       |
 | [item-sheet-creation-guide.md](./item-sheet-creation-guide.md)                     | Guide de création de fiches d'objet                      |
+
+### Tests E2E Playwright
+
+| Document                                                                                                                                                                                | Description                                                                   |
+| --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------- |
+| [playwright-e2e-guide.md](./tests/e2e/playwright-e2e-guide.md)                                                                                                                         | Guide complet E2E : prérequis, config, structure, contrat, checklist          |
+| [e2e/README.md](../e2e/README.md)                                                                                                                                                       | Vue rapide, contrat d'interaction, checklist spec                             |
+| [ADR-0017](./architecture/adr/adr-0017-e2e-playwright-interaction-contract-and-browser-error-capture.md)                                                                                | Décision architecture : contrat d'interaction et capture erreurs navigateur   |
+| [playwright-spec-squelette-mon-parcours.md](./tests/e2e/playwright-spec-squelette-mon-parcours.md)                                                                                      | Squelette de spec E2E prêt à l'emploi                                         |
 
 ## 🔍 Recherche Rapide
 

--- a/documentation/architecture/OVERVIEW.md
+++ b/documentation/architecture/OVERVIEW.md
@@ -141,6 +141,34 @@ Ce dossier décrit la façon dont swerpg s’intègre à Foundry et comment le s
 - [Performance Optimization](integration/PERFORMANCE.md)
 - [Security Guidelines](integration/SECURITY.md)
 
+## 🧪 Stratégie de Tests
+
+### Niveaux de test
+
+| Niveau | Framework | Périmètre | Commande |
+|---|---|---|---|
+| **Unitaire / Intégration** | Vitest | `module/lib/` (pur domaine) + adapters Foundry mockés | `pnpm test` |
+| **E2E — Regression** | Playwright | Workflows fonctionnels complets sur instance dédiée | `pnpm e2e:regression` |
+| **E2E — Smoke** | Playwright | Vérification de surface lecture-seule sur instance prod | `pnpm e2e:smoke` |
+
+### Contrat E2E (ADR-0017)
+
+Toute spec Playwright doit :
+
+- Importer les fixtures de la suite (`../../fixtures` regression / `./fixtures` smoke).
+- N'ajouter aucun listener `page.on('console')` ou `page.on('pageerror')` — les fixtures branchent automatiquement `createBrowserErrorCollector` et appellent `assertNoErrors` en fin de test.
+- Passer par les helpers centralisés (`foundryUI.ts`, `foundrySession.ts`, `playwrightTest.ts`) pour toute interaction critique avec Foundry.
+- Utiliser des assertions web-first, pas de `waitForTimeout`.
+
+### Références
+
+- [Stratégie de tests](../strategie-tests.md)
+- [Guide Playwright E2E](../tests/e2e/playwright-e2e-guide.md)
+- [ADR-0004 — Stratégie Vitest](./adr/adr-0004-vitest-testing-strategy.md)
+- [ADR-0017 — Contrat E2E et capture erreurs navigateur](./adr/adr-0017-e2e-playwright-interaction-contract-and-browser-error-capture.md)
+
+---
+
 ## 🚀 Démarrage Rapide
 
 ### Pour les Développeurs

--- a/documentation/architecture/adr/adr-0017-e2e-playwright-interaction-contract-and-browser-error-capture.md
+++ b/documentation/architecture/adr/adr-0017-e2e-playwright-interaction-contract-and-browser-error-capture.md
@@ -1,0 +1,115 @@
+---
+title: "ADR-0017: Contrat d'interaction E2E et capture centralisée des erreurs navigateur"
+status: "Accepted"
+date: "2026-05-24"
+authors: "Hervé Darritchon, Architecture Team"
+tags: ["architecture", "testing", "e2e", "playwright", "quality", "browser-errors"]
+supersedes: ""
+superseded_by: ""
+---
+
+## Status
+
+**Accepted** — Implémenté dans le cadre de l'issue #368 (PWE2). Applicable à toutes les specs E2E Playwright du projet.
+
+## Context
+
+Le projet dispose d'une suite E2E Playwright à deux niveaux :
+
+- **Tier 1 — Regression** (`e2e/regression/specs/`) : validation fonctionnelle pré-livraison, instance dédiée port 31001.
+- **Tier 2 — Smoke** (`e2e/smoke/`) : vérification de surface lecture-seule sur l'instance de production port 30000.
+
+Avant cette décision, chaque spec pouvait brancher ses propres listeners `page.on('console')` et `page.on('pageerror')` de façon ad hoc. La conséquence était :
+
+- détection des erreurs navigateur **non garantie** sur les specs qui ne l'implémentaient pas ;
+- duplication de logique de filtrage entre specs ;
+- patterns incohérents selon les auteurs (listener local vs fixture, reset oublié, filtres différents) ;
+- helpers d'interaction (Settings, session Foundry) réimplémantés dans certains tests plutôt que partagés.
+
+Il manquait un contrat explicite définissant ce que chaque spec **doit** et **ne doit pas** faire.
+
+## Decision
+
+### 1. Capture centralisée des erreurs navigateur
+
+Un utilitaire unique `e2e/utils/browserErrors.ts` expose `createBrowserErrorCollector(page)`.
+
+- Écoute `console.error` et `pageerror` dès l'appel.
+- Filtre automatiquement les bruits connus (`KNOWN_NOISE_PATTERNS`) : favicon, chrome-extension, moz-extension, modules Foundry manquants.
+- Expose `assertNoErrors(context?)` — lève une erreur Playwright si une erreur non filtrée a été captée.
+- Expose `reset()` — vide le buffer (utilisé par les fixtures entre setUp et début du test).
+
+### 2. Branchement automatique dans les fixtures
+
+Les fixtures `worldReady` (`e2e/fixtures/index.ts`) et `smokeReady` (`e2e/smoke/fixtures.ts`) :
+
+1. Créent un collecteur (`createBrowserErrorCollector`) **avant** le setUp.
+2. Appellent `reset()` après que le setUp est terminé (purge les erreurs de démarrage connues).
+3. Appellent `assertNoErrors` dans le `use` post-test — l'assertion fait échouer le test si une erreur non autorisée a été captée pendant le scénario.
+
+Pour `smokeReady`, l'assertion est conditionnelle : elle ne s'exécute que si le monde est configuré et que la page est en `/game` (pour ne pas faire échouer des runs smoke partiels où le monde n'est pas prêt).
+
+### 3. Contrat d'interaction partagé
+
+Toutes les interactions critiques avec Foundry VTT doivent passer par les helpers communs :
+
+| Besoin | Helper | Fichier |
+|---|---|---|
+| Bootstrap complet (licence → auth → setup → join → game) | `setUp` / `tearDown` | `e2e/utils/playwrightTest.ts` |
+| Vérifier session active `/game` | `ensureSessionActive` | `e2e/utils/foundryUI.ts` |
+| Ouvrir l'onglet Game Settings | `openGameSettings` | `e2e/utils/foundryUI.ts` |
+| Naviguer vers settings d'un système | `navigateToSystemSettings` | `e2e/utils/foundryUI.ts` |
+| Ouvrir le dialog OggDude | `openOggDudeImporterDialog` | `e2e/regression/utils/oggdude-importer.ts` |
+| Capturer les erreurs navigateur | `createBrowserErrorCollector` | `e2e/utils/browserErrors.ts` |
+
+Les helpers ne doivent pas être réimplémentés dans les specs. Si un helper manque, il doit être ajouté dans le fichier centralisé.
+
+### 4. Règles négatives (interdits dans les specs)
+
+- Pas de `page.on('console')` ou `page.on('pageerror')` ad hoc dans les specs — la fixture s'en charge.
+- Pas de `waitForTimeout` pour la synchronisation — assertions web-first uniquement.
+- Pas de `click({ force: true })` sans justification écrite dans la spec.
+- Pas d'import de fixture locale — toujours utiliser `../../fixtures` (regression) ou `./fixtures` (smoke).
+
+### 5. Politique d'évolution de `KNOWN_NOISE_PATTERNS`
+
+Chaque ajout à la liste de filtrage dans `browserErrors.ts` **doit** être accompagné d'un commentaire expliquant pourquoi ce bruit est ignoré. La liste ne doit jamais être élargie pour masquer une vraie régression.
+
+## Consequences
+
+### Positive
+
+- **POS-001** : Détection des erreurs navigateur **garantie** pour toutes les specs regression et legacy sans code additionnel dans chaque spec.
+- **POS-002** : Zéro duplication de logique de capture/filtrage entre specs.
+- **POS-003** : Contrat explicite et documenté — une nouvelle spec sait exactement ce qu'elle doit et ne doit pas faire (checklist dans `e2e/README.md` et `playwright-e2e-guide.md` §6).
+- **POS-004** : Interactions critiques Foundry centralisées — maintenabilité améliorée lors d'évolutions de l'UI Foundry.
+- **POS-005** : Specs plus courtes et plus lisibles — pas de boilerplate de gestion d'erreurs navigateur.
+
+### Negative
+
+- **NEG-001** : Un test qui recharge la page dans son scénario doit gérer manuellement le reset du collecteur (cas documenté dans `playwright-e2e-guide.md` §6.2).
+- **NEG-002** : La liste `KNOWN_NOISE_PATTERNS` doit être maintenue — tout nouveau bruit non filtré fait échouer les tests, ce qui nécessite une investigation avant d'ajouter un filtre.
+- **NEG-003** : L'assertion `assertNoErrors` de `smokeReady` est conditionnelle, ce qui réduit légèrement la couverture de détection dans les runs smoke partiels.
+
+## Alternatives Considered
+
+### Listener ad hoc par spec
+
+- **Rejection reason** : duplication, couverture non garantie, patterns divergents entre auteurs.
+
+### Assertion globale dans `afterAll` uniquement
+
+- **Rejection reason** : trop tardif — des erreurs de milieu de test seraient masquées si d'autres steps nettoient l'état.
+
+### Collecteur dans `beforeEach` Playwright global (playwright.config)
+
+- **Rejection reason** : ne fonctionne pas correctement avec les fixtures Playwright qui gèrent leur propre cycle de vie de page — mélange de responsabilités.
+
+## References
+
+- **REF-001** : [browserErrors.ts](../../../e2e/utils/browserErrors.ts) — implémentation du collecteur
+- **REF-002** : [e2e/fixtures/index.ts](../../../e2e/fixtures/index.ts) — fixture worldReady
+- **REF-003** : [e2e/smoke/fixtures.ts](../../../e2e/smoke/fixtures.ts) — fixture smokeReady
+- **REF-004** : [playwright-e2e-guide.md §6](../../tests/e2e/playwright-e2e-guide.md) — guide complet (contrat + checklist)
+- **REF-005** : [e2e/README.md](../../../e2e/README.md) — checklist rapide
+- **REF-006** : Issue #368 — PWE2 : fiabiliser les contrats d'interaction et la capture d'erreurs navigateur

--- a/documentation/plan/tests/368-pwe2-fiabiliser-les-contrats-d-interaction-et-la-capture-d-erreurs-navigateur.md
+++ b/documentation/plan/tests/368-pwe2-fiabiliser-les-contrats-d-interaction-et-la-capture-d-erreurs-navigateur.md
@@ -1,0 +1,108 @@
+# Plan d'implémentation — Issue #368
+
+**Issue** : [#368 — PWE2 - [Tier 1 Regression] Fiabiliser les contrats d'interaction et la capture d'erreurs navigateur](https://github.com/herveDarritchon/foundryvtt-swerpg/issues/368)
+**Dépendances** : [#366 — Playwright Local Foundry Smoke Tests - Sécuriser les parcours MJ essentiels en local](https://github.com/herveDarritchon/foundryvtt-swerpg/issues/366), [#367 — PWE1 - Stabiliser la baseline locale Playwright et le monde E2E](https://github.com/herveDarritchon/foundryvtt-swerpg/issues/367)
+**Domaine métier** : `tests`
+**Source de cadrage** :
+
+- `documentation/plan/tests/366-playwright-local-foundry-smoke-tests-securiser-les-parcours-mj-essentiels-en-local.md`
+- `documentation/plan/tests/367-pwe1-stabiliser-la-baseline-locale-playwright-et-le-monde-e2e.md`
+- `documentation/plan/tests/e2e/strategie-contrat-commandes-e2e-smoke-regression.md`
+
+---
+
+## 1. Objectif
+
+Fiabiliser les interactions Playwright utilisées par les scénarios de régression Tier 1 et rendre toute erreur navigateur inattendue immédiatement visible, afin de réduire la flakiness et d'améliorer le diagnostic des régressions UI Foundry/SWERPG.
+
+---
+
+## 2. Périmètre
+
+### Inclus
+
+- contrat d'interaction commun pour les helpers Playwright critiques ;
+- capture centralisée des erreurs `console` et `pageerror` non autorisées ;
+- adoption de ces garde-fous dans les specs Tier 1 prioritaires ;
+- documentation courte des règles d'usage pour les futures specs.
+
+### Exclu
+
+- ajout d'une large nouvelle couverture métier hors Tier 1 ;
+- refonte complète de toute l'arborescence E2E sans besoin direct ;
+- changements runtime applicatifs hors besoins stricts des tests Playwright.
+
+---
+
+## 3. Plan de travail proposé
+
+### Étape 1 — Formaliser le contrat d'interaction partagé
+
+**But** : supprimer les interactions fragiles dispersées et imposer des helpers de navigation/action cohérents.
+
+**Fichiers cibles** : `e2e/utils/foundrySession.ts`, `e2e/utils/foundryUI.ts`, `e2e/fixtures/index.ts`
+
+**Actions** :
+
+- identifier les interactions Tier 1 réellement critiques à centraliser ;
+- privilégier des helpers fondés sur rôles, labels et attentes explicites plutôt que des sélecteurs décoratifs ;
+- intégrer des garde-fous de synchronisation et des messages d'échec lisibles.
+
+### Étape 2 — Brancher une capture d'erreurs navigateur centralisée
+
+**But** : faire échouer rapidement les scénarios quand le navigateur remonte une régression significative.
+
+**Fichiers cibles** : `e2e/utils/playwrightTest.ts`, `e2e/fixtures/index.ts`, éventuels helpers partagés sous `e2e/utils/`
+
+**Actions** :
+
+- capturer de façon homogène les erreurs `console` et `pageerror` inattendues ;
+- définir une politique explicite de filtrage/whitelist minimale pour les bruits connus et maîtrisés ;
+- enrichir le reporting pour rattacher clairement l'erreur au scénario en échec.
+
+### Étape 3 — Migrer les scénarios Tier 1 prioritaires vers ce contrat
+
+**But** : appliquer immédiatement le contrat sur les parcours de régression qui doivent devenir la baseline fiable.
+
+**Fichiers cibles** : specs Tier 1 sous `e2e/regression/**` et/ou `e2e/specs/**`, helpers partagés sous `e2e/utils/`
+
+**Actions** :
+
+- remplacer les interactions fragiles des scénarios prioritaires par les helpers centralisés ;
+- vérifier que les scénarios échouent bien sur erreur navigateur non autorisée ;
+- conserver des scénarios courts, diagnostiquables et compatibles avec la baseline locale définie par `PWE1`.
+
+### Étape 4 — Documenter le contrat et les critères de clôture
+
+**But** : éviter le retour de patterns fragiles lors de l'ajout de nouvelles specs.
+
+**Fichiers cibles** : `e2e/README.md`, `documentation/tests/e2e/playwright-e2e-guide.md`
+
+**Actions** :
+
+- documenter quels helpers doivent être utilisés pour les interactions critiques ;
+- expliciter la règle de traitement des erreurs navigateur et des exceptions tolérées ;
+- ajouter une checklist courte pour toute nouvelle spec de régression Tier 1.
+
+---
+
+## 4. Ordre recommandé
+
+1. Contrat d'interaction partagé
+2. Capture d'erreurs navigateur
+3. Migration des scénarios Tier 1 prioritaires
+4. Documentation et critères de clôture
+
+---
+
+## 5. Validation prévue (non exécutée dans ce plan)
+
+- exécution ciblée des specs Tier 1 concernées ;
+- vérification qu'une erreur `console` / `pageerror` non autorisée fait bien échouer la spec ;
+- relecture croisée helpers ↔ fixtures ↔ documentation pour confirmer un contrat unique et explicite.
+
+---
+
+## 6. Résultat attendu
+
+Les scénarios Playwright Tier 1 reposent sur un contrat d'interaction stable, détectent explicitement les erreurs navigateur inattendues, et fournissent des diagnostics plus rapides en cas de régression locale ou pré-livraison.

--- a/documentation/plan/tests/e2e/368-pwe2-fiabiliser-les-contrats-d-interaction-et-la-capture-d-erreurs-navigateur.md
+++ b/documentation/plan/tests/e2e/368-pwe2-fiabiliser-les-contrats-d-interaction-et-la-capture-d-erreurs-navigateur.md
@@ -1,0 +1,130 @@
+# Plan d'implementation - Issue #368
+
+**Issue** : [#368 - PWE2 - [Tier 1 Regression] Fiabiliser les contrats d'interaction et la capture d'erreurs navigateur](https://github.com/herveDarritchon/foundryvtt-swerpg/issues/368)
+**Dependances** : [#366 - Playwright Local Foundry Smoke Tests - Securiser les parcours MJ essentiels en local](https://github.com/herveDarritchon/foundryvtt-swerpg/issues/366), [#367 - PWE1 - Stabiliser la baseline locale Playwright et le monde E2E](https://github.com/herveDarritchon/foundryvtt-swerpg/issues/367)
+**Domaine metier** : `tests/e2e`
+**Source de cadrage** :
+
+- `documentation/plan/tests/366-playwright-local-foundry-smoke-tests-securiser-les-parcours-mj-essentiels-en-local.md`
+- `documentation/plan/tests/367-pwe1-stabiliser-la-baseline-locale-playwright-et-le-monde-e2e.md`
+- `documentation/plan/tests/e2e/strategie-contrat-commandes-e2e-smoke-regression.md`
+
+---
+
+## 1. Objectif
+
+Fiabiliser les interactions Playwright utilisees par les scenarios de regression Tier 1 et les specs legacy encore actives, puis rendre toute erreur navigateur inattendue immediatement visible afin de reduire la flakiness et d'accelerer le diagnostic des regressions UI Foundry/SWERPG.
+
+---
+
+## 2. Perimetre
+
+### Inclus
+
+- contrat d'interaction commun pour les helpers Playwright critiques ;
+- capture centralisee des erreurs `console` et `pageerror` non autorisees ;
+- adoption de ces garde-fous dans les specs Tier 1 sous `e2e/regression/**` ;
+- adoption du meme contrat dans les specs legacy sous `e2e/specs/*.ts` tant qu'elles restent actives ;
+- documentation courte des regles d'usage pour les futures specs.
+
+### Exclu
+
+- ajout d'une large nouvelle couverture metier hors Tier 1 et hors specs legacy deja actives ;
+- refonte complete de toute l'arborescence E2E sans besoin direct ;
+- changements runtime applicatifs hors besoins stricts des tests Playwright.
+
+---
+
+## 3. Cible fonctionnelle
+
+Le meme contrat technique doit s'appliquer a deux zones tant qu'elles coexistent :
+
+- `e2e/regression/**` pour la baseline Tier 1 pre-livraison ;
+- `e2e/specs/*.ts` pour les specs legacy encore executees ou conservees comme reference.
+
+Ce contrat commun impose :
+
+- des helpers d'interaction centralises pour les etapes Foundry critiques ;
+- des attentes explicites sur la navigation et la disponibilite UI ;
+- une politique unique de capture et de filtrage des erreurs navigateur ;
+- des messages d'echec relisibles relies au scenario fautif.
+
+---
+
+## 4. Plan de travail propose
+
+### Etape 1 - Formaliser le contrat d'interaction partage
+
+**But** : supprimer les interactions fragiles dispersees et imposer des helpers de navigation/action coherents pour `regression` et `legacy`.
+
+**Fichiers cibles** : `e2e/utils/foundrySession.ts`, `e2e/utils/foundryUI.ts`, `e2e/utils/playwrightTest.ts`
+
+**Actions** :
+
+- identifier les interactions Tier 1 et legacy reellement critiques a centraliser ;
+- privilegier des helpers fondes sur roles, labels et attentes explicites plutot que des selecteurs decoratifs ;
+- integrer des garde-fous de synchronisation et des messages d'echec lisibles ;
+- verifier que les specs `e2e/specs/*.ts` utilisent elles aussi ces helpers au lieu de sequences locales ad hoc.
+
+### Etape 2 - Brancher une capture d'erreurs navigateur centralisee
+
+**But** : faire echouer rapidement tout scenario `regression` ou `legacy` quand le navigateur remonte une regression significative.
+
+**Fichiers cibles** : `e2e/fixtures/index.ts`, `e2e/utils/playwrightTest.ts`, eventuels helpers partages sous `e2e/utils/`
+
+**Actions** :
+
+- capturer de facon homogene les erreurs `console` et `pageerror` inattendues ;
+- definir une politique explicite de filtrage minimale pour les bruits connus et maitrises ;
+- enrichir le reporting pour rattacher clairement l'erreur a la spec en echec ;
+- appliquer ce branchement unique a la fixture partagee consommee par `e2e/specs/*.ts` et par les specs de regression qui importent deja `../../fixtures`.
+
+### Etape 3 - Migrer les scenarios Tier 1 et les specs legacy prioritaires vers ce contrat
+
+**But** : appliquer immediatement le contrat sur tous les parcours actuellement utilises comme baseline de confiance.
+
+**Fichiers cibles** : `e2e/regression/specs/**/*.ts`, `e2e/specs/*.ts`, helpers partages sous `e2e/utils/`
+
+**Actions** :
+
+- remplacer les interactions fragiles des scenarios prioritaires par les helpers centralises ;
+- verifier que chaque spec echoue bien sur erreur navigateur non autorisee ;
+- conserver des scenarios courts, diagnostiquables et compatibles avec la baseline locale definie par `PWE1` ;
+- reduire les divergences de comportement entre specs legacy et specs `regression` tant qu'elles reposent sur la meme fixture partagee.
+
+### Etape 4 - Documenter le contrat et les criteres de cloture
+
+**But** : eviter le retour de patterns fragiles lors de l'ajout ou de la maintenance de nouvelles specs.
+
+**Fichiers cibles** : `e2e/README.md`, `documentation/tests/e2e/playwright-e2e-guide.md`
+
+**Actions** :
+
+- documenter quels helpers doivent etre utilises pour les interactions critiques ;
+- expliciter la regle de traitement des erreurs navigateur et des exceptions tolerees ;
+- ajouter une checklist courte pour toute nouvelle spec `regression` ou spec legacy encore maintenue ;
+- rappeler que toute nouvelle spec doit converger vers le contrat partage, meme avant sa requalification structurelle.
+
+---
+
+## 5. Ordre recommande
+
+1. Contrat d'interaction partage
+2. Capture d'erreurs navigateur
+3. Migration des scenarios `regression` et `legacy`
+4. Documentation et criteres de cloture
+
+---
+
+## 6. Validation prevue
+
+- execution ciblee des specs Tier 1 concernees sous `e2e/regression/specs/` ;
+- execution ciblee des specs legacy encore actives sous `e2e/specs/*.ts` ;
+- verification qu'une erreur `console` ou `pageerror` non autorisee fait bien echouer chaque famille de specs ;
+- relecture croisee helpers <-> fixtures <-> documentation pour confirmer un contrat unique et explicite.
+
+---
+
+## 7. Resultat attendu
+
+Les scenarios Playwright Tier 1 sous `e2e/regression/**` et les specs legacy sous `e2e/specs/*.ts` reposent sur un meme contrat d'interaction stable, detectent explicitement les erreurs navigateur inattendues, et fournissent des diagnostics plus rapides en cas de regression locale ou pre-livraison.

--- a/documentation/strategie-tests.md
+++ b/documentation/strategie-tests.md
@@ -624,7 +624,7 @@ test('debug xml2js interface', () => {
 
 - **Unit Tests** : ~70% (logique métier isolée)
 - **Integration Tests** : ~25% (composants + interactions)
-- **End-to-End Tests** : ~5% (workflows complets)
+- **End-to-End Tests** : ~5% (workflows complets via Playwright — voir section dédiée ci-dessous)
 
 ## Migration et Évolution
 
@@ -636,7 +636,7 @@ test('debug xml2js interface', () => {
 
 ### Roadmap
 
-- **Phase 2** : Tests E2E avec Playwright
+- **Phase 2** : ✅ Tests E2E avec Playwright — implémenté (voir section dédiée ci-dessous)
 - **Phase 3** : Visual regression testing
 - **Phase 4** : Performance benchmarking
 
@@ -747,3 +747,52 @@ beforeEach(async () => {
 5. **Création diagrammes** - Visualisation architecture
 
 Cette documentation sert de référence complète pour comprendre, maintenir et faire évoluer la stratégie de test du système SweRPG.
+
+---
+
+## Tests E2E avec Playwright
+
+### Stratégie deux niveaux
+
+La suite E2E est organisée en deux tiers complémentaires :
+
+| Tier | Commande | Rôle | Instance | Mutations |
+|---|---|---|---|---|
+| Tier 1 — Regression | `pnpm e2e:regression` | Validation fonctionnelle pré-livraison | port 31001 (dédiée) | autorisées |
+| Tier 2 — Smoke | `pnpm e2e:smoke` | Vérification de surface post-déploiement | port 30000 (prod) | interdites |
+
+Les suites ne tournent pas en CI GitHub Actions (instance Foundry live requise). Seuls les tests marqués `[ci]` dans leur titre tournent en CI via `pnpm e2e:ci`.
+
+### Contrat d'interaction partagé
+
+Toutes les interactions critiques avec Foundry VTT passent par des helpers centralisés :
+
+| Helper | Fichier | Rôle |
+|---|---|---|
+| `setUp` / `tearDown` | `e2e/utils/playwrightTest.ts` | Bootstrap complet `licence → auth → setup → join → game` |
+| `ensureSessionActive` | `e2e/utils/foundryUI.ts` | Vérification session `/game` active |
+| `openGameSettings` | `e2e/utils/foundryUI.ts` | Ouverture onglet Settings |
+| `navigateToSystemSettings` | `e2e/utils/foundryUI.ts` | Navigation settings système |
+| `openOggDudeImporterDialog` | `e2e/regression/utils/oggdude-importer.ts` | Ouverture dialog OggDude |
+| `createBrowserErrorCollector` | `e2e/utils/browserErrors.ts` | Capture centralisée erreurs navigateur |
+
+Ne jamais réimplémenter ces helpers dans les specs. Si un helper manque, l'ajouter dans le fichier centralisé.
+
+### Capture centralisée des erreurs navigateur
+
+Les fixtures `worldReady` (regression/legacy) et `smokeReady` (smoke) branchent automatiquement un collecteur d'erreurs navigateur (`createBrowserErrorCollector`) avant le setUp. À la fin de chaque test, elles appellent `assertNoErrors` pour faire échouer explicitement si une erreur non autorisée a été captée.
+
+**Règle** : aucun listener `page.on('console')` ou `page.on('pageerror')` ad hoc dans les specs — la fixture s'en charge.
+
+Les bruits connus (favicon 404, extensions navigateur, modules Foundry absents du monde de test) sont filtrés via `KNOWN_NOISE_PATTERNS` dans `e2e/utils/browserErrors.ts`. Tout ajout à cette liste doit être justifié par un commentaire.
+
+### Décision d'architecture
+
+Cette stratégie est formalisée dans l'ADR correspondant :
+
+- [ADR-0017 — Contrat d'interaction E2E et capture centralisée des erreurs navigateur](./architecture/adr/adr-0017-e2e-playwright-interaction-contract-and-browser-error-capture.md)
+
+### Documentation de référence
+
+- [Guide complet Playwright E2E](./tests/e2e/playwright-e2e-guide.md) — prérequis, configuration, structure, contrat, checklist, troubleshooting
+- [e2e/README.md](../e2e/README.md) — vue rapide et checklist spec

--- a/documentation/tests/e2e/playwright-e2e-guide.md
+++ b/documentation/tests/e2e/playwright-e2e-guide.md
@@ -327,7 +327,7 @@ La fixture principale (par convention nommée `worldReady`) se charge de :
 - filtrer et lancer le monde Swerpg ciblé (`enterWorld`),
 - rejoindre la partie en tant que MJ (`enterGameAsGamemaster`).
 
-Ces opérations sont implémentées dans `e2e/utils/foundrySession.ts` et orchestrées par `e2e/utils/e2eTest.ts`.
+Ces opérations sont implémentées dans `e2e/utils/foundrySession.ts` et orchestrées par `e2e/utils/playwrightTest.ts`.
 
 En début de test, la page est donc déjà sur `/game` avec l’UI Swerpg chargée.
 
@@ -389,9 +389,77 @@ Pour un squelette générique et un guide plus détaillé sur la création d’u
 
 ---
 
-## 6. Bonnes pratiques spécifiques Swerpg / Foundry
+## 6. Contrat d'interaction et capture d'erreurs navigateur
 
-### 6.1. Locators accessibles
+### 6.1. Helpers d'interaction centralisés
+
+Toutes les interactions critiques avec Foundry doivent passer par les helpers communs plutôt que d'être dupliquées dans chaque spec.
+
+| Helper | Fichier | Usage |
+|---|---|---|
+| `setUp` / `tearDown` | `e2e/utils/playwrightTest.ts` | Bootstrap complet `licence → auth → setup → join → game` |
+| `ensureSessionActive` | `e2e/utils/foundryUI.ts` | Vérification que la session `/game` est toujours active |
+| `openGameSettings` | `e2e/utils/foundryUI.ts` | Ouverture de l'onglet Settings dans la sidebar |
+| `navigateToSystemSettings` | `e2e/utils/foundryUI.ts` | Navigation complète vers les settings d'un système |
+| `openOggDudeImporterDialog` | `e2e/regression/utils/oggdude-importer.ts` | Ouverture du dialog OggDude depuis les settings |
+| `createBrowserErrorCollector` | `e2e/utils/browserErrors.ts` | Capture centralisée des erreurs navigateur |
+
+Ne pas réimplémenter ces helpers dans les specs. Si un helper manque, l'ajouter dans le fichier centralisé.
+
+### 6.2. Politique de capture des erreurs navigateur
+
+Toute spec de régression et toute spec legacy active doit détecter les erreurs navigateur inattendues.
+
+#### Contrat imposé par la fixture
+
+Les fixtures `worldReady` (`e2e/fixtures/index.ts`) et `smokeReady` (`e2e/smoke/fixtures.ts`) branchent automatiquement un collecteur d'erreurs (`createBrowserErrorCollector`) avant le setUp. À la fin de chaque test, elles appellent `assertNoErrors` pour faire échouer explicitement si une erreur non autorisée a été captée.
+
+**Conséquence : aucun listener `page.on('console')` ou `page.on('pageerror')` ad hoc n'est nécessaire dans les specs qui consomment ces fixtures.**
+
+#### Utilisation explicite dans un test (cas avancé)
+
+Si un test a besoin d'isoler les erreurs d'une étape précise (par exemple après rechargement de page) :
+
+```ts
+import { createBrowserErrorCollector } from '../../utils/browserErrors'
+
+test('aucune erreur après rechargement', async ({ page }) => {
+  const errorCollector = createBrowserErrorCollector(page)
+
+  await page.reload({ waitUntil: 'domcontentloaded' })
+  await expect(page.locator('body.system-swerpg')).toHaveCount(1)
+
+  errorCollector.assertNoErrors('rechargement /game')
+})
+```
+
+#### Politique de filtrage
+
+Les patterns suivants sont filtrés automatiquement comme bruits connus (définis dans `e2e/utils/browserErrors.ts`) :
+
+- `/favicon/i`
+- `/chrome-extension:/i`
+- `/moz-extension:/i`
+- `/No module named/i`
+
+Pour ajouter un nouveau pattern de bruit maîtrisé, modifier `KNOWN_NOISE_PATTERNS` dans `e2e/utils/browserErrors.ts` et documenter pourquoi ce bruit est ignoré.
+
+Ne jamais élargir cette liste pour masquer de vraies régressions.
+
+#### Checklist pour toute nouvelle spec regression ou legacy
+
+- [ ] La spec importe depuis `../../fixtures` (regression) ou `./fixtures` (smoke) — ne pas créer de fixture locale.
+- [ ] Aucun listener `page.on('console')` ou `page.on('pageerror')` ad hoc dans la spec (sauf cas documenté).
+- [ ] Les interactions critiques utilisent les helpers de `foundryUI.ts` et `foundrySession.ts`.
+- [ ] `ensureSessionActive` est appelé avant toute séquence longue (settings, import, navigation complexe).
+- [ ] Pas de `waitForTimeout` comme synchronisation — utiliser des assertions web-first.
+- [ ] Pas de `click({ force: true })` sans justification écrite.
+
+---
+
+## 7. Bonnes pratiques spécifiques Swerpg / Foundry
+
+### 7.1. Locators accessibles
 
 Toujours privilégier les locators Playwright basés sur l’accessibilité :
 
@@ -404,7 +472,7 @@ Avantages :
 - tests plus robustes face aux refactors CSS/HTML,
 - meilleure cohérence avec les bonnes pratiques a11y (labels explicites, rôles ARIA corrects).
 
-### 6.2. Conventions Foundry
+### 7.2. Conventions Foundry
 
 - Utiliser les **URLs symboliques** plutôt que des chemins absolus complets :
   - `/license`, `/auth`, `/setup`, `/join`, `/game`
@@ -412,13 +480,13 @@ Avantages :
 - Attendre explicitement les bonnes étapes de navigation :
   - `page.waitForURL('**/setup', { waitUntil: 'domcontentloaded' })`
 
-### 6.3. Nettoyage et stabilité
+### 7.3. Nettoyage et stabilité
 
-- Le helper `tearDown` (`e2e/utils/e2eTest.ts`) est prévu pour revenir à un état stable entre les tests.
+- Le helper `tearDown` (`e2e/utils/playwrightTest.ts`) est prévu pour revenir à un état stable entre les tests.
 - En cas d’erreur lors du cleanup, les helpers se contentent d’essayer de revenir sur `/setup` ou `/auth` sans faire échouer le test : objectif → éviter les effets de bord sur les scénarios suivants.
 - Évitez de modifier à la main l’état du monde de test (suppression massive de données, changements de configuration critique) dans un test sans cleanup dédié.
 
-### 6.4. Écriture de nouveaux tests
+### 7.4. Écriture de nouveaux tests
 
 Pour tout nouveau test E2E :
 
@@ -439,9 +507,9 @@ Pour un guide complet avec un exemple de squelette de spec et comment l’adapte
 
 ---
 
-## 7. Débogage et troubleshooting
+## 8. Débogage et troubleshooting
 
-### 7.1. Foundry inaccessible
+### 8.1. Foundry inaccessible
 
 Symptôme : les tests échouent très tôt avec des erreurs de navigation ou de timeout.
 
@@ -456,7 +524,7 @@ Symptôme : les tests échouent très tôt avec des erreurs de navigation ou de
 2. Vérifier que le monde configuré dans `E2E_FOUNDRY_WORLD` existe et est jouable.
 3. S’assurer que le mot de passe admin est correct (`E2E_FOUNDRY_ADMIN_PASSWORD`).
 
-### 7.2. Problèmes de navigateurs Playwright
+### 8.2. Problèmes de navigateurs Playwright
 
 Si Playwright se plaint que les exécutables navigateur sont manquants :
 
@@ -464,7 +532,7 @@ Si Playwright se plaint que les exécutables navigateur sont manquants :
 pnpm exec playwright install --with-deps
 ```
 
-### 7.3. Timeouts, surtout en mode headed
+### 8.3. Timeouts, surtout en mode headed
 
 - Les tests headed sont parfois plus lents (latence UI humaine, animations, etc.).
 - Adaptez les timeouts via les variables d’environnement si nécessaire :
@@ -473,7 +541,7 @@ pnpm exec playwright install --with-deps
   PLAYWRIGHT_TEST_TIMEOUT=1200000 PLAYWRIGHT_EXPECT_TIMEOUT=30000 pnpm e2e:regression:headed
   ```
 
-### 7.4. Inspection et traces de tests
+### 8.4. Inspection et traces de tests
 
 Pour ouvrir l’UI Playwright et déboguer interactivement :
 
@@ -489,13 +557,13 @@ pnpm exec playwright show-trace test-results/path-to-trace/trace.zip
 
 Les rapports HTML sont générés (en CI) dans `playwright-report/`.
 
-### 7.5. Tests instables (flaky)
+### 8.5. Tests instables (flaky)
 
 - Éviter les `page.waitForTimeout()` au profit d’assertions web-first (`expect(locator).toBeVisible()`, `toHaveURL`, etc.).
 - Vérifier que les selectors ne dépendent pas de textes mouvants ou de structures trop fragiles.
 - En cas de flakiness persistante, augmenter légèrement `retries` ou investiguer les temps de réponse de Foundry.
 
-### 7.6. Raccourcis utiles pour debug et génération de tests
+### 8.6. Raccourcis utiles pour debug et génération de tests
 
 Voici quelques commandes rapides et utiles pour déboguer, visualiser les rapports, et générer des scénarios Playwright : elles sont pratiques lors du développement local des tests.
 
@@ -535,7 +603,7 @@ Remarque : si vous utilisez `pnpm` dans ce projet, vous pouvez remplacer `npx` 
 
 ---
 
-## 8. Résumé
+## 9. Résumé
 
 - `pnpm e2e:smoke` : vérification de surface, exécution manuelle, lecture seule sur instance de production.
 - `pnpm e2e:regression` : validation fonctionnelle pré-livraison sur instance dédiée, remplace les campagnes QA manuelles répétitives.

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -194,6 +194,44 @@ dédiée soit ajoutée.
 
 ---
 
+## Contrat d'interaction et erreurs navigateur
+
+### Helpers à utiliser
+
+Toutes les interactions critiques Foundry doivent passer par les helpers communs :
+
+| Besoin | Helper | Fichier |
+|---|---|---|
+| Bootstrap complet | `setUp` / `tearDown` | `utils/playwrightTest.ts` |
+| Vérifier session active | `ensureSessionActive` | `utils/foundryUI.ts` |
+| Ouvrir Game Settings | `openGameSettings` | `utils/foundryUI.ts` |
+| Naviguer vers settings système | `navigateToSystemSettings` | `utils/foundryUI.ts` |
+| Ouvrir dialog OggDude | `openOggDudeImporterDialog` | `regression/utils/oggdude-importer.ts` |
+| Capturer les erreurs navigateur | `createBrowserErrorCollector` | `utils/browserErrors.ts` |
+
+Ne pas réimplémenter ces helpers dans les specs. Si un helper manque, l'ajouter dans le fichier centralisé.
+
+### Capture d'erreurs navigateur
+
+Les fixtures `worldReady` (`fixtures/index.ts`) et `smokeReady` (`smoke/fixtures.ts`) branchent automatiquement un collecteur d'erreurs navigateur (`createBrowserErrorCollector`) avant le setUp. À la fin de chaque test, elles appellent `assertNoErrors` pour faire échouer explicitement si une erreur non autorisée a été captée.
+
+**Règle** : aucun listener `page.on('console')` ou `page.on('pageerror')` ad hoc dans les specs — la fixture s'en charge.
+
+Exception documentée : si un test recharge la page pour tester spécifiquement les erreurs au démarrage, il peut créer un collecteur local via `createBrowserErrorCollector(page)` et appeler `assertNoErrors` manuellement.
+
+### Checklist pour toute nouvelle spec
+
+- [ ] Importer depuis `../../fixtures` (regression) ou `./fixtures` (smoke)
+- [ ] Pas de listener ad hoc `page.on('console')` ou `page.on('pageerror')`
+- [ ] Interactions critiques via helpers de `foundryUI.ts` et `foundrySession.ts`
+- [ ] `ensureSessionActive` avant toute séquence longue
+- [ ] Pas de `waitForTimeout` — utiliser des assertions web-first
+- [ ] Pas de `click({ force: true })` sans justification écrite
+
+Pour les détails complets, voir `documentation/tests/e2e/playwright-e2e-guide.md` section 6.
+
+---
+
 ## Conseils
 
 Préférer `beforeEach` et `beforeAll` pour se mettre dans un état initial plutôt que

--- a/e2e/fixtures/index.ts
+++ b/e2e/fixtures/index.ts
@@ -1,6 +1,7 @@
 import { expect, test as base } from '@playwright/test'
 import { FoundrySessionOptions } from '../utils/foundrySession'
 import { setUp, tearDown } from '../utils/playwrightTest'
+import { createBrowserErrorCollector } from '../utils/browserErrors'
 
 export const beforeAllFixture = base.extend({})
 
@@ -19,12 +20,22 @@ export const test = base.extend<{ worldReady: void }>({
         world: process.env.E2E_FOUNDRY_WORLD ?? 'Swerpg-E2E-World',
       }
 
+      // Brancher la capture d'erreurs navigateur avant le setUp pour ne rien rater
+      const errorCollector = createBrowserErrorCollector(page)
+
       // INIT : on met Foundry en /game sur le bon world
       await setUp(page, options)
 
+      // Réinitialiser les erreurs captées pendant le setUp (navigation, redirections)
+      // pour ne cibler que les erreurs liées au scénario de test lui-même
+      errorCollector.reset()
+
       await use()
 
-      // CLOSE : on remet l’instance sur /setup pour le prochain navigateur/projet
+      // Vérifier qu'aucune erreur navigateur inattendue n'a été collectée pendant le test
+      errorCollector.assertNoErrors('fin du scénario worldReady')
+
+      // CLOSE : on remet l'instance sur /setup pour le prochain navigateur/projet
       await tearDown(page, options)
     },
     { auto: true },

--- a/e2e/smoke/01-health.spec.ts
+++ b/e2e/smoke/01-health.spec.ts
@@ -1,4 +1,5 @@
 import { expect, test } from './fixtures'
+import { createBrowserErrorCollector } from '../utils/browserErrors'
 
 /**
  * 01 — Smoke prod : santé de l'instance
@@ -33,30 +34,14 @@ test.describe('[smoke] 01 — health', () => {
       return
     }
 
-    const errors: string[] = []
+    // Utiliser le collecteur centralisé pour unifier la politique de filtrage
+    const errorCollector = createBrowserErrorCollector(page)
 
-    page.on('console', (msg) => {
-      if (msg.type() === 'error') {
-        errors.push(msg.text())
-      }
-    })
-
-    page.on('pageerror', (err) => {
-      errors.push(err.message)
-    })
-
-    // Recharger la page pour capturer les erreurs au démarrage
+    // Recharger la page pour capturer les erreurs au démarrage du système
     await page.reload({ waitUntil: 'domcontentloaded' })
     await expect(page.locator('body.system-swerpg')).toHaveCount(1)
 
-    const criticalErrors = errors.filter(
-      (e) =>
-        // Exclure les erreurs connues non bloquantes (ex: extensions navigateur)
-        !e.includes('favicon') &&
-        !e.includes('chrome-extension'),
-    )
-
-    expect(criticalErrors, `Erreurs console critiques détectées : ${criticalErrors.join('\n')}`).toHaveLength(0)
+    errorCollector.assertNoErrors('rechargement /game smoke')
   })
 
   test('aucun asset système critique en 404', async ({ page }) => {

--- a/e2e/smoke/fixtures.ts
+++ b/e2e/smoke/fixtures.ts
@@ -1,6 +1,7 @@
 import { expect, test as base } from '@playwright/test'
 import { accepteLicense, enterGameAsGamemaster, enterWorld, FoundrySessionOptions, loginIntoInstance } from '../utils/foundrySession'
 import { dismissOverlayIfPresent } from '../helper/overlay'
+import { createBrowserErrorCollector } from '../utils/browserErrors'
 
 /**
  * Fixtures pour la suite smoke prod.
@@ -23,9 +24,22 @@ export const test = base.extend<{ smokeReady: void }>({
         world: process.env.E2E_FOUNDRY_WORLD ?? '',
       }
 
+      // Brancher la capture d'erreurs navigateur avant le setUp pour ne rien rater
+      const errorCollector = createBrowserErrorCollector(page)
+
       await setUpSmoke(page, options)
 
+      // Réinitialiser les erreurs captées pendant le setUp (navigation, redirections)
+      // pour ne cibler que les erreurs liées au scénario de test lui-même
+      errorCollector.reset()
+
       await use()
+
+      // Vérifier qu'aucune erreur navigateur inattendue n'a été collectée pendant le test
+      // Smoke : ne pas faire échouer sur les erreurs non critiques connues de l'env de prod
+      if (options.world && page.url().includes('/game')) {
+        errorCollector.assertNoErrors('fin du scénario smokeReady')
+      }
 
       // Smoke prod : pas de tearDown destructif — retour soft à /setup seulement
       await tearDownSmoke(page, options)

--- a/e2e/specs/bootstrap.spec.ts
+++ b/e2e/specs/bootstrap.spec.ts
@@ -1,9 +1,16 @@
 import { expect, test } from '../fixtures'
 
+/**
+ * [ci] Swerpg bootstrap — spec legacy
+ *
+ * Vérifie que le monde Swerpg se charge correctement et que l'UI système est présente.
+ * Tag [ci] : exécuté en CI via `pnpm e2e:ci`.
+ *
+ * La fixture `worldReady` (auto=true) gère la connexion, la capture d'erreurs navigateur,
+ * et le tearDown pour chaque test.
+ */
 test.describe('[ci] Swerpg bootstrap', () => {
-  test('should load Foundry world and display Swerpg UI element', async ({ page, browserName }, testInfo) => {
-    console.log(`[bootstrap] 🧪 Démarrage du test sur ${browserName}`)
-
+  test('should load Foundry world and display Swerpg UI element', async ({ page }) => {
     // Vérifier l'URL
     await expect(page).toHaveURL(/.*game/)
 
@@ -14,7 +21,5 @@ test.describe('[ci] Swerpg bootstrap', () => {
     // Vérifier qu'un élément UI critique est présent (sidebar)
     const sidebar = page.locator('#sidebar')
     await expect(sidebar).toBeVisible()
-
-    console.log(`[bootstrap] ✅ Fin du test sur ${browserName}`)
   })
 })

--- a/e2e/specs/oggdude-import.spec.ts
+++ b/e2e/specs/oggdude-import.spec.ts
@@ -1,14 +1,19 @@
 import { expect, test } from '../fixtures'
 import { navigateToSystemSettings } from '../utils/foundryUI'
 
+/**
+ * OggDude importer — spec legacy
+ *
+ * Vérifie que le dialog OggDude s'ouvre depuis les System Settings.
+ * La fixture `worldReady` (auto=true) gère la connexion, la capture d'erreurs navigateur,
+ * et le tearDown pour chaque test.
+ */
 test.describe('OggDude importer', () => {
-  test('should open the OggDude import interface', async ({ page, browserName }, testInfo) => {
-    console.log(`[oggdude-import] 🧪 Démarrage du test sur ${browserName}`)
-
+  test('should open the OggDude import interface', async ({ page }) => {
     // Vérifier l'URL
     await expect(page).toHaveURL(/.*game/)
 
-    // 1-3) Navigation vers System Settings (refactorisé via helper)
+    // 1-3) Navigation vers System Settings (via helper centralisé)
     await navigateToSystemSettings(page, 'Star Wars Edge RPG')
 
     // 4) Cliquer sur la section OggDude Data Importer
@@ -27,7 +32,5 @@ test.describe('OggDude importer', () => {
     // 6) Vérifier que l'interface d'import OggDude est bien affichée
     const fileInput = page.getByRole('button', { name: 'OggDude Zip Data File' })
     await expect(fileInput).toBeVisible()
-
-    console.log(`[oggdude-import] ✅ Fin du test sur ${browserName}`)
   })
 })

--- a/e2e/utils/browserErrors.ts
+++ b/e2e/utils/browserErrors.ts
@@ -1,0 +1,103 @@
+import { Page } from '@playwright/test'
+
+/**
+ * Politique de filtrage des erreurs navigateur.
+ *
+ * Certains messages sont connus, non bloquants, et liés à l'environnement
+ * (extensions navigateur, logs Foundry non critiques, etc.).
+ * Ces patterns sont exclus de la capture avant de faire échouer un test.
+ */
+const KNOWN_NOISE_PATTERNS: RegExp[] = [
+  /favicon/i,
+  /chrome-extension:/i,
+  /moz-extension:/i,
+  // Erreurs de licence liées aux modules tiers non chargés en monde de test
+  /No module named/i,
+]
+
+/**
+ * Vérifie si un message d'erreur correspond à un bruit connu et maîtrisé.
+ * Retourne true si le message peut être ignoré en toute sécurité.
+ */
+function isKnownNoise(message: string): boolean {
+  return KNOWN_NOISE_PATTERNS.some((pattern) => pattern.test(message))
+}
+
+/**
+ * Collecteur d'erreurs navigateur pour un test Playwright.
+ * Capture les événements `console` (type "error") et `pageerror` (exceptions non gérées).
+ *
+ * Usage :
+ *
+ * ```ts
+ * const errorCollector = createBrowserErrorCollector(page)
+ * // … interactions …
+ * errorCollector.assertNoErrors('après chargement du monde')
+ * ```
+ */
+export interface BrowserErrorCollector {
+  /** Erreurs filtrées collectées depuis le lancement du collecteur. */
+  readonly errors: readonly string[]
+  /**
+   * Lève une assertion Playwright si des erreurs non autorisées ont été captées.
+   * Le message d'échec mentionne le contexte passé en argument pour faciliter le diagnostic.
+   *
+   * @param context - Description du moment où l'assertion est faite (ex: "après navigation /game")
+   * @throws {Error} Si des erreurs navigateur non autorisées sont présentes
+   */
+  assertNoErrors(context: string): void
+  /**
+   * Réinitialise la liste des erreurs collectées.
+   * Utile pour effacer le bruit capturé avant la phase critique d'un test.
+   */
+  reset(): void
+}
+
+/**
+ * Crée un collecteur d'erreurs navigateur et l'attache à la page Playwright.
+ *
+ * Les événements `console` de type "error" et les `pageerror` sont écoutés
+ * dès l'appel de cette fonction. Les bruits connus sont filtrés automatiquement.
+ *
+ * Appeler `assertNoErrors` en fin de test ou après un parcours critique pour
+ * faire échouer immédiatement le test si une erreur inattendue a été détectée.
+ *
+ * @param page - Page Playwright sur laquelle attacher les listeners
+ * @returns Un collecteur d'erreurs prêt à l'emploi
+ */
+export function createBrowserErrorCollector(page: Page): BrowserErrorCollector {
+  const collected: string[] = []
+
+  page.on('console', (msg) => {
+    if (msg.type() === 'error') {
+      const text = msg.text()
+      if (!isKnownNoise(text)) {
+        collected.push(`[console.error] ${text}`)
+      }
+    }
+  })
+
+  page.on('pageerror', (err) => {
+    const message = err.message
+    if (!isKnownNoise(message)) {
+      collected.push(`[pageerror] ${message}`)
+    }
+  })
+
+  return {
+    get errors(): readonly string[] {
+      return collected
+    },
+
+    assertNoErrors(context: string): void {
+      if (collected.length > 0) {
+        const errorList = collected.map((e, i) => `  ${i + 1}. ${e}`).join('\n')
+        throw new Error(`Erreurs navigateur inattendues détectées (${context}) :\n${errorList}`)
+      }
+    },
+
+    reset(): void {
+      collected.length = 0
+    },
+  }
+}


### PR DESCRIPTION
Closes #368

## Context
Centralize browser error capture for Playwright tests and add an ADR documenting the expected interaction contract for E2E tests. This helps stabilize specs that surface browser-side failures.

## Summary of Changes
- add ADR `documentation/architecture/adr/adr-0017-e2e-playwright-interaction-contract-and-browser-error-capture.md`
- add issue plan files under `documentation/plan/tests/` and `documentation/plan/tests/e2e/`
- add `e2e/utils/browserErrors.ts` to centralize browser error capture for Playwright
- update E2E docs, fixtures, smoke tests, and legacy specs to align with the shared contract

## Technical Notes
- the new browser error utility centralizes browser-side console and page error collection for Playwright specs
- the ADR formalizes the interaction contract expected by the E2E suite
- shared fixture changes make the same error-capture approach available to legacy specs and regression-oriented specs

## Tests Run
- not run during PR preparation

## Known Limits
- no automated validation was run as part of PR preparation
- exact behavior still depends on the local Foundry and Playwright environment configuration

## Points of Attention
- review the ADR scope against the browser-side failures observed in practice
- verify the shared fixture impact on existing E2E specs
- confirm the browser error filtering policy is strict enough without blocking known acceptable noise