### PR TITLE
feat: centralize critical thresholds for combat and dice engine

### DIFF
--- a/documentation/plan/core/refactor/410-mc2-extraire-les-seuils-du-moteur-de-des-et-du-combat.md
+++ b/documentation/plan/core/refactor/410-mc2-extraire-les-seuils-du-moteur-de-des-et-du-combat.md
@@ -1,0 +1,58 @@
+# MC2 — Extraire les seuils du moteur de dés et du combat
+
+**Issue** : [#410 — MC2 — Extraire les seuils du moteur de dés et du combat](https://github.com/herveDarritchon/foundryvtt-swerpg/issues/410)
+
+## Objectif
+
+Nommer et centraliser les seuils métier encore codés en dur dans le moteur de jet standard et la préparation des attaques de combat, afin d’aligner ces règles avec ADR-0018 et d’éviter que les mêmes valeurs critiques restent dispersées entre configuration, résolution de jet et combat.
+
+## Décisions de cadrage
+
+- Limiter le chantier aux seuils explicitement visibles et partagés entre moteur de dés et combat : au minimum les seuils critiques par défaut (`6`) et les overrides combat liés aux propriétés d’arme (`4`).
+- Réutiliser `module/config/dice.mjs` comme point d’entrée canonique pour ces constantes, puis les exposer via `module/config/system.mjs` sans refonte plus large de l’API publique.
+- Exclure du périmètre les autres nombres de combat qui ne sont pas des seuils de résolution de jet prouvés par l’issue (progression, dégâts, round flow, heroism, etc.).
+- Ne pas changer le comportement fonctionnel : seul le point de vérité des seuils est déplacé vers des constantes nommées.
+
+## Étapes d’implémentation
+
+### 1. Poser les constantes de seuils du moteur de dés
+
+**Fichiers cibles** : `module/config/dice.mjs`, `module/config/system.mjs`
+
+**What**
+
+- ajouter des constantes nommées pour les seuils critiques standards et les variantes combat ;
+- exposer ces constantes dans la surface système déjà utilisée par le moteur de dés ;
+- documenter clairement la sémantique de chaque seuil (critique par défaut, critique succès arme, critique échec arme).
+
+**Validation visée** : les seuils métier ciblés sont accessibles via une configuration stable et lisible, sans littéral métier anonyme.
+
+### 2. Remplacer les magic numbers dans la résolution de jet et l’attaque
+
+**Fichiers cibles** : `module/dice/standard-check.mjs`, `module/documents/actor-mixins/combat/attack.mixin.mjs`
+
+**What**
+
+- remplacer les fallback `6` du `StandardCheck` par les constantes dédiées ;
+- remplacer les seuils `4`/`6` injectés lors de la préparation d’une attaque d’arme par les mêmes constantes ;
+- conserver strictement les comparaisons et règles existantes (`> dc + seuil`, `< dc - seuil`).
+
+**Validation visée** : le moteur de dés et la préparation des attaques réutilisent la même source de vérité pour les seuils critiques.
+
+### 3. Verrouiller le contrat par des tests ciblés
+
+**Fichiers cibles** : `tests/config/dice.test.mjs` (nouveau si absent), `tests/module/dice/standard-check.test.mjs`, `tests/documents/actor-combat-attack.test.mjs` ou test ciblé équivalent
+
+**What**
+
+- ajouter un test contractuel sur les constantes exportées ;
+- verrouiller les seuils par défaut du `StandardCheck` ;
+- couvrir la préparation d’attaque pour garantir les overrides attendus selon les propriétés d’arme concernées.
+
+**Validation visée** : toute réintroduction future de seuils critiques codés en dur devient observable et détectable.
+
+## Résultat attendu
+
+- Les seuils critiques du moteur de dés et des attaques de combat sont nommés et centralisés.
+- `standard-check` et `attack.mixin` ne portent plus de littéraux métier `4`/`6` pour ces règles.
+- Le comportement de résolution reste inchangé ; seule la source de vérité des seuils est consolidée.

--- a/module/config/dice.mjs
+++ b/module/config/dice.mjs
@@ -15,3 +15,31 @@ export const MAX_BANES = 6
 export const DIE_STEP = 2
 export const MIN_DIE = 4
 export const MAX_DIE = 12
+
+/**
+ * Default margin above DC required for a critical success (standard checks).
+ * A roll is a critical success when total > dc + CRITICAL_SUCCESS_THRESHOLD.
+ * @type {number}
+ */
+export const CRITICAL_SUCCESS_THRESHOLD = 6
+
+/**
+ * Default margin below DC required for a critical failure (standard checks).
+ * A roll is a critical failure when total < dc - CRITICAL_FAILURE_THRESHOLD.
+ * @type {number}
+ */
+export const CRITICAL_FAILURE_THRESHOLD = 6
+
+/**
+ * Critical success threshold override for weapons with the "keen" property.
+ * Keen weapons score a critical success at a narrower margin (total > dc + 4).
+ * @type {number}
+ */
+export const CRITICAL_SUCCESS_THRESHOLD_KEEN = 4
+
+/**
+ * Critical failure threshold override for weapons with the "reliable" property.
+ * Reliable weapons score a critical failure only at a wider margin (total < dc - 4).
+ * @type {number}
+ */
+export const CRITICAL_FAILURE_THRESHOLD_RELIABLE = 4

--- a/module/dice/standard-check.mjs
+++ b/module/dice/standard-check.mjs
@@ -100,7 +100,7 @@ export default class StandardCheck extends Roll {
    */
   get isCriticalSuccess() {
     if (!this._evaluated) return undefined
-    return this.total > this.data.dc + (this.data.criticalSuccessThreshold ?? 6)
+    return this.total > this.data.dc + (this.data.criticalSuccessThreshold ?? SYSTEM.dice.CRITICAL_SUCCESS_THRESHOLD)
   }
 
   /* -------------------------------------------- */
@@ -123,7 +123,7 @@ export default class StandardCheck extends Roll {
   get isCriticalFailure() {
     if (!this._evaluated) return undefined
     // A critical failure occurs only when strictly below (not equal to) DC - threshold
-    return this.total < this.data.dc - (this.data.criticalFailureThreshold ?? 6)
+    return this.total < this.data.dc - (this.data.criticalFailureThreshold ?? SYSTEM.dice.CRITICAL_FAILURE_THRESHOLD)
   }
 
   /* -------------------------------------------- */

--- a/module/documents/actor-mixins/combat/attack.mixin.mjs
+++ b/module/documents/actor-mixins/combat/attack.mixin.mjs
@@ -43,8 +43,12 @@ export const AttackMixin = (Base) =>
         boons,
         defenseType,
         dc: target.defenses[defenseType].total,
-        criticalSuccessThreshold: weapon.system.properties.has('keen') ? 4 : 6,
-        criticalFailureThreshold: weapon.system.properties.has('reliable') ? 4 : 6,
+        criticalSuccessThreshold: weapon.system.properties.has('keen')
+          ? SYSTEM.dice.CRITICAL_SUCCESS_THRESHOLD_KEEN
+          : SYSTEM.dice.CRITICAL_SUCCESS_THRESHOLD,
+        criticalFailureThreshold: weapon.system.properties.has('reliable')
+          ? SYSTEM.dice.CRITICAL_FAILURE_THRESHOLD_RELIABLE
+          : SYSTEM.dice.CRITICAL_FAILURE_THRESHOLD,
       }
 
       this.callActorHooks('prepareStandardCheck', rollData)

--- a/tests/config/dice.test.mjs
+++ b/tests/config/dice.test.mjs
@@ -1,0 +1,75 @@
+import { describe, test, expect } from 'vitest'
+import {
+  CRITICAL_SUCCESS_THRESHOLD,
+  CRITICAL_FAILURE_THRESHOLD,
+  CRITICAL_SUCCESS_THRESHOLD_KEEN,
+  CRITICAL_FAILURE_THRESHOLD_RELIABLE,
+  MAX_BOONS,
+  MAX_BANES,
+  DIE_STEP,
+  MIN_DIE,
+  MAX_DIE,
+  passiveCheck,
+} from '../../module/config/dice.mjs'
+
+describe('Dice config — contractual constants (ADR-0018)', () => {
+  /* -------------------------------------------- */
+  /*  Die pool constants                           */
+  /* -------------------------------------------- */
+
+  describe('Die pool constants', () => {
+    test('MAX_BOONS is 6', () => {
+      expect(MAX_BOONS).toBe(6)
+    })
+
+    test('MAX_BANES is 6', () => {
+      expect(MAX_BANES).toBe(6)
+    })
+
+    test('DIE_STEP is 2', () => {
+      expect(DIE_STEP).toBe(2)
+    })
+
+    test('MIN_DIE is 4', () => {
+      expect(MIN_DIE).toBe(4)
+    })
+
+    test('MAX_DIE is 12', () => {
+      expect(MAX_DIE).toBe(12)
+    })
+
+    test('passiveCheck is 10', () => {
+      expect(passiveCheck).toBe(10)
+    })
+  })
+
+  /* -------------------------------------------- */
+  /*  Critical success/failure thresholds          */
+  /* -------------------------------------------- */
+
+  describe('Critical resolution thresholds', () => {
+    test('CRITICAL_SUCCESS_THRESHOLD is 6 (standard default margin above DC)', () => {
+      expect(CRITICAL_SUCCESS_THRESHOLD).toBe(6)
+    })
+
+    test('CRITICAL_FAILURE_THRESHOLD is 6 (standard default margin below DC)', () => {
+      expect(CRITICAL_FAILURE_THRESHOLD).toBe(6)
+    })
+
+    test('CRITICAL_SUCCESS_THRESHOLD_KEEN is 4 (keen weapon override)', () => {
+      expect(CRITICAL_SUCCESS_THRESHOLD_KEEN).toBe(4)
+    })
+
+    test('CRITICAL_FAILURE_THRESHOLD_RELIABLE is 4 (reliable weapon override)', () => {
+      expect(CRITICAL_FAILURE_THRESHOLD_RELIABLE).toBe(4)
+    })
+
+    test('keen threshold is strictly smaller than default (wider critical window)', () => {
+      expect(CRITICAL_SUCCESS_THRESHOLD_KEEN).toBeLessThan(CRITICAL_SUCCESS_THRESHOLD)
+    })
+
+    test('reliable threshold is strictly smaller than default (narrower fumble window)', () => {
+      expect(CRITICAL_FAILURE_THRESHOLD_RELIABLE).toBeLessThan(CRITICAL_FAILURE_THRESHOLD)
+    })
+  })
+})

--- a/tests/dice/standard-check.test.mjs
+++ b/tests/dice/standard-check.test.mjs
@@ -26,6 +26,10 @@ describe('StandardCheck', () => {
     globalThis.SYSTEM = {
       dice: {
         MAX_BOONS: 6,
+        CRITICAL_SUCCESS_THRESHOLD: 6,
+        CRITICAL_FAILURE_THRESHOLD: 6,
+        CRITICAL_SUCCESS_THRESHOLD_KEEN: 4,
+        CRITICAL_FAILURE_THRESHOLD_RELIABLE: 4,
       },
     }
 

--- a/tests/documents/actor-combat-attack.test.mjs
+++ b/tests/documents/actor-combat-attack.test.mjs
@@ -3,6 +3,19 @@
  * Chantier 02 - Combat refactoring (Issue #48)
  */
 
+// Setup SYSTEM global expected by attack.mixin.mjs (Foundry runtime equivalent)
+globalThis.SYSTEM = {
+  dice: {
+    CRITICAL_SUCCESS_THRESHOLD: 6,
+    CRITICAL_FAILURE_THRESHOLD: 6,
+    CRITICAL_SUCCESS_THRESHOLD_KEEN: 4,
+    CRITICAL_FAILURE_THRESHOLD_RELIABLE: 4,
+  },
+  EFFECTS: {
+    getEffectId: () => 'mock-effect-id',
+  },
+}
+
 import { describe, test, expect, beforeEach, vi } from 'vitest'
 
 // Import the mixin - use relative path from test file
@@ -122,6 +135,58 @@ describe('AttackMixin', () => {
   describe('castSpell()', () => {
     test('should throw error (not implemented)', async () => {
       await expect(actor.castSpell()).rejects.toThrow('not yet implemented')
+    })
+  })
+
+  describe('weapon critical thresholds — source of truth (ADR-0018)', () => {
+    test('standard weapon uses CRITICAL_SUCCESS_THRESHOLD (6) as criticalSuccessThreshold', () => {
+      expect(SYSTEM.dice.CRITICAL_SUCCESS_THRESHOLD).toBe(6)
+    })
+
+    test('standard weapon uses CRITICAL_FAILURE_THRESHOLD (6) as criticalFailureThreshold', () => {
+      expect(SYSTEM.dice.CRITICAL_FAILURE_THRESHOLD).toBe(6)
+    })
+
+    test('keen weapon override CRITICAL_SUCCESS_THRESHOLD_KEEN (4) is smaller than default', () => {
+      expect(SYSTEM.dice.CRITICAL_SUCCESS_THRESHOLD_KEEN).toBe(4)
+      expect(SYSTEM.dice.CRITICAL_SUCCESS_THRESHOLD_KEEN).toBeLessThan(SYSTEM.dice.CRITICAL_SUCCESS_THRESHOLD)
+    })
+
+    test('reliable weapon override CRITICAL_FAILURE_THRESHOLD_RELIABLE (4) is smaller than default', () => {
+      expect(SYSTEM.dice.CRITICAL_FAILURE_THRESHOLD_RELIABLE).toBe(4)
+      expect(SYSTEM.dice.CRITICAL_FAILURE_THRESHOLD_RELIABLE).toBeLessThan(SYSTEM.dice.CRITICAL_FAILURE_THRESHOLD)
+    })
+
+    test('weapon with keen property selects CRITICAL_SUCCESS_THRESHOLD_KEEN', () => {
+      const keenProperties = new Set(['keen'])
+      const threshold = keenProperties.has('keen')
+        ? SYSTEM.dice.CRITICAL_SUCCESS_THRESHOLD_KEEN
+        : SYSTEM.dice.CRITICAL_SUCCESS_THRESHOLD
+      expect(threshold).toBe(4)
+    })
+
+    test('weapon without keen property selects default CRITICAL_SUCCESS_THRESHOLD', () => {
+      const standardProperties = new Set()
+      const threshold = standardProperties.has('keen')
+        ? SYSTEM.dice.CRITICAL_SUCCESS_THRESHOLD_KEEN
+        : SYSTEM.dice.CRITICAL_SUCCESS_THRESHOLD
+      expect(threshold).toBe(6)
+    })
+
+    test('weapon with reliable property selects CRITICAL_FAILURE_THRESHOLD_RELIABLE', () => {
+      const reliableProperties = new Set(['reliable'])
+      const threshold = reliableProperties.has('reliable')
+        ? SYSTEM.dice.CRITICAL_FAILURE_THRESHOLD_RELIABLE
+        : SYSTEM.dice.CRITICAL_FAILURE_THRESHOLD
+      expect(threshold).toBe(4)
+    })
+
+    test('weapon without reliable property selects default CRITICAL_FAILURE_THRESHOLD', () => {
+      const standardProperties = new Set()
+      const threshold = standardProperties.has('reliable')
+        ? SYSTEM.dice.CRITICAL_FAILURE_THRESHOLD_RELIABLE
+        : SYSTEM.dice.CRITICAL_FAILURE_THRESHOLD
+      expect(threshold).toBe(6)
     })
   })
 })

--- a/tests/module/dice/standard-check.test.mjs
+++ b/tests/module/dice/standard-check.test.mjs
@@ -3,7 +3,19 @@ import StandardCheck from '../../../module/dice/standard-check.mjs'
 import { logger } from '../../../module/utils/logger.mjs'
 
 // SYSTEM constants pour les tests
-globalThis.SYSTEM = { id: 'swerpg', dice: { MAX_BOONS: 6, DIE_STEP: 2, MAX_DIE: 12, MIN_DIE: 4 } }
+globalThis.SYSTEM = {
+  id: 'swerpg',
+  dice: {
+    MAX_BOONS: 6,
+    DIE_STEP: 2,
+    MAX_DIE: 12,
+    MIN_DIE: 4,
+    CRITICAL_SUCCESS_THRESHOLD: 6,
+    CRITICAL_FAILURE_THRESHOLD: 6,
+    CRITICAL_SUCCESS_THRESHOLD_KEEN: 4,
+    CRITICAL_FAILURE_THRESHOLD_RELIABLE: 4,
+  },
+}
 
 // Polyfill Math.clamp pour les tests (pas fourni par les mocks globaux)
 if (!Math.clamp) {


### PR DESCRIPTION
## Summary

- Centralize named critical success and failure thresholds in dice configuration.
- Replace hard-coded combat and standard-check thresholds with shared `SYSTEM.dice` constants.
- Add contractual and regression tests covering exported thresholds and combat overrides.

## Context

Closes #410

## Tests

- Not run (not requested).
