### PR TITLE
feat(tests): standardize HTML report generation and PWE6 coverage matrix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -219,6 +219,8 @@ dist
 
 # Playwright outputs
 playwright-report/
+playwright-regression-report/
+playwright-smoke-report/
 test-results/
 
 ### GitHubPages template

--- a/documentation/cadrage/documentation/e2e-documentation-user-guide-generation-with-playwright-and-ai.md
+++ b/documentation/cadrage/documentation/e2e-documentation-user-guide-generation-with-playwright-and-ai.md
@@ -1,0 +1,660 @@
+# Cadrage — Suite E2E Documentation pour génération de User Guides
+
+## 1. Objectif
+
+Mettre en place un troisième type de parcours Playwright dédié à la génération de documentation utilisateur.
+
+Ces parcours ne doivent pas être considérés comme des tests de validation fonctionnelle classiques. Leur objectif principal est de parcourir l’application de manière déterministe, de capturer des screenshots propres et de produire des données structurées exploitables par une IA afin de générer un user guide en anglais.
+
+La commande cible est :
+
+```bash
+pnpm run e2e:documentation
+````
+
+Le résultat attendu est un ensemble de captures d’écran, de métadonnées de parcours et de fichiers Markdown pouvant servir de base à une documentation utilisateur.
+
+## 2. Contexte
+
+Le projet dispose déjà de tests E2E Playwright orientés validation fonctionnelle, notamment des suites de smoke tests et de regression tests.
+
+Le besoin ici est différent.
+
+Les tests E2E existants répondent à la question :
+
+> “Est-ce que l’application fonctionne correctement ?”
+
+La suite E2E Documentation doit répondre à la question :
+
+> “Comment documenter clairement un parcours utilisateur réel avec des captures à jour ?”
+
+Playwright est adapté à ce besoin car il permet d’automatiser un navigateur, d’exécuter des actions utilisateur, de capturer des screenshots, de structurer des étapes avec `test.step`, et de produire des artefacts exploitables. La documentation officielle Playwright confirme le support de l’automatisation navigateur, des tests multi-navigateurs, du tracing, des reporters et des artefacts liés à l’exécution. Source : Playwright, documentation officielle, consultée le 24 mai 2026, [https://playwright.dev/](https://playwright.dev/) ([Playwright][1])
+
+## 3. Décision de cadrage
+
+Créer un troisième type de parcours E2E :
+
+```txt
+1. Smoke E2E
+   Objectif : vérifier rapidement que les parcours critiques ne sont pas cassés.
+
+2. Regression E2E
+   Objectif : vérifier en profondeur la stabilité fonctionnelle des parcours métier.
+
+3. Documentation E2E
+   Objectif : explorer l’application, capturer des screenshots propres et produire une base de user guide en anglais.
+```
+
+La suite Documentation E2E ne doit pas être traitée comme une suite de tests bloquante au même niveau que les suites smoke ou regression.
+
+Elle peut contenir des assertions minimales de sécurité, mais son rôle principal est documentaire.
+
+## 4. Non-objectifs
+
+Cette suite ne doit pas servir à :
+
+* remplacer les tests smoke ;
+* remplacer les tests de regression ;
+* valider exhaustivement les règles métier ;
+* détecter tous les bugs fonctionnels ;
+* générer automatiquement une documentation publiable sans relecture humaine ;
+* produire une documentation commerciale ou marketing ;
+* documenter des états instables, aléatoires ou dépendants de données non maîtrisées.
+
+La documentation générée par IA doit être considérée comme une première version éditoriale, jamais comme une source finale non relue.
+
+## 5. Principe général
+
+Le pipeline cible est le suivant :
+
+```txt
+Playwright documentation scenario
+        ↓
+Exploration déterministe de l’application
+        ↓
+Screenshots propres + metadata JSON
+        ↓
+Génération IA du user guide en anglais
+        ↓
+Markdown structuré
+        ↓
+Relecture humaine
+        ↓
+Publication documentation
+```
+
+## 6. Commande cible
+
+Ajouter une commande dédiée dans `package.json` :
+
+```json
+{
+  "scripts": {
+    "e2e:documentation": "playwright test --config=e2e/documentation/playwright.documentation.config.ts"
+  }
+}
+```
+
+Cette commande doit exécuter uniquement les parcours documentaires.
+
+Elle ne doit pas lancer les suites smoke ou regression.
+
+## 7. Structure de fichiers proposée
+
+```txt
+e2e/
+  documentation/
+    playwright.documentation.config.ts
+
+    fixtures/
+      documentation-setup.ts
+
+    specs/
+      character-creation.guide.spec.ts
+      xp-spend.guide.spec.ts
+      specialization-tree.guide.spec.ts
+
+    utils/
+      documentation-world-manager.ts
+      screenshot-helper.ts
+      guide-step-recorder.ts
+      guide-metadata-writer.ts
+
+    output/
+      raw/
+        character-creation.guide.json
+      screenshots/
+        character-creation/
+          01-open-actors-directory.png
+          02-create-character-dialog.png
+          03-fill-character-form.png
+      markdown/
+        character-creation.md
+```
+
+## 8. Convention de nommage
+
+Les fichiers de parcours documentaires doivent utiliser le suffixe :
+
+```txt
+*.guide.spec.ts
+```
+
+Exemples :
+
+```txt
+character-creation.guide.spec.ts
+xp-spend.guide.spec.ts
+specialization-tree.guide.spec.ts
+```
+
+Les captures doivent être préfixées avec un numéro d’ordre stable :
+
+```txt
+01-open-actors-directory.png
+02-click-create-character.png
+03-fill-character-name.png
+04-confirm-character-creation.png
+```
+
+Cette convention permet de garantir un ordre lisible dans le user guide généré.
+
+## 9. Comportement attendu des parcours Documentation E2E
+
+Chaque parcours documentaire doit :
+
+1. préparer un état applicatif déterministe ;
+2. ouvrir l’écran cible ;
+3. effectuer les actions utilisateur représentatives ;
+4. capturer un screenshot à chaque étape importante ;
+5. enregistrer une description structurée de chaque étape ;
+6. produire un fichier JSON intermédiaire ;
+7. optionnellement déclencher la génération Markdown via IA.
+
+Exemple de données structurées :
+
+```json
+{
+  "guideId": "character-creation",
+  "title": "Creating a Character",
+  "audience": "End user",
+  "language": "en",
+  "steps": [
+    {
+      "order": 1,
+      "title": "Open the Actors directory",
+      "userAction": "Click the Actors tab in the sidebar.",
+      "expectedScreenState": "The Actors directory is visible.",
+      "screenshot": "screenshots/character-creation/01-open-actors-directory.png"
+    },
+    {
+      "order": 2,
+      "title": "Create a new character",
+      "userAction": "Click the Create Actor button.",
+      "expectedScreenState": "The character creation dialog is displayed.",
+      "screenshot": "screenshots/character-creation/02-create-character-dialog.png"
+    }
+  ]
+}
+```
+
+## 10. Rôle de Playwright
+
+Playwright est utilisé pour :
+
+* piloter le navigateur ;
+* ouvrir l’application ;
+* cliquer dans l’interface ;
+* remplir des formulaires ;
+* stabiliser les attentes avant capture ;
+* capturer des screenshots ;
+* produire des artefacts techniques ;
+* structurer les étapes de parcours.
+
+Playwright ne doit pas être utilisé ici pour faire des assertions métier complexes. Les assertions doivent rester limitées aux conditions nécessaires pour garantir que la capture est pertinente.
+
+Exemples d’assertions acceptables :
+
+```ts
+await expect(page.getByRole('heading', { name: 'Actors' })).toBeVisible();
+await expect(page.getByRole('button', { name: 'Create Actor' })).toBeVisible();
+```
+
+Exemples d’assertions à éviter dans cette suite :
+
+```ts
+await expect(character.xp).toBe(42);
+await expect(databaseState).toEqual(expectedComplexState);
+```
+
+Ces vérifications appartiennent aux suites regression.
+
+## 11. Rôle de l’IA
+
+L’IA est utilisée pour transformer les données structurées et les screenshots en user guide anglais.
+
+Elle peut :
+
+* reformuler les étapes en anglais clair ;
+* produire des titres lisibles ;
+* générer une introduction ;
+* générer des notes utilisateur ;
+* proposer des warnings ou tips si fournis dans les métadonnées ;
+* transformer le JSON intermédiaire en Markdown ;
+* harmoniser le ton et le niveau de détail.
+
+L’IA ne doit pas :
+
+* inventer des fonctionnalités ;
+* ajouter des boutons qui ne sont pas présents dans le parcours ;
+* extrapoler des règles métier ;
+* modifier le sens d’une étape ;
+* remplacer la validation humaine ;
+* produire une documentation finale sans relecture.
+
+## 12. Format cible du user guide
+
+Le user guide doit être généré en anglais.
+
+Format recommandé : Markdown.
+
+Exemple :
+
+```md
+# Creating a Character
+
+This guide explains how to create a new character from the Actors directory.
+
+## Prerequisites
+
+- The application is running.
+- The user has access to the Actors directory.
+
+## Step 1 — Open the Actors directory
+
+Click the **Actors** tab in the sidebar.
+
+![Open the Actors directory](../screenshots/character-creation/01-open-actors-directory.png)
+
+## Step 2 — Create a new character
+
+Click **Create Actor** to open the character creation dialog.
+
+![Create character dialog](../screenshots/character-creation/02-create-character-dialog.png)
+
+## Step 3 — Fill in the character information
+
+Enter the character name and confirm the creation.
+
+![Fill character form](../screenshots/character-creation/03-fill-character-form.png)
+```
+
+## 13. Exemple de spec Playwright documentaire
+
+```ts
+import { test, expect } from '@playwright/test';
+import { createGuideRecorder } from '../utils/guide-step-recorder';
+
+test.describe('User Guide — Character Creation', () => {
+  test('Generate documentation assets for character creation', async ({ page }) => {
+    const guide = createGuideRecorder({
+      guideId: 'character-creation',
+      title: 'Creating a Character',
+      language: 'en',
+      outputDir: 'e2e/documentation/output',
+    });
+
+    await page.goto('/');
+
+    await test.step('Open the Actors directory', async () => {
+      await page.getByRole('tab', { name: 'Actors' }).click();
+
+      await expect(
+        page.getByRole('heading', { name: 'Actors' })
+      ).toBeVisible();
+
+      await guide.captureStep(page, {
+        title: 'Open the Actors directory',
+        userAction: 'Click the Actors tab in the sidebar.',
+        expectedScreenState: 'The Actors directory is visible.',
+        screenshotName: '01-open-actors-directory.png',
+      });
+    });
+
+    await test.step('Create a new character', async () => {
+      await page.getByRole('button', { name: 'Create Actor' }).click();
+
+      await expect(
+        page.getByRole('dialog')
+      ).toBeVisible();
+
+      await guide.captureStep(page, {
+        title: 'Create a new character',
+        userAction: 'Click the Create Actor button.',
+        expectedScreenState: 'The character creation dialog is displayed.',
+        screenshotName: '02-create-character-dialog.png',
+      });
+    });
+
+    await guide.writeMetadata();
+  });
+});
+```
+
+## 14. Configuration Playwright dédiée
+
+Créer une configuration séparée :
+
+```ts
+// e2e/documentation/playwright.documentation.config.ts
+
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './specs',
+  timeout: 60_000,
+  fullyParallel: false,
+  retries: 0,
+
+  use: {
+    baseURL: process.env.E2E_BASE_URL ?? 'http://localhost:30000',
+    screenshot: 'off',
+    video: 'off',
+    trace: 'retain-on-failure',
+    viewport: {
+      width: 1440,
+      height: 1000,
+    },
+  },
+
+  reporter: [
+    ['list'],
+    ['html', { outputFolder: 'e2e/documentation/output/playwright-report', open: 'never' }],
+  ],
+});
+```
+
+Décision importante : `fullyParallel: false`.
+
+Pour de la documentation, la priorité n’est pas la vitesse. La priorité est la stabilité, la lisibilité et la reproductibilité des captures.
+
+## 15. Gestion des screenshots
+
+Les screenshots doivent être :
+
+* stables ;
+* lisibles ;
+* non bruités ;
+* exempts de données personnelles ;
+* produits avec une taille de viewport constante ;
+* nommés explicitement ;
+* versionnables si nécessaire ;
+* ou générés en artefacts CI si l’équipe ne veut pas les committer.
+
+Recommandation :
+
+```ts
+await page.screenshot({
+  path: screenshotPath,
+  fullPage: false,
+  animations: 'disabled',
+});
+```
+
+Les animations doivent être désactivées ou neutralisées autant que possible pour éviter les captures instables.
+
+## 16. Données de test
+
+La suite Documentation E2E doit utiliser un monde ou un état applicatif dédié.
+
+Elle ne doit jamais être exécutée sur :
+
+* un environnement de production ;
+* un environnement client partagé ;
+* une base contenant des données sensibles ;
+* un monde de test utilisé en parallèle par une autre suite.
+
+Recommandation :
+
+```txt
+documentation-world
+```
+
+Ce monde doit être réinitialisé avant chaque génération documentaire.
+
+## 17. Relation avec le reset déterministe
+
+La suite Documentation E2E peut réutiliser les helpers de reset déterministe existants, mais avec prudence.
+
+Si les helpers actuels sont orientés regression, il est préférable de créer une couche dédiée :
+
+```txt
+documentation-world-manager.ts
+```
+
+Objectif : garantir un état visuel propre, pas seulement un état fonctionnel valide.
+
+Exemples de responsabilités :
+
+* supprimer les entités créées par une génération précédente ;
+* recréer les données minimales nécessaires ;
+* garantir des noms stables ;
+* éviter les timestamps variables ;
+* éviter les états aléatoires ;
+* nettoyer les notifications ou popups parasites.
+
+## 18. Intégration IA
+
+Deux options sont possibles.
+
+### Option A — Génération séparée
+
+La commande `pnpm run e2e:documentation` génère uniquement les screenshots et JSON.
+
+Puis une seconde commande génère le guide :
+
+```bash
+pnpm run docs:generate-user-guides
+```
+
+Avantage : séparation propre entre automation et génération éditoriale.
+
+### Option B — Génération intégrée
+
+La commande `pnpm run e2e:documentation` exécute tout :
+
+```txt
+Playwright
+→ screenshots
+→ JSON
+→ IA
+→ Markdown
+```
+
+Avantage : plus simple pour l’utilisateur final.
+
+Inconvénient : plus fragile, car une erreur IA peut faire échouer toute la génération.
+
+Recommandation : commencer avec l’option A.
+
+## 19. Commandes recommandées
+
+```json
+{
+  "scripts": {
+    "e2e:documentation": "playwright test --config=e2e/documentation/playwright.documentation.config.ts",
+    "docs:generate-user-guides": "tsx scripts/generate-user-guides.ts",
+    "docs:user-guides": "pnpm run e2e:documentation && pnpm run docs:generate-user-guides"
+  }
+}
+```
+
+Ainsi :
+
+```bash
+pnpm run e2e:documentation
+```
+
+génère les assets.
+
+```bash
+pnpm run docs:generate-user-guides
+```
+
+génère les guides Markdown.
+
+```bash
+pnpm run docs:user-guides
+```
+
+génère l’ensemble.
+
+## 20. Prompt IA recommandé
+
+Le prompt IA doit être strict pour éviter les hallucinations.
+
+Exemple :
+
+```txt
+You are generating an English user guide from structured Playwright documentation metadata.
+
+Rules:
+- Use only the provided steps.
+- Do not invent features, buttons, labels, screens, warnings, or business rules.
+- Keep the guide clear and user-oriented.
+- Use Markdown.
+- Include each screenshot exactly where it belongs.
+- If information is missing, write a neutral sentence or omit the detail.
+- Do not mention Playwright, automated tests, or internal implementation details.
+- The target audience is an end user, not a developer.
+
+Input:
+{{GUIDE_JSON}}
+```
+
+## 21. Critères d’acceptation
+
+La mise en place est considérée comme valide si :
+
+* une commande `pnpm run e2e:documentation` existe ;
+* la commande exécute uniquement les specs `*.guide.spec.ts` ;
+* au moins un parcours documentaire complet est disponible ;
+* le parcours génère des screenshots stables ;
+* le parcours génère un fichier JSON structuré ;
+* une commande séparée permet de générer un user guide Markdown en anglais ;
+* le Markdown référence correctement les screenshots ;
+* les captures ne contiennent pas de données sensibles ;
+* les specs documentaires ne sont pas mélangées avec les specs smoke ou regression ;
+* la documentation explique clairement comment relancer la génération.
+
+## 22. Exemple de sortie attendue
+
+```txt
+e2e/documentation/output/
+  raw/
+    character-creation.guide.json
+
+  screenshots/
+    character-creation/
+      01-open-actors-directory.png
+      02-create-character-dialog.png
+      03-fill-character-form.png
+
+  markdown/
+    character-creation.md
+
+  playwright-report/
+    index.html
+```
+
+## 23. Risques identifiés
+
+### Risque 1 — Confusion entre test et documentation
+
+Les specs documentaires peuvent être perçues comme des tests de regression.
+
+Mesure :
+
+* utiliser le suffixe `*.guide.spec.ts` ;
+* documenter explicitement leur rôle ;
+* ne pas les inclure dans les pipelines bloquants de validation fonctionnelle.
+
+### Risque 2 — Screenshots instables
+
+Les captures peuvent varier à cause d’animations, de données dynamiques ou de résolutions différentes.
+
+Mesure :
+
+* viewport fixe ;
+* données déterministes ;
+* animations désactivées ;
+* reset documentaire dédié ;
+* masquage des éléments variables si nécessaire.
+
+### Risque 3 — Hallucinations IA
+
+L’IA peut inventer des étapes, des fonctionnalités ou des explications.
+
+Mesure :
+
+* prompt restrictif ;
+* JSON structuré ;
+* interdiction d’utiliser des informations hors input ;
+* relecture humaine obligatoire.
+
+### Risque 4 — Maintenance excessive
+
+Les guides peuvent casser si l’interface change souvent.
+
+Mesure :
+
+* cibler uniquement les parcours utilisateur stables ;
+* commencer avec peu de guides ;
+* réutiliser les helpers Playwright ;
+* éviter les sélecteurs fragiles.
+
+## 24. Recommandation de gouvernance
+
+La suite Documentation E2E doit être maintenue par les mêmes personnes que les parcours E2E, mais validée par une personne responsable de la documentation produit.
+
+Responsabilités recommandées :
+
+```txt
+Développeur / QA
+- maintient les parcours Playwright ;
+- garantit la stabilité des screenshots ;
+- maintient les fixtures et le reset.
+
+Rédacteur / Product Owner
+- relit le user guide généré ;
+- valide le vocabulaire métier ;
+- confirme que le guide est compréhensible pour un utilisateur final.
+
+IA
+- transforme les données structurées en brouillon Markdown ;
+- harmonise la langue anglaise ;
+- ne prend aucune décision fonctionnelle.
+```
+
+## 25. Position recommandée
+
+Il est pertinent d’ajouter cette troisième suite E2E, mais elle doit être assumée comme une suite documentaire, pas comme une suite de tests.
+
+Le nom `e2e:documentation` est bon, car il évite l’ambiguïté.
+
+La bonne séparation est :
+
+```txt
+e2e:smoke
+→ qualité minimale immédiate
+
+e2e:regression
+→ validation fonctionnelle approfondie
+
+e2e:documentation
+→ génération assistée de user guides
+```
+
+Cette approche permet de produire une documentation utilisateur plus fiable, plus visuelle et plus facile à maintenir, tout en évitant de polluer les tests de validation existants.
+
+[1]: https://playwright.dev/?utm_source=chatgpt.com "Playwright: Fast and reliable end-to-end testing for modern ..."

--- a/documentation/plan/tests/e2e/372-pwe6-matrice-de-couverture-regression-et-validation-finale-de-la-strategie-a-deux-etages.md
+++ b/documentation/plan/tests/e2e/372-pwe6-matrice-de-couverture-regression-et-validation-finale-de-la-strategie-a-deux-etages.md
@@ -1,0 +1,120 @@
+# Plan d'implémentation — Issue #372
+
+**Issue** : [#372 — PWE6 - Matrice de couverture regression et validation finale de la stratégie à deux étages](https://github.com/herveDarritchon/foundryvtt-swerpg/issues/372)
+**Dépendances** : [#366 — Playwright Local Foundry Smoke Tests - Sécuriser les parcours MJ essentiels en local](https://github.com/herveDarritchon/foundryvtt-swerpg/issues/366), [#367 — PWE1 - Stabiliser la baseline locale Playwright et le monde E2E](https://github.com/herveDarritchon/foundryvtt-swerpg/issues/367), [#368 — PWE2 - Fiabiliser les contrats d'interaction et la capture d'erreurs navigateur](https://github.com/herveDarritchon/foundryvtt-swerpg/issues/368), [#369 — PWE3 - Tier 1 Regression Spec : création personnage et ouverture de fiche](https://github.com/herveDarritchon/foundryvtt-swerpg/issues/369), [#370 — PWE4 - Tier 1 Regression Spec : dépense simple d'XP et ouverture arbre de spécialisation](https://github.com/herveDarritchon/foundryvtt-swerpg/issues/370), [#371 — PWE5 - Hygiène monde de test Tier 1 et stratégie de reset déterministe](https://github.com/herveDarritchon/foundryvtt-swerpg/issues/371)
+**Domaine métier** : `tests/e2e`
+**Source de cadrage** :
+
+- `documentation/plan/tests/366-playwright-local-foundry-smoke-tests-securiser-les-parcours-mj-essentiels-en-local.md`
+- `documentation/plan/tests/371-pwe5-tier-1-regression-hygiene-monde-de-test-tier-1-et-strategie-de-reset-deterministe.md`
+- `documentation/plan/tests/e2e/strategie-e2e-deux-etages-regression-et-smoke-prod.md`
+- `documentation/ways-of-work/plan/tests-e2e/playwright-local-foundry-smoke-tests/project-plan.md`
+- `documentation/ways-of-work/plan/tests-e2e/playwright-local-foundry-smoke-tests/issues-checklist.md`
+- `documentation/tests/e2e/playwright-e2e-guide.md`
+- `e2e/README.md`
+
+---
+
+## 1. Objectif
+
+Finaliser la stratégie E2E à deux étages en rendant explicite la couverture actuelle `regression` / `smoke`, en synchronisant la documentation et les contrats d'exécution, puis en fermant l'issue avec des critères de validation lisibles et reproductibles.
+
+---
+
+## 2. Périmètre
+
+### Inclus
+
+- matrice de couverture reliant domaines fonctionnels, parcours critiques, specs Playwright et éventuels relais Vitest ;
+- validation documentaire finale de la frontière `regression` / `smoke` / `[ci]` ;
+- consolidation des critères de clôture : erreurs navigateur, artefacts conservés à l'échec, exécution locale vs CI.
+
+### Exclu
+
+- ajout d'une nouvelle feature métier hors couverture déjà décidée ;
+- extension opportuniste de la suite Playwright au-delà des parcours déjà priorisés ;
+- refonte technique large des helpers ou des configs sans écart documenté à corriger.
+
+---
+
+## 3. Plan de travail proposé
+
+### Étape 1 — Établir la matrice de couverture de référence
+
+**But** : rendre visible ce qui est réellement couvert par `regression`, `smoke` et les tests `[ci]`, ainsi que ce qui reste volontairement hors scope Playwright.
+
+**Fichiers cibles** : nouvelle documentation dédiée sous `documentation/tests/e2e/`, `e2e/README.md`, `documentation/tests/e2e/playwright-e2e-guide.md`
+
+**Actions** :
+
+- inventorier les specs existantes sous `e2e/regression/specs/`, `e2e/smoke/` et `e2e/specs/` legacy ;
+- lister par domaine les parcours et champs critiques déjà contractualisés (`bootstrap`, création personnage, XP simple, arbre de spécialisation, import si déjà assumé) ;
+- relier chaque ligne de matrice à une spec Playwright, à un test Vitest si la bonne couche est unitaire, ou à un statut explicite `non couvert / hors scope`.
+
+### Étape 2 — Verrouiller le contrat final de la stratégie à deux étages
+
+**But** : supprimer les ambiguïtés restantes entre commandes, environnements, règles de mutation et frontière CI / validation locale manuelle.
+
+**Fichiers cibles** : `documentation/tests/e2e/playwright-e2e-guide.md`, `e2e/README.md`, éventuels fichiers de configuration ou scripts E2E seulement si un écart documentaire prouvé doit être réaligné
+
+**Actions** :
+
+- vérifier la cohérence croisée `README ↔ guide E2E ↔ stratégie à deux étages` sur `pnpm e2e`, `pnpm e2e:regression`, `pnpm e2e:smoke` et `pnpm e2e:ci` ;
+- expliciter la règle finale sur la capture des erreurs `console` / `pageerror`, la conservation des artefacts à l'échec et l'interdiction de mutation en `smoke` ;
+- documenter la place résiduelle des specs legacy `[ci]` et leur frontière avec les suites métier `regression` / `smoke`.
+
+### Étape 3 — Standardiser le report HTML Playwright (local uniquement)
+
+**But** : rendre les runs `regression` et `smoke` auditables via un report HTML exploitable pour diagnostic local, preuve de validation et clôture PWE6. **Aucun report HTML n'est généré en CI** — les tests Playwright ne tournent jamais en GitHub Actions.
+
+**Fichiers cibles** : `playwright.regression.config.ts`, `playwright.smoke.config.ts`, `documentation/tests/e2e/playwright-e2e-guide.md`, `e2e/README.md`, éventuels scripts npm ou doc de la matrice
+
+**Actions** :
+
+- définir le contrat cible de reporting pour chaque suite :
+  - `e2e:regression` → report HTML dans `playwright-regression-report/` systématiquement en local ;
+  - `e2e:smoke` → report HTML dans `playwright-smoke-report/` systématiquement en local ;
+  - `e2e:ci` (unique suite CI) → reporter `list` seulement, pas de HTML (cohérent avec l'absence de Playwright en CI dans ce projet) ;
+- choisir une convention claire de dossiers de sortie et les aligner entre suites (`playwright-{suite}-report/`) ;
+- documenter comment ouvrir et exploiter les reports HTML (`pnpm exec playwright show-report <dossier>`) pour analyser résultats, traces, screenshots et vidéos ;
+- spécifier que le report HTML est généré systématiquement sur tout run local (pas seulement en cas d'échec), pour servir de preuve reproductible ;
+- adapter les configurations Playwright : passer le reporter de `'list'` à `[['list'], ['html', { outputFolder: 'playwright-smoke-report' }]]` pour `smoke`, et vérifier que `regression` a déjà `list + html` en local (pas seulement en CI) ;
+- intégrer le report HTML dans la checklist de validation finale PWE6 comme artefact de clôture.
+
+### Étape 4 — Préparer la validation finale et les critères de clôture PWE6
+
+**But** : fermer la boucle avec une checklist opérationnelle permettant de conclure que la stratégie est effectivement stabilisée.
+
+**Fichiers cibles** : matrice de couverture créée à l'étape 1, `documentation/tests/e2e/playwright-e2e-guide.md`, `e2e/README.md`
+
+**Actions** :
+
+- définir l'ordre de validation recommandé : parcours `PWE3` / `PWE4` côté `regression`, puis contrôle `smoke` non destructif, puis revue des scénarios `[ci]` encore légitimes ;
+- formaliser les signaux de clôture : aucune erreur navigateur inattendue, matrice à jour, commandes et prérequis alignés, frontière CI documentée, report HTML produit et vérifié pour chaque suite ;
+- vérifier que le report HTML attendu (`playwright-regression-report/`, `playwright-smoke-report/`) est bien généré à l'issue des runs, et que les artefacts (traces, screenshots, vidéos) sont retrouvables depuis le report ;
+- isoler explicitement les trous de couverture restant acceptés pour éviter qu'ils soient confondus avec des oublis.
+
+---
+
+## 4. Ordre recommandé
+
+1. Construire la matrice de couverture
+2. Synchroniser le contrat documentaire final
+3. Standardiser le report HTML Playwright (configs + doc)
+4. Formaliser la checklist de validation et clôture
+
+---
+
+## 5. Validation prévue (non exécutée dans ce plan)
+
+- exécution ciblée des parcours `PWE3` et `PWE4` sur la suite `regression` ;
+- exécution manuelle de la suite `smoke` pour confirmer la lecture seule et l'absence d'erreur navigateur inattendue ;
+- vérification que les scénarios `[ci]` restant hors `regression` / `smoke` sont justifiés et documentés ;
+- relecture croisée `matrice ↔ README ↔ guide E2E ↔ stratégie à deux étages` pour confirmer un contrat unique ;
+- vérification que les reports HTML sont bien générés pour les suites `regression` et `smoke` sur un run local complet, et que les artefacts d'échec sont accessibles depuis le report.
+
+---
+
+## 6. Résultat attendu
+
+Le projet dispose d'une matrice de couverture E2E exploitable, d'une stratégie `regression` / `smoke` définitivement clarifiée, d'un reporting HTML standardisé pour les runs locaux, et d'un paquet de critères de validation permettant de conclure la phase PWE6 sans ambiguïté sur le périmètre réellement automatisé.

--- a/documentation/tests/e2e/couverture-e2e-matrice.md
+++ b/documentation/tests/e2e/couverture-e2e-matrice.md
@@ -1,0 +1,123 @@
+# Matrice de couverture E2E — Swerpg
+
+> Document de référence PWE6. Mis à jour lors de tout ajout, suppression ou déplacement de spec.
+
+---
+
+## 1. Lecture de la matrice
+
+Chaque ligne représente un domaine fonctionnel ou un parcours critique. Les colonnes indiquent :
+
+- **Suite** : `regression`, `smoke`, `[ci]` (legacy), ou `—` (hors scope).
+- **Spec** : chemin relatif depuis `e2e/`, ou test Vitest si la couche est unitaire.
+- **Statut** : `couvert`, `hors scope accepté`, ou `non couvert`.
+- **Notes** : contexte utile.
+
+---
+
+## 2. Matrice
+
+### 2.1. Bootstrap / santé instance
+
+| Domaine | Parcours critique | Suite | Spec | Statut | Notes |
+|---|---|---|---|---|---|
+| Bootstrap Foundry | Instance répond, système swerpg chargé | `regression` | `regression/specs/01-smoke.spec.ts` — `monde chargé avec système swerpg` | couvert | |
+| Bootstrap Foundry | Sidebar présente (Actors, Items, Settings) | `regression` | `regression/specs/01-smoke.spec.ts` — `sidebar contient les sections principales` | couvert | |
+| Bootstrap Foundry | Instance répond, système swerpg chargé | `smoke` | `smoke/01-health.spec.ts` — `l'instance répond et charge le système swerpg` | couvert | lecture seule, prod |
+| Bootstrap Foundry | body.system-swerpg présent | `smoke` | `smoke/01-health.spec.ts` — `body.system-swerpg est présent quand le système est chargé` | couvert | |
+| Bootstrap Foundry | Aucune erreur console critique sur /game | `smoke` | `smoke/01-health.spec.ts` — `aucune erreur console critique sur /game` | couvert | |
+| Bootstrap Foundry | Aucun asset système critique en 404 | `smoke` | `smoke/01-health.spec.ts` — `aucun asset système critique en 404` | couvert | |
+| Bootstrap Foundry | Instance répond, world load | `[ci]` (legacy) | `specs/bootstrap.spec.ts` | couvert | candidat migration vers `regression` |
+
+### 2.2. Interface — surfaces UI et i18n
+
+| Domaine | Parcours critique | Suite | Spec | Statut | Notes |
+|---|---|---|---|---|---|
+| UI / i18n | Sidebar : onglets sans clé i18n brute | `smoke` | `smoke/02-surfaces.spec.ts` — `sidebar affiche les onglets principaux sans clé i18n brute` | couvert | |
+| UI / i18n | Sidebar : aucun placeholder cassé (undefined, null) | `smoke` | `smoke/02-surfaces.spec.ts` — `aucun placeholder cassé visible dans la sidebar` | couvert | |
+| UI / i18n | Onglet Actors accessible en lecture | `smoke` | `smoke/02-surfaces.spec.ts` — `onglet Actors visible et accessible en lecture` | couvert | |
+| UI / i18n | Onglet Items accessible en lecture | `smoke` | `smoke/02-surfaces.spec.ts` — `onglet Items visible et accessible en lecture` | couvert | |
+| UI / i18n | Onglet Settings accessible en lecture | `smoke` | `smoke/02-surfaces.spec.ts` — `onglet Settings visible et accessible en lecture` | couvert | |
+
+### 2.3. Import OggDude
+
+| Domaine | Parcours critique | Suite | Spec | Statut | Notes |
+|---|---|---|---|---|---|
+| Import OggDude | Dialog OggDude s'ouvre depuis les settings système | `regression` | `regression/specs/02-oggdude-import.spec.ts` — `dialog OggDude s'ouvre depuis les settings système` | couvert | |
+| Import OggDude | Import complet depuis un ZIP OggDude | `regression` | `regression/specs/02-oggdude-import.spec.ts` — `import complet depuis un ZIP OggDude` | couvert | |
+| Import OggDude | Ouverture dialog OggDude | `[ci]` (legacy) | `specs/oggdude-import.spec.ts` | couvert | candidat migration vers `regression` |
+
+### 2.4. Création de personnage
+
+| Domaine | Parcours critique | Suite | Spec | Statut | Notes |
+|---|---|---|---|---|---|
+| Création personnage | Onglet Actors accessible depuis la sidebar | `regression` | `regression/specs/03-character-creation.spec.ts` — `onglet Actors accessible depuis la sidebar` | couvert | |
+| Création personnage | Création et ouverture de fiche sans erreur navigateur | `regression` | `regression/specs/03-character-creation.spec.ts` — `création personnage et ouverture de fiche sans erreur navigateur` | couvert | teardown acteur `Test-Personnage-*` |
+
+### 2.5. XP et arbre de spécialisation
+
+| Domaine | Parcours critique | Suite | Spec | Statut | Notes |
+|---|---|---|---|---|---|
+| XP / compétences | Console XP visible sur fiche fraîchement créée | `regression` | `regression/specs/04-xp-spend-and-specialization-tree.spec.ts` — `console XP visible sur fiche de personnage fraîchement créé` | couvert | teardown acteur `Test-XP-*` |
+| XP / compétences | Achat rang compétence — console XP cohérente | `regression` | `regression/specs/04-xp-spend-and-specialization-tree.spec.ts` — `achat rang compétence : console XP reste cohérente après transaction` | couvert | teardown acteur `Test-XP-Skill-*` |
+| Arbre spécialisation | Arbre de spécialisation s'ouvre sans erreur navigateur | `regression` | `regression/specs/04-xp-spend-and-specialization-tree.spec.ts` — `arbre de spécialisation s'ouvre sans erreur navigateur` | couvert | teardown acteur `Test-SpecTree-*` |
+
+### 2.6. Domaines hors scope Playwright (relais Vitest)
+
+| Domaine | Justification hors scope Playwright | Couverture alternative |
+|---|---|---|
+| Calculs XP (coûts, seuils) | Logique pure testable sans navigateur | `tests/lib/` — Vitest |
+| Calculs dés narratifs (pools, symboles) | Logique pure testable sans navigateur | `tests/dice/` — Vitest |
+| Mapping import OggDude (XML → modèle) | Transformation pure testable sans navigateur | `tests/` — Vitest |
+| Validation TypeDataModel | Dépend de Foundry mais ne requiert pas un navigateur complet | Vitest + mocks Foundry |
+| Combat / jets de dés avancés | Hors scope PWE6 — aucune spec prévue pour l'instant | non couvert — hors scope accepté |
+| Gestion joueur non-MJ | Hors scope PWE6 — aucune spec prévue pour l'instant | non couvert — hors scope accepté |
+
+---
+
+## 3. Trous de couverture acceptés
+
+Les domaines suivants ne sont pas couverts par la suite E2E actuelle. Cette décision est intentionnelle et documentée ici pour éviter toute confusion avec des oublis :
+
+| Domaine | Raison | Priorité future |
+|---|---|---|
+| Parcours joueur non-MJ | Requiert un second compte — hors scope PWE1–6 | moyenne |
+| Jets de dés dans le chat | Difficile à vérifier sans UI de dés — hors scope PWE1–6 | basse |
+| Combat (initiative, attaques) | Hors scope PWE1–6 | basse |
+| Équipement / items (gear, armes, armures) | Hors scope PWE1–6 | moyenne |
+| Talents avancés (achat depuis arbre) | Extension naturelle de PWE4 — non encore spécifié | haute |
+
+---
+
+## 4. Specs legacy à requalifier
+
+Les specs dans `e2e/specs/` sont des specs legacy non encore migrées :
+
+| Spec legacy | Migration cible | État |
+|---|---|---|
+| `specs/bootstrap.spec.ts` | `regression/specs/01-smoke.spec.ts` | doublon couvert — à archiver ou supprimer |
+| `specs/oggdude-import.spec.ts` | `regression/specs/02-oggdude-import.spec.ts` | doublon couvert — à archiver ou supprimer |
+
+Ces specs ne sont accessibles qu'avec `pnpm e2e:ci` (tag `[ci]`). Leur migration vers `regression` est souhaitable mais non urgente pour PWE6.
+
+---
+
+## 5. Commandes de référence
+
+```bash
+# Validation fonctionnelle pré-livraison (PWE3 + PWE4)
+pnpm e2e:regression
+
+# Contrôle de surface post-déploiement (lecture seule)
+pnpm e2e:smoke
+
+# Campagne complète (les deux instances doivent être disponibles)
+pnpm e2e
+
+# Specs legacy [ci]
+pnpm e2e:ci
+
+# Ouvrir le report HTML après un run
+pnpm exec playwright show-report playwright-regression-report
+pnpm exec playwright show-report playwright-smoke-report
+```

--- a/documentation/tests/e2e/playwright-e2e-guide.md
+++ b/documentation/tests/e2e/playwright-e2e-guide.md
@@ -252,8 +252,11 @@ chacune chargeant son propre fichier d'environnement.
 
 Reporter :
 
-- En local : `list`
-- En CI : `list` + `html`
+- `regression` (local) : `list` + `html` dans `playwright-regression-report/` — systématiquement généré
+- `smoke` (local) : `list` + `html` dans `playwright-smoke-report/` — systématiquement généré
+- `e2e:ci` : `list` + `html` dans `playwright-report/` (héritage config `playwright.config.ts`) — non pertinent en pratique car Playwright ne tourne pas en CI
+
+> Les suites `regression` et `smoke` ne tournent **jamais** en CI. Le report HTML est donc un artefact local de diagnostic et de preuve de validation.
 
 ### 4.1. Spécificités Chromium
 
@@ -603,7 +606,12 @@ Pour analyser une trace générée (par défaut conservée en cas d’échec) :
 pnpm exec playwright show-trace test-results/path-to-trace/trace.zip
 ```
 
-Les rapports HTML sont générés (en CI) dans `playwright-report/`.
+Les rapports HTML sont générés systématiquement lors de tout run local dans `playwright-regression-report/` (suite regression) et `playwright-smoke-report/` (suite smoke) :
+
+```bash
+pnpm exec playwright show-report playwright-regression-report
+pnpm exec playwright show-report playwright-smoke-report
+```
 
 ### 8.5. Tests instables (flaky)
 
@@ -651,15 +659,74 @@ Remarque : si vous utilisez `pnpm` dans ce projet, vous pouvez remplacer `npx` 
 
 ---
 
-## 9. Résumé
+## 9. Matrice de couverture E2E
+
+La matrice de couverture officielle reliant domaines fonctionnels, parcours critiques et specs Playwright se trouve dans :
+
+- `documentation/tests/e2e/couverture-e2e-matrice.md`
+
+Elle liste les parcours couverts par suite (`regression`, `smoke`, `[ci]`), les relais Vitest pour les couches pures, et les trous de couverture acceptés. Mettre ce document à jour à chaque ajout ou déplacement de spec.
+
+---
+
+## 10. Checklist de validation et clôture PWE6
+
+Cette checklist permet de conclure qu'une campagne E2E est valide et que la stratégie à deux étages est effectivement stabilisée.
+
+### Ordre de validation recommandé
+
+1. Lancer la suite `regression` et vérifier tous les parcours PWE3 / PWE4 :
+
+   ```bash
+   pnpm e2e:regression
+   ```
+
+2. Lancer la suite `smoke` et vérifier la lecture seule sans erreur inattendue :
+
+   ```bash
+   pnpm e2e:smoke
+   ```
+
+3. Vérifier les specs `[ci]` legacy si un changement les concerne :
+
+   ```bash
+   pnpm e2e:ci
+   ```
+
+### Signaux de clôture
+
+- [ ] Aucune erreur navigateur inattendue (ni `console.error` non filtré, ni `pageerror`) dans `regression` ni dans `smoke`.
+- [ ] Matrice de couverture (`couverture-e2e-matrice.md`) à jour avec toutes les specs actives.
+- [ ] Commandes `pnpm e2e:regression` et `pnpm e2e:smoke` alignées avec les configs `playwright.regression.config.ts` et `playwright.smoke.config.ts`.
+- [ ] Fichiers d'environnement `.env.e2e.regression` et `.env.e2e.smoke.prod` documentés et exemples à jour.
+- [ ] Frontière CI documentée : `regression` et `smoke` ne tournent jamais en CI — seul `e2e:ci` est autorisé en pipeline.
+- [ ] Report HTML généré et vérifiable après chaque run local :
+  - `playwright-regression-report/` après `pnpm e2e:regression`
+  - `playwright-smoke-report/` après `pnpm e2e:smoke`
+- [ ] Artefacts d'échec (traces, screenshots, vidéos) retrouvables depuis le report HTML en cas d'échec.
+- [ ] Trous de couverture restants explicitement listés dans `couverture-e2e-matrice.md` section 3 (non confondus avec des oublis).
+
+### Ouvrir les reports HTML
+
+```bash
+pnpm exec playwright show-report playwright-regression-report
+pnpm exec playwright show-report playwright-smoke-report
+```
+
+---
+
+## 11. Résumé
 
 - `pnpm e2e:smoke` : vérification de surface, exécution manuelle, lecture seule sur instance de production.
 - `pnpm e2e:regression` : validation fonctionnelle pré-livraison sur instance dédiée, remplace les campagnes QA manuelles répétitives.
 - `pnpm e2e` : campagne complète qui orchestre `regression` puis `smoke` — requiert les deux instances disponibles.
 - Trois configs Playwright distinctes, chacune chargeant son propre fichier d'environnement.
+- Reports HTML générés systématiquement en local (`playwright-regression-report/`, `playwright-smoke-report/`).
 - Les helpers `foundrySession.ts`, `e2eTest.ts` et les fixtures partagées encapsulent la logique de connexion et de lancement du monde Swerpg.
 - Les scénarios doivent rester courts, robustes, et utiliser des locators accessibles.
 - Toute nouvelle spec doit être placée dans `e2e/smoke/` ou `e2e/regression/specs/` selon son type.
+- Matrice de couverture : `documentation/tests/e2e/couverture-e2e-matrice.md`.
+
 ---
 
 > Remarque pour l'intégration continue (GitHub Actions) : en raison des contraintes de performance des runners GitHub, la pipeline CI n'exécute **que** les tests explicitement marqués avec le tag `[ci]` dans leur titre. Le script `e2e:ci` (défini ci‑dessus) filtre les tests via `--grep "[ci]"` pour ne lancer que ces scénarios critiques.

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -8,6 +8,10 @@ se référer au guide complet :
 
 - `documentation/tests/e2e/playwright-e2e-guide.md`
 
+Pour la matrice de couverture (domaines fonctionnels, parcours critiques, specs et trous de couverture acceptés) :
+
+- `documentation/tests/e2e/couverture-e2e-matrice.md`
+
 ---
 
 ## Contrat des commandes E2E
@@ -113,6 +117,21 @@ pnpm e2e:smoke:headed
 
 Les suites `regression` et `smoke` ne tournent pas en CI car elles nécessitent une machine locale
 adaptée (GPU, performances navigateur, instance Foundry live).
+
+---
+
+## Reports HTML
+
+Les suites `regression` et `smoke` génèrent un report HTML systématiquement lors de tout run local.
+
+| Suite | Dossier de sortie | Commande pour ouvrir |
+|---|---|---|
+| `pnpm e2e:regression` | `playwright-regression-report/` | `pnpm exec playwright show-report playwright-regression-report` |
+| `pnpm e2e:smoke` | `playwright-smoke-report/` | `pnpm exec playwright show-report playwright-smoke-report` |
+
+Ces reports permettent d'inspecter les résultats, traces, screenshots et vidéos de chaque run. Ils constituent la preuve de validation reproductible pour les campagnes pre-livraison.
+
+En cas d'échec, les artefacts (traces `.zip`, screenshots, vidéos) sont conservés et accessibles directement depuis le report HTML.
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -22,6 +22,8 @@
     "e2e:regression:ui": "playwright test --config playwright.regression.config.ts --ui",
     "e2e:smoke": "playwright test --config playwright.smoke.config.ts",
     "e2e:smoke:headed": "playwright test --config playwright.smoke.config.ts --headed",
+    "e2e:regression:report": "playwright test --config playwright.regression.config.ts && playwright show-report playwright-regression-report",
+    "e2e:smoke:report": "playwright test --config playwright.smoke.config.ts && playwright show-report playwright-smoke-report",
     "fmt": "prettier --write .",
     "fmt:check": "prettier --check .",
     "foundry:e2e:start": "bash ./scripts/e2e-foundry-start.sh start",

--- a/playwright.regression.config.ts
+++ b/playwright.regression.config.ts
@@ -38,6 +38,8 @@ export default defineConfig({
       },
     },
   ],
-  reporter: process.env.CI ? [['list'], ['html', { outputFolder: 'playwright-regression-report' }]] : 'list',
+  // Générer le report HTML systématiquement en local pour diagnostic et preuve de validation.
+  // En CI, les tests Playwright regression ne tournent jamais — cette ligne ne s'applique donc qu'en local.
+  reporter: [['list'], ['html', { outputFolder: 'playwright-regression-report', open: 'never' }]],
   retries: 0,
 })

--- a/playwright.smoke.config.ts
+++ b/playwright.smoke.config.ts
@@ -39,6 +39,8 @@ export default defineConfig({
       },
     },
   ],
-  reporter: 'list',
+  // Générer le report HTML systématiquement en local pour diagnostic et preuve de validation.
+  // En CI, les tests Playwright smoke ne tournent jamais — cette ligne ne s'applique donc qu'en local.
+  reporter: [['list'], ['html', { outputFolder: 'playwright-smoke-report', open: 'never' }]],
   retries: 0,
 })


### PR DESCRIPTION
Closes #372

## Contexte

Finalisation de la stratégie E2E à deux étages (PWE6) : matrice de couverture, contrat documentaire unifié, reporting HTML standardisé pour les suites `regression` et `smoke`.

## Changements

- **Matrice de couverture E2E** : `documentation/tests/e2e/couverture-e2e-matrice.md` — inventaire des specs existantes par domaine, statut de couverture, relais Vitest
- **Plan d'implémentation PWE6** : `documentation/plan/tests/e2e/372-pwe6-...`
- **Reporting HTML standardisé** :
  - `playwright.regression.config.ts` : génération systématique du report HTML local dans `playwright-regression-report/`
  - `playwright.smoke.config.ts` : passage de `'list'` à `list + html` dans `playwright-smoke-report/`
  - `e2e:ci` conserve `list` seulement (pas de Playwright en CI)
- **Documentation** : synchronisation `e2e/README.md` et `documentation/tests/e2e/playwright-e2e-guide.md` (commandes, reporting, artefacts)
- **Hygiène** : ajout des dossiers de report à `.gitignore`

## Notes techniques

- Les reports HTML sont générés localement uniquement — Playwright ne tourne pas en CI GitHub Actions
- Ouverture d'un report : `pnpm exec playwright show-report playwright-{suite}-report/`
- La matrice de couverture sert de référence pour les futures specs à ajouter

## Tests exécutés

Aucun test, lint ou build exécuté dans cette PR (documentation + configuration uniquement).