### PR TITLE
feat(tests): add Tier 1 regression spec for character creation and sheet opening

### DIFF
--- a/documentation/plan/tests/369-pwe3-tier-1-regression-spec-regression-creation-personnage-et-ouverture-de-fiche.md
+++ b/documentation/plan/tests/369-pwe3-tier-1-regression-spec-regression-creation-personnage-et-ouverture-de-fiche.md
@@ -1,0 +1,95 @@
+# Plan d'implémentation — Issue #369
+
+**Issue** : [#369 — PWE3 - [Tier 1 Regression] Spec regression : création personnage et ouverture de fiche](https://github.com/herveDarritchon/foundryvtt-swerpg/issues/369)
+**Dépendances** : [#366 — Playwright Local Foundry Smoke Tests - Sécuriser les parcours MJ essentiels en local](https://github.com/herveDarritchon/foundryvtt-swerpg/issues/366), [#367 — PWE1 - Stabiliser la baseline locale Playwright et le monde E2E](https://github.com/herveDarritchon/foundryvtt-swerpg/issues/367), [#368 — PWE2 - [Tier 1 Regression] Fiabiliser les contrats d'interaction et la capture d'erreurs navigateur](https://github.com/herveDarritchon/foundryvtt-swerpg/issues/368)
+**Domaine métier** : `tests`
+**Source de cadrage** :
+
+- `documentation/plan/tests/366-playwright-local-foundry-smoke-tests-securiser-les-parcours-mj-essentiels-en-local.md`
+- `documentation/plan/tests/367-pwe1-stabiliser-la-baseline-locale-playwright-et-le-monde-e2e.md`
+- `documentation/plan/tests/368-pwe2-fiabiliser-les-contrats-d-interaction-et-la-capture-d-erreurs-navigateur.md`
+- `documentation/plan/tests/e2e/strategie-contrat-commandes-e2e-smoke-regression.md`
+
+---
+
+## 1. Objectif
+
+Corriger la régression de la spec Tier 1 couvrant la création de personnage et l'ouverture de fiche, afin de restaurer un parcours E2E local fiable, diagnostiquable et cohérent avec les contrats Playwright déjà définis par `PWE1` et `PWE2`.
+
+---
+
+## 2. Périmètre
+
+### Inclus
+
+- diagnostic précis du point de rupture dans le parcours `création personnage → ouverture de fiche` ;
+- réalignement de la spec sur les helpers, fixtures et attentes supportés ;
+- verrouillage des critères d'ouverture de fiche et de détection d'erreurs navigateur pour ce scénario.
+
+### Exclu
+
+- ajout d'une nouvelle couverture métier hors scénario déjà ciblé ;
+- refonte générale de tout le socle Playwright ;
+- changements runtime applicatifs sans lien direct avec la régression observée.
+
+---
+
+## 3. Plan de travail proposé
+
+### Étape 1 — Circonscrire précisément la régression du scénario
+
+**But** : identifier si la rupture vient du setup du monde, de la création d'acteur, de l'ouverture de fiche ou d'un bruit navigateur désormais bloquant.
+
+**Fichiers cibles** : spec Tier 1 concernée sous `e2e/regression/**` et/ou `e2e/specs/**`, fixtures sous `e2e/fixtures/**`, helpers sous `e2e/utils/**`
+
+**Actions** :
+
+- isoler la séquence minimale qui échoue dans le parcours ;
+- qualifier la cause dominante : précondition monde/données, contrat d'interaction UI, attente asynchrone ou erreur navigateur ;
+- formaliser le signal attendu de succès et le signal d'échec utile au diagnostic.
+
+### Étape 2 — Réaligner la création de personnage et l'ouverture de fiche sur le contrat partagé
+
+**But** : rendre le scénario compatible avec les helpers d'interaction et les garde-fous introduits pour la baseline locale.
+
+**Fichiers cibles** : spec Tier 1 concernée, `e2e/utils/foundrySession.ts`, `e2e/utils/foundryUI.ts`, `e2e/fixtures/index.ts`, éventuels helpers partagés sous `e2e/utils/`
+
+**Actions** :
+
+- remplacer les interactions fragiles restantes par les helpers centralisés déjà retenus ;
+- expliciter les préconditions déterministes nécessaires à la création du personnage ;
+- verrouiller l'enchaînement d'ouverture de fiche avec des attentes lisibles sur l'UI réellement utile.
+
+### Étape 3 — Sécuriser le diagnostic et les critères de clôture du scénario
+
+**But** : éviter qu'une future dérive rende à nouveau la spec opaque ou flaky.
+
+**Fichiers cibles** : spec Tier 1 concernée, éventuelle documentation courte sous `e2e/README.md` ou `documentation/tests/e2e/`
+
+**Actions** :
+
+- conserver une détection explicite des erreurs `console` / `pageerror` non autorisées pour ce parcours ;
+- clarifier l'assertion finale qui prouve que la fiche du personnage est bien ouverte et exploitable ;
+- documenter brièvement les préconditions et le contrat minimal du scénario si une ambiguïté subsiste.
+
+---
+
+## 4. Ordre recommandé
+
+1. Circonscrire la régression
+2. Réaligner le scénario sur le contrat partagé
+3. Sécuriser le diagnostic et les critères de clôture
+
+---
+
+## 5. Validation prévue (non exécutée dans ce plan)
+
+- exécution ciblée de la spec Tier 1 impactée ;
+- vérification que la création du personnage aboutit et que sa fiche s'ouvre sans erreur navigateur non autorisée ;
+- relecture croisée `spec ↔ helpers ↔ fixtures` pour confirmer un contrat unique et déterministe sur ce parcours.
+
+---
+
+## 6. Résultat attendu
+
+Le scénario Tier 1 centré sur la création de personnage et l'ouverture de fiche redevient une baseline locale fiable, avec un contrat d'interaction explicite et un diagnostic rapide en cas de nouvelle régression.

--- a/documentation/plan/tests/e2e/369-pwe3-tier-1-regression-spec-regression-creation-personnage-et-ouverture-de-fiche.md
+++ b/documentation/plan/tests/e2e/369-pwe3-tier-1-regression-spec-regression-creation-personnage-et-ouverture-de-fiche.md
@@ -1,0 +1,66 @@
+# Plan d'implémentation — Issue #369
+
+**Issue** : [#369 — PWE3 - [Tier 1 Regression] Spec regression : création personnage et ouverture de fiche](https://github.com/herveDarritchon/foundryvtt-swerpg/issues/369)
+
+**Domaine métier** : `tests/e2e`
+
+**Dépendances** : #366, #367, #368 (contrats interaction + capture erreurs navigateur)
+
+## 1. Constat
+
+La spec Tier 1 qui devait couvrir `création personnage → ouverture de fiche` n'existe pas encore comme spec dédiée.
+Les seules regression specs présentes sont `01-smoke.spec.ts` (sidebar, onglets) et `02-oggdude-import.spec.ts`.
+Aucun helper partagé d'interaction acteur n'existe dans `e2e/utils/foundryUI.ts` (settings uniquement) ou `e2e/utils/foundrySession.ts` (session uniquement).
+
+## 2. Fichiers ciblés
+
+| Fichier | Action |
+|---------|--------|
+| `e2e/regression/specs/03-character-creation.spec.ts` | **Créer** — nouvelle spec Tier 1 |
+| `e2e/utils/foundryUI.ts` | **Étendre** — ajouter helpers `openActorsTab()`, `createActor(name, type)` |
+| `e2e/utils/browserErrors.ts` | **Aucun changement** — déjà fonctionnel, utilisé via la fixture |
+| `e2e/fixtures/index.ts` | **Aucun changement** — `worldReady` + `createBrowserErrorCollector` déjà branchés |
+
+## 3. Plan de travail
+
+### Étape 1 — Ajouter les helpers d'interaction acteur dans `foundryUI.ts`
+
+**But** : factoriser la création d'acteur et l'ouverture de fiche pour toutes les specs.
+
+- `openActorsTab(page)` : clic sur l'onglet Actors, attente section `#actors` visible.
+- `createActor(page, name, type)` : bouton "Create Actor", sélection du type (Personnage), remplissage nom, validation.
+
+**Signature** (approximative) :
+
+```ts
+export async function openActorsTab(page: Page): Promise<void>
+export async function createActor(page: Page, name: string, type: string): Promise<string> /* actorId */
+```
+
+### Étape 2 — Créer la spec Tier 1 `03-character-creation.spec.ts`
+
+**Répertoire** : `e2e/regression/specs/`
+
+**Scénario** :
+1. Fixture `worldReady` (auto) → page en `/game`.
+2. Ouvrir l'onglet Actors.
+3. Créer un personnage (nom unique, type personnage).
+4. Vérifier que la fiche s'ouvre (élément visible, titre correct).
+5. Vérifier qu'aucune erreur navigateur n'est survenue (via `errorCollector` déjà dans la fixture).
+
+**Assertions clés** :
+- Acteur créé visible dans la directory Actors.
+- Fiche ouverte (fenêtre de sheet avec le bon titre).
+- `assertNoErrors('création personnage')` en fin de scénario.
+
+### Étape 3 — Exécuter et valider
+
+- `pnpm e2e` ou `pnpm e2e:headed` sur la spec ciblée.
+- Vérifier que le test passe en local (port 31001) sans erreur navigateur.
+- Vérifier que les tests existants (`01-smoke`, `02-oggdude-import`) ne régressent pas.
+
+## 4. Résultat attendu
+
+Une spec Tier 1 stable, déterministe et diagnostiquable pour le parcours
+`connexion → onglet Actors → création personnage → ouverture fiche → zéro erreur navigateur`,
+réutilisant les helpers partagés et le contrat d'erreur déjà établi par PWE1/PWE2.

--- a/e2e/regression/specs/03-character-creation.spec.ts
+++ b/e2e/regression/specs/03-character-creation.spec.ts
@@ -1,0 +1,60 @@
+import { expect, test } from '../../fixtures'
+import { createActor, openActorsTab } from '../../utils/foundryUI'
+
+/**
+ * 03 — Création de personnage et ouverture de fiche (Tier 1 Regression)
+ *
+ * Parcours complet :
+ *   1. Monde chargé (fixture `worldReady` auto) → page en /game
+ *   2. Ouvrir l'onglet Actors dans la sidebar
+ *   3. Créer un personnage (nom unique, type "character")
+ *   4. Vérifier que la fiche s'ouvre (fenêtre de sheet visible avec le bon titre)
+ *   5. Vérifier l'absence d'erreur navigateur (contrôle assuré automatiquement
+ *      par la fixture `worldReady` en teardown via `assertNoErrors`)
+ *
+ * Pré-requis :
+ *   - Instance Foundry sur port 31001 avec monde Swerpg-Regression-World
+ *   - La fixture `worldReady` (auto=true) gère la connexion/déconnexion et la capture d'erreurs.
+ *
+ * Issue : #369 — PWE3 - [Tier 1 Regression] Spec regression : création personnage et ouverture de fiche
+ */
+test.describe('[regression] 03 — character creation', () => {
+  test('onglet Actors accessible depuis la sidebar', async ({ page }) => {
+    // Arrange : world chargé par la fixture worldReady
+    await expect(page).toHaveURL(/.*\/game/)
+
+    // Act : ouvrir l'onglet Actors
+    await openActorsTab(page)
+
+    // Assert : la section #actors est visible
+    await expect(page.locator('#actors')).toBeVisible()
+  })
+
+  test('création personnage et ouverture de fiche sans erreur navigateur', async ({ page }) => {
+    // Arrange : world chargé, on génère un nom unique pour éviter les collisions entre runs
+    await expect(page).toHaveURL(/.*\/game/)
+    const actorName = `Test-Personnage-${Date.now()}`
+
+    // Act 1 : ouvrir l'onglet Actors
+    await openActorsTab(page)
+    await expect(page.locator('#actors')).toBeVisible()
+
+    // Act 2 : créer l'acteur de type "character"
+    await createActor(page, actorName, 'character')
+
+    // Assert 1 : l'acteur créé est visible dans la directory Actors
+    const actorEntry = page.locator('#actors').getByText(actorName)
+    await expect(actorEntry).toBeVisible()
+
+    // Assert 2 : la fiche de l'acteur est ouverte et affiche le bon titre
+    // Foundry v14 ApplicationV2 rend : <form class="application sheet ...">
+    const actorSheet = page
+      .locator('.application.sheet, .app.sheet, .window-app, dialog.sheet, [role="dialog"]')
+      .filter({ hasText: actorName })
+      .first()
+    await expect(actorSheet).toBeVisible()
+
+    // Assert 3 (implicite) : aucune erreur navigateur — vérifiée automatiquement
+    // par la fixture `worldReady` en teardown via errorCollector.assertNoErrors()
+  })
+})

--- a/e2e/utils/foundryUI.ts
+++ b/e2e/utils/foundryUI.ts
@@ -107,3 +107,106 @@ export async function navigateToSystemSettings(page: Page, systemName: string): 
   await openGameSettings(page)
   await openSystemSettings(page, systemName)
 }
+
+/**
+ * Ouvre l'onglet Actors dans la sidebar Foundry.
+ *
+ * Foundry v14 utilise des onglets avec data-tab="actors" sans libellé visible.
+ * On essaie plusieurs sélecteurs pour la compatibilité v13/v14.
+ *
+ * @param page - Page Playwright
+ */
+export async function openActorsTab(page: Page): Promise<void> {
+  await ensureSessionActive(page)
+  await dismissOverlayIfPresent(page)
+
+  // Foundry v14 : onglet sidebar = <button role="tab" data-tab="actors">
+  // Fallback v13 : role="tab" avec libellé "Actors"
+  const actorsTab = page
+    .locator('[role="tab"][data-tab="actors"]')
+    .or(page.locator('[data-action="tab"][data-tab="actors"]'))
+    .or(page.getByRole('tab', { name: /^Actors$/i }))
+    .first()
+
+  await actorsTab.waitFor({ state: 'visible', timeout: 10000 })
+  await actorsTab.click()
+
+  // Attendre que la section #actors soit visible
+  await page.locator('#actors').waitFor({ state: 'visible', timeout: 10000 })
+}
+
+/**
+ * Crée un acteur depuis la sidebar Actors et attend l'ouverture de sa fiche.
+ *
+ * Workflow :
+ * 1. Clic sur le bouton "Create Actor" dans la sidebar.
+ * 2. Sélection du type d'acteur dans le dialog de création.
+ * 3. Saisie du nom et validation.
+ * 4. Attente de l'ouverture de la fiche (dialog visible avec le bon titre).
+ *
+ * Pré-requis : l'onglet Actors doit être actif (`openActorsTab` appelé avant).
+ *
+ * @param page - Page Playwright
+ * @param name - Nom de l'acteur à créer
+ * @param type - Type d'acteur Foundry (ex: "character")
+ * @returns Le nom de l'acteur tel que saisi (utilisable pour vérifier la fiche)
+ */
+export async function createActor(page: Page, name: string, type: string): Promise<string> {
+  await ensureSessionActive(page)
+
+  // Clic sur le bouton de création d'acteur dans la section #actors
+  // Foundry v14 : bouton avec data-action="create" ou libellé "Create Actor"
+  const createButton = page
+    .locator('#actors')
+    .locator('[data-action="create"]')
+    .or(page.locator('#actors').getByRole('button', { name: /Create Actor/i }))
+    .first()
+
+  await createButton.waitFor({ state: 'visible', timeout: 10000 })
+  await createButton.click()
+
+  // Attendre le dialog de création d'acteur
+  const createDialog = page
+    .locator('dialog.dialog, .dialog, [role="dialog"]')
+    .filter({ hasText: /type|create|actor/i })
+    .first()
+
+  await createDialog.waitFor({ state: 'visible', timeout: 10000 })
+
+  // Remplir le nom de l'acteur
+  const nameInput = createDialog
+    .locator('input[name="name"]')
+    .or(createDialog.locator('input[type="text"]'))
+    .first()
+
+  await nameInput.waitFor({ state: 'visible', timeout: 5000 })
+  await nameInput.fill(name)
+
+  // Sélectionner le type d'acteur si un select est présent
+  const typeSelect = createDialog.locator('select[name="type"]')
+  if ((await typeSelect.count()) > 0) {
+    await typeSelect.selectOption({ value: type })
+  }
+
+  // Valider la création (bouton de confirmation)
+  const confirmButton = createDialog
+    .getByRole('button', { name: /^Create Actor$/i })
+    .or(createDialog.getByRole('button', { name: /^Create$/i }))
+    .or(createDialog.locator('[data-action="submit"], button[type="submit"]'))
+    .first()
+
+  await confirmButton.waitFor({ state: 'visible', timeout: 5000 })
+  await confirmButton.click()
+
+  // Attendre l'ouverture de la fiche (window/dialog avec le nom de l'acteur)
+  // Foundry v14 ApplicationV2 rend : <form class="application sheet ...">
+  // Foundry v13 ApplicationV1 rend : <div class="app window-app ...">
+  const sheet = page
+    .locator('.application.sheet, .app.sheet, .window-app, dialog.sheet, [role="dialog"]')
+    .filter({ hasText: name })
+    .first()
+
+  await sheet.waitFor({ state: 'visible', timeout: 15000 })
+
+  return name
+}


### PR DESCRIPTION
Linked issue: #369

Context:
- Adds a Tier 1 regression end-to-end spec covering character creation and opening the actor sheet in the E2E regression suite.

Summary of changes:
- e2e/regression/specs/03-character-creation.spec.ts: New Playwright Playwright spec for character creation and sheet opening (60 lines).
- e2e/utils/foundryUI.ts: Utilities for Foundry UI interaction used by the spec (103 lines).
- documentation/plan/tests/369-pwe3-tier-1-regression-spec-regression-creation-personnage-et-ouverture-de-fiche.md: Plan / spec description (95 lines added).
- documentation/plan/tests/e2e/369-pwe3-tier-1-regression-spec-regression-creation-personnage-et-ouverture-de-fiche.md: E2E plan (66 lines added).

Commits included:
- be05e778 feat(tests): add Tier 1 regression spec for character creation and sheet opening

Technical notes:
- This is an E2E regression spec targeting the existing E2E harness (Playwright). The new spec depends on the test environment described in the project's e2e README and assumes a running Foundry instance where the test runner attaches.
- No source code or game system runtime code is modified; changes are limited to tests and documentation.

Tests run:
- No CI/lint/tests were executed locally as part of this PR creation. The branch adds tests (Playwright/E2E) that will run in CI according to existing pipeline configuration.

Known limits:
- The spec is intended for the regression tier and may require the local or CI Foundry test environment to be configured (ports, environment files) as per project docs.
- This PR does not include environment setup or Docker images.

Points of attention for reviewers:
- Review Playwright selectors and timing assumptions in e2e/regression/specs/03-character-creation.spec.ts; E2E tests are sensitive to UI changes.
- Verify that e2e/utils/foundryUI.ts utilities are generic and do not rely on hard-coded environment values.

If you'd like me to push the branch (if not already pushed) or run local checks before creating the PR, tell me and I will proceed.