### PR TITLE
docs(e2e): clarify documentation suite governance and add EDG6 plan

### DIFF
--- a/documentation/plan/tests/e2e/388-edg6-valider-la-stabilite-des-captures-la-surete-des-donnees-et-la-checklist-de-release.md
+++ b/documentation/plan/tests/e2e/388-edg6-valider-la-stabilite-des-captures-la-surete-des-donnees-et-la-checklist-de-release.md
@@ -1,0 +1,120 @@
+# Plan d'implémentation — Issue #388
+
+**Issue** : [#388 — EDG6 - Valider la stabilité des captures, la sûreté des données et la checklist de release](https://github.com/herveDarritchon/foundryvtt-swerpg/issues/388)
+**Dépendances** :
+
+- [#383 — EDG1 - Cadrer la suite e2e:documentation et sa configuration dédiée](https://github.com/herveDarritchon/foundryvtt-swerpg/issues/383)
+- [#384 — EDG2 - Mettre en place un monde documentaire déterministe et les helpers d'artefacts](https://github.com/herveDarritchon/foundryvtt-swerpg/issues/384)
+- [#385 — EDG3 - Livrer un premier parcours *.guide.spec.ts avec screenshots et JSON](https://github.com/herveDarritchon/foundryvtt-swerpg/issues/385)
+- [#386 — EDG4 - Générer un user guide Markdown en anglais via commande séparée](https://github.com/herveDarritchon/foundryvtt-swerpg/issues/386)
+- [#387 — EDG5 - Documenter l'exploitation, la gouvernance et la séparation avec smoke/regression](https://github.com/herveDarritchon/foundryvtt-swerpg/issues/387)
+
+**Domaine métier** : `tests/e2e`
+**Source de cadrage** :
+
+- issue fournie par l'utilisateur ;
+- `documentation/cadrage/documentation/e2e-documentation-user-guide-generation-with-playwright-and-ai.md` ;
+- `documentation/plan/tests/e2e/383-edg1-cadrer-la-suite-e2e-documentation-et-sa-configuration-dediee.md` ;
+- `documentation/plan/tests/e2e/384-edg2-mettre-en-place-un-monde-documentaire-deterministe-et-les-helpers-d-artefacts.md` ;
+- `documentation/plan/tests/e2e/385-edg3-livrer-un-premier-parcours-guide-spec-ts-avec-screenshots-et-json.md` ;
+- `documentation/plan/tests/e2e/386-edg4-generer-un-user-guide-markdown-en-anglais-via-commande-separee.md` ;
+- `documentation/plan/tests/e2e/387-edg5-documenter-l-exploitation-la-gouvernance-et-la-separation-avec-smoke-regression.md`.
+
+---
+
+## 1. Objectif
+
+Clore le chantier `e2e:documentation` avec une passe finale de sécurisation avant release, en validant la reproductibilité des captures, l'absence de données sensibles dans les artefacts produits et l'existence d'une checklist courte permettant d'exécuter puis relire le flux documentaire de bout en bout.
+
+---
+
+## 2. Périmètre
+
+### Inclus
+
+- validation du contrat de stabilité visuelle des screenshots et du JSON associé ;
+- formalisation des garde-fous sur les données visibles dans le monde documentaire et les artefacts générés ;
+- checklist de release dédiée à `e2e:documentation` couvrant capture, génération Markdown et revue humaine ;
+- synchronisation finale de la documentation d'exploitation avec ces critères de sortie.
+
+### Exclu
+
+- ajout d'un nouveau parcours guide hors besoin de validation finale ;
+- refonte large des helpers ou de la configuration sans écart prouvé ;
+- automatisation de publication ou usage de la suite comme validation fonctionnelle bloquante.
+
+---
+
+## 3. Plan de travail proposé
+
+### Étape 1 — Verrouiller le contrat de stabilité des captures et des artefacts
+
+**But** : figer ce qui doit rester déterministe entre deux reruns identiques pour qu'un guide soit diffable et relisible avant release.
+
+**Fichiers cibles** : `e2e/documentation/specs/*.guide.spec.ts`, `e2e/documentation/utils/`, `e2e/documentation/README.md`, `documentation/tests/e2e/playwright-e2e-guide.md`.
+
+**Actions** :
+
+- lister les invariants attendus sur les captures : ordre stable, viewport constant, nommage déterministe, écrans sans bruit parasite ;
+- vérifier que le JSON intermédiaire reste aligné avec l'ordre réel des screenshots et ne dépend pas d'un état aléatoire ;
+- documenter les écarts tolérés vs les écarts bloquants avant release documentaire.
+
+### Étape 2 — Formaliser la sûreté des données du monde documentaire
+
+**But** : empêcher qu'un rerun documentaire expose des données sensibles, environnementales ou non maîtrisées dans les captures, le JSON ou le Markdown généré.
+
+**Fichiers cibles** : `e2e/documentation/utils/`, `e2e/documentation/README.md`, `documentation/tests/e2e/playwright-e2e-guide.md`, éventuelle documentation dédiée au monde documentaire.
+
+**Actions** :
+
+- expliciter les catégories de données interdites dans les artefacts (identifiants réels, données client, secrets, URLs non prévues, bruit de session) ;
+- cadrer les mécanismes à utiliser pour les éviter : monde dédié, fixtures déterministes, noms neutres, nettoyage préalable, masquage minimal si nécessaire ;
+- ajouter un point de contrôle documentaire confirmant que la génération Markdown n'introduit pas d'information hors JSON source.
+
+### Étape 3 — Construire la checklist de release `e2e:documentation`
+
+**But** : fournir une séquence courte et exécutable pour conclure qu'un guide peut être rerun, relu et diffusé sans ambiguïté.
+
+**Fichiers cibles** : `e2e/documentation/README.md`, `documentation/tests/e2e/playwright-e2e-guide.md`, éventuelle checklist dédiée sous `documentation/tests/e2e/`.
+
+**Actions** :
+
+- définir l'ordre canonique : préparation du monde, run de capture, vérification des screenshots/JSON, génération Markdown, relecture humaine ;
+- lister les preuves minimales à conserver pour la clôture : artefacts produits, absence d'erreurs navigateur inattendues, captures lisibles, contrôle des données sensibles ;
+- distinguer clairement ce qui relève d'un feu vert documentaire et ce qui reste hors scope d'une release applicative globale.
+
+### Étape 4 — Synchroniser les critères de clôture finaux
+
+**But** : aligner en un seul contrat la stabilité des captures, la sûreté des données et la checklist de release.
+
+**Fichiers cibles** : `e2e/README.md`, `e2e/documentation/README.md`, `documentation/tests/e2e/playwright-e2e-guide.md`, éventuelle checklist dédiée.
+
+**Actions** :
+
+- harmoniser les formulations sur `e2e:documentation` comme suite documentaire non bloquante mais exploitable avant publication ;
+- regrouper les critères de sortie finaux pour éviter des consignes concurrentes entre README, guide E2E et cadrage documentaire ;
+- expliciter le signal de clôture EDG6 : captures stables, artefacts sûrs, checklist courte, rerun compréhensible et revue humaine prévue.
+
+---
+
+## 4. Ordre recommandé
+
+1. Figer le contrat de stabilité des captures
+2. Sécuriser le contrat de données du monde documentaire
+3. Formaliser la checklist de release
+4. Synchroniser les critères de clôture dans la documentation
+
+---
+
+## 5. Validation prévue (non exécutée dans ce plan)
+
+- rerun ciblé d'un parcours `*.guide.spec.ts` de référence pour vérifier la stabilité des screenshots et du JSON ;
+- contrôle manuel qu'aucune donnée sensible ou non maîtrisée n'apparaît dans `screenshots/`, `raw/` ou `markdown/` ;
+- relecture croisée `README documentation ↔ guide E2E ↔ checklist` pour confirmer un seul contrat de release documentaire ;
+- vérification qu'une revue humaine reste explicitement requise avant diffusion d'un guide généré.
+
+---
+
+## 6. Résultat attendu
+
+Le projet dispose d'une fermeture EDG6 claire pour `e2e:documentation`, avec des captures reproductibles, des artefacts sûrs vis-à-vis des données exposées et une checklist de release courte permettant de relancer puis valider le flux documentaire avant diffusion.

--- a/documentation/tests/e2e/playwright-e2e-guide.md
+++ b/documentation/tests/e2e/playwright-e2e-guide.md
@@ -49,14 +49,25 @@ opérationnelles avant de lancer cette commande.
 
 ### `pnpm e2e:documentation` — validation documentaire (manuelle)
 
-- **Instance** : instance de production ou dédiée stable, port 30000
-- **Monde** : monde stable dans un état représentatif des captures attendues
+- **Instance** : instance dédiée stable, port 30000 — **jamais sur production partagée ni environnement client actif**
+- **Monde** : monde dédié stable (`documentation-world` recommandé, distinct de la production et du monde de régression)
 - **Usage** : exécution manuelle lors de mise à jour de documentation, refactor UI, ou validation de stabilité documentaire
 - **Mutations** : lecture seule par défaut — prérequis contrôlés autorisés si documentés dans la spec
+- **Caractère** : **non bloquante** — ne fait partie d'aucun pipeline CI, ne conditionne aucun merge ni aucune release
 - **Config** : `.env.e2e.documentation` (copier depuis `.env.e2e.documentation.example`)
 - **Commandes** : `pnpm e2e:documentation`, `pnpm e2e:documentation:headed`, `pnpm e2e:documentation:ui`
 
 **Périmètre** : parcours documentables (feuilles d'acteur, interfaces clés), invariants visibles (i18n, absence de placeholder cassé), absence d'erreurs navigateur inattendues dans les zones documentées.
+
+**Non-objectifs** : la suite `e2e:documentation` ne valide pas les features fonctionnelles (rôle de `e2e:regression`), ne vérifie pas la santé de surface de production (rôle de `e2e:smoke`), ne conditionne aucun merge ni aucune release.
+
+**Mode rerun documentaire** :
+
+| Situation | Action |
+|---|---|
+| Mise à jour d'un parcours (spec, UI, données) | `pnpm e2e:documentation` puis `pnpm docs:generate-user-guides` |
+| Seule la mise en forme Markdown change | `pnpm docs:generate-user-guides` uniquement — pas de rerun Playwright |
+| Artefacts JSON ou screenshots absents | Rerun Playwright obligatoire avant toute génération |
 
 **Frontière avec `regression` et `smoke`** :
 
@@ -65,6 +76,20 @@ opérationnelles avant de lancer cette commande.
 | Objectif | Captures documentaires, invariants visibles | Validation fonctionnelle pré-livraison | Santé de surface post-déploiement |
 | Mutations | Lecture seule par défaut (prérequis contrôlés documentés) | Autorisées | Interdites |
 | Instance cible | Port 30000 | Port 31001 | Port 30000 |
+| Monde | Dédié stable (`documentation-world`) | Contrôlé jetable | Production stable |
+| Niveau de confiance | Documentaire — invariants visibles seulement | Validation fonctionnelle profonde | Santé minimale de surface |
+| Statut CI | Non — manuel uniquement | Non — manuel uniquement | Non — manuel uniquement |
+| Bloquant | Non | Oui (pré-livraison) | Non (diagnostic) |
+
+**Gouvernance** :
+
+| Périmètre | Responsable |
+|---|---|
+| Parcours Playwright, screenshots, monde documentaire | Dev / QA |
+| Relecture métier et validation des guides générés | Documentation / PO |
+| Décision de publication d'un guide | Documentation / PO (exclusivement) |
+
+Pour le contrat d'exploitation complet (rerun, prérequis, gouvernance, critères de clôture), voir `e2e/documentation/README.md`.
 
 ### Frontière CI / local manuel
 
@@ -742,12 +767,21 @@ Cette checklist permet de conclure qu'une campagne E2E est valide et que la stra
 - [ ] Matrice de couverture (`couverture-e2e-matrice.md`) à jour avec toutes les specs actives.
 - [ ] Commandes `pnpm e2e:regression` et `pnpm e2e:smoke` alignées avec les configs `playwright.regression.config.ts` et `playwright.smoke.config.ts`.
 - [ ] Fichiers d'environnement `.env.e2e.regression` et `.env.e2e.smoke.prod` documentés et exemples à jour.
-- [ ] Frontière CI documentée : `regression` et `smoke` ne tournent jamais en CI — seul `e2e:ci` est autorisé en pipeline.
+- [ ] Frontière CI documentée : `regression`, `smoke` et `documentation` ne tournent jamais en CI — seul `e2e:ci` est autorisé en pipeline.
 - [ ] Report HTML généré et vérifiable après chaque run local :
   - `playwright-regression-report/` après `pnpm e2e:regression`
   - `playwright-smoke-report/` après `pnpm e2e:smoke`
+  - `playwright-documentation-report/` après `pnpm e2e:documentation`
 - [ ] Artefacts d'échec (traces, screenshots, vidéos) retrouvables depuis le report HTML en cas d'échec.
 - [ ] Trous de couverture restants explicitement listés dans `couverture-e2e-matrice.md` section 3 (non confondus avec des oublis).
+
+### Signaux de clôture spécifiques à `e2e:documentation`
+
+- [ ] Mode rerun documentaire explicite : commandes canoniques, prérequis, monde dédié, cas où seule la génération Markdown doit être relancée.
+- [ ] Rôles de gouvernance clairs : Dev/QA (parcours, screenshots, monde) — Documentation/PO (relecture métier, validation, publication).
+- [ ] Suite documentée comme non bloquante, non CI, et distincte de `smoke` / `regression`.
+- [ ] Recommandation explicite contre l'exécution sur production ou environnement client partagé.
+- [ ] Matrice de frontière à jour dans `e2e/README.md`, `e2e/documentation/README.md` et ce guide.
 
 ### Ouvrir les reports HTML
 
@@ -762,7 +796,7 @@ pnpm exec playwright show-report playwright-smoke-report
 
 - `pnpm e2e:smoke` : vérification de surface, exécution manuelle, lecture seule sur instance de production.
 - `pnpm e2e:regression` : validation fonctionnelle pré-livraison sur instance dédiée, remplace les campagnes QA manuelles répétitives.
-- `pnpm e2e:documentation` : captures documentaires et invariants visibles, exécution manuelle, lecture seule par défaut.
+- `pnpm e2e:documentation` : captures documentaires et invariants visibles, exécution manuelle, lecture seule par défaut, **non bloquante**, jamais en CI, jamais sur production ou environnement client partagé.
 - `pnpm e2e` : campagne complète qui orchestre `regression` puis `smoke` — requiert les deux instances disponibles.
 - Quatre configs Playwright distinctes, chacune chargeant son propre fichier d'environnement.
 - Reports HTML générés systématiquement en local (`playwright-regression-report/`, `playwright-smoke-report/`, `playwright-documentation-report/`).
@@ -770,6 +804,7 @@ pnpm exec playwright show-report playwright-smoke-report
 - Les scénarios doivent rester courts, robustes, et utiliser des locators accessibles.
 - Toute nouvelle spec doit être placée dans `e2e/smoke/`, `e2e/regression/specs/` ou `e2e/documentation/specs/` selon son type.
 - Matrice de couverture : `documentation/tests/e2e/couverture-e2e-matrice.md`.
+- Gouvernance `e2e:documentation` : Dev/QA maintient les parcours et le monde — Documentation/PO valide les guides et décide de la publication. Voir `e2e/documentation/README.md`.
 
 ---
 

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -115,10 +115,11 @@ pnpm e2e:smoke:headed
 **Caractéristiques** :
 
 - instance Foundry sur port 30000 (`E2E_FOUNDRY_BASE_URL=http://localhost:30000`) ;
-- monde stable dans un état représentatif des captures attendues ;
+- monde dédié stable (`documentation-world` recommandé, distinct de la production et du monde de régression) ;
 - lecture seule par défaut — prérequis contrôlés autorisés si documentés dans la spec ;
 - traces et captures systématiques (pas seulement en échec) ;
-- durée courte acceptable.
+- durée courte acceptable ;
+- **non bloquante** — ne fait partie d'aucun pipeline CI, ne conditionne aucun merge ni aucune release.
 
 **Ce que la suite couvre :**
 
@@ -126,13 +127,26 @@ pnpm e2e:smoke:headed
 - invariants visibles : absence de placeholder cassé (`undefined`, `null`, clé brute `SWERPG.*`) ;
 - absence d'erreurs `console.error` ou `pageerror` inattendues dans les zones documentées.
 
-**Frontière avec `regression` et `smoke`** :
+**Ce que la suite ne couvre pas (non-objectifs) :**
+
+- validation fonctionnelle des features (rôle de `e2e:regression`) ;
+- vérification de la santé de surface de production (rôle de `e2e:smoke`) ;
+- validation métier humaine des parcours ;
+- gate de qualité bloquant un merge ou une release.
+
+**Matrice de frontière entre les trois suites :**
 
 | Critère | `documentation` | `regression` | `smoke` |
 |---|---|---|---|
 | Objectif | Captures documentaires, invariants visibles | Validation fonctionnelle pré-livraison | Santé de surface post-déploiement |
 | Mutations | Lecture seule par défaut (prérequis contrôlés documentés acceptés) | Autorisées | Interdites |
 | Instance cible | Port 30000 | Port 31001 | Port 30000 |
+| Monde | Dédié stable (`documentation-world`) | Contrôlé jetable (`Swerpg-Regression-World`) | Production (`test-v14-309`) |
+| Niveau de confiance | Documentaire — invariants visibles seulement | Validation fonctionnelle profonde | Santé minimale de surface |
+| Statut CI | Non — manuel uniquement | Non — manuel uniquement | Non — manuel uniquement |
+| Bloquant | Non | Oui (pré-livraison) | Non (diagnostic) |
+
+**Recommandation d'environnement** : exécuter uniquement sur un environnement contrôlé dédié. Ne **jamais** exécuter sur un environnement de production partagé, un environnement client actif, ou un environnement en cours de migration.
 
 **Configuration** : `.env.e2e.documentation` (copier depuis `.env.e2e.documentation.example`)
 
@@ -145,6 +159,8 @@ pnpm e2e:documentation:ui
 ```
 
 **Specs** : `e2e/documentation/specs/`
+
+Pour le contrat d'exploitation complet (mode rerun, gouvernance, rôles, critères de clôture), voir `e2e/documentation/README.md`.
 
 ---
 

--- a/e2e/documentation/README.md
+++ b/e2e/documentation/README.md
@@ -398,6 +398,110 @@ Elle ne relance pas Playwright.
 
 ---
 
+## Contrat d'exploitation et mode rerun
+
+### Quand relancer la suite
+
+| Situation | Action recommandée |
+|---|---|
+| Mise à jour d'un parcours (spec, UI, données) | Rerun Playwright complet (`pnpm e2e:documentation`) puis génération Markdown (`pnpm docs:generate-user-guides`) |
+| Seule la mise en forme Markdown change | Relancer uniquement `pnpm docs:generate-user-guides` — pas de rerun Playwright |
+| Artefacts JSON ou screenshots absents ou corrompus | Rerun Playwright obligatoire avant toute génération |
+| Vérification ponctuelle de la stabilité visuelle | Rerun Playwright ciblé sur la spec concernée |
+
+### Commande canonique de rerun documentaire
+
+```bash
+# Rerun complet — Playwright puis génération Markdown
+pnpm e2e:documentation
+pnpm docs:generate-user-guides
+
+# Rerun ciblé sur un seul parcours
+pnpm e2e:documentation -- e2e/documentation/specs/character-sheet.guide.spec.ts
+pnpm docs:generate-user-guides -- --guide character-sheet
+
+# Rerun avec navigateur visible (debug)
+pnpm e2e:documentation:headed
+```
+
+### Prérequis avant tout rerun
+
+1. Instance Foundry accessible et stabilisée sur le port configuré dans `E2E_FOUNDRY_BASE_URL` (port 30000 par défaut).
+2. Fichier `.env.e2e.documentation` configuré avec les bonnes valeurs.
+3. Monde documentaire (`documentation-world` ou valeur de `E2E_FOUNDRY_WORLD`) dans un état stable et représentatif **avant** le run — la suite ne le crée pas et ne le réinitialise pas.
+4. Artefacts du run précédent présents dans `documentation-output/` si seule la génération Markdown est relancée.
+
+### Caractère non bloquant et documentaire
+
+La suite `e2e:documentation` est **strictement documentaire et non bloquante** :
+
+- elle ne fait partie d'aucun pipeline CI ;
+- ses résultats ne conditionnent pas un merge, une release ni une validation fonctionnelle ;
+- un échec de spec documentaire ne bloque pas le développement — il indique que les captures sont à régénérer ou qu'un invariant visible a régressé ;
+- la suite ne remplace pas `e2e:smoke` ni `e2e:regression`.
+
+### Environnement recommandé
+
+La suite documentaire doit être exécutée sur un **environnement contrôlé dédié**, jamais sur :
+
+- un environnement de production partagé avec des utilisateurs actifs ;
+- un environnement client ou de démonstration ;
+- un environnement instable ou en cours de migration.
+
+Le monde documentaire `documentation-world` doit être distinct du monde de production et du monde de régression. Aucune donnée critique ne doit y être présente.
+
+---
+
+## Gouvernance et responsabilités
+
+### Qui maintient quoi
+
+| Périmètre | Responsable |
+|---|---|
+| Parcours Playwright (`*.guide.spec.ts`) | Dev / QA |
+| Screenshots et artefacts documentaires (`documentation-output/`) | Dev / QA |
+| Monde documentaire (`documentation-world`) — stabilité et état représentatif | Dev / QA |
+| Relecture métier des guides générés | Documentation / PO |
+| Validation de la pertinence et de la publication des guides | Documentation / PO |
+| Génération Markdown (`docs:generate-user-guides`) | Dev / QA (déclenchement) |
+
+### Rôle de l'IA dans la génération
+
+La commande `docs:generate-user-guides` utilise une assistance IA pour rédiger les guides Markdown en anglais depuis les métadonnées JSON.
+
+L'IA **assiste la rédaction** mais :
+
+- ne valide **pas** la cohérence fonctionnelle du contenu ;
+- ne valide **pas** que les captures reflètent fidèlement le comportement attendu ;
+- ne prend **pas** de décision de publication.
+
+La validation du fond fonctionnel et la décision de diffusion appartiennent exclusivement à Documentation / PO.
+
+### Point de passage avant diffusion
+
+Avant toute mise à jour ou diffusion d'un guide généré :
+
+1. Dev / QA confirme que les captures sont à jour et représentatives.
+2. Documentation / PO relit le contenu sur le fond fonctionnel.
+3. Documentation / PO valide ou demande une correction.
+4. Le guide est diffusé uniquement après validation explicite de Documentation / PO.
+
+---
+
+## Non-objectifs de la suite documentaire
+
+La suite `e2e:documentation` **ne fait pas** :
+
+- validation fonctionnelle des features (c'est le rôle de `e2e:regression`) ;
+- vérification de la santé de surface de production (c'est le rôle de `e2e:smoke`) ;
+- validation métier humaine des parcours utilisateur ;
+- gate de qualité bloquant un merge ou une release ;
+- détection de régressions fonctionnelles profondes.
+
+Les invariants minimaux vérifiés (i18n, absence de placeholder cassé, absence d'erreur navigateur inattendue) sont des **garde-fous documentaires**, pas des checks de validation fonctionnelle.
+
+---
+
 ## Prérequis
 
 1. Instance Foundry accessible sur le port configuré dans `E2E_FOUNDRY_BASE_URL`


### PR DESCRIPTION
## Linked issues
Refs #387
Refs #388

## Context
This branch contains documentation updates around the `e2e:documentation` suite and a follow-up implementation plan for EDG6.

## Summary of changes
- clarify the operating contract, rerun flow, and suite boundaries for `e2e:documentation`
- update the shared E2E guides in `e2e/README.md` and `documentation/tests/e2e/playwright-e2e-guide.md`
- add the EDG6 implementation plan under `documentation/plan/tests/e2e/388-edg6-valider-la-stabilite-des-captures-la-surete-des-donnees-et-la-checklist-de-release.md`

## Technical notes
- documentation-only changes
- 4 files changed against `develop`
- no source code, CI, or build configuration changes

## Tests run
- none

## Known limits
- this PR mixes the `#387` documentation updates with the addition of the `#388` plan file on the same branch
- the added plan is a planning artifact only and does not implement automation or executable tests

## Points of attention
- review the wording around documentation suite governance, rerun prerequisites, and boundaries with `smoke` and `regression`
- confirm the mixed scope is acceptable for merge, or split `#388` into a separate branch/PR later if preferred