### PR TITLE
refactor(character): extract progression magic numbers into named constants

### DIFF
--- a/documentation/audit/adr-0018-audit-magic-numbers-mjs.md
+++ b/documentation/audit/adr-0018-audit-magic-numbers-mjs.md
@@ -1,0 +1,505 @@
+# Audit ADR-0018 — Magic Numbers et constantes nommées dans le code `*.mjs`
+
+## Résumé
+
+L’ADR [ADR-0018](../architecture/adr/adr-0018-no-magic-numbers-named-constants.md) n’est **pas validée globalement** sur la codebase `*.mjs`.
+
+L’audit montre une adoption **partielle mais incomplète** du pattern :
+
+- certaines constantes métier ont bien été extraites dans `module/config/` ;
+- plusieurs règles métier importantes restent encore dupliquées sous forme de literals numériques ou textuels ;
+- une part importante du bruit relevé provient aussi de la couche UI/canvas, où l’intention de l’ADR doit être appliquée avec discernement.
+
+### Chiffres clés
+
+Scan numérique ciblé sur le code applicatif hors `module/config/` :
+
+- **316 occurrences candidates**
+- **73 fichiers touchés**
+
+Répartition par zone :
+
+- `module/canvas` : **106**
+- `module/importer` : **56**
+- `module/applications` : **49**
+- `module/models` : **40**
+- `module/documents` : **20**
+- `module/dice` : **19**
+- `module/lib` : **19**
+- `module/utils` : **7**
+
+Passage ciblé sur des magic strings à forte confiance :
+
+- `forget` : **41**
+- `train` : **35**
+- `talent` : **31+**
+- `mainhand` : **23**
+- `none` : **7+**
+- `physical` : **5**
+- `single` : **3**
+- `brawn` : **2**
+- `medium` : **2+**
+
+## Conclusion
+
+Conclusion courte : **l’ADR est pertinente, déjà engagée dans certains modules, mais elle n’est pas encore respectée de façon systémique**.
+
+Je considère donc que l’ADR doit être évaluée comme :
+
+- **acceptée architecturalement** ;
+- **partiellement appliquée** ;
+- **non validée en conformité codebase** à date.
+
+Le code montre déjà la bonne direction sur certains axes, par exemple :
+
+- `module/config/skills.mjs:217-223`
+- `module/config/dice.mjs:11-17`
+- `module/models/character.mjs:417`
+
+Mais de nombreuses règles métier restent encore encodées en dur dans les couches :
+
+- `lib/`
+- `models/`
+- `documents/`
+- `dice/`
+- `importer/`
+- certaines parties de `applications/`
+
+## Ce que l’audit valide déjà
+
+### 1. Le pattern ADR existe bien dans la codebase
+
+Le pattern cible est déjà appliqué sur certains cas :
+
+- `module/config/skills.mjs`
+  - `MAX_RANK_AT_CREATION = 2`
+  - `MAX_RANK = 5`
+- `module/config/dice.mjs`
+  - `MAX_BOONS`
+  - `MAX_BANES`
+  - `DIE_STEP`
+  - `MIN_DIE`
+  - `MAX_DIE`
+
+Exposition via `SYSTEM` :
+
+- `module/config/system.mjs:198-207`
+- `module/config/system.mjs:213-243`
+
+Consommation correcte observée :
+
+- `module/models/character.mjs:417`
+
+Tests contractuels déjà présents :
+
+- `tests/config/skills.test.mjs`
+- `tests/config/system.test.mjs`
+
+### 2. L’ADR est donc techniquement faisable sans rupture de pattern
+
+Le mécanisme recommandé par l’ADR est déjà opérationnel :
+
+- export dans `module/config/<entity>.mjs`
+- exposition via `SYSTEM`
+- usage côté logique
+- tests contractuels de config
+
+Le problème n’est donc **pas** un manque d’infrastructure, mais une **adoption incomplète**.
+
+## Findings
+
+### 1. Critique — règles métier de progression / XP / rangs encore codées en dur
+
+#### Constat
+
+Les règles métier les plus structurantes du système restent largement dupliquées en literals numériques.
+
+Références principales :
+
+- `module/lib/skills/skill-cost-calculator.mjs:16,21`
+- `module/lib/skills/trained-skill.mjs:56,60`
+- `module/lib/skills/career-free-skill.mjs:55`
+- `module/lib/skills/specialization-free-skill.mjs:55`
+- `module/lib/characteristics/characteristic-cost-calculator.mjs:32`
+- `module/lib/characteristics/trained-characteristic.mjs:33,37`
+- `module/lib/specializations/specialization-cost-service.mjs:54,59`
+- `module/models/actor-type.mjs:167,176,391,445,476,499-501`
+- `module/models/character.mjs:283,313,328-330,367-368,481,485`
+- `module/models/adversary.mjs:58,70-71,89,94,114`
+
+Valeurs concernées :
+
+- `2`
+- `3`
+- `5`
+- `6`
+- `10`
+- `12`
+- `1.5`
+
+#### Évaluation
+
+- **Correction requise** : Oui
+- **Criticité** : Critique
+- **Motif** :
+  - ce sont des règles métier partagées ;
+  - elles apparaissent dans plusieurs couches ;
+  - certaines ont déjà une version centralisée, mais la migration n’est pas terminée ;
+  - leur duplication augmente fortement le risque de divergence silencieuse.
+
+#### Recommandation
+
+Créer ou compléter des constantes métier dans `module/config/` pour couvrir :
+
+- coûts XP par rang ;
+- limites de rang création / hors création ;
+- seuils de caractéristiques ;
+- règles de coût des spécialisations ;
+- multiplicateurs et seuils de ressources calculées.
+
+### 2. Critique — moteur de dés et seuils de combat encore partiellement en dur
+
+#### Constat
+
+Une partie du moteur de résolution continue d’utiliser des seuils numériques en dur, malgré l’existence d’un début de centralisation dans `module/config/dice.mjs`.
+
+Références principales :
+
+- `module/dice/standard-check.mjs:103,126,169-171,207,217,358,363`
+- `module/documents/actor-mixins/combat/attack.mixin.mjs:46-47,136`
+- `module/documents/actor-mixins/combat/defense.mixin.mjs:80-85`
+- `module/documents/combat.mjs:93,110-122,136-185`
+
+Valeurs concernées :
+
+- `4`
+- `6`
+- `8`
+- `12`
+- `2`
+- `-4`
+
+#### Évaluation
+
+- **Correction requise** : Oui
+- **Criticité** : Critique
+- **Motif** :
+  - ces valeurs ont un sens mécanique explicite ;
+  - elles pilotent le comportement des checks, critiques, boons/banes, défense et heroism ;
+  - la zone est sensible au risque de régression fonctionnelle.
+
+#### Recommandation
+
+Étendre `module/config/dice.mjs` et, si nécessaire, `module/config/system.mjs` pour nommer :
+
+- seuil critique succès / échec par défaut ;
+- bornes ability / skill / enchantment ;
+- pool de dés par défaut ;
+- seuils heroism et escalade ;
+- pénalités de résistance / défense.
+
+### 3. Critique — magic strings métier de schéma, enums et valeurs par défaut
+
+#### Constat
+
+De nombreuses valeurs textuelles à sens métier sont encore écrites en dur dans les schémas, validations et documents.
+
+Références principales :
+
+- `module/models/weapon.mjs:14,37-38,162,235,253,264,305`
+- `module/models/action.mjs:135,579,585,1100,1322,1344,1347`
+- `module/models/physical.mjs:17-18`
+- `module/models/adversary.mjs:27`
+- `module/models/species.mjs:87,104`
+- `module/documents/actor-mixins/combat/attack.mixin.mjs:28`
+- `module/documents/actor-mixins/combat/defense.mixin.mjs:19,31,80,84`
+- `module/documents/actor.mjs:273,385,397,399,556-562,577`
+
+Exemples :
+
+- `'rangedLight'`
+- `'medium'`
+- `'single'`
+- `'standard'`
+- `'none'`
+- `'normal'`
+- `'physical'`
+- `'health'`
+- `'restricted'`
+- `'mainhand'`
+
+#### Évaluation
+
+- **Correction requise** : Oui, par vagues
+- **Criticité** : Critique
+- **Motif** :
+  - ces valeurs représentent des identifiants métier, pas de simples détails d’implémentation ;
+  - elles sont utilisées comme defaults, discriminants, clés d’aiguillage et règles de fallback ;
+  - leur duplication rend les schémas moins fiables et moins lisibles.
+
+#### Recommandation
+
+Prioriser :
+
+1. les valeurs par défaut de schéma adossées à des registres `SYSTEM.*`
+2. les identifiants d’états et de portées
+3. les types d’objets métier récurrents
+4. les slots / catégories / niveaux de restriction
+
+### 4. Majeure — importer OggDude avec bornes et defaults métier encore dupliqués
+
+#### Constat
+
+L’importer concentre un volume important de literals numériques et textuels à sens métier.
+
+Références principales :
+
+- `module/importer/items/weapon-ogg-dude.mjs:146-149,191,199,206`
+- `module/importer/items/armor-ogg-dude.mjs:227-232,261,281`
+- `module/importer/items/career-ogg-dude.mjs:106-110,185-186,237,243,282,303`
+- `module/importer/utils/description-markup-utils.mjs:13-18,57,63,108,140`
+- `module/importer/mappers/oggdude-talent-mapper.mjs:173,212`
+
+Exemples :
+
+- bornes `0..20`
+- bornes `0..8`
+- défauts de rang gratuit
+- longueurs max de description
+- valeurs par défaut comme `'mainhand'`, `'medium'`, `'restricted'`, `'none'`
+
+#### Évaluation
+
+- **Correction requise** : Oui, partielle
+- **Criticité** : Majeure
+- **Motif** :
+  - plusieurs valeurs sont de vraies contraintes métier ou contractuelles ;
+  - d’autres relèvent plutôt de sanitation ou de robustesse locale.
+
+#### Recommandation
+
+Corriger en priorité :
+
+- bornes métier partagées avec les modèles runtime ;
+- defaults de mapping qui correspondent à des valeurs de config système ;
+- limites de rang gratuit ;
+- clamps liés au contrat de schéma.
+
+Ne pas sur-centraliser immédiatement :
+
+- limites purement techniques de sanitation ou de formatting, si elles restent nommées localement.
+
+### 5. Majeure — règles UI / applications encore implicites
+
+#### Constat
+
+Certaines règles d’interface ou de comportement produit sont encore encodées directement en literals.
+
+Références principales :
+
+- `module/applications/sheets/base-actor-sheet.mjs:212,363,399,534`
+- `module/applications/character-audit-log.mjs:407,432`
+- `module/applications/config/skill.mjs:67-69,129`
+
+Exemples :
+
+- `count > 3`
+- `1000000`
+- `slice(0, 10)`
+- sentinelles `-1`
+
+#### Évaluation
+
+- **Correction requise** : Oui, sélectivement
+- **Criticité** : Majeure
+- **Motif** :
+  - certaines valeurs représentent de vraies règles UI ;
+  - d’autres sont surtout des constantes techniques de présentation.
+
+#### Recommandation
+
+- remonter les vraies règles UI transverses dans `module/config/ui.mjs` ou `module/config/system.mjs`
+- laisser les constantes purement locales dans le fichier, mais **nommées explicitement en tête de module**
+
+### 6. Mineure à Majeure — bruit important dans `canvas/` et rendu Pixi
+
+#### Constat
+
+La plus forte densité d’occurrences numériques est dans la couche graphique.
+
+Top fichiers :
+
+- `module/canvas/token.mjs` : `42`
+- `module/applications/specialization-tree/pixi-tree-renderer.mjs` : `26`
+- `module/canvas/talent-tree-node.mjs` : `13`
+- `module/canvas/talent-tree.mjs` : `13`
+- `module/canvas/talent-icon.mjs` : `12`
+
+Références typiques :
+
+- tailles
+- offsets
+- couleurs hexadécimales
+- alphas
+- paddings
+- throttles
+- rayons de coins
+- marges de badge
+
+#### Évaluation
+
+- **Correction requise** : Oui, localement
+- **Criticité** : Mineure à Majeure selon le cas
+- **Motif** :
+  - beaucoup de ces valeurs ont un sens d’implémentation visuelle locale, pas un sens métier global ;
+  - elles enfreignent souvent la lettre de l’ADR, mais pas toujours son intention.
+
+#### Recommandation
+
+- nommer localement les constantes visuelles réutilisées ;
+- ne pas remonter automatiquement toutes ces valeurs dans `module/config/` ;
+- corriger en priorité les seuils qui impactent un vrai comportement utilisateur, pas seulement la géométrie.
+
+Exemple positif déjà présent :
+
+- `module/applications/specialization-tree/layout.mjs:17-30`
+
+### 7. Faible — faux positifs ADR ou dette purement technique
+
+#### Constat
+
+Une partie des occurrences relèvent davantage :
+
+- de sentinelles techniques ;
+- de couleurs ;
+- de formatage ;
+- de compatibilité runtime ;
+- ou de détails internes d’implémentation.
+
+Exemples :
+
+- `-1`
+- `0xffffff`
+- `0x333333`
+- `0xff0000`
+- `1000`
+- `1024`
+- `game.release.generation < 13`
+
+#### Évaluation
+
+- **Correction requise** : Non prioritaire
+- **Criticité** : Faible
+- **Motif** :
+  - faible portée métier ;
+  - faible probabilité de dérive fonctionnelle ;
+  - intérêt principal : lisibilité locale.
+
+#### Recommandation
+
+Si ces zones sont retouchées :
+- nommer localement les constantes techniques ;
+- ne pas lancer de chantier dédié uniquement pour ces cas.
+
+## Fichiers les plus denses
+
+| Occurrences numériques | Fichier |
+| ---: | --- |
+| 42 | `module/canvas/token.mjs` |
+| 26 | `module/applications/specialization-tree/pixi-tree-renderer.mjs` |
+| 13 | `module/canvas/talent-tree-node.mjs` |
+| 13 | `module/canvas/talent-tree.mjs` |
+| 12 | `module/canvas/talent-icon.mjs` |
+| 12 | `module/dice/standard-check.mjs` |
+| 10 | `module/models/actor-type.mjs` |
+| 9 | `module/importer/utils/global-import-metrics.mjs` |
+| 8 | `module/applications/sheets/adversary-sheet.mjs` |
+| 8 | `module/importer/items/career-ogg-dude.mjs` |
+
+## Évaluation par famille
+
+| Famille | Volume approx. | Criticité | Corriger |
+| --- | ---: | --- | --- |
+| Progression / XP / rangs | 30+ | Critique | Oui |
+| Dés / combat / résolution | 20+ | Critique | Oui |
+| Magic strings de schéma / enums métier | 80+ | Critique | Oui, par vagues |
+| Importer OggDude | 50+ | Majeure | Oui, partiel |
+| Applications / sheets | 49 | Majeure | Oui, sélectif |
+| Canvas / Pixi / rendu | 106 | Mineure à Majeure | Oui localement |
+| Sentinelles / couleurs / formatage | variable | Faible | Non prioritaire |
+
+## Cas déjà alignés avec l’ADR
+
+### 1. Skills max rank
+
+Constantes déjà extraites :
+
+- `module/config/skills.mjs:217-223`
+
+Exposition via `SYSTEM` :
+
+- `module/config/system.mjs:204-207`
+
+Consommation correcte :
+
+- `module/models/character.mjs:417`
+
+Tests présents :
+
+- `tests/config/skills.test.mjs`
+- `tests/config/system.test.mjs`
+
+### 2. Dice base config
+
+Constantes déjà présentes :
+
+- `module/config/dice.mjs:11-17`
+
+Mais la migration n’est pas terminée dans :
+
+- `module/dice/standard-check.mjs`
+- `module/documents/actor-mixins/combat/attack.mixin.mjs`
+
+## Recommandation
+
+Je recommande de considérer l’ADR-0018 comme :
+
+- **bonne et validée sur le fond** ;
+- **non conforme globalement dans son application actuelle** ;
+- **à industrialiser par lots**, pas en une seule passe.
+
+### Ordre recommandé de remédiation
+
+1. **Lot 1 — métier critique**
+   - progression
+   - XP
+   - rangs
+   - caractéristiques
+   - spécialisations
+
+2. **Lot 2 — moteur de dés et combat**
+   - seuils critiques
+   - bornes de check
+   - pénalités et caps
+
+3. **Lot 3 — magic strings métier**
+   - defaults de schéma
+   - enums et discriminants récurrents
+   - types d’objets
+
+4. **Lot 4 — importer**
+   - clamps métier
+   - defaults de mapping
+   - limites contractuelles
+
+5. **Lot 5 — UI et canvas**
+   - constantes locales nommées
+   - centralisation seulement si la règle est réellement transverse
+
+## Verdict final
+
+L’ADR-0018 est **partiellement appliquée mais non validée à l’échelle de la codebase**.
+
+Le système a déjà commencé la transition vers des constantes nommées dans `module/config/`, mais les violations restantes restent suffisamment nombreuses et suffisamment centrales pour empêcher une validation de conformité aujourd’hui.
+
+Le problème principal n’est pas dans quelques oublis isolés, mais dans une **dette transversale encore présente sur les règles métier, le moteur de dés, les schémas et l’importer**.

--- a/documentation/plan/character-sheet/refactor/409-mc1-extraire-les-constantes-de-progression-xp-rangs-couts-metier.md
+++ b/documentation/plan/character-sheet/refactor/409-mc1-extraire-les-constantes-de-progression-xp-rangs-couts-metier.md
@@ -1,0 +1,58 @@
+# MC1 — Extraire les constantes de progression/XP/rangs/coûts métier
+
+**Issue** : [#409 — MC1 — Extraire les constantes de progression/XP/rangs/coûts métier](https://github.com/herveDarritchon/foundryvtt-swerpg/issues/409)
+
+## Objectif
+
+Centraliser les derniers nombres métier encore codés en dur dans les flux de progression personnage (XP, rangs, coûts de skills, caractéristiques et spécialisations) afin d'aligner le domaine avec ADR-0018 et de supprimer les divergences entre calculs, validations et surfaces `SYSTEM.*`.
+
+## Décisions de cadrage
+
+- Réutiliser `SYSTEM.SKILLS.MAX_RANK_AT_CREATION` et `SYSTEM.SKILLS.MAX_RANK` déjà introduites par `#395` ; ne pas recréer un second point de vérité.
+- Introduire uniquement les constantes métier manquantes pour les coûts et plafonds encore dispersés (`5`, `+5`, `10`, `6`, première spécialisation gratuite, pénalité hors carrière, etc.).
+- Exclure `module/lib/talents/talent-cost-calculator.mjs` du périmètre : logique legacy Crucible déjà dépréciée, sans intérêt pour ce chantier de centralisation métier V1.
+- Ne pas mélanger ce chantier avec une refonte UX, i18n ou un changement de règles de progression.
+
+## Étapes d’implémentation
+
+### 1. Poser la surface de constantes métier de progression
+
+**Fichiers cibles** : `module/config/progression.mjs`, `module/config/system.mjs`
+
+**What**
+
+- créer un namespace dédié (`SYSTEM.PROGRESSION`) pour les constantes transverses encore absentes ;
+- garder les constantes déjà portées par `SYSTEM.SKILLS` comme source canonique pour les plafonds de skills ;
+- documenter explicitement les coefficients métier attendus : coût XP des skills, surcharge hors carrière, coût des caractéristiques, plafonds de caractéristiques, coût de spécialisation et pénalité hors carrière.
+
+**Validation visée** : toutes les règles numériques ciblées sont adressables via une surface de config nommée, stable et lisible.
+
+### 2. Remplacer les magic numbers dans les services de progression
+
+**Fichiers cibles** : `module/lib/skills/skill-cost-calculator.mjs`, `module/lib/skills/trained-skill.mjs`, `module/lib/skills/career-free-skill.mjs`, `module/lib/skills/specialization-free-skill.mjs`, `module/lib/characteristics/characteristic-cost-calculator.mjs`, `module/lib/characteristics/trained-characteristic.mjs`, `module/lib/specializations/specialization-cost-service.mjs`, `module/models/actor-type.mjs`
+
+**What**
+
+- remplacer les littéraux métier par les constantes dédiées ;
+- aligner les validations de rang/plafond et les calculateurs de coût sur la même source ;
+- conserver le comportement actuel, sans changer les règles métier ni les messages au-delà du strict nécessaire pour lire les nouvelles constantes.
+
+**Validation visée** : les flux `skill`, `characteristic` et `specialization` ne portent plus de nombres métier codés en dur sur les cas couverts par l’issue.
+
+### 3. Verrouiller le contrat par des tests ciblés
+
+**Fichiers cibles** : `tests/config/progression.test.mjs`, tests ciblés sous `tests/lib/skills/`, `tests/lib/characteristics/`, `tests/lib/specializations/` et validation associée côté `actor-type` si déjà couverte
+
+**What**
+
+- ajouter un test contractuel pour chaque constante exportée ;
+- couvrir au minimum les cas représentatifs : skill carrière/hors carrière, plafond skill création/hors création, coût caractéristique, plafond caractéristique, spécialisation initiale/gratuite puis coût incrémental et pénalité hors carrière ;
+- verrouiller que `#395` reste la source de vérité des plafonds de skills.
+
+**Validation visée** : la centralisation des constantes devient observable et protégée contre toute réintroduction future de magic numbers métier.
+
+## Résultat attendu
+
+- Les règles numériques de progression ciblées sont nommées et exposées via `SYSTEM.*`.
+- Les services de coût et de validation réutilisent ces constantes au lieu de littéraux `2/5/6/10` dispersés.
+- Le comportement métier reste inchangé ; seule la source de vérité est consolidée.

--- a/documentation/ways-of-work/plan/core-refactor/adr-0018-magic-numbers-compliance/issues-checklist.md
+++ b/documentation/ways-of-work/plan/core-refactor/adr-0018-magic-numbers-compliance/issues-checklist.md
@@ -1,0 +1,57 @@
+# Issues Checklist — ADR-0018 Magic Numbers Compliance
+
+## Feature Issue
+
+| # | Type | Titre | Priorité | Estimate |
+| --- | --- | --- | --- | --- |
+| F1 | Feature | ADR-0018 Magic Numbers Compliance — Mettre la codebase en conformité ADR-0018 | P1 | 21 |
+
+## Story / Enabler Issues
+
+| # | Type | Titre | Priorité | Estimate | Dépendances | Fichiers impactés (indicatif) |
+| --- | --- | --- | --- | --- | --- | --- |
+| MC1 | Story | Extraire les constantes de progression/XP/rangs/coûts métier | P1 | 5 | F1 | `module/lib/skills/*.mjs`, `module/lib/characteristics/*.mjs`, `module/lib/specializations/*.mjs`, `module/models/actor-type.mjs`, `module/models/character.mjs`, `module/models/adversary.mjs`, `module/config/skills.mjs`, `module/config/system.mjs` |
+| MC2 | Story | Extraire les seuils du moteur de dés et du combat | P1 | 5 | F1 | `module/dice/standard-check.mjs`, `module/documents/combat.mjs`, `module/documents/actor-mixins/combat/attack.mixin.mjs`, `module/documents/actor-mixins/combat/defense.mixin.mjs`, `module/config/dice.mjs`, `module/config/system.mjs` |
+| MC3 | Story | Centraliser les enums et defaults de schéma métier | P1 | 8 | F1 | `module/models/weapon.mjs`, `module/models/action.mjs`, `module/models/physical.mjs`, `module/models/adversary.mjs`, `module/models/species.mjs`, `module/documents/actor-mixins/combat/*.mjs`, `module/documents/actor.mjs`, `module/config/items.mjs`, `module/config/weapon.mjs`, `module/config/action.mjs` |
+| MC4 | Enabler | Normaliser l'importer OggDude avec les constantes partagées | P2 | 3 | MC1, MC3 | `module/importer/items/weapon-ogg-dude.mjs`, `module/importer/items/armor-ogg-dude.mjs`, `module/importer/items/career-ogg-dude.mjs`, `module/importer/utils/description-markup-utils.mjs`, `module/importer/mappers/oggdude-talent-mapper.mjs` |
+| MC5 | Enabler | Nommer les constantes UI/canvas locales | P2 | 3 | F1 | `module/canvas/token.mjs`, `module/canvas/talent-tree-node.mjs`, `module/canvas/talent-tree.mjs`, `module/canvas/talent-icon.mjs`, `module/applications/specialization-tree/pixi-tree-renderer.mjs` |
+| MC6 | Test | Verrouiller les contrats config et valider la non-régression | P1 | 3 | MC1, MC2, MC3, MC4, MC5 | `tests/config/skills.test.mjs`, `tests/config/system.test.mjs`, `tests/config/dice.test.mjs`, `tests/config/items.test.mjs`, `tests/config/weapon.test.mjs`, `tests/config/action.test.mjs` |
+
+## Labels recommandés
+
+- `epic:core-refactor`
+- `feature:adr-0018-compliance`
+- `area:config`
+- `area:models`
+- `area:dice`
+- `area:combat`
+- `area:importer`
+- `area:canvas`
+- `type:refactor`
+- `type:test`
+- `priority:p1`
+- `priority:p2`
+
+## Dépendances entre sous-issues
+
+```mermaid
+graph TD
+    F1[Feature: ADR-0018 Compliance] --> MC1
+    F1 --> MC2
+    F1 --> MC3
+    F1 --> MC5
+    MC1 --> MC4
+    MC3 --> MC4
+    MC1 --> MC6
+    MC2 --> MC6
+    MC3 --> MC6
+    MC4 --> MC6
+    MC5 --> MC6
+```
+
+## Ordre de création recommandé
+
+1. **Feature** `F1`
+2. **Story** `MC1` + `MC2` + `MC3` + `MC5` (parallélisables)
+3. **Enabler** `MC4` (après MC1 et MC3 partiellement livrés)
+4. **Test** `MC6` (après tous les lots)

--- a/documentation/ways-of-work/plan/core-refactor/adr-0018-magic-numbers-compliance/project-plan.md
+++ b/documentation/ways-of-work/plan/core-refactor/adr-0018-magic-numbers-compliance/project-plan.md
@@ -1,0 +1,133 @@
+# Project Plan — Core Refactor / ADR-0018 Magic Numbers Compliance
+
+## Contexte source
+
+- `documentation/architecture/adr/adr-0018-no-magic-numbers-named-constants.md`
+- `documentation/audit/adr-0018-audit-magic-numbers-mjs.md`
+
+## 1. Vue d'ensemble
+
+- **Epic**: `Core Refactor`
+- **Feature**: `ADR-0018 Magic Numbers Compliance`
+- **Positionnement**: mise en conformité transverse de la codebase `.mjs` avec l'ADR-0018 — interdiction des literals numériques et textuels à sens métier non nommés.
+
+### Résumé
+
+L'audit ADR-0018 a révélé **316 occurrences candidates** dans **73 fichiers**, avec une adoption partielle du pattern (constantes déjà extraites dans `module/config/skills.mjs`, `module/config/dice.mjs`). Ce plan organise la remédiation en 5 lots progressifs, du plus critique (progression/XP/rangs) au moins prioritaire (sentinelles/couleurs techniques).
+
+### Valeur métier
+
+- réduire le risque de **divergence silencieuse** des règles métier dupliquées ;
+- rendre les **règles découvrables** depuis `module/config/` ;
+- fiabiliser les **tests contractuels** en les adossant à des constantes nommées ;
+- supprimer la **dette ADR** qui bloque la validation de conformité de l'architecture.
+
+## 2. Critères de succès
+
+- les règles métier de progression, XP, rangs, caractéristiques et spécialisations sont centralisées dans `module/config/` et consommées via `SYSTEM.*` ;
+- les seuils du moteur de dés et de combat sont nommés ;
+- les enums et valeurs par défaut de schéma sont adossés à des registres `SYSTEM.*` ;
+- l'importer OggDude utilise les constantes partagées pour ses bornes et defaults ;
+- les constantes UI/canvas sont au minimum nommées localement ;
+- les tests contractuels `tests/config/*.test.mjs` couvrent les nouvelles constantes ;
+- la règle ESLint `no-magic-numbers` peut être activée sans faux positifs bloquants.
+
+## 3. Jalons
+
+1. **Lot 1 — Métier critique** : progression, XP, rangs, caractéristiques, spécialisations.
+2. **Lot 2 — Moteur de dés et combat** : seuils, bornes de check, pénalités et caps.
+3. **Lot 3 — Magic strings métier** : defaults de schéma, enums, discriminants récurrents.
+4. **Lot 4 — Importer OggDude** : clamps métier, defaults de mapping, limites contractuelles.
+5. **Lot 5 — UI et canvas** : constantes locales nommées.
+
+## 4. Risques
+
+| Risque | Impact | Mitigation |
+| --- | --- | --- |
+| Sur-centralisation de constantes purement visuelles dans `module/config/` | dilution du catalogue, perte de lisibilité | lot 5 : nommer localement, ne centraliser que si la règle est transverse |
+| Collision de namespace `SYSTEM.*` (ex. `SYSTEM.SKILLS` déjà utilisé) | régression silencieuse des consommateurs | vérifier itérateurs + `Object.defineProperty` si `enumerable: false` requis |
+| Régressions sur règles métier partagées (XP, rangs) | fausse facturation, corruption de personnage | tests contractuels + tests existants inchangés |
+| Étendue trop large du lot 3 (80+ magic strings) | dispersion, PR trop grosse | découper par entité métier (weapon, action, adversary, species, etc.) |
+
+## 5. Hiérarchie des work items
+
+```mermaid
+graph TD
+    A[Epic: Core Refactor] --> B[Feature: ADR-0018 Magic Numbers Compliance]
+    B --> C[Story: Extraire constantes progression/XP/rangs]
+    B --> D[Story: Extraire seuils dés/combat]
+    B --> E[Story: Centraliser enums et defaults métier]
+    B --> F[Enabler: Normaliser importer OggDude]
+    B --> G[Enabler: Nommer constantes UI/canvas locales]
+    B --> H[Test: Verrouiller contrats config et non-régression]
+
+    C --> C1[Task: coûts XP par rang + limites rang]
+    C --> C2[Task: seuils caractéristiques + coûts spécialisation]
+    D --> D1[Task: seuils critique, boons/banes, heroism]
+    D --> D2[Task: bornes ability/skill/enchantment]
+    E --> E1[Task: defaults weapon/action/adversary/species]
+    E --> E2[Task: registres portée/type/slot]
+    F --> F1[Task: bornes partagées + defaults mapping]
+    F --> F2[Task: limites rang gratuit]
+    G --> G1[Task: tailles, offsets, couleurs, alphas]
+    G --> G2[Task: seuils comportement utilisateur]
+    H --> H1[Task: tests contractuels config/*.test.mjs]
+    H --> H2[Task: vérifier non-régression tests existants]
+```
+
+## 6. Découpage GitHub recommandé
+
+| Type | Titre | Priorité | Estimate | Dépendances |
+| --- | --- | --- | --- | --- |
+| Feature | `ADR-0018 Magic Numbers Compliance — Mettre la codebase en conformité ADR-0018` | P1 | 21 | Epic `Core Refactor` |
+| Story | `MC1 — Extraire les constantes de progression/XP/rangs/coûts métier` | P1 | 5 | Feature |
+| Story | `MC2 — Extraire les seuils du moteur de dés et du combat` | P1 | 5 | Feature |
+| Story | `MC3 — Centraliser les enums et defaults de schéma métier` | P1 | 8 | Feature |
+| Enabler | `MC4 — Normaliser l'importer OggDude avec les constantes partagées` | P2 | 3 | MC1, MC3 |
+| Enabler | `MC5 — Nommer les constantes UI/canvas locales` | P2 | 3 | Feature |
+| Test | `MC6 — Verrouiller les contrats config et valider la non-régression` | P1 | 3 | MC1, MC2, MC3, MC4, MC5 |
+
+## 7. Dépendances et ordre recommandé
+
+1. **MC1** — le plus gros gain métier, socle pour MC4.
+2. **MC2** — indépendant, peut avancer en parallèle de MC1.
+3. **MC3** — vaste (80+ strings), à découper par entité ; dépend de MC1 pour le pattern.
+4. **MC4** — consomme MC1 + MC3 ; peut démarrer après livraison partielle.
+5. **MC5** — indépendant, faible risque de régression.
+6. **MC6** — ferme la boucle : tests contractuels + validation non-régression.
+
+## 8. Board Kanban
+
+- **Backlog**: feature et sous-issues créées
+- **Sprint Ready**: AC détaillés, fichiers cibles listés, dépendances posées
+- **In Progress**: un lot principal + au maximum un lot secondaire en parallèle
+- **In Review**: relecture architecture + vérification ADR + tests
+- **Testing**: validation locale + exécution complète `pnpm test`
+- **Done**: constantes centralisées, tests contractuels présents, CI vert
+
+### Champs recommandés
+
+- `Priority`: `P1` / `P2`
+- `Value`: `High` / `Medium`
+- `Component`: `Core / Config / Models / Dice / Combat / Importer / Canvas`
+- `Estimate`: `3`, `5`, `8`, `21`
+- `Epic`: `Core Refactor`
+- `Track`: `ADR-0018 Compliance`
+
+## 9. Définition de done
+
+- toutes les règles métier identifiées dans l'audit comme critiques sont centralisées dans `module/config/` ;
+- les constantes sont exposées via `SYSTEM.*` et consommées par la logique applicative ;
+- les enums et defaults de schéma sont adossés à des registres nommés ;
+- l'importer utilise les constantes partagées pour ses bornes et defaults ;
+- les constantes UI/canvas sont au minimum nommées localement ;
+- les tests contractuels `tests/config/*.test.mjs` existent pour chaque groupe de constantes ;
+- `pnpm test` passe intégralement ;
+- la règle `no-magic-numbers` ESLint peut être activée sans régression.
+
+## 10. Métriques de pilotage
+
+- **Couverture audit traitée** : 100% des occurrences critiques, 100% des majeures, 0% des faibles (intentionnellement exclues) ;
+- **Rétention de pattern** : 0 nouveau magic number introduit dans les fichiers modifiés ;
+- **Tests contractuels** : chaque groupe de constantes a son test dans `tests/config/` ;
+- **Stabilité** : `pnpm test` vert sur chaque PR.

--- a/module/config/progression.mjs
+++ b/module/config/progression.mjs
@@ -1,0 +1,127 @@
+/**
+ * Centralised business constants for character progression (XP, ranks, costs).
+ *
+ * These constants replace all inline literals in skill, characteristic and
+ * specialisation calculators so that every rule has a single named source of
+ * truth (ADR-0018).
+ *
+ * Do NOT import this file from inside module/config/skills.mjs — skills.mjs
+ * already defines MAX_RANK_AT_CREATION and MAX_RANK which are the canonical
+ * source for skill rank caps and are re-exported via SYSTEM.SKILLS.
+ */
+
+/* -------------------------------------------- */
+/*  Skill XP costs                              */
+/* -------------------------------------------- */
+
+/**
+ * Multiplier applied to rank value to compute the base XP cost of training a
+ * career (or specialisation) skill rank.
+ *
+ * Formula: cost = SKILL_RANK_COST_MULTIPLIER * rankValue
+ *
+ * @type {number}
+ */
+export const SKILL_RANK_COST_MULTIPLIER = 5
+
+/**
+ * Flat XP surcharge added when training a skill that is neither a career skill
+ * nor a specialisation skill.
+ *
+ * Formula: cost = SKILL_RANK_COST_MULTIPLIER * rankValue + SKILL_NON_CAREER_SURCHARGE
+ *
+ * @type {number}
+ */
+export const SKILL_NON_CAREER_SURCHARGE = 5
+
+/* -------------------------------------------- */
+/*  Skill rank limits                           */
+/* -------------------------------------------- */
+
+/**
+ * Maximum number of times a character may apply a career-free rank to the
+ * same skill.
+ * @type {number}
+ */
+export const SKILL_MAX_CAREER_FREE_RANK_PER_SKILL = 1
+
+/**
+ * Maximum number of times a character may apply a specialisation-free rank to
+ * the same skill.
+ * @type {number}
+ */
+export const SKILL_MAX_SPECIALIZATION_FREE_RANK_PER_SKILL = 1
+
+/* -------------------------------------------- */
+/*  Characteristic XP costs                    */
+/* -------------------------------------------- */
+
+/**
+ * Multiplier applied to the new characteristic value to compute the XP cost of
+ * raising a characteristic by one rank.
+ *
+ * Formula: cost = CHARACTERISTIC_RANK_COST_MULTIPLIER * newValue
+ *
+ * @type {number}
+ */
+export const CHARACTERISTIC_RANK_COST_MULTIPLIER = 10
+
+/* -------------------------------------------- */
+/*  Characteristic rank limits                 */
+/* -------------------------------------------- */
+
+/**
+ * Maximum characteristic value a character may reach during character
+ * creation.
+ * @type {number}
+ */
+export const CHARACTERISTIC_MAX_RANK_AT_CREATION = 5
+
+/**
+ * Absolute maximum characteristic value a character may ever reach.
+ * @type {number}
+ */
+export const CHARACTERISTIC_MAX_RANK = 6
+
+/* -------------------------------------------- */
+/*  Specialisation XP costs                    */
+/* -------------------------------------------- */
+
+/**
+ * Base XP cost for the first specialisation (index 0 → 1).
+ * The first specialisation is always free.
+ * @type {number}
+ */
+export const SPECIALIZATION_FIRST_COST = 0
+
+/**
+ * Multiplier applied to the total number of owned specialisations (after
+ * acquisition) to compute the base XP cost for every specialisation beyond
+ * the first.
+ *
+ * Formula: baseCost = SPECIALIZATION_RANK_COST_MULTIPLIER * ownedCountAfter
+ *
+ * @type {number}
+ */
+export const SPECIALIZATION_RANK_COST_MULTIPLIER = 10
+
+/**
+ * Flat XP penalty applied when the acquired specialisation is neither a career
+ * specialisation nor a universal specialisation.
+ * @type {number}
+ */
+export const SPECIALIZATION_NON_CAREER_PENALTY = 10
+
+/* -------------------------------------------- */
+/*  Actor derived attributes                   */
+/* -------------------------------------------- */
+
+/**
+ * Flat bonus added to the Brawn characteristic value when computing the
+ * encumbrance threshold.
+ *
+ * Formula: encumbranceThreshold = brawn + ENCUMBRANCE_BASE_BONUS
+ *
+ * @type {number}
+ */
+export const ENCUMBRANCE_BASE_BONUS = 5

--- a/module/config/system.mjs
+++ b/module/config/system.mjs
@@ -7,6 +7,7 @@ import { logger } from '../utils/logger.mjs'
 import * as EFFECTS from './effects.mjs'
 import * as SKILL from './skills.mjs'
 import { MAX_RANK_AT_CREATION, MAX_RANK } from './skills.mjs'
+import * as PROGRESSION from './progression.mjs'
 import * as WEAPON from './weapon.mjs'
 import { ENCHANTMENT_TIERS, QUALITY_TIERS } from './items.mjs'
 import { ASCII, ASCII_DEV_MODE, DEV_MODE } from '../applications/system/constants.mjs'
@@ -229,6 +230,7 @@ export const SYSTEM = {
   EFFECTS,
   ENCHANTMENT_TIERS,
   PASSIVE_BASE: ATTRIBUTES.PASSIVE_BASE,
+  PROGRESSION,
   QUALITY_TIERS,
   RESTRICTION_LEVELS,
   RESOURCES: ATTRIBUTES.RESOURCES,

--- a/module/lib/characteristics/characteristic-cost-calculator.mjs
+++ b/module/lib/characteristics/characteristic-cost-calculator.mjs
@@ -1,4 +1,5 @@
 import TrainedCharacteristic from './trained-characteristic.mjs'
+import { CHARACTERISTIC_RANK_COST_MULTIPLIER } from '../../config/progression.mjs'
 
 /**
  * CharacteristicCostCalculator class
@@ -29,7 +30,7 @@ export default class CharacteristicCostCalculator {
   }
 
   #calculateTrainCost(value) {
-    return value * 10
+    return value * CHARACTERISTIC_RANK_COST_MULTIPLIER
   }
 
   #calculateForgetCost(value) {

--- a/module/lib/characteristics/trained-characteristic.mjs
+++ b/module/lib/characteristics/trained-characteristic.mjs
@@ -1,6 +1,7 @@
 import Characteristic from './characteristic.mjs'
 import ErrorCharacteristic from './error-characteristic.mjs'
 import CharacteristicCostCalculator from './characteristic-cost-calculator.mjs'
+import { CHARACTERISTIC_MAX_RANK_AT_CREATION, CHARACTERISTIC_MAX_RANK } from '../../config/progression.mjs'
 
 export default class TrainedCharacteristic extends Characteristic {
   constructor(actor, data, params, options) {
@@ -30,11 +31,11 @@ export default class TrainedCharacteristic extends Characteristic {
       return new ErrorCharacteristic(this.actor, this.data, {}, { message: "you can't forget this rank anymore because you are at & (minimal value)!" })
     }
 
-    if (this.isCreation && value > 5) {
+    if (this.isCreation && value > CHARACTERISTIC_MAX_RANK_AT_CREATION) {
       return new ErrorCharacteristic(this.actor, this.data, {}, { message: "you can't have more than 5 rank during creation!" })
     }
 
-    if (!this.isCreation && value > 6) {
+    if (!this.isCreation && value > CHARACTERISTIC_MAX_RANK) {
       return new ErrorCharacteristic(this.actor, this.data, {}, { message: "you can't have more than 6 rank!" })
     }
 

--- a/module/lib/skills/career-free-skill.mjs
+++ b/module/lib/skills/career-free-skill.mjs
@@ -1,5 +1,7 @@
 import ErrorSkill from './error-skill.mjs'
 import Skill from './skill.mjs'
+import { MAX_RANK_AT_CREATION } from '../../config/skills.mjs'
+import { SKILL_MAX_CAREER_FREE_RANK_PER_SKILL } from '../../config/progression.mjs'
 
 export default class CareerFreeSkill extends Skill {
   getCost() {
@@ -33,7 +35,7 @@ export default class CareerFreeSkill extends Skill {
       return this.createError("you can't forget this career free rank because this skill has no career free rank!")
     }
 
-    if (careerFree > 1) {
+    if (careerFree > SKILL_MAX_CAREER_FREE_RANK_PER_SKILL) {
       return this.createError("you can't use more than 1 career free skill rank into the same skill!")
     }
 
@@ -52,7 +54,7 @@ export default class CareerFreeSkill extends Skill {
     this.data.rank.careerFree = careerFree
     this.data.rank.value = this.computeRankValue()
 
-    if (this.isCreation && this.data.rank.value > 2) {
+    if (this.isCreation && this.data.rank.value > MAX_RANK_AT_CREATION) {
       return this.createError("you can't have more than 2 ranks at creation!")
     }
 

--- a/module/lib/skills/skill-cost-calculator.mjs
+++ b/module/lib/skills/skill-cost-calculator.mjs
@@ -1,4 +1,5 @@
 import TrainedSkill from './trained-skill.mjs'
+import { SKILL_RANK_COST_MULTIPLIER, SKILL_NON_CAREER_SURCHARGE } from '../../config/progression.mjs'
 
 export default class SkillCostCalculator {
   constructor(skillTransaction) {
@@ -13,12 +14,14 @@ export default class SkillCostCalculator {
    */
   static computeCost({ action, rankValue, isSpecialized }) {
     if (action === 'train') {
-      return isSpecialized ? rankValue * 5 : rankValue * 5 + 5
+      return isSpecialized ? rankValue * SKILL_RANK_COST_MULTIPLIER : rankValue * SKILL_RANK_COST_MULTIPLIER + SKILL_NON_CAREER_SURCHARGE
     }
 
     if (action === 'forget') {
       // forget cost = train cost at (rankAfterDecrease + 1)
-      return isSpecialized ? (rankValue + 1) * 5 : (rankValue + 1) * 5 + 5
+      return isSpecialized
+        ? (rankValue + 1) * SKILL_RANK_COST_MULTIPLIER
+        : (rankValue + 1) * SKILL_RANK_COST_MULTIPLIER + SKILL_NON_CAREER_SURCHARGE
     }
 
     return 0

--- a/module/lib/skills/specialization-free-skill.mjs
+++ b/module/lib/skills/specialization-free-skill.mjs
@@ -1,5 +1,7 @@
 import Skill from './skill.mjs'
 import ErrorSkill from './error-skill.mjs'
+import { MAX_RANK_AT_CREATION } from '../../config/skills.mjs'
+import { SKILL_MAX_SPECIALIZATION_FREE_RANK_PER_SKILL } from '../../config/progression.mjs'
 
 export default class SpecializationFreeSkill extends Skill {
   getCost() {
@@ -33,7 +35,7 @@ export default class SpecializationFreeSkill extends Skill {
       return this.createError("you can't forget this specialization free rank because this skill has no specialization free rank!")
     }
 
-    if (specializationFree > 1) {
+    if (specializationFree > SKILL_MAX_SPECIALIZATION_FREE_RANK_PER_SKILL) {
       return this.createError("you can't use more than 1 specialization free skill rank into the same skill!")
     }
 
@@ -52,7 +54,7 @@ export default class SpecializationFreeSkill extends Skill {
     this.data.rank.specializationFree = specializationFree
     this.data.rank.value = this.computeRankValue()
 
-    if (this.isCreation && this.data.rank.value > 2) {
+    if (this.isCreation && this.data.rank.value > MAX_RANK_AT_CREATION) {
       return this.createError("you can't have more than 2 ranks at creation!")
     }
 

--- a/module/lib/skills/trained-skill.mjs
+++ b/module/lib/skills/trained-skill.mjs
@@ -1,6 +1,7 @@
 import Skill from './skill.mjs'
 import ErrorSkill from './error-skill.mjs'
 import SkillCostCalculator from './skill-cost-calculator.mjs'
+import { MAX_RANK_AT_CREATION, MAX_RANK } from '../../config/skills.mjs'
 
 export default class TrainedSkill extends Skill {
   getCost(oldRank) {
@@ -53,11 +54,11 @@ export default class TrainedSkill extends Skill {
     this.data.rank.trained = trained
     this.data.rank.value = this.computeRankValue()
 
-    if (this.isCreation && this.data.rank.value > 2) {
+    if (this.isCreation && this.data.rank.value > MAX_RANK_AT_CREATION) {
       return this.createError("you can't have more than 2 ranks at creation!")
     }
 
-    if (!this.isCreation && this.data.rank.value > 5) {
+    if (!this.isCreation && this.data.rank.value > MAX_RANK) {
       return this.createError("you can't have more than 5 ranks!")
     }
 

--- a/module/lib/specializations/specialization-cost-service.mjs
+++ b/module/lib/specializations/specialization-cost-service.mjs
@@ -10,6 +10,7 @@
  */
 
 import { isTreatedAsCareerForCost } from './owned-specializations.mjs'
+import { SPECIALIZATION_FIRST_COST, SPECIALIZATION_RANK_COST_MULTIPLIER, SPECIALIZATION_NON_CAREER_PENALTY } from '../../config/progression.mjs'
 
 /**
  * @typedef {Object} SpecializationCostResult
@@ -49,14 +50,14 @@ export function calculateSpecializationCost(params) {
   // Coût de base
   let baseCost
   if (ownedCountBefore === 0) {
-    baseCost = 0
+    baseCost = SPECIALIZATION_FIRST_COST
   } else {
-    baseCost = 10 * ownedCountAfter
+    baseCost = SPECIALIZATION_RANK_COST_MULTIPLIER * ownedCountAfter
   }
 
   // Pénalité hors carrière
   const isCareerOrUniversal = isTreatedAsCareerForCost(candidateSpecialization, career)
-  const nonCareerPenalty = isCareerOrUniversal ? 0 : 10
+  const nonCareerPenalty = isCareerOrUniversal ? 0 : SPECIALIZATION_NON_CAREER_PENALTY
 
   // Coût final
   const finalCost = baseCost + nonCareerPenalty

--- a/module/models/actor-type.mjs
+++ b/module/models/actor-type.mjs
@@ -1,5 +1,6 @@
 import { logger } from '../utils/logger.mjs'
 import { getPositiveDicePoolPreview } from '../utils/skill-costs.mjs'
+import { ENCUMBRANCE_BASE_BONUS } from '../config/progression.mjs'
 /**
  * @typedef {Object} SwerpgActorSkill
  * @property {Object} rank
@@ -388,7 +389,7 @@ export default class SwerpgActorType extends foundry.abstract.TypeDataModel {
   static #calculateEncumbranceThreshold(actor) {
     const { characteristics } = actor
     const brawn = characteristics?.brawn?.rank?.value ?? 0
-    const result = brawn + 5
+    const result = brawn + ENCUMBRANCE_BASE_BONUS
     logger.debug(`Calculating Encumbrance Threshold for actor: ${result}`, actor)
     return result
   }

--- a/tests/config/progression.test.mjs
+++ b/tests/config/progression.test.mjs
@@ -1,0 +1,155 @@
+import { describe, test, expect } from 'vitest'
+import {
+  SKILL_RANK_COST_MULTIPLIER,
+  SKILL_NON_CAREER_SURCHARGE,
+  SKILL_MAX_CAREER_FREE_RANK_PER_SKILL,
+  SKILL_MAX_SPECIALIZATION_FREE_RANK_PER_SKILL,
+  CHARACTERISTIC_RANK_COST_MULTIPLIER,
+  CHARACTERISTIC_MAX_RANK_AT_CREATION,
+  CHARACTERISTIC_MAX_RANK,
+  SPECIALIZATION_FIRST_COST,
+  SPECIALIZATION_RANK_COST_MULTIPLIER,
+  SPECIALIZATION_NON_CAREER_PENALTY,
+  ENCUMBRANCE_BASE_BONUS,
+} from '../../module/config/progression.mjs'
+import { MAX_RANK_AT_CREATION, MAX_RANK } from '../../module/config/skills.mjs'
+
+describe('Progression config — contractual constants (ADR-0018)', () => {
+  /* -------------------------------------------- */
+  /*  Skill XP costs                              */
+  /* -------------------------------------------- */
+
+  describe('Skill XP cost constants', () => {
+    test('SKILL_RANK_COST_MULTIPLIER is 5 (career skill base cost per rank)', () => {
+      expect(SKILL_RANK_COST_MULTIPLIER).toBe(5)
+    })
+
+    test('SKILL_NON_CAREER_SURCHARGE is 5 (flat penalty for non-career skills)', () => {
+      expect(SKILL_NON_CAREER_SURCHARGE).toBe(5)
+    })
+
+    test('career rank-1 cost formula yields 5', () => {
+      expect(1 * SKILL_RANK_COST_MULTIPLIER).toBe(5)
+    })
+
+    test('non-career rank-1 cost formula yields 10', () => {
+      expect(1 * SKILL_RANK_COST_MULTIPLIER + SKILL_NON_CAREER_SURCHARGE).toBe(10)
+    })
+
+    test('career rank-2 cost formula yields 10', () => {
+      expect(2 * SKILL_RANK_COST_MULTIPLIER).toBe(10)
+    })
+
+    test('non-career rank-2 cost formula yields 15', () => {
+      expect(2 * SKILL_RANK_COST_MULTIPLIER + SKILL_NON_CAREER_SURCHARGE).toBe(15)
+    })
+  })
+
+  /* -------------------------------------------- */
+  /*  Skill free-rank limits                      */
+  /* -------------------------------------------- */
+
+  describe('Skill free-rank limit constants', () => {
+    test('SKILL_MAX_CAREER_FREE_RANK_PER_SKILL is 1', () => {
+      expect(SKILL_MAX_CAREER_FREE_RANK_PER_SKILL).toBe(1)
+    })
+
+    test('SKILL_MAX_SPECIALIZATION_FREE_RANK_PER_SKILL is 1', () => {
+      expect(SKILL_MAX_SPECIALIZATION_FREE_RANK_PER_SKILL).toBe(1)
+    })
+  })
+
+  /* -------------------------------------------- */
+  /*  Skill rank caps — #395 remains the source   */
+  /* -------------------------------------------- */
+
+  describe('Skill rank caps — #395 (skills.mjs) remains the source of truth', () => {
+    test('MAX_RANK_AT_CREATION from skills.mjs is 2', () => {
+      expect(MAX_RANK_AT_CREATION).toBe(2)
+    })
+
+    test('MAX_RANK from skills.mjs is 5', () => {
+      expect(MAX_RANK).toBe(5)
+    })
+  })
+
+  /* -------------------------------------------- */
+  /*  Characteristic XP cost                      */
+  /* -------------------------------------------- */
+
+  describe('Characteristic XP cost constants', () => {
+    test('CHARACTERISTIC_RANK_COST_MULTIPLIER is 10 (XP cost per rank value)', () => {
+      expect(CHARACTERISTIC_RANK_COST_MULTIPLIER).toBe(10)
+    })
+
+    test('raising characteristic to value 2 costs 20 XP', () => {
+      expect(2 * CHARACTERISTIC_RANK_COST_MULTIPLIER).toBe(20)
+    })
+
+    test('raising characteristic to value 5 costs 50 XP', () => {
+      expect(5 * CHARACTERISTIC_RANK_COST_MULTIPLIER).toBe(50)
+    })
+  })
+
+  /* -------------------------------------------- */
+  /*  Characteristic rank caps                    */
+  /* -------------------------------------------- */
+
+  describe('Characteristic rank cap constants', () => {
+    test('CHARACTERISTIC_MAX_RANK_AT_CREATION is 5', () => {
+      expect(CHARACTERISTIC_MAX_RANK_AT_CREATION).toBe(5)
+    })
+
+    test('CHARACTERISTIC_MAX_RANK is 6', () => {
+      expect(CHARACTERISTIC_MAX_RANK).toBe(6)
+    })
+
+    test('CHARACTERISTIC_MAX_RANK_AT_CREATION is strictly less than CHARACTERISTIC_MAX_RANK', () => {
+      expect(CHARACTERISTIC_MAX_RANK_AT_CREATION).toBeLessThan(CHARACTERISTIC_MAX_RANK)
+    })
+  })
+
+  /* -------------------------------------------- */
+  /*  Specialisation XP costs                     */
+  /* -------------------------------------------- */
+
+  describe('Specialisation XP cost constants', () => {
+    test('SPECIALIZATION_FIRST_COST is 0 (first specialisation is free)', () => {
+      expect(SPECIALIZATION_FIRST_COST).toBe(0)
+    })
+
+    test('SPECIALIZATION_RANK_COST_MULTIPLIER is 10', () => {
+      expect(SPECIALIZATION_RANK_COST_MULTIPLIER).toBe(10)
+    })
+
+    test('SPECIALIZATION_NON_CAREER_PENALTY is 10', () => {
+      expect(SPECIALIZATION_NON_CAREER_PENALTY).toBe(10)
+    })
+
+    test('2nd specialisation base cost formula yields 20 (ownedCountAfter=2)', () => {
+      expect(SPECIALIZATION_RANK_COST_MULTIPLIER * 2).toBe(20)
+    })
+
+    test('3rd specialisation base cost formula yields 30 (ownedCountAfter=3)', () => {
+      expect(SPECIALIZATION_RANK_COST_MULTIPLIER * 3).toBe(30)
+    })
+
+    test('2nd non-career specialisation total cost formula yields 30', () => {
+      expect(SPECIALIZATION_RANK_COST_MULTIPLIER * 2 + SPECIALIZATION_NON_CAREER_PENALTY).toBe(30)
+    })
+  })
+
+  /* -------------------------------------------- */
+  /*  Actor derived attributes                    */
+  /* -------------------------------------------- */
+
+  describe('Actor derived attribute constants', () => {
+    test('ENCUMBRANCE_BASE_BONUS is 5', () => {
+      expect(ENCUMBRANCE_BASE_BONUS).toBe(5)
+    })
+
+    test('encumbrance threshold formula for brawn 2 yields 7', () => {
+      expect(2 + ENCUMBRANCE_BASE_BONUS).toBe(7)
+    })
+  })
+})


### PR DESCRIPTION
Linked issue: #409

**Context**
Extract XP/rank/cost magic numbers into `module/config/progression.mjs`.

**Changes**
- `module/config/progression.mjs` — new constants module
- `module/config/system.mjs` — export PROGRESSION
- `module/lib/characteristics/*`, `module/lib/skills/*`, `module/lib/specializations/*`, `module/models/actor-type.mjs` — use named constants
- `tests/config/progression.test.mjs` — contractual tests
- `documentation/` — ADR + plan

**Notes**
- Pure refactor, no behavioral change
- Check no circular imports