### PR TITLE
refactor(importers): normalize OggDude importer with shared constants

### DIFF
--- a/documentation/plan/core/refactor/412-mc4-normaliser-limporter-oggdude-avec-les-constantes-partagees.md
+++ b/documentation/plan/core/refactor/412-mc4-normaliser-limporter-oggdude-avec-les-constantes-partagees.md
@@ -1,0 +1,58 @@
+# MC4 — Normaliser l'importer OggDude avec les constantes partagées
+
+**Issue** : [#412 — MC4 — Normaliser l'importer OggDude avec les constantes partagées](https://github.com/herveDarritchon/foundryvtt-swerpg/issues/412)
+
+## Objectif
+
+Faire consommer à l'importer OggDude les constantes métier déjà centralisées par MC1 et MC3, afin de supprimer les derniers fallbacks codés en dur dans les mappers/importers ciblés sans changer le comportement fonctionnel de l'import.
+
+## Décisions de cadrage
+
+- Limiter le chantier aux fichiers explicitement listés par l'issue : `weapon-ogg-dude`, `armor-ogg-dude`, `career-ogg-dude`, `description-markup-utils` et `oggdude-talent-mapper`.
+- Réutiliser en priorité les surfaces déjà partagées (`SYSTEM.WEAPON.*`, `SYSTEM.ARMOR.*`, `SYSTEM.DEFAULT_RESTRICTION_LEVEL`, `SYSTEM.RESTRICTION_LEVELS`, `SYSTEM.TALENT_ACTIVATION`, `SYSTEM.SKILLS.MAX_RANK*`) au lieu d'introduire un registre spécifique à l'importer.
+- Si une constante manque encore pour un cas prouvé par l'issue, l'ajouter dans le module métier canonique déjà cohérent avec son domaine, pas dans le code d'import.
+- Exclure du périmètre toute refonte de taxonomie OggDude, de pipeline d'import ou de comportement métier au-delà du déplacement du point de vérité.
+
+## Étapes d’implémentation
+
+### 1. Aligner les fallbacks métier du weapon/armor importer sur la config partagée
+
+**Fichiers cibles** : `module/importer/items/weapon-ogg-dude.mjs`, `module/importer/items/armor-ogg-dude.mjs`, plus config métier ciblée uniquement si une constante manque (`module/config/weapon.mjs`, `module/config/armor.mjs`, `module/config/items.mjs`, `module/config/system.mjs`)
+
+**What**
+
+- remplacer les defaults locaux encore en dur (`rangedLight`, `medium`, `mainhand`, `restricted` / `none`, catégorie armor de repli) par les constantes déjà exposées par le domaine ;
+- aligner les bornes et valeurs de fallback métier sur les modules `config` déjà consommés par les modèles/documents ;
+- conserver strictement les tables de mapping OggDude et les règles de fallback actuelles, seule la source des valeurs change.
+
+**Validation visée** : les imports weapon/armor gardent les mêmes sorties, mais leurs valeurs métier par défaut proviennent désormais de constantes partagées.
+
+### 2. Supprimer les duplications de bornes/defaults dans career, description et talent
+
+**Fichiers cibles** : `module/importer/items/career-ogg-dude.mjs`, `module/importer/utils/description-markup-utils.mjs`, `module/importer/mappers/oggdude-talent-mapper.mjs`
+
+**What**
+
+- faire converger `freeSkillRank` (défaut, min/max, limites de liste) sur les constantes déjà centralisées au lieu de conserver des `4` / `8` dupliqués ;
+- réutiliser le helper partagé de description/source au lieu de garder des implémentations parallèles portant les mêmes bornes et defaults ;
+- remplacer les defaults talent encore en dur (`unspecified`, source d'import par défaut, tier diagnostic de repli) par des points de vérité partagés ou un helper ciblé si aucun point canonique n'existe encore.
+
+**Validation visée** : les importers career/talent et les utilitaires de description n'embarquent plus de valeurs métier partagées codées en dur sur ce périmètre.
+
+### 3. Verrouiller les contrats d'import ciblés
+
+**Fichiers cibles** : `tests/importer/weapon-import.spec.mjs`, `tests/importer/armor-import.integration.spec.mjs` ou `tests/importer/armor-import-mapping.spec.mjs`, `tests/importer/career-ogg-dude.spec.mjs`, `tests/importer/talent-mapper.spec.mjs`, `tests/importer/utils/description-markup-utils.test.mjs`, tests `config` associés si une nouvelle constante canonique est créée
+
+**What**
+
+- ajuster les assertions pour prouver que les fallbacks passent par les constantes partagées attendues ;
+- couvrir au minimum un cas représentatif par domaine : restriction weapon/armor, `freeSkillRank` carrière, activation talent, limite/section source des descriptions ;
+- ajouter un contrat `tests/config/*` minimal seulement si MC4 doit compléter une surface canonique absente.
+
+**Validation visée** : toute réintroduction future de defaults métier codés en dur dans l'importer OggDude devient observable et détectable.
+
+## Résultat attendu
+
+- L'importer OggDude consomme les constantes métier déjà partagées par la codebase au lieu de recopier ses propres defaults.
+- Les duplications entre importers et utilitaires communs sont réduites au strict nécessaire.
+- Le comportement fonctionnel de l'import reste inchangé ; seule la source de vérité des valeurs métier est normalisée.

--- a/module/config/armor.mjs
+++ b/module/config/armor.mjs
@@ -67,6 +67,13 @@ export const PROPERTIES = {
 }
 
 /**
+ * The default armor category applied when an OggDude armor has no recognizable category.
+ * Canonical key from CATEGORIES enum.
+ * @type {string}
+ */
+export const DEFAULT_CATEGORY = 'medium'
+
+/**
  * Data representing the default "unarmored" armor item.
  * @type {object}
  */

--- a/module/config/progression.mjs
+++ b/module/config/progression.mjs
@@ -125,3 +125,35 @@ export const SPECIALIZATION_NON_CAREER_PENALTY = 10
  * @type {number}
  */
 export const ENCUMBRANCE_BASE_BONUS = 5
+
+/* -------------------------------------------- */
+/*  Career skill list limits                    */
+/* -------------------------------------------- */
+
+/**
+ * Maximum number of career skills that can be assigned to a single career.
+ * Matches SwerpgCareer schema validation (careerSkills.length <= CAREER_MAX_SKILL_COUNT).
+ * @type {number}
+ */
+export const CAREER_MAX_SKILL_COUNT = 8
+
+/**
+ * Default value for the free skill rank granted by a career at character creation.
+ * Matches SwerpgCareer schema initial value for freeSkillRank.
+ * @type {number}
+ */
+export const CAREER_DEFAULT_FREE_SKILL_RANK = 4
+
+/**
+ * Minimum value for the free skill rank granted by a career.
+ * Matches SwerpgCareer schema min for freeSkillRank.
+ * @type {number}
+ */
+export const CAREER_MIN_FREE_SKILL_RANK = 0
+
+/**
+ * Maximum value for the free skill rank granted by a career.
+ * Matches SwerpgCareer schema max for freeSkillRank.
+ * @type {number}
+ */
+export const CAREER_MAX_FREE_SKILL_RANK = 8

--- a/module/importer/items/armor-ogg-dude.mjs
+++ b/module/importer/items/armor-ogg-dude.mjs
@@ -19,7 +19,6 @@ import {
 } from '../utils/armor-import-utils.mjs'
 import { parseOggDudeBoolean } from '../mappings/oggdude-weapon-utils.mjs'
 
-const DEFAULT_CATEGORY = 'medium'
 const DEFAULT_SOAK = 2
 const DEFAULT_DEFENSE = 0
 
@@ -111,7 +110,7 @@ function resolveArmorCategoryWithFallback(xmlCategories, armorName) {
     return { category: null, unknownCategories }
   }
 
-  return { category: SYSTEM.ARMOR.DEFAULT_CATEGORY || 'medium', unknownCategories }
+  return { category: SYSTEM.ARMOR.DEFAULT_CATEGORY, unknownCategories }
 }
 
 /**
@@ -278,7 +277,7 @@ function mapOggDudeArmor(xmlArmor) {
         rarity,
         price,
         qualities: propertyResult.qualities,
-        restrictionLevel: isRestricted ? 'restricted' : 'none',
+        restrictionLevel: isRestricted ? SYSTEM.RESTRICTION_LEVELS.restricted.id : SYSTEM.DEFAULT_RESTRICTION_LEVEL,
         description,
       },
       flags,

--- a/module/importer/items/career-ogg-dude.mjs
+++ b/module/importer/items/career-ogg-dude.mjs
@@ -12,6 +12,7 @@ import {
   FLAG_STRICT_CAREER_VALIDATION,
 } from '../utils/career-import-utils.mjs'
 import { sanitizeDescription } from '../utils/text.mjs'
+import { normalizeFreeSkillRank } from '../utils/description-markup-utils.mjs'
 
 /**
  * Career Array Mapper : Map the Career XML data to the SwerpgCareer creation objects.
@@ -96,19 +97,6 @@ export function careerMapper(careers, { strictSkills = false } = {}) {
   })
   logger.debug('[CareerImporter] Statistiques après mapping', { stats: getCareerImportStats() })
   return mapped
-}
-
-/**
- * Normalise la valeur FreeRanks en entier borné 0-8, défaut 4.
- * @param {any} raw
- * @returns {number}
- */
-function normalizeFreeSkillRank(raw) {
-  let n = Number.parseInt(raw, 10)
-  if (Number.isNaN(n)) n = 4
-  if (n < 0) n = 0
-  if (n > 8) n = 8
-  return n
 }
 
 /**

--- a/module/importer/items/weapon-ogg-dude.mjs
+++ b/module/importer/items/weapon-ogg-dude.mjs
@@ -29,8 +29,6 @@ import {
   resetWeaponImportStats,
 } from '../utils/weapon-import-utils.mjs'
 
-const DEFAULT_SKILL = 'rangedLight'
-const DEFAULT_RANGE = 'medium'
 const DEFAULT_QUALITY_COUNT = 1
 
 function coerceQualityCount(value) {
@@ -128,7 +126,7 @@ function mapOggDudeWeapon(xmlWeapon) {
         incrementWeaponImportStat('rejected')
         return null
       }
-      mappedSkill = DEFAULT_SKILL
+      mappedSkill = SYSTEM.WEAPON.DEFAULT_SKILL
     }
 
     const rangeCode = xmlWeapon.RangeValue || xmlWeapon.Range
@@ -140,7 +138,7 @@ function mapOggDudeWeapon(xmlWeapon) {
         incrementWeaponImportStat('rejected')
         return null
       }
-      mappedRange = DEFAULT_RANGE
+      mappedRange = SYSTEM.WEAPON.DEFAULT_RANGE
     }
 
     const baseDamage = clampNumber(xmlWeapon.Damage, 0, 20, 0)
@@ -188,7 +186,7 @@ function mapOggDudeWeapon(xmlWeapon) {
     qualities.sort((a, b) => a.key.localeCompare(b.key))
 
     const handsCode = xmlWeapon.Hands
-    const mappedSlot = WEAPON_HANDS_MAP[handsCode] || 'mainhand'
+    const mappedSlot = WEAPON_HANDS_MAP[handsCode] || SYSTEM.WEAPON.SLOTS.MAINHAND
 
     const rarity = clampNumber(xmlWeapon.Rarity, 0, 20, 0)
     const price = clampNumber(xmlWeapon.Price, 0, Number.MAX_SAFE_INTEGER, 0)
@@ -196,14 +194,14 @@ function mapOggDudeWeapon(xmlWeapon) {
     const hp = clampNumber(xmlWeapon.HP, 0, Number.MAX_SAFE_INTEGER, 0)
 
     const isRestricted = parseOggDudeBoolean(xmlWeapon.Restricted)
-    const restrictionLevel = isRestricted ? 'restricted' : 'none'
+    const restrictionLevel = isRestricted ? SYSTEM.RESTRICTION_LEVELS.restricted.id : SYSTEM.DEFAULT_RESTRICTION_LEVEL
     const rawType = xmlWeapon.Type || ''
     const categoryTags = normalizeCategoryValues(xmlWeapon?.Categories?.Category)
     const sizeHigh = normalizeSizeHigh(xmlWeapon.SizeHigh)
     const { name: sourceName, page: sourcePage } = extractSourceInfo(xmlWeapon.Source)
 
     // Resolve system.category (ADR-0007 priority: Categories → SkillKey → Range → default)
-    const { category: resolvedCategory, source: categorySource } = resolveWeaponCategory(categoryTags, mappedSkill, mappedRange, 'ranged')
+    const { category: resolvedCategory, source: categorySource } = resolveWeaponCategory(categoryTags, mappedSkill, mappedRange, SYSTEM.WEAPON.CATEGORIES.ranged.id)
     if (categorySource !== 'category') {
       incrementWeaponCategoryFallback()
     }

--- a/module/importer/mappers/oggdude-talent-mapper.mjs
+++ b/module/importer/mappers/oggdude-talent-mapper.mjs
@@ -5,6 +5,13 @@
 
 import { logger } from '../../utils/logger.mjs'
 import { buildTalentImportDiagnostics, incrementTalentImportStat } from '../utils/talent-import-utils.mjs'
+import { SYSTEM } from '../../config/system.mjs'
+
+/**
+ * Default source label applied when no source information is found in OggDude data.
+ * @type {string}
+ */
+const OGGDUDE_DEFAULT_SOURCE = 'OggDude Import'
 
 // Mappings spécialisés
 import { resolveTalentActivation } from '../mappings/oggdude-talent-activation-map.mjs'
@@ -113,12 +120,12 @@ export class OggDudeTalentMapper {
         originalData: talentData,
 
         // Métadonnées
-        source: talentData.Source || talentData.SourceBook || 'OggDude Import',
+        source: talentData.Source || talentData.SourceBook || OGGDUDE_DEFAULT_SOURCE,
         custom: talentData.Custom === 'true' || talentData.IsCustom === 'true',
 
         // Données transformées (contrat canonique : system.* générique uniquement)
         activation,
-        hasUnknownActivation: activation === 'unspecified' && typeof rawActivation === 'string' && rawActivation.trim() !== '',
+        hasUnknownActivation: activation === SYSTEM.TALENT_ACTIVATION.unspecified.id && typeof rawActivation === 'string' && rawActivation.trim() !== '',
         // Diagnostics legacy — calculés mais NON persistés dans system.*.
         //   node : résolution de nœud OggDude / Crucible (legacy, diagnostic only)
         //   tier : tier OggDude, stocké dans flags.swerpg.import.tier (diagnostic)
@@ -272,7 +279,7 @@ export class OggDudeTalentMapper {
         type: 'talent',
         system: {
           id: context.key,
-          activation: context.activation || 'unspecified',
+          activation: context.activation || SYSTEM.TALENT_ACTIVATION.unspecified.id,
           isRanked: context.isRanked || false,
           description: enrichedDescription,
         },
@@ -281,7 +288,7 @@ export class OggDudeTalentMapper {
             oggdudeKey: context.key,
             import: {
               ...diagnostics,
-              source: context.source || 'OggDude Import',
+              source: context.source || OGGDUDE_DEFAULT_SOURCE,
               sourceText: context.sourceText || '',
               dieModifiers: context.dieModifiers || [],
               prerequisites: context.prerequisites || {},

--- a/module/importer/utils/description-markup-utils.mjs
+++ b/module/importer/utils/description-markup-utils.mjs
@@ -4,17 +4,23 @@
  */
 
 import { sanitizeDescription } from './text.mjs'
+import {
+  CAREER_DEFAULT_FREE_SKILL_RANK,
+  CAREER_MIN_FREE_SKILL_RANK,
+  CAREER_MAX_FREE_SKILL_RANK,
+} from '../../config/progression.mjs'
 
 /**
- * Normalise la valeur FreeRanks en entier borné 0-8, défaut 4.
+ * Normalise la valeur FreeRanks en entier borné [CAREER_MIN_FREE_SKILL_RANK, CAREER_MAX_FREE_SKILL_RANK],
+ * défaut CAREER_DEFAULT_FREE_SKILL_RANK.
  * @param {any} raw
  * @returns {number}
  */
 export function normalizeFreeSkillRank(raw) {
   let n = Number.parseInt(raw, 10)
-  if (Number.isNaN(n)) n = 4
-  if (n < 0) n = 0
-  if (n > 8) n = 8
+  if (Number.isNaN(n)) n = CAREER_DEFAULT_FREE_SKILL_RANK
+  if (n < CAREER_MIN_FREE_SKILL_RANK) n = CAREER_MIN_FREE_SKILL_RANK
+  if (n > CAREER_MAX_FREE_SKILL_RANK) n = CAREER_MAX_FREE_SKILL_RANK
   return n
 }
 

--- a/tests/config/armor.test.mjs
+++ b/tests/config/armor.test.mjs
@@ -1,0 +1,24 @@
+import { describe, test, expect } from 'vitest'
+import { DEFAULT_CATEGORY, CATEGORIES } from '../../module/config/armor.mjs'
+import { SYSTEM } from '../../module/config/system.mjs'
+
+describe('armor config — ADR-0018 contractual constants', () => {
+  describe('DEFAULT_CATEGORY', () => {
+    test('is a key of CATEGORIES', () => {
+      expect(DEFAULT_CATEGORY in CATEGORIES).toBe(true)
+    })
+
+    test('equals "medium"', () => {
+      expect(DEFAULT_CATEGORY).toBe('medium')
+    })
+
+    test('is exposed on SYSTEM.ARMOR.DEFAULT_CATEGORY', () => {
+      expect(SYSTEM.ARMOR.DEFAULT_CATEGORY).toBe(DEFAULT_CATEGORY)
+    })
+
+    test('is a non-empty string', () => {
+      expect(typeof DEFAULT_CATEGORY).toBe('string')
+      expect(DEFAULT_CATEGORY.length).toBeGreaterThan(0)
+    })
+  })
+})

--- a/tests/config/progression.test.mjs
+++ b/tests/config/progression.test.mjs
@@ -11,6 +11,10 @@ import {
   SPECIALIZATION_RANK_COST_MULTIPLIER,
   SPECIALIZATION_NON_CAREER_PENALTY,
   ENCUMBRANCE_BASE_BONUS,
+  CAREER_MAX_SKILL_COUNT,
+  CAREER_DEFAULT_FREE_SKILL_RANK,
+  CAREER_MIN_FREE_SKILL_RANK,
+  CAREER_MAX_FREE_SKILL_RANK,
 } from '../../module/config/progression.mjs'
 import { MAX_RANK_AT_CREATION, MAX_RANK } from '../../module/config/skills.mjs'
 
@@ -150,6 +154,37 @@ describe('Progression config — contractual constants (ADR-0018)', () => {
 
     test('encumbrance threshold formula for brawn 2 yields 7', () => {
       expect(2 + ENCUMBRANCE_BASE_BONUS).toBe(7)
+    })
+  })
+
+  /* -------------------------------------------- */
+  /*  Career skill list limits                     */
+  /* -------------------------------------------- */
+
+  describe('Career skill list constants (MC4 — ADR-0018)', () => {
+    test('CAREER_MAX_SKILL_COUNT is 8 (matches SwerpgCareer schema)', () => {
+      expect(CAREER_MAX_SKILL_COUNT).toBe(8)
+    })
+
+    test('CAREER_DEFAULT_FREE_SKILL_RANK is 4 (matches SwerpgCareer schema initial)', () => {
+      expect(CAREER_DEFAULT_FREE_SKILL_RANK).toBe(4)
+    })
+
+    test('CAREER_MIN_FREE_SKILL_RANK is 0 (matches SwerpgCareer schema min)', () => {
+      expect(CAREER_MIN_FREE_SKILL_RANK).toBe(0)
+    })
+
+    test('CAREER_MAX_FREE_SKILL_RANK is 8 (matches SwerpgCareer schema max)', () => {
+      expect(CAREER_MAX_FREE_SKILL_RANK).toBe(8)
+    })
+
+    test('CAREER_DEFAULT_FREE_SKILL_RANK is within [CAREER_MIN_FREE_SKILL_RANK, CAREER_MAX_FREE_SKILL_RANK]', () => {
+      expect(CAREER_DEFAULT_FREE_SKILL_RANK).toBeGreaterThanOrEqual(CAREER_MIN_FREE_SKILL_RANK)
+      expect(CAREER_DEFAULT_FREE_SKILL_RANK).toBeLessThanOrEqual(CAREER_MAX_FREE_SKILL_RANK)
+    })
+
+    test('CAREER_MAX_FREE_SKILL_RANK matches CAREER_MAX_SKILL_COUNT (same upper bound)', () => {
+      expect(CAREER_MAX_FREE_SKILL_RANK).toBe(CAREER_MAX_SKILL_COUNT)
     })
   })
 })

--- a/tests/importer/armor-import.integration.spec.mjs
+++ b/tests/importer/armor-import.integration.spec.mjs
@@ -301,3 +301,53 @@ describe('SwerpgArmor - getTags restrictionLevel', () => {
     expect(localizeSpy).toHaveBeenCalledWith('ARMOR.CATEGORIES.MEDIUM')
   })
 })
+
+describe('armorMapper — MC4 shared-constant fallbacks', () => {
+  beforeEach(() => {
+    resetArmorImportStats()
+  })
+
+  it('unknown category falls back to SYSTEM.ARMOR.DEFAULT_CATEGORY', () => {
+    const result = armorMapper([
+      {
+        Name: 'Mysterious Plates',
+        Key: 'mystery_armor',
+        Soak: 3,
+        Defense: 5,
+        Categories: { Category: ['UnknownCategoryXYZ'] },
+      },
+    ])
+    expect(result).toHaveLength(1)
+    expect(result[0].system.category).toBe(SYSTEM.ARMOR.DEFAULT_CATEGORY)
+  })
+
+  it('unrestricted armor uses SYSTEM.DEFAULT_RESTRICTION_LEVEL', () => {
+    const result = armorMapper([
+      {
+        Name: 'Padded Vest',
+        Key: 'padded_vest',
+        Soak: 2,
+        Defense: 0,
+        Categories: { Category: ['Light'] },
+        Restricted: 'false',
+      },
+    ])
+    expect(result).toHaveLength(1)
+    expect(result[0].system.restrictionLevel).toBe(SYSTEM.DEFAULT_RESTRICTION_LEVEL)
+  })
+
+  it('restricted armor uses SYSTEM.RESTRICTION_LEVELS.restricted.id', () => {
+    const result = armorMapper([
+      {
+        Name: 'Battle Armor',
+        Key: 'battle_armor',
+        Soak: 5,
+        Defense: 3,
+        Categories: { Category: ['Heavy'] },
+        Restricted: 'true',
+      },
+    ])
+    expect(result).toHaveLength(1)
+    expect(result[0].system.restrictionLevel).toBe(SYSTEM.RESTRICTION_LEVELS.restricted.id)
+  })
+})

--- a/tests/importer/career-ogg-dude.spec.mjs
+++ b/tests/importer/career-ogg-dude.spec.mjs
@@ -1,4 +1,10 @@
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, beforeEach } from 'vitest'
+import {
+  CAREER_DEFAULT_FREE_SKILL_RANK,
+  CAREER_MIN_FREE_SKILL_RANK,
+  CAREER_MAX_FREE_SKILL_RANK,
+  CAREER_MAX_SKILL_COUNT,
+} from '../../module/config/progression.mjs'
 // Minimal SYSTEM mock must precede imports that rely on SYSTEM
 if (globalThis.SYSTEM === undefined) {
   globalThis.SYSTEM = {
@@ -185,5 +191,60 @@ describe('careerMapper', () => {
       { id: 'rangedlight' },
     ])
     expect(mapped.system.careerSkills.length).toBe(6)
+  })
+})
+
+describe('careerMapper — MC4 shared-constant freeSkillRank', () => {
+  beforeEach(() => {
+    resetCareerImportStats()
+  })
+
+  it('invalid FreeRanks falls back to CAREER_DEFAULT_FREE_SKILL_RANK', () => {
+    const [mapped] = careerMapper([
+      {
+        Name: 'DefaultRankCareer',
+        Key: 'default_rank_career',
+        CareerSkills: [],
+        FreeRanks: 'not-a-number',
+      },
+    ])
+    expect(mapped.system.freeSkillRank).toBe(CAREER_DEFAULT_FREE_SKILL_RANK)
+  })
+
+  it('FreeRanks below minimum clamps to CAREER_MIN_FREE_SKILL_RANK', () => {
+    const [mapped] = careerMapper([
+      {
+        Name: 'MinRankCareer',
+        Key: 'min_rank_career',
+        CareerSkills: [],
+        FreeRanks: '-5',
+      },
+    ])
+    expect(mapped.system.freeSkillRank).toBe(CAREER_MIN_FREE_SKILL_RANK)
+  })
+
+  it('FreeRanks above maximum clamps to CAREER_MAX_FREE_SKILL_RANK', () => {
+    const [mapped] = careerMapper([
+      {
+        Name: 'MaxRankCareer',
+        Key: 'max_rank_career',
+        CareerSkills: [],
+        FreeRanks: '99',
+      },
+    ])
+    expect(mapped.system.freeSkillRank).toBe(CAREER_MAX_FREE_SKILL_RANK)
+  })
+
+  it('career skills are truncated to CAREER_MAX_SKILL_COUNT', () => {
+    const overflowSkills = ['ATHL', 'AWAR', 'COOL', 'DISC', 'GUNN', 'MED', 'PILOTPL', 'PILOTSP', 'RANGEDHEAVY']
+    const [mapped] = careerMapper([
+      {
+        Name: 'LargeCareer',
+        Key: 'large_career',
+        CareerSkills: overflowSkills,
+        FreeRanks: '4',
+      },
+    ])
+    expect(mapped.system.careerSkills.length).toBeLessThanOrEqual(CAREER_MAX_SKILL_COUNT)
   })
 })

--- a/tests/importer/talent-mapper.spec.mjs
+++ b/tests/importer/talent-mapper.spec.mjs
@@ -3,6 +3,7 @@
  */
 import { describe, it, expect, beforeEach, vi } from 'vitest'
 import { OggDudeTalentMapper } from '../../module/importer/mappers/oggdude-talent-mapper.mjs'
+import { SYSTEM } from '../../module/config/system.mjs'
 
 // Mock des dépendances
 vi.mock('../../module/utils/logger.mjs', () => ({
@@ -349,5 +350,33 @@ describe('OggDudeTalentMapper', () => {
       expect(context.activation).toBe('passive')
       expect(result.get('lightsaber_training').activation).toBe('active')
     })
+  })
+})
+
+describe('OggDudeTalentMapper — MC4 shared-constant activation', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('missing activation produces SYSTEM.TALENT_ACTIVATION.unspecified.id in transform output', () => {
+    const context = OggDudeTalentMapper.buildSingleTalentContext(
+      { Name: 'Blank Talent', Key: 'blank_talent', Description: 'A talent with no activation' },
+      {},
+    )
+    expect(context).not.toBeNull()
+    const transformed = OggDudeTalentMapper.transform(context)
+    expect(transformed.system.activation).toBe(SYSTEM.TALENT_ACTIVATION.unspecified.id)
+  })
+
+  it('hasUnknownActivation is true only when activation equals SYSTEM.TALENT_ACTIVATION.unspecified.id with non-empty raw value', () => {
+    const context = OggDudeTalentMapper.buildSingleTalentContext(
+      { Name: 'Mystery Talent', Key: 'mystery_talent', Description: 'Unknown activation', ActivationValue: 'taWhatever' },
+      {},
+    )
+    expect(context).not.toBeNull()
+    // taWhatever not in map → resolved to 'active' (non-empty non-passive fallback)
+    // so hasUnknownActivation should be false
+    expect(context.hasUnknownActivation).toBe(false)
+    expect(context.activation).toBe('active')
   })
 })

--- a/tests/importer/utils/description-markup-utils.test.mjs
+++ b/tests/importer/utils/description-markup-utils.test.mjs
@@ -6,6 +6,11 @@ import {
   resolveSource,
   normalizeFreeSkillRank,
 } from '../../../module/importer/utils/description-markup-utils.mjs'
+import {
+  CAREER_DEFAULT_FREE_SKILL_RANK,
+  CAREER_MIN_FREE_SKILL_RANK,
+  CAREER_MAX_FREE_SKILL_RANK,
+} from '../../../module/config/progression.mjs'
 
 describe('Description Markup Utils', () => {
   describe('normalizeFreeSkillRank', () => {
@@ -159,5 +164,29 @@ describe('Description Markup Utils', () => {
       const result = buildDescription('Content', { name: '', page: null })
       expect(result).not.toContain('<strong>Source:</strong>')
     })
+  })
+})
+
+describe('normalizeFreeSkillRank — MC4 shared-constant bounds', () => {
+  it('default value matches CAREER_DEFAULT_FREE_SKILL_RANK', () => {
+    expect(normalizeFreeSkillRank(undefined)).toBe(CAREER_DEFAULT_FREE_SKILL_RANK)
+    expect(normalizeFreeSkillRank(null)).toBe(CAREER_DEFAULT_FREE_SKILL_RANK)
+    expect(normalizeFreeSkillRank('invalid')).toBe(CAREER_DEFAULT_FREE_SKILL_RANK)
+  })
+
+  it('minimum clamp matches CAREER_MIN_FREE_SKILL_RANK', () => {
+    expect(normalizeFreeSkillRank(-10)).toBe(CAREER_MIN_FREE_SKILL_RANK)
+    expect(normalizeFreeSkillRank(-1)).toBe(CAREER_MIN_FREE_SKILL_RANK)
+  })
+
+  it('maximum clamp matches CAREER_MAX_FREE_SKILL_RANK', () => {
+    expect(normalizeFreeSkillRank(100)).toBe(CAREER_MAX_FREE_SKILL_RANK)
+    expect(normalizeFreeSkillRank(CAREER_MAX_FREE_SKILL_RANK + 1)).toBe(CAREER_MAX_FREE_SKILL_RANK)
+  })
+
+  it('valid in-range value passes through unchanged', () => {
+    expect(normalizeFreeSkillRank(CAREER_DEFAULT_FREE_SKILL_RANK)).toBe(CAREER_DEFAULT_FREE_SKILL_RANK)
+    expect(normalizeFreeSkillRank(CAREER_MIN_FREE_SKILL_RANK)).toBe(CAREER_MIN_FREE_SKILL_RANK)
+    expect(normalizeFreeSkillRank(CAREER_MAX_FREE_SKILL_RANK)).toBe(CAREER_MAX_FREE_SKILL_RANK)
   })
 })

--- a/tests/importer/weapon-import.spec.mjs
+++ b/tests/importer/weapon-import.spec.mjs
@@ -449,3 +449,49 @@ describe('SwerpgWeapon - schema taxonomy', () => {
     expect(weaponSchema.restrictionLevel.config.choices).toBe(SYSTEM.RESTRICTION_LEVELS)
   })
 })
+
+describe('weaponMapper — MC4 shared-constant fallbacks', () => {
+  beforeEach(() => {
+    resetWeaponImportStats()
+  })
+
+  it('unknown skill falls back to SYSTEM.WEAPON.DEFAULT_SKILL', () => {
+    const result = weaponMapper([
+      { Name: 'Mystery Gun', Key: 'mystery', SkillKey: 'UNKNOWN_SKILL_XYZ', Range: 'Short', Damage: 3, Crit: 3 },
+    ])
+    expect(result).toHaveLength(1)
+    expect(result[0].system.skill).toBe(SYSTEM.WEAPON.DEFAULT_SKILL)
+  })
+
+  it('unknown range falls back to SYSTEM.WEAPON.DEFAULT_RANGE', () => {
+    const result = weaponMapper([
+      { Name: 'Mystery Gun', Key: 'mystery2', SkillKey: 'RangedLight', Range: 'UNKNOWN_RANGE_XYZ', Damage: 3, Crit: 3 },
+    ])
+    expect(result).toHaveLength(1)
+    expect(result[0].system.range).toBe(SYSTEM.WEAPON.DEFAULT_RANGE)
+  })
+
+  it('unknown hands falls back to SYSTEM.WEAPON.SLOTS.MAINHAND', () => {
+    const result = weaponMapper([
+      { Name: 'Mystery Gun', Key: 'mystery3', SkillKey: 'RangedLight', Range: 'Short', Hands: 'UNKNOWN_HAND_XYZ', Damage: 3, Crit: 3 },
+    ])
+    expect(result).toHaveLength(1)
+    expect(result[0].system.slot).toBe(SYSTEM.WEAPON.SLOTS.MAINHAND)
+  })
+
+  it('unrestricted weapon uses SYSTEM.DEFAULT_RESTRICTION_LEVEL', () => {
+    const result = weaponMapper([
+      { Name: 'Basic Pistol', Key: 'basic', SkillKey: 'RangedLight', Range: 'Short', Restricted: 'false', Damage: 3, Crit: 3 },
+    ])
+    expect(result).toHaveLength(1)
+    expect(result[0].system.restrictionLevel).toBe(SYSTEM.DEFAULT_RESTRICTION_LEVEL)
+  })
+
+  it('restricted weapon uses SYSTEM.RESTRICTION_LEVELS.restricted.id', () => {
+    const result = weaponMapper([
+      { Name: 'Military Rifle', Key: 'milrifle', SkillKey: 'RangedHeavy', Range: 'Long', Restricted: 'true', Damage: 5, Crit: 3 },
+    ])
+    expect(result).toHaveLength(1)
+    expect(result[0].system.restrictionLevel).toBe(SYSTEM.RESTRICTION_LEVELS.restricted.id)
+  })
+})


### PR DESCRIPTION
## Summary

- Normalize the OggDude importer to use shared constants and consolidate mapping logic.
- Update armor and progression configs to expose constants used by the importer.
- Add integration and unit tests for importer, mappers, and description markup utilities.

## Context

This branch refactors the importer implementation and related configuration so the OggDude importer reuses shared constants and clearer mappers. Changes span importer modules, config files and tests to ensure behavior is covered by automated specs.

## Tests

- Not run (not requested).

## Notes

- Diff against develop: 15 files changed, 401 insertions(+), 32 deletions(-).
- Key files: module/importer/*, module/importer/mappers/oggdude-talent-mapper.mjs, module/config/{armor,progression}.mjs, tests/importer/*.
