### PR TITLE
refactor(canvas): name local UI constants for improved readability

### DIFF
--- a/.opencode/agents/cmd-create-pr.md
+++ b/.opencode/agents/cmd-create-pr.md
@@ -41,7 +41,7 @@ Rôle unique : utiliser `creer-pull-request` pour préparer ou créer une PR fac
 Règles :
 
 - Vérifie d'abord que la branche courante n’est pas `main`, `master` ou `develop`.
-- Si la branche courante est `main`, `master` ou `develop`, arrête immédiatement.
+  - Si la branche courante est `main`, `master` ou `develop`, arrête immédiatement.
 - Vérifie `git status`.
 - Si le worktree contient des modifications, crée d'abord un commit Conventional Commits compatible semantic-release.
 - Le commit doit être factuel, dérivé du diff, par exemple `feat: ...`, `fix: ...`, `docs: ...`, `test: ...`, `chore: ...`.

--- a/documentation/plan/core/refactor/413-mc5-nommer-les-constantes-ui-canvas-locales.md
+++ b/documentation/plan/core/refactor/413-mc5-nommer-les-constantes-ui-canvas-locales.md
@@ -1,0 +1,58 @@
+# MC5 — Nommer les constantes UI/canvas locales
+
+**Issue** : [#413 — MC5 — Nommer les constantes UI/canvas locales](https://github.com/herveDarritchon/foundryvtt-swerpg/issues/413)
+
+## Objectif
+
+Nommer les valeurs visuelles et techniques réutilisées dans la couche canvas/PIXI afin de supprimer les magic numbers locales les plus denses sans les promouvoir abusivement au rang de constantes métier `SYSTEM.*`, conformément à ADR-0018 et à l’exemple déjà posé par `module/applications/specialization-tree/layout.mjs`.
+
+## Décisions de cadrage
+
+- Limiter le chantier aux fichiers explicitement listés par l’issue : `module/canvas/token.mjs`, `module/canvas/talent-tree-node.mjs`, `module/canvas/talent-tree.mjs`, `module/canvas/talent-icon.mjs`, `module/applications/specialization-tree/pixi-tree-renderer.mjs`.
+- Traiter les tailles, offsets, couleurs, alphas, paddings, rayons et facteurs de scale comme des constantes locales de module ; ne pas les déplacer dans `module/config/` tant qu’aucune règle transverse n’est prouvée.
+- Réutiliser les points de vérité UI déjà existants (`layout.mjs`, `node-ui-state.mjs`, `connection-ui-state.mjs`) plutôt que dupliquer des dimensions ou styles déjà nommés.
+- Exclure du périmètre toute refonte UX, i18n ou évolution fonctionnelle du canvas/token : seul le nommage et la consolidation locale des littéraux changent.
+
+## Étapes d’implémentation
+
+### 1. Poser le vocabulaire local des constantes UI/canvas
+
+**Fichiers cibles** : `module/canvas/token.mjs`, `module/canvas/talent-tree-node.mjs`, `module/canvas/talent-tree.mjs`, `module/canvas/talent-icon.mjs`, `module/applications/specialization-tree/pixi-tree-renderer.mjs`
+
+**What**
+
+- inventorier, par fichier, les littéraux visuels réutilisés plus d’une fois ;
+- remonter en tête de module des constantes explicites ou petits registres gelés par thème (bars, pips, hover, overlays, icon slots, viewport, sharpness) ;
+- garder les constantes strictement locales quand leur sémantique reste confinée au fichier.
+
+**Validation visée** : chaque module ciblé expose des constantes locales lisibles pour ses règles visuelles récurrentes.
+
+### 2. Refactorer les routines de rendu sans changer le comportement
+
+**Fichiers cibles** : `module/applications/specialization-tree/pixi-tree-renderer.mjs`, `module/canvas/token.mjs`, `module/canvas/talent-tree-node.mjs`, `module/canvas/talent-tree.mjs`, `module/canvas/talent-icon.mjs`
+
+**What**
+
+- remplacer dans les routines de draw/refresh/interaction les tailles, offsets, couleurs, alpha et seuils UI réutilisés par les constantes nommées ;
+- aligner le renderer PIXI moderne et les modules canvas legacy sur la même stratégie de nommage local ;
+- ne promouvoir une constante hors du fichier que si la duplication inter-modules est prouvée et sémantiquement identique.
+
+**Validation visée** : les fichiers du périmètre ne portent plus de magic numbers UI/canvas réutilisés, sans régression visuelle ou comportementale attendue.
+
+### 3. Verrouiller le contrat sur les helpers et points testables
+
+**Fichiers cibles** : `tests/integration/specialization-tree-pixi-render.test.mjs`, tests ciblés adjacents éventuels si un helper pur est extrait pendant le refactor
+
+**What**
+
+- étendre les tests déjà existants du renderer sur les contrats observables issus des constantes nommées (viewport minimal, sharpness config, positionnement/slots testables) ;
+- ajouter un test unitaire uniquement pour les helpers purs extraits durant le chantier, sans forcer une couverture artificielle des classes PIXI legacy si elles ne deviennent pas isolables ;
+- conserver les assertions centrées sur le comportement rendu observable plutôt que sur l’implémentation interne.
+
+**Validation visée** : le refactor reste observable par des tests ciblés et limite le risque de réintroduire des littéraux réutilisés sur les surfaces testables.
+
+## Résultat attendu
+
+- Les modules canvas/PIXI ciblés nomment leurs constantes locales réutilisées.
+- Aucune centralisation abusive dans `module/config/` n’est introduite pour de simples détails visuels.
+- Le rendu et les interactions restent inchangés ; seule la lisibilité et la maintenabilité de la couche UI/canvas progressent.

--- a/module/applications/specialization-tree/pixi-tree-renderer.mjs
+++ b/module/applications/specialization-tree/pixi-tree-renderer.mjs
@@ -37,6 +37,73 @@ const MIN_VIEWPORT_SIZE = 320
 const NODE_CORNER_ICON_SIZE = 16
 const NODE_CORNER_ICON_MARGIN = 4
 
+/* ── Node card geometry ───────────────────────────────────────── */
+
+/** Corner radius of the node card background rectangle. */
+const NODE_CARD_CORNER_RADIUS = 4
+
+/** Default X padding between the left edge and the talent name text. */
+const NODE_NAME_DEFAULT_X = 4
+
+/** X padding applied to the talent name when a top-left icon is present. */
+const NODE_NAME_ICON_OFFSET_X = 24
+
+/** Default right padding for the talent name when no top-right icon is present. */
+const NODE_NAME_DEFAULT_RIGHT_PADDING = 4
+
+/** Right padding applied to the talent name when a top-right icon is present. */
+const NODE_NAME_ICON_RIGHT_PADDING = 24
+
+/** Y position of the talent name text inside the node card. */
+const NODE_NAME_Y = 4
+
+/* ── Cost badge geometry ──────────────────────────────────────── */
+
+/** Horizontal padding on each side of the cost badge. */
+const BADGE_PADDING_X = 5
+
+/** Vertical padding on each side of the cost badge. */
+const BADGE_PADDING_Y = 2
+
+/** X offset of the cost badge from the left edge of the node card. */
+const BADGE_X = 4
+
+/**
+ * Distance from the bottom of the node card to the bottom of the cost badge.
+ * badgeY = nodeHeight - BADGE_BOTTOM_OFFSET
+ */
+const BADGE_BOTTOM_OFFSET = 17
+
+/* ── Cost text (plain mode) ───────────────────────────────────── */
+
+/**
+ * Distance from the bottom of the node card to the baseline of the plain cost text.
+ * costTextY = nodeHeight - COST_TEXT_BOTTOM_OFFSET
+ */
+const COST_TEXT_BOTTOM_OFFSET = 14
+
+/* ── Hit area ─────────────────────────────────────────────────── */
+
+/**
+ * Near-transparent fill alpha for the hit-area overlay.
+ * Non-zero so PIXI registers pointer events without visual impact.
+ */
+const HIT_AREA_FILL_ALPHA = 0.001
+
+/* ── State-pictogram slot ─────────────────────────────────────── */
+
+/** Size (width and height) in pixels of the state-pictogram sprite. */
+const STATE_PICTOGRAM_SIZE = 16
+
+/** Y position of the state-pictogram sprite inside the node card. */
+const STATE_PICTOGRAM_Y = 4
+
+/**
+ * X offset from the right edge of the node card for the state-pictogram.
+ * pictogramX = nodeWidth - STATE_PICTOGRAM_RIGHT_OFFSET
+ */
+const STATE_PICTOGRAM_RIGHT_OFFSET = 20
+
 const ICON_SLOT_POSITIONS = Object.freeze({
   topLeft: Object.freeze({ x: NODE_CORNER_ICON_MARGIN, y: NODE_CORNER_ICON_MARGIN }),
   topRight: Object.freeze({ x: NODE_WIDTH - NODE_CORNER_ICON_SIZE - NODE_CORNER_ICON_MARGIN, y: NODE_CORNER_ICON_MARGIN }),
@@ -695,14 +762,14 @@ export class PixiTreeRenderer {
       setPixiDebugLabel(background, `${nodeLabel}:background`)
       background.beginFill(v.fillColor, v.alpha)
       background.lineStyle(v.borderWidth, v.borderColor, v.alpha)
-      background.drawRoundedRect(0, 0, this.nodeWidth, this.nodeHeight, 4)
+      background.drawRoundedRect(0, 0, this.nodeWidth, this.nodeHeight, NODE_CARD_CORNER_RADIUS)
       background.endFill()
       nodeContainer.addChild(background)
 
       const hasTopLeftIcon = Boolean(node.iconSlots?.topLeft)
       const hasTopRightIcon = Boolean(node.iconSlots?.topRight)
-      const nameOffsetX = hasTopLeftIcon ? 24 : 4
-      const nameRightPadding = hasTopRightIcon ? 24 : 4
+      const nameOffsetX = hasTopLeftIcon ? NODE_NAME_ICON_OFFSET_X : NODE_NAME_DEFAULT_X
+      const nameRightPadding = hasTopRightIcon ? NODE_NAME_ICON_RIGHT_PADDING : NODE_NAME_DEFAULT_RIGHT_PADDING
 
       // Talent name — local coords
       const nameText = new PIXI.Text(node.talentName, {
@@ -715,7 +782,7 @@ export class PixiTreeRenderer {
       setPixiDebugLabel(nameText, `${nodeLabel}:title`)
       nameText.alpha = v.textAlpha ?? 1
       nameText.x = nameOffsetX
-      nameText.y = 4
+      nameText.y = NODE_NAME_Y
       nodeContainer.addChild(nameText)
 
       // Cost badge and cost text — local coords
@@ -730,25 +797,22 @@ export class PixiTreeRenderer {
 
       let badge = null
       if (v.costDisplay === 'badge') {
-        const badgePaddingX = 5
-        const badgePaddingY = 2
-        const badgeX = 4
-        const badgeY = this.nodeHeight - 17
-        const badgeWidth = costText.width + badgePaddingX * 2
-        const badgeHeight = costText.height + badgePaddingY * 2
+        const badgeY = this.nodeHeight - BADGE_BOTTOM_OFFSET
+        const badgeWidth = costText.width + BADGE_PADDING_X * 2
+        const badgeHeight = costText.height + BADGE_PADDING_Y * 2
         badge = new PIXI.Graphics()
         setPixiDebugLabel(badge, `${nodeLabel}:cost-badge`)
         badge.beginFill(v.costBadgeFillColor ?? 0x333333, 1)
         badge.lineStyle(1, v.costBadgeBorderColor ?? v.borderColor, 1)
-        badge.drawRoundedRect(badgeX, badgeY, badgeWidth, badgeHeight, 6)
+        badge.drawRoundedRect(BADGE_X, badgeY, badgeWidth, badgeHeight, 6)
         badge.endFill()
         nodeContainer.addChild(badge)
 
-        costText.x = badgeX + badgePaddingX
-        costText.y = badgeY + badgePaddingY
+        costText.x = BADGE_X + BADGE_PADDING_X
+        costText.y = badgeY + BADGE_PADDING_Y
       } else {
-        costText.x = 4
-        costText.y = this.nodeHeight - 14
+        costText.x = NODE_NAME_DEFAULT_X
+        costText.y = this.nodeHeight - COST_TEXT_BOTTOM_OFFSET
       }
       nodeContainer.addChild(costText)
 
@@ -757,7 +821,7 @@ export class PixiTreeRenderer {
       // Hit area — local coords, transparent overlay
       const hitArea = new PIXI.Graphics()
       setPixiDebugLabel(hitArea, `${nodeLabel}:hit-area`)
-      hitArea.beginFill(0xffffff, 0.001)
+      hitArea.beginFill(0xffffff, HIT_AREA_FILL_ALPHA)
       hitArea.drawRect(0, 0, this.nodeWidth, this.nodeHeight)
       hitArea.endFill()
       hitArea.eventMode = 'static'
@@ -795,10 +859,10 @@ export class PixiTreeRenderer {
 
       const sprite = new PIXI.Sprite(texture)
       setPixiDebugLabel(sprite, `${nodeLabel}:state-pictogram`)
-      sprite.x = this.nodeWidth - 20
-      sprite.y = 4
-      sprite.width = 16
-      sprite.height = 16
+      sprite.x = this.nodeWidth - STATE_PICTOGRAM_RIGHT_OFFSET
+      sprite.y = STATE_PICTOGRAM_Y
+      sprite.width = STATE_PICTOGRAM_SIZE
+      sprite.height = STATE_PICTOGRAM_SIZE
       sprite.tint = 0xffffff
       parent.addChild(sprite)
       return true

--- a/module/canvas/talent-icon.mjs
+++ b/module/canvas/talent-icon.mjs
@@ -1,3 +1,31 @@
+/* ── Default icon config ──────────────────────────────────────── */
+
+/** Default overall opacity for icons. */
+const ICON_DEFAULT_ALPHA = 1.0
+
+/** Default background fill color for icons (opaque black). */
+const ICON_DEFAULT_BACKGROUND_COLOR = 0x000000
+
+/** Default border stroke width for icons. */
+const ICON_DEFAULT_BORDER_WIDTH = 3
+
+/** Default icon size (width and height) in pixels. */
+const ICON_DEFAULT_SIZE = 50
+
+/** Default tint for icon sprites (white = no tint). */
+const ICON_DEFAULT_TINT = 0xffffff
+
+/* ── Number badge ─────────────────────────────────────────────── */
+
+/** Font size in pixels for the count badge text. */
+const ICON_NUMBER_FONT_SIZE = 24
+
+/**
+ * Divisor applied to icon size to compute the number badge position offset.
+ * Badge is placed at (size / DIVISOR, -size / DIVISOR) relative to center.
+ */
+const ICON_NUMBER_POSITION_DIVISOR = 3
+
 export default class SwerpgTalentIcon extends PIXI.Container {
   constructor(config) {
     super(config)
@@ -7,15 +35,15 @@ export default class SwerpgTalentIcon extends PIXI.Container {
      * @type {object}
      */
     this.config = {
-      alpha: 1.0,
-      backgroundColor: 0x000000,
+      alpha: ICON_DEFAULT_ALPHA,
+      backgroundColor: ICON_DEFAULT_BACKGROUND_COLOR,
       borderColor: undefined,
-      borderWidth: 3,
+      borderWidth: ICON_DEFAULT_BORDER_WIDTH,
       borderRadius: undefined,
-      size: 50,
+      size: ICON_DEFAULT_SIZE,
       text: undefined,
       texture: undefined,
-      tint: 0xffffff,
+      tint: ICON_DEFAULT_TINT,
       ...config,
     }
 
@@ -31,10 +59,10 @@ export default class SwerpgTalentIcon extends PIXI.Container {
     this.border = this.addChild(new PIXI.Graphics())
 
     // Number
-    const textStyle = PreciseText.getTextStyle({ fontSize: 24 })
+    const textStyle = PreciseText.getTextStyle({ fontSize: ICON_NUMBER_FONT_SIZE })
     this.number = this.addChild(new PreciseText('', textStyle))
     this.number.anchor.set(0.5, 0.5)
-    this.number.position.set(this.config.size / 3, -this.config.size / 3)
+    this.number.position.set(this.config.size / ICON_NUMBER_POSITION_DIVISOR, -this.config.size / ICON_NUMBER_POSITION_DIVISOR)
   }
 
   /* -------------------------------------------- */

--- a/module/canvas/talent-tree-node.mjs
+++ b/module/canvas/talent-tree-node.mjs
@@ -1,5 +1,50 @@
 import SwerpgTalentIcon from './talent-icon.mjs'
 
+/* ── Node interaction scales ───────────────────────────────────── */
+
+/** Scale applied to a node on pointer hover or when the node is active. */
+const NODE_HOVER_SCALE = 1.2
+
+/** Scale applied to a node in its default resting state. */
+const NODE_NORMAL_SCALE = 1.0
+
+/* ── Signature node geometry ───────────────────────────────────── */
+
+/** Size (width and height) in pixels for signature-type nodes. */
+const SIGNATURE_NODE_SIZE = 80
+
+/** Border radius for signature-type nodes (fully rounded). */
+const SIGNATURE_NODE_BORDER_RADIUS = 80
+
+/* ── Standard node visual config ──────────────────────────────── */
+
+/** Border width for accessible (but not purchased) nodes. */
+const NODE_ACCESSIBLE_BORDER_WIDTH = 2
+
+/** Alpha for accessible (but not purchased) nodes. */
+const NODE_ACCESSIBLE_ALPHA = 0.4
+
+/** Border color for accessible (but not purchased) nodes. */
+const NODE_ACCESSIBLE_BORDER_COLOR = 0x827f7d
+
+/** Alpha for inaccessible nodes. */
+const NODE_INACCESSIBLE_ALPHA = 0.1
+
+/** Border color for inaccessible nodes. */
+const NODE_INACCESSIBLE_BORDER_COLOR = 0x262322
+
+/** Border width for inaccessible nodes. */
+const NODE_INACCESSIBLE_BORDER_WIDTH = 2
+
+/** Alpha for fully purchased nodes. */
+const NODE_PURCHASED_ALPHA = 1.0
+
+/** Border width for purchased nodes. */
+const NODE_PURCHASED_BORDER_WIDTH = 3
+
+/** Border color for banned (but not purchased) nodes. */
+const NODE_BANNED_BORDER_COLOR = 0x330000
+
 export default class SwerpgTalentTreeNode extends SwerpgTalentIcon {
   constructor(node, config) {
     super(config)
@@ -36,31 +81,31 @@ export default class SwerpgTalentTreeNode extends SwerpgTalentIcon {
 
     // Signature nodes
     if (this.node.type === 'signature') {
-      config.size = 80
-      config.borderRadius = 80
+      config.size = SIGNATURE_NODE_SIZE
+      config.borderRadius = SIGNATURE_NODE_BORDER_RADIUS
     }
 
     // Is the node accessible or not?
     if (state.accessible) {
-      config.alpha = 0.4
-      config.borderColor = 0x827f7d
-      config.borderWidth = 2
+      config.alpha = NODE_ACCESSIBLE_ALPHA
+      config.borderColor = NODE_ACCESSIBLE_BORDER_COLOR
+      config.borderWidth = NODE_ACCESSIBLE_BORDER_WIDTH
     } else {
-      config.alpha = 0.1
-      config.borderColor = 0x262322
-      config.borderWidth = 2
+      config.alpha = NODE_INACCESSIBLE_ALPHA
+      config.borderColor = NODE_INACCESSIBLE_BORDER_COLOR
+      config.borderWidth = NODE_INACCESSIBLE_BORDER_WIDTH
     }
 
     // Has the node been purchased?
     if (state.purchased) {
-      config.alpha = 1.0
+      config.alpha = NODE_PURCHASED_ALPHA
       config.borderColor = this.node.color
-      config.borderWidth = 3
+      config.borderWidth = NODE_PURCHASED_BORDER_WIDTH
     }
 
     // Has the node been banned?
     else if (state.banned) {
-      config.borderColor = 0x330000
+      config.borderColor = NODE_BANNED_BORDER_COLOR
     }
 
     // Draw Icon
@@ -135,7 +180,7 @@ export default class SwerpgTalentTreeNode extends SwerpgTalentIcon {
     if (!tree.app.renderer.enabled) return
     if (document.elementFromPoint(event.globalX, event.globalY)?.id !== 'swerpg-talent-tree') return
     tree.hud.activate(this)
-    this.scale.set(1.2, 1.2)
+    this.scale.set(NODE_HOVER_SCALE, NODE_HOVER_SCALE)
   }
 
   /* -------------------------------------------- */
@@ -147,6 +192,6 @@ export default class SwerpgTalentTreeNode extends SwerpgTalentIcon {
     if (document.elementFromPoint(event.globalX, event.globalY)?.id !== 'swerpg-talent-tree') return
     tree.hud.clear()
     if (this.isActive) return // Don't un-hover an active node
-    this.scale.set(1.0, 1.0)
+    this.scale.set(NODE_NORMAL_SCALE, NODE_NORMAL_SCALE)
   }
 }

--- a/module/canvas/talent-tree.mjs
+++ b/module/canvas/talent-tree.mjs
@@ -4,6 +4,68 @@ import SwerpgTalentTreeNode from './talent-tree-node.mjs'
 import SwerpgTalentChoiceWheel from './talent-choice-wheel.mjs'
 import SwerpgTalentHUD from './talent-hud.mjs'
 
+/* ── Background and viewport ──────────────────────────────────── */
+
+/** Background color of the talent tree canvas (dark near-black). */
+const CANVAS_BACKGROUND_COLOR = 0x0b0909
+
+/** Half-width and half-height of the square used by darkenBackground. */
+const DARKEN_RECT_HALF_SIZE = 6000
+
+/** Alpha of the darkening overlay applied when a node is active. */
+const DARKEN_OVERLAY_ALPHA = 0.5
+
+/* ── Tree decoration circles ──────────────────────────────────── */
+
+/** Radius of the inner decorative circle drawn on the tree background. */
+const TREE_INNER_CIRCLE_RADIUS = 1400
+
+/** Radius of the outer decorative circle drawn on the tree background. */
+const TREE_OUTER_CIRCLE_RADIUS = 2000
+
+/* ── Character sprite ─────────────────────────────────────────── */
+
+/** Height in pixels of the actor portrait sprite at the tree center. */
+const CHARACTER_SPRITE_HEIGHT = 200
+
+/* ── Active connections ───────────────────────────────────────── */
+
+/** Line width for active (purchased) connections between nodes. */
+const CONNECTION_LINE_WIDTH = 3
+
+/** Line alpha for active (purchased) connections between nodes. */
+const CONNECTION_LINE_ALPHA = 1.0
+
+/** Background edge line alpha (dim, non-interactive). */
+const EDGE_LINE_ALPHA = 0.35
+
+/* ── Audio ────────────────────────────────────────────────────── */
+
+/** Volume for UI click sound effects. */
+const CLICK_SOUND_VOLUME = 0.2
+
+/* ── Interaction ──────────────────────────────────────────────── */
+
+/** Speed multiplier applied to right-drag pan deltas. */
+const DRAG_PAN_SPEED = 0.8
+
+/** Zoom scale multiplier for a single wheel-up tick. */
+const ZOOM_IN_FACTOR = 1.05
+
+/** Zoom scale multiplier for a single wheel-down tick. */
+const ZOOM_OUT_FACTOR = 0.95
+
+/** Scale applied to a deactivated node returning to its resting state. */
+const NODE_NORMAL_SCALE = 1.0
+
+/* ── Z-index ──────────────────────────────────────────────────── */
+
+/** Z-index applied to the HUD element while the talent tree is open. */
+const HUD_Z_INDEX_TREE_OPEN = 9999
+
+/** Z-index applied to the talent tree canvas in development mode. */
+const TREE_CANVAS_Z_INDEX_DEV = 0
+
 /**
  * @typedef {Object} SwerpgTalentNodeState
  * @property {boolean} [accessible]
@@ -125,7 +187,7 @@ export default class SwerpgTalentTree extends PIXI.Container {
         transparent: false,
         resolution: 1,
         autoDensity: true,
-        background: 0x0b0909,
+        background: CANVAS_BACKGROUND_COLOR,
         antialias: false, // Not needed because we use SmoothGraphics
         powerPreference: 'high-performance', // Prefer high performance GPU for devices with dual graphics cards
       }),
@@ -165,7 +227,7 @@ export default class SwerpgTalentTree extends PIXI.Container {
 
     // Background connections
     this.edges = this.background.addChild(new PIXI.Graphics())
-    this.edges.lineStyle({ color: 0x000000, alpha: 0.35, width: 3 })
+    this.edges.lineStyle({ color: 0x000000, alpha: EDGE_LINE_ALPHA, width: CONNECTION_LINE_WIDTH })
 
     // Active connections
     this.connections = this.background.addChild(new PIXI.Graphics())
@@ -229,7 +291,7 @@ export default class SwerpgTalentTree extends PIXI.Container {
   #drawCharacter(texture) {
     if (!this.actor) return (this.character.visible = false)
     if (texture) this.character.texture = texture
-    this.character.height = 200
+    this.character.height = CHARACTER_SPRITE_HEIGHT
     this.character.scale.x = this.character.scale.y
     this.character.anchor.set(0.5, 0.5)
     this.character.visible = true
@@ -240,7 +302,7 @@ export default class SwerpgTalentTree extends PIXI.Container {
   #drawConnections(node, seen) {
     for (const c of node.connected) {
       if (seen.has(c) || c.tier < 0 || !this.state.get(c).purchased) continue
-      this.connections.lineStyle({ color: c.color, width: 3, alpha: 1.0 }).moveTo(node.point.x, node.point.y).lineTo(c.point.x, c.point.y)
+      this.connections.lineStyle({ color: c.color, width: CONNECTION_LINE_WIDTH, alpha: CONNECTION_LINE_ALPHA }).moveTo(node.point.x, node.point.y).lineTo(c.point.x, c.point.y)
     }
   }
 
@@ -280,9 +342,8 @@ export default class SwerpgTalentTree extends PIXI.Container {
   /* -------------------------------------------- */
 
   #drawCircles() {
-    // This.edges.drawCircle(0, 0, 800);
-    this.edges.drawCircle(0, 0, 1400)
-    this.edges.drawCircle(0, 0, 2000)
+    this.edges.drawCircle(0, 0, TREE_INNER_CIRCLE_RADIUS)
+    this.edges.drawCircle(0, 0, TREE_OUTER_CIRCLE_RADIUS)
   }
 
   /* -------------------------------------------- */
@@ -327,8 +388,8 @@ export default class SwerpgTalentTree extends PIXI.Container {
     this.stage.eventMode = 'static'
     this.stage.interactiveChildren = true
     this.canvas.hidden = false
-    if (this.developmentMode) this.canvas.style.zIndex = 0
-    else canvas.hud.element.style.zIndex = 9999 // Move HUD above our canvas
+    if (this.developmentMode) this.canvas.style.zIndex = TREE_CANVAS_Z_INDEX_DEV
+    else canvas.hud.element.style.zIndex = HUD_Z_INDEX_TREE_OPEN // Move HUD above our canvas
   }
 
   /* -------------------------------------------- */
@@ -410,7 +471,7 @@ export default class SwerpgTalentTree extends PIXI.Container {
    */
   playClick() {
     const src = this.constructor.clickSounds[Math.floor(Math.random() * this.constructor.clickSounds.length)]
-    game.audio.play(src, { volume: 0.2, loop: false, context: game.audio.interface })
+    game.audio.play(src, { volume: CLICK_SOUND_VOLUME, loop: false, context: game.audio.interface })
   }
 
   /* -------------------------------------------- */
@@ -431,7 +492,7 @@ export default class SwerpgTalentTree extends PIXI.Container {
   deactivateNode({ click = true } = {}) {
     if (!this.active) return
     this.wheel.deactivate()
-    this.active.scale.set(1.0, 1.0)
+    this.active.scale.set(NODE_NORMAL_SCALE, NODE_NORMAL_SCALE)
     this.active = null
     this.darkenBackground(false)
     if (click) this.playClick()
@@ -441,11 +502,11 @@ export default class SwerpgTalentTree extends PIXI.Container {
 
   darkenBackground(fade = true) {
     this.background.darken.clear()
-    const w = 12000
+    const w = DARKEN_RECT_HALF_SIZE * 2
     if (fade)
       this.background.darken
-        .beginFill(0x000000, 0.5)
-        .drawRect(-w / 2, -w / 2, w, w)
+        .beginFill(0x000000, DARKEN_OVERLAY_ALPHA)
+        .drawRect(-DARKEN_RECT_HALF_SIZE, -DARKEN_RECT_HALF_SIZE, w, w)
         .endFill()
     this.background.blurFilter.enabled = fade
   }
@@ -558,13 +619,12 @@ export default class SwerpgTalentTree extends PIXI.Container {
    * @param {PIXI.FederatedEvent} event
    */
   #onDragRightMove(event) {
-    const DRAG_SPEED_MODIFIER = 0.8
     const { origin, destination } = event.interactionData
     const dx = destination.x - origin.x
     const dy = destination.y - origin.y
     this.pan({
-      x: this.stage.pivot.x - dx * DRAG_SPEED_MODIFIER,
-      y: this.stage.pivot.y - dy * DRAG_SPEED_MODIFIER,
+      x: this.stage.pivot.x - dx * DRAG_PAN_SPEED,
+      y: this.stage.pivot.y - dy * DRAG_PAN_SPEED,
     })
   }
 
@@ -588,7 +648,7 @@ export default class SwerpgTalentTree extends PIXI.Container {
    */
   #onWheel(event) {
     if (this.canvas.hidden || event.target?.id !== 'swerpg-talent-tree') return
-    let dz = event.delta < 0 ? 1.05 : 0.95
+    const dz = event.delta < 0 ? ZOOM_IN_FACTOR : ZOOM_OUT_FACTOR
     this.pan({ scale: dz * this.stage.scale.x })
   }
 

--- a/module/canvas/token.mjs
+++ b/module/canvas/token.mjs
@@ -1,3 +1,54 @@
+/* ── Bar geometry ──────────────────────────────────────────────── */
+
+/** Height in pixels of the primary (health) resource bar. */
+const BAR_PRIMARY_HEIGHT = 8
+
+/** Height in pixels of the secondary (morale) resource bar. */
+const BAR_SECONDARY_HEIGHT = 6
+
+/** Border stroke width for resource bars. */
+const BAR_BORDER_WIDTH = 1
+
+/** Fill alpha for the bar background (dark tint). */
+const BAR_BG_ALPHA = 0.5
+
+/** Alpha filter opacity applied to the bars container. */
+const BAR_ALPHA_FILTER = 0.6
+
+/** Y offset from bottom of token for the primary bar. */
+const BAR_PRIMARY_Y_OFFSET = 8
+
+/** Y offset from bottom of token for the secondary bar. */
+const BAR_SECONDARY_Y_OFFSET = 14
+
+/* ── Pip geometry ──────────────────────────────────────────────── */
+
+/** Radius in pixels of each resource pip circle. */
+const PIP_RADIUS = 3
+
+/** Horizontal spacing between consecutive pips. */
+const PIP_SPACING = 10
+
+/** X offset from the left edge for the first action pip. */
+const PIP_ACTION_START_X = 6
+
+/** X offset from the right edge for the first focus pip. */
+const PIP_FOCUS_END_X = 6
+
+/* ── Overlay and effect geometry ───────────────────────────────── */
+
+/** Fraction of token width/height used for the overlay effect size. */
+const OVERLAY_SCALE_FACTOR = 0.6
+
+/** Rounding radius for status-effect background rectangles. */
+const STATUS_EFFECT_CORNER_RADIUS = 2
+
+/** Margin inset on each side for rounded status-effect backgrounds. */
+const STATUS_EFFECT_BG_INSET = 1
+
+/** Scale factor for the target indicator size relative to token size. */
+const TARGET_SIZE_SCALE = 0.5
+
 export default class SwerpgTokenObject extends foundry.canvas.placeables.Token {
   /** @inheritDoc */
   static RENDER_FLAGS = { ...super.RENDER_FLAGS, refreshFlanking: {} }
@@ -50,7 +101,7 @@ export default class SwerpgTokenObject extends foundry.canvas.placeables.Token {
    * TODO remove in V13+ if core supports better UI scale
    */
   _drawTarget(options = {}) {
-    return super._drawTarget({ ...options, size: 0.5 })
+    return super._drawTarget({ ...options, size: TARGET_SIZE_SCALE })
   }
 
   /* -------------------------------------------- */
@@ -64,7 +115,7 @@ export default class SwerpgTokenObject extends foundry.canvas.placeables.Token {
       this.bars.alphaFilter = new PIXI.filters.AlphaFilter()
       this.bars.filters = [this.bars.alphaFilter]
     }
-    this.bars.alphaFilter.alpha = 0.6
+    this.bars.alphaFilter.alpha = BAR_ALPHA_FILTER
   }
 
   /* -------------------------------------------- */
@@ -80,8 +131,8 @@ export default class SwerpgTokenObject extends foundry.canvas.placeables.Token {
     // Determine sizing
     const { width, height } = this.getSize()
     const bw = width
-    const bh = number === 0 ? 8 : 6
-    const bs = 1
+    const bh = number === 0 ? BAR_PRIMARY_HEIGHT : BAR_SECONDARY_HEIGHT
+    const bs = BAR_BORDER_WIDTH
 
     // Determine the color to use
     const colors = number === 0 ? SYSTEM.RESOURCES.health.color : SYSTEM.RESOURCES.morale.color
@@ -90,11 +141,11 @@ export default class SwerpgTokenObject extends foundry.canvas.placeables.Token {
     // Draw bar
     bar.clear()
     bar.lineStyle(bs, 0x000000, 1.0)
-    bar.beginFill(0x000000, 0.5).drawRect(0, 0, bw, bh, 3)
+    bar.beginFill(0x000000, BAR_BG_ALPHA).drawRect(0, 0, bw, bh, 3)
     bar.beginFill(color, 1.0).drawRect(0, 0, pct * bw, bh, 2)
 
     // Set position
-    const posY = number === 0 ? height - 8 : height - 14
+    const posY = number === 0 ? height - BAR_PRIMARY_Y_OFFSET : height - BAR_SECONDARY_Y_OFFSET
     bar.position.set(0, posY)
     return true
   }
@@ -116,17 +167,17 @@ export default class SwerpgTokenObject extends foundry.canvas.placeables.Token {
 
     // Action Pips
     const ac = SYSTEM.RESOURCES.action.color
-    r.beginFill(ac, 1.0).lineStyle({ color: 0x000000, width: 1 })
+    r.beginFill(ac, 1.0).lineStyle({ color: 0x000000, width: BAR_BORDER_WIDTH })
     for (let i = 0; i < action.value; i++) {
-      r.drawCircle(6 + i * 10, height - 8, 3)
+      r.drawCircle(PIP_ACTION_START_X + i * PIP_SPACING, height - BAR_PRIMARY_Y_OFFSET, PIP_RADIUS)
     }
     r.endFill()
 
     // Focus Pips
     const fc = SYSTEM.RESOURCES.focus.color
-    r.beginFill(fc, 1.0).lineStyle({ color: 0x000000, width: 1 })
+    r.beginFill(fc, 1.0).lineStyle({ color: 0x000000, width: BAR_BORDER_WIDTH })
     for (let i = 0; i < focus.value; i++) {
-      r.drawCircle(width - 6 - i * 10, height - 14, 3)
+      r.drawCircle(width - PIP_FOCUS_END_X - i * PIP_SPACING, height - BAR_SECONDARY_Y_OFFSET, PIP_RADIUS)
     }
     r.endFill()
   }
@@ -148,7 +199,7 @@ export default class SwerpgTokenObject extends foundry.canvas.placeables.Token {
       // Overlay effect
       if (effect === this.effects.overlay) {
         const { width, height } = this.getSize()
-        const size = Math.min(width * 0.6, height * 0.6)
+        const size = Math.min(width * OVERLAY_SCALE_FACTOR, height * OVERLAY_SCALE_FACTOR)
         effect.width = effect.height = size
         effect.position = this.getCenterPoint({ x: 0, y: 0 })
         effect.anchor.set(0.5, 0.5)
@@ -159,7 +210,13 @@ export default class SwerpgTokenObject extends foundry.canvas.placeables.Token {
         effect.width = effect.height = size
         effect.x = Math.floor(i / rows) * size
         effect.y = (i % rows) * size
-        bg.drawRoundedRect(effect.x + 1, effect.y + 1, size - 2, size - 2, 2)
+        bg.drawRoundedRect(
+          effect.x + STATUS_EFFECT_BG_INSET,
+          effect.y + STATUS_EFFECT_BG_INSET,
+          size - STATUS_EFFECT_BG_INSET * 2,
+          size - STATUS_EFFECT_BG_INSET * 2,
+          STATUS_EFFECT_CORNER_RADIUS,
+        )
         i++
       }
     }

--- a/tests/integration/specialization-tree-pixi-render.test.mjs
+++ b/tests/integration/specialization-tree-pixi-render.test.mjs
@@ -720,4 +720,54 @@ describe('PixiTreeRenderer integration', () => {
     expect(renderer.pixiApp).toBeNull()
     expect(renderer.treeContainer).toBeNull()
   })
+
+  /* ═══════════════════════════════════════════════════════════════ */
+  /*  MC5 — Named constants contract tests                          */
+  /* ═══════════════════════════════════════════════════════════════ */
+
+  it('MIN_VIEWPORT_SIZE clamps small host dimensions to at least 320', () => {
+    // width=50 and height=80 are both below MIN_VIEWPORT_SIZE (320)
+    expect(getViewportDimensions({ clientWidth: 50, clientHeight: 80 })).toEqual({ width: 320, height: 320 })
+    // width=400 is above MIN_VIEWPORT_SIZE; height=100 is below
+    expect(getViewportDimensions({ clientWidth: 400, clientHeight: 100 })).toEqual({ width: 400, height: 320 })
+  })
+
+  it('node card background uses the corner-radius constant (4px rounded rect)', async () => {
+    const host = createMockHost()
+    const renderer = new PixiTreeRenderer()
+    renderer.mount(host)
+    await renderer.update(createViewModel(), {})
+
+    const descendants = flattenChildren(renderer.treeContainer)
+    const bg = descendants.find((c) => c.label === 'node:n1:Tough:background')
+    expect(bg).toBeDefined()
+    // drawRoundedRect is called with (0, 0, nodeWidth, nodeHeight, cornerRadius)
+    const drawCall = bg.calls.find((c) => c[0] === 'drawRoundedRect')
+    expect(drawCall).toBeDefined()
+    expect(drawCall[5]).toBe(4) // NODE_CARD_CORNER_RADIUS
+  })
+
+  it('cost badge geometry uses the named padding constants', async () => {
+    const host = createMockHost()
+    const renderer = new PixiTreeRenderer()
+    renderer.mount(host)
+    await renderer.update(createViewModel(), {})
+
+    const descendants = flattenChildren(renderer.treeContainer)
+    // n1 (AVAILABLE state) has a badge-mode cost display
+    const badge = descendants.find((c) => c.label === 'node:n1:Tough:cost-badge')
+    expect(badge).toBeDefined()
+    // drawRoundedRect(badgeX, badgeY, badgeWidth, badgeHeight, cornerRadius)
+    const drawCall = badge.calls.find((c) => c[0] === 'drawRoundedRect')
+    expect(drawCall).toBeDefined()
+    // badgeX = BADGE_X = 4
+    expect(drawCall[1]).toBe(4)
+    // badgeY = nodeHeight - BADGE_BOTTOM_OFFSET = 48 - 17 = 31
+    expect(drawCall[2]).toBe(31)
+  })
+
+  it('getCanvasSharpnessConfig backgroundAlpha is always 0 (transparent canvas)', () => {
+    const config = getCanvasSharpnessConfig()
+    expect(config.backgroundAlpha).toBe(0)
+  })
 })


### PR DESCRIPTION
# refactor(canvas): name local UI constants for improved readability

## Summary
Refactor: rename local UI/canvas-related constants in several modules to give them clear, descriptive names and improve readability. Files changed include canvas renderers and token/tree modules plus a corresponding integration test and documentation/plan entry. No API or public surface changes are expected — this is an internal code readability refactor.

## Testing notes
- Run unit and integration tests: `pnpm test` (or run the specific integration test `tests/integration/specialization-tree-pixi-render.test.mjs`).
- Manually verify in Foundry (dev build): rebuild and load system, open specialization tree UI and inspect that tokens, talent icons and tree nodes render without errors.
- No behavior changes expected; look for console errors during UI rendering.

## Related issue
Closes/refactors work for issue: #413

