### PR TITLE
docs(playwright-e2e-guide): formalize EDG6 closure criteria and data safety contract

### DIFF
--- a/documentation/tests/e2e/edg6-release-checklist.md
+++ b/documentation/tests/e2e/edg6-release-checklist.md
@@ -1,0 +1,181 @@
+# Checklist de release — `e2e:documentation` (EDG6)
+
+Ce document fournit la séquence courte et exécutable pour conclure qu'un guide documentaire peut être rerun, relu et diffusé sans ambiguïté.
+
+Il clôt le chantier EDG6 : stabilité des captures, sûreté des données et checklist de release.
+
+---
+
+## Séquence canonique de release documentaire
+
+### Ordre obligatoire
+
+```
+1. Préparer le monde documentaire
+2. Lancer la capture (Playwright)
+3. Vérifier les artefacts produits (screenshots + JSON)
+4. Générer le guide Markdown
+5. Relire le guide généré (humain)
+```
+
+### Étape 1 — Préparer le monde documentaire
+
+- [ ] L'instance Foundry est accessible à l'URL configurée dans `E2E_FOUNDRY_BASE_URL` (port 30000 par défaut).
+- [ ] Le fichier `.env.e2e.documentation` est configuré (copier depuis `.env.e2e.documentation.example` si absent).
+- [ ] Le monde documentaire (`documentation-world` ou valeur de `E2E_FOUNDRY_WORLD`) est dans un état **stable et représentatif** des captures attendues.
+- [ ] Le monde documentaire est **distinct** du monde de production et du monde de régression (`Swerpg-Regression-World`).
+- [ ] Aucune donnée sensible, client, ou non maîtrisée n'est présente dans le monde documentaire.
+
+### Étape 2 — Lancer la capture (Playwright)
+
+```bash
+# Run complet de la suite documentaire
+pnpm e2e:documentation
+
+# Run ciblé sur un seul parcours
+pnpm e2e:documentation -- e2e/documentation/specs/character-sheet.guide.spec.ts
+
+# Run avec navigateur visible (debug)
+pnpm e2e:documentation:headed
+```
+
+**Preuves minimales à conserver :**
+
+- [ ] La commande s'est terminée sans erreur de spec.
+- [ ] Aucune erreur navigateur inattendue (`console.error` non filtré, `pageerror`) dans la sortie.
+- [ ] Le report Playwright est disponible : `pnpm exec playwright show-report playwright-documentation-report`
+
+### Étape 3 — Vérifier les artefacts produits
+
+Après le run, vérifier manuellement :
+
+```
+documentation-output/
+  screenshots/<guide>/
+    01-<slug>.png   ← présent, lisible, dans le bon ordre
+    02-<slug>.png
+    …
+  guides/
+    <guide>.json    ← présent, cohérent avec les étapes capturées
+```
+
+**Contrôle de stabilité :**
+
+- [ ] Les captures sont dans l'ordre stable attendu (préfixe `01-`, `02-`, `03-`, `04-`).
+- [ ] Les noms de fichier sont déterministes (slug kebab-case, sans espace ni caractère aléatoire).
+- [ ] Le viewport est constant (1920×1080 configuré dans `playwright.documentation.config.ts`).
+- [ ] Pas de bruit parasite visible (animations gelées, overlays fermés, apps fermées).
+
+**Contrôle de sûreté des données :**
+
+- [ ] Aucun identifiant réel d'utilisateur ou de compte visible dans les captures.
+- [ ] Aucune donnée client ou de production dans les captures, le JSON ou le futur Markdown.
+- [ ] Aucun secret, URL non prévue, ou token visible dans les artefacts.
+- [ ] Les noms d'artefacts éphémères utilisent le préfixe `Doc-` + horodatage — aucune donnée personnelle.
+- [ ] Le JSON intermédiaire ne contient que les métadonnées déclarées : titre, actions, états attendus, chemins de screenshots.
+
+**Contrôle de cohérence JSON :**
+
+- [ ] Le nombre d'étapes dans le JSON correspond au nombre de captures présentes dans `screenshots/<guide>/`.
+- [ ] Chaque `screenshotPath` dans le JSON pointe vers un fichier réellement présent.
+- [ ] L'ordre des étapes dans le JSON est aligné avec l'ordre des captures (index `01-`, `02-`, …).
+
+### Étape 4 — Générer le guide Markdown
+
+```bash
+# Générer tous les guides disponibles
+pnpm run docs:generate-user-guides
+
+# Générer un guide ciblé
+pnpm run docs:generate-user-guides -- --guide character-sheet
+```
+
+**Preuves minimales à conserver :**
+
+- [ ] La commande s'est terminée sans erreur (fichier JSON source présent, dossier screenshots présent).
+- [ ] Le fichier Markdown est présent dans `documentation-output/markdown/<guide>.md`.
+- [ ] Les chemins de screenshots dans le Markdown sont relatifs et stables.
+
+### Étape 5 — Relecture humaine
+
+- [ ] Un lecteur Dev/QA confirme que les captures sont à jour et représentatives de l'interface actuelle.
+- [ ] Un lecteur Documentation/PO relit le contenu Markdown sur le fond fonctionnel.
+- [ ] Aucune information hors JSON source n'a été introduite par la génération.
+- [ ] Le guide est compréhensible et exploitable par un utilisateur final.
+
+**Signal de diffusion :**
+
+Le guide ne peut être diffusé qu'après validation explicite de Documentation/PO.
+La validation Dev/QA seule ne suffit pas pour autoriser la publication.
+
+---
+
+## Écarts tolérés vs écarts bloquants
+
+### Écarts tolérés avant release documentaire
+
+| Écart | Tolérance |
+|---|---|
+| Légère variation de rendu due à la police ou au zoom | Toléré si le contenu reste lisible et représentatif |
+| Durée de chargement variable selon l'environnement | Toléré si `networkidle` stabilise les captures |
+| Captures partiellement décalées d'1-2px entre reruns | Toléré — pas de comparaison pixel-à-pixel |
+| Artefacts d'un run précédent présents dans `documentation-output/` | Toléré — les fichiers sont écrasés lors du rerun |
+
+### Écarts bloquants avant release documentaire
+
+| Écart | Statut |
+|---|---|
+| Capture manquante ou fichier PNG corrompu | **Bloquant** — rerun obligatoire |
+| Ordre des captures incohérent avec le JSON | **Bloquant** — rerun obligatoire |
+| Nom de fichier contenant un horodatage ou un identifiant aléatoire | **Bloquant** — rerun et correction de la spec |
+| Donnée sensible, client ou non maîtrisée visible dans une capture | **Bloquant** — nettoyage du monde et rerun obligatoire |
+| Erreur navigateur inattendue non filtrée pendant le run | **Bloquant** — investigation et rerun après correction |
+| JSON incohérent avec les captures (étape manquante, chemin invalide) | **Bloquant** — rerun obligatoire |
+| Guide généré contenant des informations hors JSON source | **Bloquant** — investigation du générateur Markdown |
+
+---
+
+## Données interdites dans les artefacts
+
+Les catégories suivantes ne doivent **jamais** apparaître dans `screenshots/`, `guides/*.json` ou `markdown/*.md` :
+
+| Catégorie | Exemples | Mécanisme d'évitement |
+|---|---|---|
+| Identifiants réels | Noms d'utilisateurs réels, comptes client, emails | Monde dédié, noms neutres (`Doc-*`) |
+| Données client | Personnages issus d'une campagne réelle, données de jeu partagées | Monde dédié isolé |
+| Secrets et tokens | Mots de passe, clés API, tokens de session visibles | Monde dédié, captures sans zone sensible |
+| URLs non prévues | Redirections vers un autre environnement, URLs de production dans le DOM | Contrôle du point d'entrée avant run |
+| Bruit de session | Notifications d'usage Foundry, alertes de mise à jour, popups de cookies | `dismissOverlayIfPresent` + `closeAllOpenApplications` |
+| Données non représentatives | États d'erreur, données de migration incomplète | État stable du monde avant run |
+
+**Mécanismes en place :**
+
+- Le monde documentaire est distinct du monde de production (pas de données partagées).
+- Chaque prérequis contrôlé utilise un préfixe neutre `Doc-` + horodatage — pas de nom personnel ou client.
+- Le helper `prepareDocumentationState` ferme les overlays et les applications avant chaque capture.
+- Les animations sont désactivées — pas d'état intermédiaire capturé par inadvertance.
+- Le JSON ne contient que les métadonnées déclarées dans la spec — pas d'injection automatique de contenu externe.
+
+---
+
+## Feu vert documentaire vs release applicative globale
+
+La clôture EDG6 s'applique **uniquement** au flux documentaire `e2e:documentation`.
+
+| Signal | Périmètre |
+|---|---|
+| Feu vert documentaire (EDG6) | Captures stables + artefacts sûrs + checklist complète + relecture humaine |
+| Release applicative globale | Inclut régression fonctionnelle, smoke, validation métier, tests Vitest — indépendant d'EDG6 |
+
+La suite `e2e:documentation` n'est **jamais** un gate bloquant pour un merge ou une release applicative.
+Un guide documentaire non à jour ne bloque pas la livraison — il indique que la documentation est à régénérer.
+
+---
+
+## Références
+
+- Contrat d'exploitation complet : `e2e/documentation/README.md`
+- Guide Playwright E2E (incluant la checklist PWE6) : `documentation/tests/e2e/playwright-e2e-guide.md`
+- Matrice de couverture : `documentation/tests/e2e/couverture-e2e-matrice.md`
+- Helpers documentaires : `e2e/documentation/utils/`
+- Configuration Playwright documentation : `playwright.documentation.config.ts`

--- a/documentation/tests/e2e/playwright-e2e-guide.md
+++ b/documentation/tests/e2e/playwright-e2e-guide.md
@@ -792,7 +792,87 @@ pnpm exec playwright show-report playwright-smoke-report
 
 ---
 
-## 11. Résumé
+## 11. Clôture EDG6 — Stabilité des captures, sûreté des données et checklist de release
+
+Cette section formalise les critères de sortie du chantier `e2e:documentation` (EDG6) et complète le contrat de qualité documentaire.
+
+Pour la checklist complète et exécutable, voir : `documentation/tests/e2e/edg6-release-checklist.md`
+
+### 11.1. Contrat de stabilité des captures
+
+Pour qu'un guide soit reproductible et diffable, les invariants suivants doivent tenir entre deux reruns identiques :
+
+| Invariant | Mécanisme |
+|---|---|
+| Ordre des captures | Préfixe d'index `01-`, `02-`, `03-`, `04-` — incrémenté dans l'ordre des étapes |
+| Viewport constant | `1920×1080` fixé dans `playwright.documentation.config.ts` |
+| Nommage déterministe | Slugs kebab-case stables via `toKebabSlug` — pas d'horodatage ni d'aléatoire dans le nom |
+| Écrans sans bruit parasite | `prepareDocumentationState` appelé avant chaque capture (overlays, apps, animations) |
+| Cohérence JSON ↔ screenshots | `writeGuideMetadata` écrit les chemins dans l'ordre d'enregistrement |
+
+**Écarts tolérés :** légère variation de rendu entre machines, durée de chargement variable (compensée par `networkidle`), artefacts du run précédent (écrasés au rerun).
+
+**Écarts bloquants :** capture manquante ou PNG corrompu, ordre incohérent JSON ↔ fichiers, nom de fichier avec identifiant aléatoire, donnée sensible visible, `screenshotPath` pointant vers un fichier absent.
+
+### 11.2. Sûreté des données du monde documentaire
+
+Les catégories suivantes ne doivent **jamais** apparaître dans `screenshots/`, `guides/*.json` ou `markdown/*.md` :
+
+| Catégorie interdite | Mécanisme d'évitement |
+|---|---|
+| Identifiants réels (noms d'utilisateurs, comptes client) | Monde dédié, noms neutres `Doc-<Prefixe>-${Date.now()}` |
+| Données client ou de campagne réelle | Monde documentaire isolé, distinct de la production |
+| Secrets et tokens (mots de passe, clés API) | Monde dédié, captures sans zone sensible |
+| URLs non prévues ou redirections vers un autre environnement | Contrôle du point d'entrée avant run |
+| Bruit de session (notifications, popups, alertes de mise à jour) | `prepareDocumentationState` avant chaque capture |
+| États non représentatifs (erreur, migration incomplète) | Monde stable et représentatif avant run |
+
+**Point de contrôle génération :** la commande `pnpm run docs:generate-user-guides` ne peut introduire aucune information hors JSON source. Le JSON source ne contient que les métadonnées déclarées dans la spec.
+
+### 11.3. Checklist de release `e2e:documentation`
+
+La séquence canonique pour conclure qu'un guide est prêt à être diffusé :
+
+```
+1. Préparer le monde documentaire (état stable, aucune donnée sensible)
+2. Lancer la capture : pnpm e2e:documentation
+3. Vérifier screenshots + JSON (ordre, nommage, cohérence, sûreté des données)
+4. Générer le Markdown : pnpm run docs:generate-user-guides
+5. Relecture humaine Dev/QA + Documentation/PO avant diffusion
+```
+
+**Preuves minimales à conserver à la clôture :**
+
+- Artefacts produits présents et cohérents dans `documentation-output/`.
+- Absence d'erreurs navigateur inattendues dans la sortie du run.
+- Captures lisibles et représentatives (vérification manuelle).
+- Contrôle des données sensibles effectué.
+- Relecture métier effectuée par Documentation/PO.
+
+### 11.4. Frontière feu vert documentaire vs release applicative globale
+
+| Signal | Périmètre |
+|---|---|
+| Feu vert documentaire (EDG6) | Captures stables + artefacts sûrs + checklist complète + relecture humaine |
+| Release applicative globale | Régression fonctionnelle, smoke, Vitest, validation métier — indépendant d'EDG6 |
+
+La suite `e2e:documentation` n'est **jamais** un gate bloquant pour un merge ou une release applicative.
+Un guide documentaire non à jour ne bloque pas la livraison — il indique que la documentation est à régénérer.
+
+### 11.5. Signal de clôture EDG6
+
+Le chantier `e2e:documentation` est clos quand :
+
+- [x] Captures reproductibles — contrat de stabilité formalisé et outillé (`prepareDocumentationState`, `toKebabSlug`, viewport fixe)
+- [x] Artefacts sûrs — catégories de données interdites documentées, mécanismes d'évitement en place
+- [x] Checklist de release courte et exécutable — `documentation/tests/e2e/edg6-release-checklist.md`
+- [x] Rerun compréhensible — commandes canoniques, prérequis et cas de rerun dans `e2e/documentation/README.md`
+- [x] Revue humaine explicitement requise avant toute diffusion
+- [x] Un seul contrat de release documentaire — `e2e/documentation/README.md` + `e2e/README.md` + ce guide + `edg6-release-checklist.md` sans consignes concurrentes
+
+---
+
+## 12. Résumé
 
 - `pnpm e2e:smoke` : vérification de surface, exécution manuelle, lecture seule sur instance de production.
 - `pnpm e2e:regression` : validation fonctionnelle pré-livraison sur instance dédiée, remplace les campagnes QA manuelles répétitives.
@@ -805,6 +885,7 @@ pnpm exec playwright show-report playwright-smoke-report
 - Toute nouvelle spec doit être placée dans `e2e/smoke/`, `e2e/regression/specs/` ou `e2e/documentation/specs/` selon son type.
 - Matrice de couverture : `documentation/tests/e2e/couverture-e2e-matrice.md`.
 - Gouvernance `e2e:documentation` : Dev/QA maintient les parcours et le monde — Documentation/PO valide les guides et décide de la publication. Voir `e2e/documentation/README.md`.
+- Clôture EDG6 : contrat de stabilité des captures, sûreté des données et checklist de release dans `documentation/tests/e2e/edg6-release-checklist.md` et section 11 de ce guide.
 
 ---
 

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -162,6 +162,18 @@ pnpm e2e:documentation:ui
 
 Pour le contrat d'exploitation complet (mode rerun, gouvernance, rôles, critères de clôture), voir `e2e/documentation/README.md`.
 
+**Clôture EDG6 — signal de fermeture du chantier `e2e:documentation` :**
+
+Le chantier `e2e:documentation` est considéré clos quand les cinq conditions suivantes sont remplies :
+
+1. **Captures stables** — invariants de stabilité formalisés (ordre, viewport, nommage, reset visuel) : `e2e/documentation/README.md` section "Contrat de stabilité".
+2. **Artefacts sûrs** — catégories de données interdites documentées et mécanismes d'évitement en place : `e2e/documentation/README.md` section "Sûreté des données".
+3. **Checklist de release courte** — séquence canonique exécutable en 5 étapes : `documentation/tests/e2e/edg6-release-checklist.md`.
+4. **Rerun compréhensible** — commandes canoniques, prérequis et cas de rerun documentés : `e2e/documentation/README.md` section "Contrat d'exploitation".
+5. **Revue humaine explicitement requise** — Documentation/PO valide avant toute diffusion : contrat de gouvernance dans `e2e/documentation/README.md`.
+
+La suite reste **strictement documentaire et non bloquante** — elle ne conditionne aucun merge ni aucune release applicative.
+
 ---
 
 ### `pnpm run docs:generate-user-guides` — génération des guides Markdown (séparée)

--- a/e2e/documentation/README.md
+++ b/e2e/documentation/README.md
@@ -507,3 +507,99 @@ Les invariants minimaux vérifiés (i18n, absence de placeholder cassé, absence
 1. Instance Foundry accessible sur le port configuré dans `E2E_FOUNDRY_BASE_URL`
 2. Fichier `.env.e2e.documentation` configuré
 3. Monde stable dans un état représentatif des captures attendues (configuré dans `E2E_FOUNDRY_WORLD`)
+
+---
+
+## Contrat de stabilité des captures et des artefacts (EDG6)
+
+### Invariants attendus entre deux reruns identiques
+
+Pour qu'un guide soit diffable et relisible avant release, les éléments suivants doivent rester déterministes :
+
+| Invariant | Mécanisme |
+|---|---|
+| Ordre des captures | Préfixe d'index `01-`, `02-`, `03-`, `04-` — incrémenté dans l'ordre des étapes de la spec |
+| Viewport constant | `1920×1080` défini dans `playwright.documentation.config.ts` — ne pas modifier entre les runs |
+| Nommage déterministe | Slugs kebab-case fixes (`toKebabSlug`) — pas d'horodatage ni d'identifiant aléatoire dans le nom de fichier |
+| Écrans sans bruit parasite | `prepareDocumentationState` appelé avant chaque capture (overlays, apps, animations) |
+| Cohérence JSON ↔ screenshots | `writeGuideMetadata` écrit les chemins dans l'ordre d'enregistrement — aligné avec les fichiers produits |
+
+### Écarts tolérés
+
+- Légère variation de rendu due à la police ou au zoom entre machines.
+- Durée de chargement variable — le helper attend `networkidle` avant chaque capture.
+- Artefacts d'un run précédent dans `documentation-output/` — les fichiers sont écrasés lors du rerun.
+
+### Écarts bloquants avant release documentaire
+
+- Capture manquante ou fichier PNG corrompu → rerun obligatoire.
+- Ordre des captures incohérent avec le JSON → rerun obligatoire.
+- Nom de fichier contenant un identifiant aléatoire ou un horodatage → correction de la spec + rerun.
+- Donnée sensible visible dans une capture → nettoyage du monde + rerun obligatoire.
+- JSON dont un `screenshotPath` pointe vers un fichier absent → rerun obligatoire.
+
+---
+
+## Sûreté des données du monde documentaire (EDG6)
+
+### Données interdites dans les artefacts
+
+Les catégories suivantes ne doivent **jamais** apparaître dans `screenshots/`, `guides/*.json` ou `markdown/*.md` :
+
+| Catégorie | Mécanisme d'évitement |
+|---|---|
+| Identifiants réels (noms d'utilisateurs, comptes client, emails) | Monde dédié, noms neutres (`Doc-<Prefixe>-${Date.now()}`) |
+| Données client ou de campagne réelle | Monde documentaire isolé, distinct de la production |
+| Secrets et tokens (mots de passe, clés API, tokens de session) | Monde dédié, captures sans zone sensible |
+| URLs non prévues ou redirections vers un autre environnement | Contrôle du point d'entrée avant run |
+| Bruit de session (notifications d'usage, alertes de mise à jour, popups) | `dismissOverlayIfPresent` + `closeAllOpenApplications` dans `prepareDocumentationState` |
+| États non représentatifs (erreur, migration incomplète) | Monde stable et représentatif avant run |
+
+### Point de contrôle documentaire
+
+La génération Markdown (`pnpm run docs:generate-user-guides`) ne peut introduire aucune information hors JSON source.
+Le JSON source ne contient que les métadonnées déclarées dans la spec : titre, actions utilisateur, états attendus, chemins de screenshots.
+
+Avant diffusion d'un guide :
+1. Dev/QA confirme que les captures sont à jour et représentatives.
+2. Documentation/PO relit le contenu sur le fond fonctionnel.
+3. Documentation/PO valide ou demande une correction.
+4. Le guide est diffusé uniquement après validation explicite de Documentation/PO.
+
+---
+
+## Checklist de release `e2e:documentation` (EDG6)
+
+La checklist complète est disponible dans `documentation/tests/e2e/edg6-release-checklist.md`.
+
+### Séquence canonique (rappel court)
+
+```
+1. Préparer le monde documentaire (état stable, aucune donnée sensible)
+2. Lancer la capture : pnpm e2e:documentation
+3. Vérifier screenshots + JSON (ordre, nommage, cohérence, sûreté des données)
+4. Générer le Markdown : pnpm run docs:generate-user-guides
+5. Relecture humaine Dev/QA + Documentation/PO avant diffusion
+```
+
+### Signal de clôture EDG6
+
+Un flux documentaire peut être rerun, relu et diffusé quand :
+
+- [x] Captures stables et déterministes entre deux reruns identiques
+- [x] Artefacts sûrs — aucune donnée sensible, client ou non maîtrisée visible
+- [x] Checklist de release courte et exécutable (`edg6-release-checklist.md`)
+- [x] Rerun compréhensible — commandes canoniques, prérequis et cas de rerun documentés
+- [x] Revue humaine explicitement requise avant toute diffusion
+
+### Feu vert documentaire vs release applicative globale
+
+La suite `e2e:documentation` est **strictement documentaire et non bloquante** :
+
+- Elle ne fait partie d'aucun pipeline CI.
+- Ses résultats ne conditionnent pas un merge, une release ni une validation fonctionnelle.
+- Un guide documentaire non à jour ne bloque pas la livraison — il indique que la documentation est à régénérer.
+
+---
+
+## Critères de clôture du socle documentaire (issue #384)


### PR DESCRIPTION
Closes #384

Contexte
- Amélioration de la documentation E2E (Playwright) pour formaliser les critères de fermeture EDG6 et le contrat de sécurité des données.

Résumé des changements
- Ajout: documentation/tests/e2e/edg6-release-checklist.md (nouvelle checklist EDG6)
- Modifié: documentation/tests/e2e/playwright-e2e-guide.md (formalisations et clarifications)
- Modifié: e2e/README.md (références documentation)
- Modifié: e2e/documentation/README.md (réorganisation / liens)

Notes techniques
- Changements purement documentaires et guides E2E. Aucun code source produit ou modifié.
- Le commit inclus: 3116bf1a docs(playwright-e2e-guide): formalize EDG6 closure criteria and data safety contract

Tests exécutés
- Aucune exécution automatique (lint/tests/build) effectuée pour cette PR. Il s'agit de documentation uniquement.

Limites connues
- Cette PR ne modifie pas les suites E2E elles-mêmes, seulement la documentation et les checklists. Les actions automatisées restent inchangées.

Points d'attention pour la revue
- Vérifier la clarté et l'exhaustivité de la checklist EDG6 (documentation/tests/e2e/edg6-release-checklist.md).
- Vérifier que les liens et références dans les README mis à jour sont corrects et ne cassent pas la navigation.
