### PR TITLE
feat(tests): implement Tier 1 hygiene strategy and deterministic reset

### DIFF
--- a/documentation/plan/tests/371-pwe5-tier-1-regression-hygiene-monde-de-test-tier-1-et-strategie-de-reset-deterministe.md
+++ b/documentation/plan/tests/371-pwe5-tier-1-regression-hygiene-monde-de-test-tier-1-et-strategie-de-reset-deterministe.md
@@ -1,0 +1,105 @@
+# Plan d'implémentation — Issue #371
+
+**Issue** : [#371 — PWE5 - [Tier 1 Regression] Hygiène monde de test Tier 1 et stratégie de reset déterministe](https://github.com/herveDarritchon/foundryvtt-swerpg/issues/371)
+**Dépendances** : [#366 — Playwright Local Foundry Smoke Tests - Sécuriser les parcours MJ essentiels en local](https://github.com/herveDarritchon/foundryvtt-swerpg/issues/366), [#367 — PWE1 - [Tier 1 Regression] Stabiliser la baseline et l'environnement dédié (port 31001, Docker)](https://github.com/herveDarritchon/foundryvtt-swerpg/issues/367), [#368 — PWE2 - [Tier 1 Regression] Fiabiliser les contrats d'interaction et la capture d'erreurs navigateur](https://github.com/herveDarritchon/foundryvtt-swerpg/issues/368), [#369 — PWE3 - [Tier 1 Regression] Spec regression : création personnage et ouverture de fiche](https://github.com/herveDarritchon/foundryvtt-swerpg/issues/369), [#370 — PWE4 - [Tier 1 Regression] Spec regression : dépense simple d'XP et ouverture arbre de spécialisation](https://github.com/herveDarritchon/foundryvtt-swerpg/issues/370)
+**Domaine métier** : `tests`
+**Source de cadrage** :
+
+- `documentation/plan/tests/366-playwright-local-foundry-smoke-tests-securiser-les-parcours-mj-essentiels-en-local.md`
+- `documentation/plan/tests/367-pwe1-stabiliser-la-baseline-locale-playwright-et-le-monde-e2e.md`
+- `documentation/plan/tests/368-pwe2-fiabiliser-les-contrats-d-interaction-et-la-capture-d-erreurs-navigateur.md`
+- `documentation/plan/tests/369-pwe3-tier-1-regression-spec-regression-creation-personnage-et-ouverture-de-fiche.md`
+- `documentation/plan/tests/370-pwe4-tier-1-regression-spec-regression-depense-simple-d-xp-et-ouverture-arbre-de-specialisation.md`
+- `documentation/plan/tests/e2e/strategie-e2e-deux-etages-regression-et-smoke-prod.md`
+- `documentation/tests/e2e/playwright-e2e-guide.md`
+- `e2e/README.md`
+
+---
+
+## 1. Objectif
+
+Formaliser puis outiller une stratégie de reset déterministe pour le monde Tier 1 afin que les specs de régression restent reproductibles, idempotentes et indépendantes de leur ordre d'exécution.
+
+---
+
+## 2. Périmètre
+
+### Inclus
+
+- décision explicite entre reset complet du monde et cleanup ciblé par spec ;
+- définition des données minimales attendues par domaine fonctionnel couvert ;
+- politique de noms uniques et/ou suppression systématique des artefacts de test ;
+- sécurisation du bootstrap `globalSetup` quand le monde existe déjà ;
+- vérification du déterminisme sur les parcours `PWE3` et `PWE4`.
+
+### Exclu
+
+- extension de couverture E2E hors parcours déjà priorisés ;
+- refonte générale des helpers Playwright sans lien direct avec l'hygiène du monde ;
+- changement applicatif runtime sans preuve qu'il est nécessaire pour stabiliser le reset Tier 1.
+
+---
+
+## 3. Plan de travail proposé
+
+### Étape 1 — Trancher et documenter le contrat d'hygiène Tier 1
+
+**But** : décider un contrat unique de remise à zéro, compréhensible et applicable par toutes les specs de régression.
+
+**Fichiers cibles** : `e2e/README.md`, `documentation/tests/e2e/playwright-e2e-guide.md`, éventuelle documentation courte sous `documentation/tests/e2e/`
+
+**Actions** :
+
+- comparer explicitement les deux approches visées par l'issue : monde jetable/recréé vs cleanup systématique par spec ;
+- retenir une règle opérationnelle par défaut, ainsi que les exceptions tolérées si certaines specs doivent nettoyer leurs propres artefacts ;
+- documenter les données minimales requises par domaine déjà couvert (`smoke`, création personnage, dépense XP / arbre) ;
+- expliciter la règle de nommage unique ou de teardown obligatoire pour éviter les collisions inter-specs.
+
+### Étape 2 — Rendre le bootstrap monde idempotent et reproductible
+
+**But** : garantir qu'un lancement sur monde absent, déjà présent, partiellement pollué ou déjà actif converge vers un état connu.
+
+**Fichiers cibles** : `e2e/regression/fixtures/global-setup.ts`, `e2e/regression/utils/world-manager.ts`, éventuels helpers partagés sous `e2e/regression/utils/` et `e2e/fixtures/`
+
+**Actions** :
+
+- clarifier le rôle exact de `globalSetup` : créer, réinitialiser ou nettoyer le monde selon la politique retenue ;
+- fiabiliser la gestion des cas `monde déjà existant`, `monde déjà actif`, `retour setup` et `rebootstrap` sans dépendance à l'ordre des specs ;
+- centraliser les primitives de reset/cleanup pour éviter des nettoyages ad hoc dispersés dans les specs ;
+- rendre observable le reset réellement exécuté pour accélérer le diagnostic en cas d'échec de préparation.
+
+### Étape 3 — Réaligner les specs Tier 1 prioritaires sur ce contrat
+
+**But** : prouver que la stratégie retenue fonctionne sur les deux parcours réels déjà identifiés comme sensibles.
+
+**Fichiers cibles** : specs Tier 1 sous `e2e/regression/specs/**`, fixtures sous `e2e/fixtures/**` ou `e2e/regression/fixtures/**`, éventuels helpers sous `e2e/utils/**`
+
+**Actions** :
+
+- expliciter pour `PWE3` et `PWE4` quelles données doivent être présentes avant exécution et lesquelles doivent être créées/effacées par le scénario ;
+- remplacer les hypothèses implicites sur l'état du monde par des préconditions ou nettoyages centralisés compatibles avec la politique retenue ;
+- verrouiller un ordre d'exécution indifférent : exécution isolée, séquentielle, puis répétée sur monde déjà existant ;
+- documenter brièvement la frontière entre données communes de baseline et artefacts éphémères de scénario.
+
+---
+
+## 4. Ordre recommandé
+
+1. Contrat d'hygiène Tier 1
+2. Bootstrap monde idempotent
+3. Réalignement des specs prioritaires
+
+---
+
+## 5. Validation prévue (non exécutée dans ce plan)
+
+- exécution ciblée de `PWE3` puis `PWE4`, puis dans l'ordre inverse, pour vérifier l'indépendance ;
+- relance complète sur un monde déjà existant pour confirmer le comportement idempotent de `globalSetup` ;
+- vérification qu'aucun artefact métier résiduel ne pollue la campagne suivante ;
+- relecture croisée `README ↔ guide E2E ↔ helpers de reset ↔ specs` pour confirmer un contrat unique et explicite.
+
+---
+
+## 6. Résultat attendu
+
+Le Tier 1 dispose d'une stratégie de reset claire, documentée et outillée ; les specs prioritaires restent déterministes même sur monde déjà existant, et les futures régressions liées à la pollution de données deviennent rapides à diagnostiquer.

--- a/documentation/plan/tests/e2e/371-pwe5-tier-1-regression-hygiene-monde-de-test-tier-1-et-strategie-de-reset-deterministe.md
+++ b/documentation/plan/tests/e2e/371-pwe5-tier-1-regression-hygiene-monde-de-test-tier-1-et-strategie-de-reset-deterministe.md
@@ -1,0 +1,105 @@
+# Plan d'implémentation — Issue #371
+
+**Issue** : [#371 — PWE5 - [Tier 1 Regression] Hygiène monde de test Tier 1 et stratégie de reset déterministe](https://github.com/herveDarritchon/foundryvtt-swerpg/issues/371)
+**Dépendances** : [#366 — Playwright Local Foundry Smoke Tests - Sécuriser les parcours MJ essentiels en local](https://github.com/herveDarritchon/foundryvtt-swerpg/issues/366), [#367 — PWE1 - [Tier 1 Regression] Stabiliser la baseline et l'environnement dédié (port 31001, Docker)](https://github.com/herveDarritchon/foundryvtt-swerpg/issues/367), [#368 — PWE2 - [Tier 1 Regression] Fiabiliser les contrats d'interaction et la capture d'erreurs navigateur](https://github.com/herveDarritchon/foundryvtt-swerpg/issues/368), [#369 — PWE3 - [Tier 1 Regression] Spec regression : création personnage et ouverture de fiche](https://github.com/herveDarritchon/foundryvtt-swerpg/issues/369), [#370 — PWE4 - [Tier 1 Regression] Spec regression : dépense simple d'XP et ouverture arbre de spécialisation](https://github.com/herveDarritchon/foundryvtt-swerpg/issues/370)
+**Domaine métier** : `tests`
+**Source de cadrage** :
+
+- `documentation/plan/tests/366-playwright-local-foundry-smoke-tests-securiser-les-parcours-mj-essentiels-en-local.md`
+- `documentation/plan/tests/367-pwe1-stabiliser-la-baseline-locale-playwright-et-le-monde-e2e.md`
+- `documentation/plan/tests/368-pwe2-fiabiliser-les-contrats-d-interaction-et-la-capture-d-erreurs-navigateur.md`
+- `documentation/plan/tests/369-pwe3-tier-1-regression-spec-regression-creation-personnage-et-ouverture-de-fiche.md`
+- `documentation/plan/tests/370-pwe4-tier-1-regression-spec-regression-depense-simple-d-xp-et-ouverture-arbre-de-specialisation.md`
+- `documentation/plan/tests/e2e/strategie-e2e-deux-etages-regression-et-smoke-prod.md`
+- `documentation/tests/e2e/playwright-e2e-guide.md`
+- `e2e/README.md`
+
+---
+
+## 1. Objectif
+
+Formaliser puis outiller une stratégie de reset déterministe pour le monde Tier 1 afin que les specs de régression restent reproductibles, idempotentes et indépendantes de leur ordre d'exécution.
+
+---
+
+## 2. Périmètre
+
+### Inclus
+
+- décision explicite entre reset complet du monde et cleanup ciblé par spec ;
+- définition des données minimales attendues par domaine fonctionnel couvert ;
+- politique de noms uniques et/ou suppression systématique des artefacts de test ;
+- sécurisation du bootstrap `globalSetup` quand le monde existe déjà ;
+- vérification du déterminisme sur les parcours `PWE3` et `PWE4`.
+
+### Exclu
+
+- extension de couverture E2E hors parcours déjà priorisés ;
+- refonte générale des helpers Playwright sans lien direct avec l'hygiène du monde ;
+- changement applicatif runtime sans preuve qu'il est nécessaire pour stabiliser le reset Tier 1.
+
+---
+
+## 3. Plan de travail proposé
+
+### Étape 1 — Trancher et documenter le contrat d'hygiène Tier 1
+
+**But** : décider un contrat unique de remise à zéro, compréhensible et applicable par toutes les specs de régression.
+
+**Fichiers cibles** : `e2e/README.md`, `documentation/tests/e2e/playwright-e2e-guide.md`, éventuelle documentation courte sous `documentation/tests/e2e/`
+
+**Actions** :
+
+- comparer explicitement les deux approches visées par l'issue : monde jetable/recréé vs cleanup systématique par spec ;
+- retenir une règle opérationnelle par défaut, ainsi que les exceptions tolérées si certaines specs doivent nettoyer leurs propres artefacts ;
+- documenter les données minimales requises par domaine déjà couvert (`smoke`, création personnage, dépense XP / arbre) ;
+- expliciter la règle de nommage unique ou de teardown obligatoire pour éviter les collisions inter-specs.
+
+### Étape 2 — Rendre le bootstrap monde idempotent et reproductible
+
+**But** : garantir qu'un lancement sur monde absent, déjà présent, partiellement pollué ou déjà actif converge vers un état connu.
+
+**Fichiers cibles** : `e2e/regression/fixtures/global-setup.ts`, `e2e/regression/utils/world-manager.ts`, éventuels helpers partagés sous `e2e/regression/utils/` et `e2e/fixtures/`
+
+**Actions** :
+
+- clarifier le rôle exact de `globalSetup` : créer, réinitialiser ou nettoyer le monde selon la politique retenue ;
+- fiabiliser la gestion des cas `monde déjà existant`, `monde déjà actif`, `retour setup` et `rebootstrap` sans dépendance à l'ordre des specs ;
+- centraliser les primitives de reset/cleanup pour éviter des nettoyages ad hoc dispersés dans les specs ;
+- rendre observable le reset réellement exécuté pour accélérer le diagnostic en cas d'échec de préparation.
+
+### Étape 3 — Réaligner les specs Tier 1 prioritaires sur ce contrat
+
+**But** : prouver que la stratégie retenue fonctionne sur les deux parcours réels déjà identifiés comme sensibles.
+
+**Fichiers cibles** : specs Tier 1 sous `e2e/regression/specs/**`, fixtures sous `e2e/fixtures/**` ou `e2e/regression/fixtures/**`, éventuels helpers sous `e2e/utils/**`
+
+**Actions** :
+
+- expliciter pour `PWE3` et `PWE4` quelles données doivent être présentes avant exécution et lesquelles doivent être créées/effacées par le scénario ;
+- remplacer les hypothèses implicites sur l'état du monde par des préconditions ou nettoyages centralisés compatibles avec la politique retenue ;
+- verrouiller un ordre d'exécution indifférent : exécution isolée, séquentielle, puis répétée sur monde déjà existant ;
+- documenter brièvement la frontière entre données communes de baseline et artefacts éphémères de scénario.
+
+---
+
+## 4. Ordre recommandé
+
+1. Contrat d'hygiène Tier 1
+2. Bootstrap monde idempotent
+3. Réalignement des specs prioritaires
+
+---
+
+## 5. Validation prévue (non exécutée dans ce plan)
+
+- exécution ciblée de `PWE3` puis `PWE4`, puis dans l'ordre inverse, pour vérifier l'indépendance ;
+- relance complète sur un monde déjà existant pour confirmer le comportement idempotent de `globalSetup` ;
+- vérification qu'aucun artefact métier résiduel ne pollue la campagne suivante ;
+- relecture croisée `README ↔ guide E2E ↔ helpers de reset ↔ specs` pour confirmer un contrat unique et explicite.
+
+---
+
+## 6. Résultat attendu
+
+Le Tier 1 dispose d'une stratégie de reset claire, documentée et outillée ; les specs prioritaires restent déterministes même sur monde déjà existant, et les futures régressions liées à la pollution de données deviennent rapides à diagnostiquer.

--- a/documentation/tests/e2e/playwright-e2e-guide.md
+++ b/documentation/tests/e2e/playwright-e2e-guide.md
@@ -486,6 +486,54 @@ Avantages :
 - En cas d’erreur lors du cleanup, les helpers se contentent d’essayer de revenir sur `/setup` ou `/auth` sans faire échouer le test : objectif → éviter les effets de bord sur les scénarios suivants.
 - Évitez de modifier à la main l’état du monde de test (suppression massive de données, changements de configuration critique) dans un test sans cleanup dédié.
 
+
+### 7.3b. Stratégie de reset déterministe Tier 1 (contrat d’hygiène)
+
+La suite de régression Tier 1 applique un **cleanup ciblé par spec** (pas de recréation du monde).
+
+#### Décision
+
+| Approche | Décision |
+|---|---|
+| Monde jetable recréé à chaque run | Non retenu — trop lent, masque les régressions de persistance |
+| Cleanup ciblé par spec | **Retenu** — rapide, déterministe, préserve la baseline commune |
+
+#### Règles à respecter
+
+1. **Noms uniques horodatés** : utiliser `<Prefixe>-${Date.now()}` pour tout artefact créé par une spec.
+2. **Teardown explicite** : appeler `deleteActorByName(page, actorName)` après les assertions du test, avant que la fixture `worldReady` ne clôture la session.
+3. **Pas de dépendance inter-specs** : chaque spec doit fonctionner seule, dans n’importe quel ordre, même sur un monde déjà existant.
+4. **Bootstrap idempotent** : le `globalSetup` crée le monde s’il est absent, ne fait rien s’il est présent — il ne réinitialise pas le contenu.
+
+#### Primitives disponibles
+
+| Fonction | Fichier | Usage |
+|---|---|---|
+| `deleteActorByName(page, name)` | `e2e/regression/utils/world-manager.ts` | Supprimer un acteur en fin de test |
+| `cleanupTestActors(page, prefix)` | `e2e/regression/utils/world-manager.ts` | Nettoyer des artefacts résiduels par préfixe |
+
+#### Exemple de teardown dans une spec
+
+```ts
+test('création personnage et ouverture de fiche', async ({ page }) => {
+  const actorName = `Test-Personnage-${Date.now()}`
+
+  // ... Act et Assert ...
+
+  // Teardown : supprimer l’artefact de test pour ne pas polluer le monde
+  await deleteActorByName(page, actorName)
+})
+```
+
+#### Données minimales par domaine
+
+| Spec | Données communes attendues | Artefacts éphémères |
+|---|---|---|
+| 01 — smoke | monde actif, système swerpg chargé | aucun |
+| 02 — OggDude import | monde actif, settings accessibles | aucun |
+| 03 — création personnage | monde actif | acteurs `Test-Personnage-*` |
+| 04 — XP / arbre | monde actif | acteurs `Test-XP-*`, `Test-XP-Skill-*`, `Test-SpecTree-*` |
+
 ### 7.4. Écriture de nouveaux tests
 
 Pour tout nouveau test E2E :

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -232,6 +232,50 @@ Pour les détails complets, voir `documentation/tests/e2e/playwright-e2e-guide.m
 
 ---
 
+## Hygiène monde Tier 1 et stratégie de reset déterministe
+
+### Décision retenue
+
+La suite de régression Tier 1 repose sur un **cleanup ciblé par spec**, pas sur la recréation du monde entre chaque run.
+
+| Approche | Décision |
+|---|---|
+| Monde jetable recréé à chaque run | Non retenu — trop long, masque des régressions de persistance |
+| Cleanup ciblé par spec (artefacts éphémères) | **Retenu** — rapide, déterministe, préserve la baseline |
+
+### Règles opérationnelles
+
+1. **Noms uniques** : chaque spec crée ses acteurs avec un nom horodaté unique (ex. `Test-Personnage-<timestamp>`). Cette convention suffit à éviter les collisions si le teardown échoue.
+2. **Teardown obligatoire** : chaque spec supprime ses acteurs après les assertions via `deleteActorByName` (importé depuis `e2e/regression/utils/world-manager.ts`).
+3. **Bootstrap idempotent** : le `globalSetup` crée le monde s'il est absent, ne fait rien s'il est présent. Un monde partiellement pollué est accepté — les specs nettoient leurs propres artefacts.
+4. **Nettoyage résiduel** : en cas de run interrompu, `cleanupTestActors(page, 'Test-')` permet de nettoyer les artefacts résiduels par préfixe depuis `/game`.
+
+### Données minimales requises par domaine
+
+| Spec | Données communes attendues | Artefacts éphémères (créés / supprimés par la spec) |
+|---|---|---|
+| 01 — smoke | monde actif, système swerpg chargé | aucun |
+| 02 — OggDude import | monde actif, settings système accessibles | aucun |
+| 03 — création personnage | monde actif | acteurs préfixés `Test-Personnage-*` |
+| 04 — XP / arbre spécialisation | monde actif | acteurs préfixés `Test-XP-*`, `Test-XP-Skill-*`, `Test-SpecTree-*` |
+
+### Primitives de cleanup disponibles
+
+| Fonction | Fichier | Usage |
+|---|---|---|
+| `deleteActorByName(page, name)` | `e2e/regression/utils/world-manager.ts` | Supprimer un acteur précis en fin de test |
+| `cleanupTestActors(page, prefix)` | `e2e/regression/utils/world-manager.ts` | Nettoyer tous les artefacts résiduels d'un préfixe |
+| `ensureWorldExists(page, opts)` | `e2e/regression/utils/world-manager.ts` | Bootstrap idempotent (globalSetup) |
+
+### Checklist pour toute nouvelle spec qui crée des données
+
+- [ ] Nom de l'artefact horodaté unique (`<Prefixe>-${Date.now()}`)
+- [ ] `deleteActorByName` (ou équivalent) appelé en fin de test après les assertions
+- [ ] Préfixe documenté dans le tableau "données minimales" ci-dessus
+- [ ] Pas de dépendance à l'état d'un artefact créé par une autre spec
+
+---
+
 ## Conseils
 
 Préférer `beforeEach` et `beforeAll` pour se mettre dans un état initial plutôt que

--- a/e2e/regression/fixtures/global-setup.ts
+++ b/e2e/regression/fixtures/global-setup.ts
@@ -7,8 +7,15 @@ dotenv.config({ path: process.env.E2E_ENV_FILE || '.env.e2e.regression' })
 /**
  * Global setup des tests de non-régression.
  *
- * Garantit qu'une instance Foundry est accessible sur port 31001
- * et que le monde de régression existe (le crée si absent).
+ * Stratégie de reset Tier 1 (voir world-manager.ts pour le contrat complet) :
+ * - monde absent → création via l'UI Foundry /setup ;
+ * - monde déjà présent → validation seulement (idempotent) ;
+ * - monde déjà actif (/join ou /game) → retour à /setup puis validation ;
+ * - monde partiellement pollué → les specs nettoient leurs propres artefacts en teardown.
+ *
+ * Le globalSetup ne réinitialise PAS le contenu du monde (acteurs, items, etc.).
+ * Seule l'existence du monde est garantie. Les artefacts de test sont gérés
+ * par chaque spec via `deleteActorByName` (e2e/regression/utils/world-manager.ts).
  *
  * Exécuté une seule fois avant tous les tests de la suite.
  */
@@ -21,15 +28,19 @@ export default async function globalSetup(_config: FullConfig): Promise<void> {
     throw new Error('[globalSetup] E2E_FOUNDRY_ADMIN_PASSWORD non défini — configurer .env.e2e.regression')
   }
 
-  console.log(`[globalSetup] Instance: ${baseURL}`)
+  console.log(`[globalSetup] Instance cible: ${baseURL}`)
   console.log(`[globalSetup] Monde cible: "${world}"`)
+  console.log('[globalSetup] Stratégie: monde existant conservé (cleanup par spec) — monde absent créé')
 
   const browser = await chromium.launch({ headless: true })
   const page = await browser.newPage()
 
   try {
     await ensureWorldExists(page, { baseURL, adminPassword, world })
-    console.log('[globalSetup] ✅ Prêt pour les tests de non-régression')
+    console.log('[globalSetup] Bootstrap Tier 1 reussi — monde disponible pour les specs')
+  } catch (error) {
+    console.error('[globalSetup] ECHEC du bootstrap — les specs ne peuvent pas demarrer:', error)
+    throw error
   } finally {
     await browser.close()
   }

--- a/e2e/regression/specs/03-character-creation.spec.ts
+++ b/e2e/regression/specs/03-character-creation.spec.ts
@@ -1,5 +1,6 @@
 import { expect, test } from '../../fixtures'
 import { createActor, openActorsTab } from '../../utils/foundryUI'
+import { deleteActorByName } from '../utils/world-manager'
 
 /**
  * 03 — Création de personnage et ouverture de fiche (Tier 1 Regression)
@@ -11,6 +12,11 @@ import { createActor, openActorsTab } from '../../utils/foundryUI'
  *   4. Vérifier que la fiche s'ouvre (fenêtre de sheet visible avec le bon titre)
  *   5. Vérifier l'absence d'erreur navigateur (contrôle assuré automatiquement
  *      par la fixture `worldReady` en teardown via `assertNoErrors`)
+ *
+ * Stratégie d'hygiène (contrat Tier 1) :
+ *   - Chaque test crée ses acteurs avec un nom horodaté unique (`Test-Personnage-<timestamp>`).
+ *   - Chaque test supprime ses acteurs en teardown via `deleteActorByName`.
+ *   - Le monde n'est pas recréé entre les runs : seuls les artefacts éphémères sont nettoyés.
  *
  * Pré-requis :
  *   - Instance Foundry sur port 31001 avec monde Swerpg-Regression-World
@@ -48,13 +54,14 @@ test.describe('[regression] 03 — character creation', () => {
 
     // Assert 2 : la fiche de l'acteur est ouverte et affiche le bon titre
     // Foundry v14 ApplicationV2 rend : <form class="application sheet ...">
-    const actorSheet = page
-      .locator('.application.sheet, .app.sheet, .window-app, dialog.sheet, [role="dialog"]')
-      .filter({ hasText: actorName })
-      .first()
+    const actorSheet = page.locator('.application.sheet, .app.sheet, .window-app, dialog.sheet, [role="dialog"]').filter({ hasText: actorName }).first()
     await expect(actorSheet).toBeVisible()
 
     // Assert 3 (implicite) : aucune erreur navigateur — vérifiée automatiquement
     // par la fixture `worldReady` en teardown via errorCollector.assertNoErrors()
+
+    // Teardown : supprimer l'artefact de test pour ne pas polluer le monde
+    // (effectué après les assertions pour ne pas masquer un éventuel échec)
+    await deleteActorByName(page, actorName)
   })
 })

--- a/e2e/regression/specs/04-xp-spend-and-specialization-tree.spec.ts
+++ b/e2e/regression/specs/04-xp-spend-and-specialization-tree.spec.ts
@@ -1,5 +1,6 @@
 import { expect, test } from '../../fixtures'
 import { createActor, openActorsTab, openActorSkillsTab, openSpecializationTree } from '../../utils/foundryUI'
+import { deleteActorByName } from '../utils/world-manager'
 
 /**
  * 04 — Dépense simple d'XP et ouverture arbre de spécialisation (Tier 1 Regression)
@@ -13,6 +14,11 @@ import { createActor, openActorsTab, openActorSkillsTab, openSpecializationTree 
  *   6. Vérifier que le recalcul XP est visible et persistant dans la console
  *   7. Ouvrir l'arbre de spécialisation via le bouton dédié de la fiche
  *   8. Vérifier que l'arbre s'ouvre sans erreur navigateur non autorisée
+ *
+ * Stratégie d'hygiène (contrat Tier 1) :
+ *   - Chaque test crée ses acteurs avec un nom horodaté unique (`Test-XP-<timestamp>`, etc.).
+ *   - Chaque test supprime ses acteurs en teardown via `deleteActorByName`.
+ *   - Le monde n'est pas recréé entre les runs : seuls les artefacts éphémères sont nettoyés.
  *
  * Pré-requis :
  *   - Instance Foundry sur port 31001 avec monde Swerpg-Regression-World
@@ -40,10 +46,7 @@ test.describe('[regression] 04 — XP spend and specialization tree', () => {
     await createActor(page, actorName, 'character')
 
     // Assert 1 : la fiche est ouverte
-    const actorSheet = page
-      .locator('.application.sheet, .app.sheet, .window-app, dialog.sheet, [role="dialog"]')
-      .filter({ hasText: actorName })
-      .first()
+    const actorSheet = page.locator('.application.sheet, .app.sheet, .window-app, dialog.sheet, [role="dialog"]').filter({ hasText: actorName }).first()
     await expect(actorSheet).toBeVisible()
 
     // Assert 2 : le panneau XP console est visible (mode création incomplète = L0)
@@ -56,6 +59,9 @@ test.describe('[regression] 04 — XP spend and specialization tree', () => {
     const spentEl = xpConsole.locator('[data-xp-spent]')
     await expect(availableEl).toBeVisible()
     await expect(spentEl).toBeVisible()
+
+    // Teardown : supprimer l'artefact de test
+    await deleteActorByName(page, actorName)
   })
 
   test('achat rang compétence : console XP reste cohérente après transaction', async ({ page }) => {
@@ -69,10 +75,7 @@ test.describe('[regression] 04 — XP spend and specialization tree', () => {
     // Ouvrir l'onglet Skills de la fiche
     await openActorSkillsTab(page, actorName)
 
-    const actorSheet = page
-      .locator('.application.sheet, .app.sheet, .window-app, dialog.sheet, [role="dialog"]')
-      .filter({ hasText: actorName })
-      .first()
+    const actorSheet = page.locator('.application.sheet, .app.sheet, .window-app, dialog.sheet, [role="dialog"]').filter({ hasText: actorName }).first()
 
     // Assert : la console XP et au moins une compétence sont visibles
     const xpConsole = actorSheet.locator('[data-skill-purchase-console]')
@@ -108,6 +111,9 @@ test.describe('[regression] 04 — XP spend and specialization tree', () => {
 
     // Documenter les valeurs avant/après pour diagnostic en cas de régression
     expect({ availableBefore, spentBefore, availableAfter, spentAfter }).toBeDefined()
+
+    // Teardown : supprimer l'artefact de test
+    await deleteActorByName(page, actorName)
   })
 
   test("arbre de spécialisation s'ouvre sans erreur navigateur", async ({ page }) => {
@@ -131,5 +137,8 @@ test.describe('[regression] 04 — XP spend and specialization tree', () => {
 
     // Assert 3 (implicite) : aucune erreur navigateur — vérifiée automatiquement
     // par la fixture `worldReady` en teardown via errorCollector.assertNoErrors()
+
+    // Teardown : supprimer l'artefact de test
+    await deleteActorByName(page, actorName)
   })
 })

--- a/e2e/regression/utils/world-manager.ts
+++ b/e2e/regression/utils/world-manager.ts
@@ -8,6 +8,29 @@ export interface WorldManagerOptions {
   world: string
 }
 
+// ---------------------------------------------------------------------------
+// Contrat d'hygiène Tier 1
+// ---------------------------------------------------------------------------
+//
+// Stratégie retenue : cleanup ciblé par spec (pas de recréation du monde).
+//
+// Règles opérationnelles :
+// 1. Chaque spec crée ses artefacts avec un nom unique horodaté (ex. `Test-${Date.now()}`).
+// 2. Chaque spec supprime ses propres artefacts en afterEach via `deleteActorByName`.
+// 3. Le bootstrap `globalSetup` est idempotent : monde absent → création, monde présent → validation.
+// 4. En cas d'artefacts résiduels, `cleanupTestActors` permet un nettoyage ciblé par préfixe.
+//
+// Données minimales requises par domaine :
+// - smoke (01) : monde actif, système swerpg chargé, sidebar visible.
+// - OggDude import (02) : monde actif, settings système accessibles.
+// - création personnage (03) : monde actif, aucun acteur préexistant requis.
+// - dépense XP / arbre (04) : monde actif, aucun acteur préexistant requis.
+//
+// Frontière données communes vs artefacts éphémères :
+// - données communes de baseline : le monde lui-même (`Swerpg-Regression-World`), système swerpg.
+// - artefacts éphémères de scénario : acteurs créés par les specs 03 et 04 (nommés `Test-*`).
+// ---------------------------------------------------------------------------
+
 /**
  * Navigue vers /setup en gérant toutes les pages intermédiaires :
  * /license → /auth → /setup (ou /join si monde déjà actif → Return to Setup).
@@ -49,9 +72,7 @@ export async function navigateToSetup(page: Page, options: WorldManagerOptions):
   await dismissShareUsageDataIfPresent(page)
   await dismissTourIfPresent(page)
   // Cleanup résiduel du DOM (au cas où le dismiss partiel laisserait l'overlay)
-  await page.evaluate(() =>
-    document.querySelectorAll('.tour-overlay, .tour-container').forEach((el) => el.remove()),
-  )
+  await page.evaluate(() => document.querySelectorAll('.tour-overlay, .tour-container').forEach((el) => el.remove()))
 
   console.log('[worldManager] Sur /setup ✔')
 }
@@ -204,5 +225,121 @@ async function returnToSetupFromGame(page: Page, options: WorldManagerOptions): 
   } catch (error) {
     await page.goto(`${options.baseURL}/setup`, { waitUntil: 'domcontentloaded' }).catch(() => {})
     console.warn('[worldManager] returnToSetupFromGame fallback:', error)
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Primitives de cleanup d'artefacts de test
+// ---------------------------------------------------------------------------
+
+/**
+ * Supprime un acteur par nom depuis la sidebar Actors en /game.
+ *
+ * Utilisé en teardown de spec pour éliminer les artefacts de test et garantir
+ * que le monde ne soit pas pollué entre les runs.
+ *
+ * Pré-requis : être en /game avec la sidebar Actors accessible.
+ *
+ * @param page - Page Playwright
+ * @param actorName - Nom exact de l'acteur à supprimer
+ */
+export async function deleteActorByName(page: Page, actorName: string): Promise<void> {
+  try {
+    // S'assurer que l'onglet Actors est actif
+    const actorsTab = page
+      .locator('[role="tab"][data-tab="actors"]')
+      .or(page.locator('[data-action="tab"][data-tab="actors"]'))
+      .or(page.getByRole('tab', { name: /^Actors$/i }))
+      .first()
+
+    await actorsTab.waitFor({ state: 'visible', timeout: 5000 })
+    await actorsTab.click()
+    await page.locator('#actors').waitFor({ state: 'visible', timeout: 5000 })
+
+    // Localiser l'entrée de l'acteur dans la liste
+    const actorEntry = page.locator('#actors').locator('li.actor, li.document').filter({ hasText: actorName }).first()
+    const exists = await actorEntry.isVisible({ timeout: 3000 }).catch(() => false)
+
+    if (!exists) {
+      console.log(`[worldManager] Acteur "${actorName}" introuvable dans la liste — pas de suppression nécessaire`)
+      return
+    }
+
+    // Clic droit pour ouvrir le menu contextuel
+    await actorEntry.click({ button: 'right' })
+
+    // Foundry v14 : menu contextuel avec option "Delete"
+    const deleteOption = page
+      .locator('[data-action="delete"]')
+      .or(page.locator('.context-menu li').filter({ hasText: /^Delete$/i }))
+      .or(page.getByRole('menuitem', { name: /Delete/i }))
+      .first()
+
+    await deleteOption.waitFor({ state: 'visible', timeout: 5000 })
+    await deleteOption.click()
+
+    // Confirmer la suppression dans le dialog de confirmation Foundry
+    const confirmBtn = page
+      .getByRole('button', { name: /^Yes$/i })
+      .or(page.getByRole('button', { name: /Confirm/i }))
+      .or(page.locator('[data-button="yes"]'))
+      .first()
+
+    await confirmBtn.waitFor({ state: 'visible', timeout: 5000 })
+    await confirmBtn.click()
+
+    // Attendre que l'entrée disparaisse de la liste
+    await actorEntry.waitFor({ state: 'hidden', timeout: 5000 }).catch(() => {})
+
+    console.log(`[worldManager] Acteur "${actorName}" supprimé ✔`)
+  } catch (error) {
+    console.warn(`[worldManager] deleteActorByName("${actorName}") échoué (non bloquant):`, error)
+  }
+}
+
+/**
+ * Supprime tous les acteurs dont le nom correspond au préfixe donné.
+ *
+ * Utile en cas d'artefacts résiduels laissés par des runs précédents interrompus.
+ * Les specs créent leurs acteurs avec un préfixe fixe (ex. "Test-Personnage-", "Test-XP-")
+ * afin de permettre ce nettoyage ciblé sans affecter d'autres données du monde.
+ *
+ * Pré-requis : être en /game avec la sidebar Actors accessible.
+ *
+ * @param page - Page Playwright
+ * @param prefix - Préfixe des acteurs à supprimer (ex: "Test-")
+ */
+export async function cleanupTestActors(page: Page, prefix: string): Promise<void> {
+  try {
+    // S'assurer que l'onglet Actors est actif
+    const actorsTab = page
+      .locator('[role="tab"][data-tab="actors"]')
+      .or(page.locator('[data-action="tab"][data-tab="actors"]'))
+      .or(page.getByRole('tab', { name: /^Actors$/i }))
+      .first()
+
+    await actorsTab.waitFor({ state: 'visible', timeout: 5000 })
+    await actorsTab.click()
+    await page.locator('#actors').waitFor({ state: 'visible', timeout: 5000 })
+
+    // Récupérer tous les noms d'acteurs correspondant au préfixe
+    const actorEntries = page.locator('#actors').locator('li.actor, li.document')
+    const names = await actorEntries.allTextContents()
+    const toDelete = names.filter((n) => n.trim().startsWith(prefix))
+
+    if (toDelete.length === 0) {
+      console.log(`[worldManager] cleanupTestActors("${prefix}"): aucun artefact résiduel trouvé`)
+      return
+    }
+
+    console.log(`[worldManager] cleanupTestActors("${prefix}"): ${toDelete.length} artefact(s) à supprimer`)
+
+    for (const name of toDelete) {
+      await deleteActorByName(page, name.trim())
+    }
+
+    console.log(`[worldManager] cleanupTestActors("${prefix}") terminé ✔`)
+  } catch (error) {
+    console.warn(`[worldManager] cleanupTestActors("${prefix}") échoué (non bloquant):`, error)
   }
 }


### PR DESCRIPTION
Closes #371

## Context

This branch implements a Tier 1 regression hygiene strategy for E2E tests and provides a deterministic world reset helper to stabilise Playwright regression runs. It follows the implementation plan added under `documentation/plan/tests/`.

## Summary of changes

- Add implementation plan: `documentation/plan/tests/371-pwe5-tier-1-regression-hygiene-monde-de-test-tier-1-et-strategie-de-reset-deterministe.md`
- Add E2E guide updates: `documentation/tests/e2e/playwright-e2e-guide.md`
- Update E2E README: `e2e/README.md`
- Add/modify regression fixtures and helpers:
  - `e2e/regression/fixtures/global-setup.ts`
  - `e2e/regression/utils/world-manager.ts`
- Add/modify E2E specs:
  - `e2e/regression/specs/03-character-creation.spec.ts`
  - `e2e/regression/specs/04-xp-spend-and-specialization-tree.spec.ts`

## Technical notes

- The deterministic reset logic is implemented in `e2e/regression/utils/world-manager.ts` and exercised by updated fixtures in `e2e/regression/fixtures/global-setup.ts`.
- The changes include documentation to guide running the E2E suites and the hygiene strategy.
- No source runtime code under `module/` is modified; this is focused on test infrastructure and documentation.

## Tests run

No tests, lints, or builds were executed as part of PR creation.

The branch adds Playwright E2E specs and helpers. Reviewers should run the E2E smoke/regression suites locally or in CI.

See:

- `e2e/README.md`
- `documentation/tests/e2e/playwright-e2e-guide.md`

## Known limits

- E2E changes require a running Foundry instance and an environment configured as described in `e2e/README.md`.
- This PR does not include CI pipeline changes to run the new suites automatically.

## Points of attention for reviewers

- Review the deterministic reset implementation for safety and side effects around world state management.
- Confirm the fixtures do not leak persistent test data into shared environments.
- Ensure documentation steps match the implemented helpers and fixtures.