### PR TITLE
refactor(character): remove thresholds stubs and centralize threshold bonuses

### DIFF
--- a/documentation/plan/character-sheet/refactor/394-supprimer-stubs-fixme-thresholds-strain-wounds-dans-swerpg-character.md
+++ b/documentation/plan/character-sheet/refactor/394-supprimer-stubs-fixme-thresholds-strain-wounds-dans-swerpg-character.md
@@ -1,0 +1,47 @@
+# Plan — Supprimer les stubs FIXME `thresholds.strain/wounds` dans `SwerpgCharacter`
+
+**Issue** : [#394 — Refactor: supprimer stubs FIXME thresholds.strain/wounds dans SwerpgCharacter](https://github.com/herveDarritchon/foundryvtt-swerpg/issues/394)
+
+## Décision de périmètre
+
+- **À faire** : supprimer le transport intermédiaire des bonus de seuil via `this.thresholds.wounds` / `this.thresholds.strain` lorsqu'ils ne servent qu'à recopier les modificateurs de l'espèce.
+- **À ne pas faire** : ne pas renommer dans cette issue la sémantique publique des ressources (`resources.wounds.threshold`, `resources.strain.threshold`) ni lancer une refonte plus large du naming `thresholds`.
+- **Hypothèse retenue** : le calcul métier reste `caractéristique + modificateur d'espèce`; seule la couche de stub runtime disparaît.
+
+## Fichiers impactés
+
+| Fichier                         | Nature du changement                                                |
+| ------------------------------- | ------------------------------------------------------------------- |
+| `module/models/actor-type.mjs`  | Remplacer la dépendance à `actor.thresholds.*` par un point d'accès explicite aux bonus |
+| `module/models/character.mjs`   | Calculer les bonus depuis l'espèce et retirer le stub `thresholds.*` |
+| `tests/models/character-thresholds.test.mjs` | Verrouiller le calcul des seuils sans champ intermédiaire |
+
+## Étapes
+
+### 1. Introduire un point d'extension explicite pour les bonus de seuil
+
+- Refactorer `SwerpgActorType` pour que le calcul de `wounds.threshold` et `strain.threshold` lise des helpers dédiés (`_getWoundThresholdBonus()`, `_getStrainThresholdBonus()` ou équivalent) au lieu de dépendre directement de `actor.thresholds`.
+- Garder un défaut neutre (`0`) pour les sous-types qui n'ont pas de bonus spécifique.
+
+### 2. Brancher `SwerpgCharacter` directement sur les modificateurs d'espèce
+
+- Lire `this.details.species?.woundThreshold?.modifier` et `this.details.species?.strainThreshold?.modifier` dans le nouveau point d'extension.
+- Supprimer `schema.thresholds` et les affectations dans `#prepareSpecies()` si plus aucun consommateur ne lit `this.thresholds`.
+
+### 3. Couvrir le contrat métier par des tests ciblés
+
+- Ajouter un test qui vérifie : `wounds.threshold = brawn + species.woundThreshold.modifier`.
+- Ajouter un test qui vérifie : `strain.threshold = willpower + species.strainThreshold.modifier`.
+- Ajouter une non-régression avec espèce absente pour confirmer le fallback à `0` côté bonus.
+
+## Points de vigilance
+
+- `#calculateWoundThreshold` et `#calculateStrainThreshold` sont privés statiques aujourd'hui : la refactor doit éviter de dupliquer le calcul entre classe mère et sous-classe.
+- Le retrait de `schema.thresholds` change la forme du data model : confirmer qu'aucun consommateur hors modèle ne lit encore `system.thresholds.wounds` / `system.thresholds.strain`.
+- Ne pas toucher dans cette issue à la règle existante `resources.*.max = Math.ceil(1.5 * resources.*.threshold)`.
+
+## Résultat attendu
+
+- `SwerpgCharacter` ne maintient plus de stub runtime `thresholds.wounds` / `thresholds.strain`.
+- Le calcul utilisateur des seuils reste inchangé.
+- Le bonus de seuil provient directement de l'espèce via un contrat explicite et testé.

--- a/module/models/actor-type.mjs
+++ b/module/models/actor-type.mjs
@@ -336,6 +336,30 @@ export default class SwerpgActorType extends foundry.abstract.TypeDataModel {
   /* -------------------------------------------- */
 
   /**
+   * Return the bonus to add to the wound threshold for this actor subtype.
+   * Subclasses override this method to provide species or item-based bonuses.
+   * The base implementation returns 0, which is correct for adversaries.
+   *
+   * @returns {number} Non-negative bonus applied on top of the brawn characteristic.
+   * @protected
+   */
+  _getWoundThresholdBonus() {
+    return 0
+  }
+
+  /**
+   * Return the bonus to add to the strain threshold for this actor subtype.
+   * Subclasses override this method to provide species or item-based bonuses.
+   * The base implementation returns 0, which is correct for adversaries.
+   *
+   * @returns {number} Non-negative bonus applied on top of the willpower characteristic.
+   * @protected
+   */
+  _getStrainThresholdBonus() {
+    return 0
+  }
+
+  /**
    * The wound threshold determines how much damage a character can take
    * before experiencing significant negative effects.
    *
@@ -347,10 +371,10 @@ export default class SwerpgActorType extends foundry.abstract.TypeDataModel {
    * @returns {number} The calculated wound threshold value.
    */
   static #calculateWoundThreshold(actor) {
-    const { characteristics, thresholds } = actor
+    const { characteristics } = actor
     const brawn = characteristics?.brawn?.rank?.value ?? 0
-    const wounds = thresholds?.wounds ?? 0
-    const result = brawn + wounds
+    const bonus = actor._getWoundThresholdBonus()
+    const result = brawn + bonus
     logger.debug(`Calculating Wound Threshold for actor: ${result}`, actor)
     return result
   }
@@ -367,10 +391,10 @@ export default class SwerpgActorType extends foundry.abstract.TypeDataModel {
    * @returns {number} The calculated strain threshold value.
    */
   static #calculateStrainThreshold(actor) {
-    const { characteristics, thresholds } = actor
+    const { characteristics } = actor
     const willpower = characteristics?.willpower?.rank?.value ?? 0
-    const strain = thresholds?.strain ?? 0
-    const result = willpower + strain
+    const bonus = actor._getStrainThresholdBonus()
+    const result = willpower + bonus
     logger.debug(`Calculating Strain Threshold for actor: ${result}`, actor)
     return result
   }

--- a/module/models/character.mjs
+++ b/module/models/character.mjs
@@ -7,12 +7,6 @@ import SwerpgSpecialization from './specialization.mjs'
 import { getSkillPurchaseState } from '../utils/skill-costs.mjs'
 
 /**
- * @typedef {Object} Thresholds
- * @property {number} wounds - The wounds threshold
- * @property {number} strain - The strain threshold
- */
-
-/**
  * @typedef {Object} Experience
  * @property {number} spent - The number of experience points spent
  * @property {number} gained - The number of experience points gained
@@ -71,31 +65,6 @@ export default class SwerpgCharacter extends SwerpgActorType {
     for (const characteristicField of Object.values(schema.characteristics.fields)) {
       characteristicField.options.validate = SwerpgCharacter.#validateAttribute
     }
-
-    schema.thresholds = new fields.SchemaField({
-      wounds: new fields.NumberField(
-        {
-          required: true,
-          integer: true,
-          initial: 0,
-          min: 0,
-          max: 2000,
-          step: 1,
-        },
-        { label: 'THRESHOLD.Wounds' },
-      ),
-      strain: new fields.NumberField(
-        {
-          required: true,
-          integer: true,
-          initial: 0,
-          min: 0,
-          max: 2000,
-          step: 1,
-        },
-        { label: 'THRESHOLD.Strain' },
-      ),
-    })
 
     // Experience/Advancement
     schema.progression = new fields.SchemaField({
@@ -266,6 +235,34 @@ export default class SwerpgCharacter extends SwerpgActorType {
   /* -------------------------------------------- */
 
   /**
+   * Return the wound threshold bonus sourced from the character's species.
+   * Reads `details.species.woundThreshold.modifier` and defaults to 0 when no
+   * species is set or the modifier is absent.
+   *
+   * @override
+   * @returns {number}
+   */
+  _getWoundThresholdBonus() {
+    return this.details.species?.woundThreshold?.modifier ?? 0
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Return the strain threshold bonus sourced from the character's species.
+   * Reads `details.species.strainThreshold.modifier` and defaults to 0 when no
+   * species is set or the modifier is absent.
+   *
+   * @override
+   * @returns {number}
+   */
+  _getStrainThresholdBonus() {
+    return this.details.species?.strainThreshold?.modifier ?? 0
+  }
+
+  /* -------------------------------------------- */
+
+  /**
    * Validate an attribute field
    * @param actor
    */
@@ -357,10 +354,6 @@ export default class SwerpgCharacter extends SwerpgActorType {
    */
   #prepareSpecies() {
     const species = this.details.species
-    const thresholds = this.thresholds
-
-    thresholds.wounds = species?.woundThreshold?.modifier ?? 0
-    thresholds.strain = species?.strainThreshold?.modifier ?? 0
 
     for (let a in SYSTEM.CHARACTERISTICS) {
       const characteristic = this.characteristics[a]

--- a/tests/models/character-specializations.test.mjs
+++ b/tests/models/character-specializations.test.mjs
@@ -6,7 +6,6 @@ function buildCharacterData({ specializations } = {}) {
   const characteristicRank = { base: 1, trained: 0, bonus: 0, value: 1 }
 
   return {
-    thresholds: { wounds: 0, strain: 0 },
     progression: {
       freeSkillRanks: {
         career: { id: '', name: '', spent: 0, gained: 0 },

--- a/tests/models/character-thresholds.test.mjs
+++ b/tests/models/character-thresholds.test.mjs
@@ -1,0 +1,216 @@
+import { describe, expect, test } from 'vitest'
+
+import SwerpgCharacter from '../../module/models/character.mjs'
+
+/**
+ * Build a minimal SwerpgCharacter data payload.
+ *
+ * @param {object} [overrides]
+ * @param {object|null} [overrides.species] - Species data embedded in details.
+ * @param {number} [overrides.brawn] - Base brawn rank value.
+ * @param {number} [overrides.willpower] - Base willpower rank value.
+ * @returns {object} Plain data object suitable for `new SwerpgCharacter(data)`.
+ */
+function buildCharacterData({ species = null, brawn = 2, willpower = 2 } = {}) {
+  const makeRank = (base) => ({ base, trained: 0, bonus: 0, value: base })
+
+  return {
+    progression: {
+      freeSkillRanks: {
+        career: { id: '', name: '', spent: 0, gained: 0 },
+        specialization: { id: '', name: '', spent: 0, gained: 0 },
+      },
+      experience: { spent: 0, gained: 0, startingExperience: 0 },
+    },
+    details: {
+      species,
+      career: {},
+      specializations: new Set(),
+    },
+    characteristics: {
+      brawn: { rank: makeRank(brawn) },
+      agility: { rank: makeRank(2) },
+      intellect: { rank: makeRank(2) },
+      cunning: { rank: makeRank(2) },
+      willpower: { rank: makeRank(willpower) },
+      presence: { rank: makeRank(2) },
+    },
+    // Include all resource pools accessed during _prepareResources and _prepareDerivedAttributes
+    // so that preparation methods can run without crashing on undefined references.
+    resources: {
+      action: { value: 0, threshold: 0 },
+      wounds: { value: 0, threshold: 0 },
+      strain: { value: 0, threshold: 0 },
+      encumbrance: { value: 0, threshold: 0 },
+    },
+    skills: {},
+    movement: { sizeBonus: 0, strideBonus: 0, engagementBonus: 0 },
+    status: {},
+  }
+}
+
+/**
+ * Minimal species data mirroring the fields read by
+ * `_getWoundThresholdBonus` and `_getStrainThresholdBonus`.
+ *
+ * @param {number} woundModifier
+ * @param {number} strainModifier
+ * @param {object} [characteristics] - Per-characteristic base values used during #prepareSpecies.
+ *   Defaults to 2 for all characteristics when not supplied.
+ * @returns {object}
+ */
+function buildSpecies(woundModifier, strainModifier, characteristics = {}) {
+  const baseCharacteristics = {
+    brawn: 2,
+    agility: 2,
+    intellect: 2,
+    cunning: 2,
+    willpower: 2,
+    presence: 2,
+    ...characteristics,
+  }
+  return {
+    characteristics: baseCharacteristics,
+    freeSkills: new Set(),
+    startingExperience: 0,
+    woundThreshold: { modifier: woundModifier },
+    strainThreshold: { modifier: strainModifier },
+  }
+}
+
+/**
+ * Minimal mock parent sufficient for `_prepareResources` and `prepareDerivedData`.
+ * Provides the actor-level properties accessed during derived data preparation.
+ *
+ * @returns {object}
+ */
+function buildMockParent() {
+  return {
+    isIncapacitated: false,
+    isWeakened: false,
+    statuses: new Set(),
+    callActorHooks: () => {},
+    isL0: false,
+    items: [],
+    type: 'character',
+  }
+}
+
+describe('SwerpgCharacter — threshold bonus methods', () => {
+  describe('_getWoundThresholdBonus', () => {
+    test('returns species woundThreshold modifier when species is set', () => {
+      const character = new SwerpgCharacter(buildCharacterData({ species: buildSpecies(10, 0) }))
+      expect(character._getWoundThresholdBonus()).toBe(10)
+    })
+
+    test('returns 0 when species is null', () => {
+      const character = new SwerpgCharacter(buildCharacterData({ species: null }))
+      expect(character._getWoundThresholdBonus()).toBe(0)
+    })
+
+    test('returns 0 when species has no woundThreshold', () => {
+      const character = new SwerpgCharacter(buildCharacterData({ species: { characteristics: {}, freeSkills: new Set(), startingExperience: 0 } }))
+      expect(character._getWoundThresholdBonus()).toBe(0)
+    })
+  })
+
+  describe('_getStrainThresholdBonus', () => {
+    test('returns species strainThreshold modifier when species is set', () => {
+      const character = new SwerpgCharacter(buildCharacterData({ species: buildSpecies(0, 8) }))
+      expect(character._getStrainThresholdBonus()).toBe(8)
+    })
+
+    test('returns 0 when species is null', () => {
+      const character = new SwerpgCharacter(buildCharacterData({ species: null }))
+      expect(character._getStrainThresholdBonus()).toBe(0)
+    })
+
+    test('returns 0 when species has no strainThreshold', () => {
+      const character = new SwerpgCharacter(buildCharacterData({ species: { characteristics: {}, freeSkills: new Set(), startingExperience: 0 } }))
+      expect(character._getStrainThresholdBonus()).toBe(0)
+    })
+  })
+})
+
+describe('SwerpgCharacter — threshold schema', () => {
+  test('defineSchema does not include a thresholds field', () => {
+    const schema = SwerpgCharacter.defineSchema()
+    expect(schema).not.toHaveProperty('thresholds')
+  })
+})
+
+describe('SwerpgCharacter — wound threshold calculation contract', () => {
+  test('wounds.threshold equals brawn + species woundThreshold modifier', () => {
+    // brawn base comes from species.characteristics.brawn (set to 3) after #prepareSpecies
+    const species = buildSpecies(10, 0, { brawn: 3 })
+    const character = new SwerpgCharacter(buildCharacterData({ species }))
+    character.parent = buildMockParent()
+
+    // prepareBaseData populates characteristic rank.value via #prepareSpecies, then
+    // _prepareDerivedAttributes reads rank.value and _getWoundThresholdBonus() to set the threshold
+    character.prepareBaseData()
+    character.prepareDerivedData()
+
+    expect(character.resources.wounds.threshold).toBe(3 + 10)
+  })
+
+  test('wounds.threshold equals brawn when species woundThreshold.modifier is 0', () => {
+    const species = buildSpecies(0, 0, { brawn: 4 })
+    const character = new SwerpgCharacter(buildCharacterData({ species }))
+    character.parent = buildMockParent()
+
+    character.prepareBaseData()
+    character.prepareDerivedData()
+
+    expect(character.resources.wounds.threshold).toBe(4)
+  })
+
+  test('wounds.threshold equals brawn with non-zero strain modifier only', () => {
+    // wound modifier is 0 — the strain modifier (5) must not bleed into wound threshold
+    const species = buildSpecies(0, 5, { brawn: 2 })
+    const character = new SwerpgCharacter(buildCharacterData({ species }))
+    character.parent = buildMockParent()
+
+    character.prepareBaseData()
+    character.prepareDerivedData()
+
+    expect(character.resources.wounds.threshold).toBe(2)
+  })
+})
+
+describe('SwerpgCharacter — strain threshold calculation contract', () => {
+  test('strain.threshold equals willpower + species strainThreshold modifier', () => {
+    // willpower base comes from species.characteristics.willpower (set to 3) after #prepareSpecies
+    const species = buildSpecies(0, 8, { willpower: 3 })
+    const character = new SwerpgCharacter(buildCharacterData({ species }))
+    character.parent = buildMockParent()
+
+    character.prepareBaseData()
+    character.prepareDerivedData()
+
+    expect(character.resources.strain.threshold).toBe(3 + 8)
+  })
+
+  test('strain.threshold equals willpower when species strainThreshold.modifier is 0', () => {
+    const species = buildSpecies(0, 0, { willpower: 4 })
+    const character = new SwerpgCharacter(buildCharacterData({ species }))
+    character.parent = buildMockParent()
+
+    character.prepareBaseData()
+    character.prepareDerivedData()
+
+    expect(character.resources.strain.threshold).toBe(4)
+  })
+
+  test('strain.threshold equals willpower with non-zero wound modifier only', () => {
+    // strain modifier is 0 — the wound modifier (5) must not bleed into strain threshold
+    const species = buildSpecies(5, 0, { willpower: 2 })
+    const character = new SwerpgCharacter(buildCharacterData({ species }))
+    character.parent = buildMockParent()
+
+    character.prepareBaseData()
+    character.prepareDerivedData()
+
+    expect(character.resources.strain.threshold).toBe(2)
+  })
+})


### PR DESCRIPTION
## Objectif

Supprimer le transport intermédiaire `system.thresholds.wounds` / `system.thresholds.strain` dans `SwerpgCharacter`. Ces champs ne servaient qu'à recopier les modificateurs de l'espèce vers `#calculateWoundThreshold` / `#calculateStrainThreshold`.

## Changements

### `module/models/character.mjs`
- Suppression de `schema.thresholds` (champ persisted). Les données existantes `system.thresholds.wounds` / `system.thresholds.strain` deviennent inertes — pas de migration.
- Suppression des affectations `thresholds.wounds = species.woundThreshold.modifier` / `thresholds.strain = species.strainThreshold.modifier` dans `#prepareSpecies()`.
- Ajout des overrides `_getWoundThresholdBonus()` et `_getStrainThresholdBonus()` qui lisent directement `this.details.species?.woundThreshold?.modifier` / `this.details.species?.strainThreshold?.modifier`.

### `module/models/actor-type.mjs`
- Ajout des méthodes protégées `_getWoundThresholdBonus()` et `_getStrainThresholdBonus()` (retournent `0` par défaut pour les adversaires).
- `#calculateWoundThreshold` et `#calculateStrainThreshold` lisent désormais `actor._getWoundThresholdBonus()` / `actor._getStrainThresholdBonus()` au lieu de `actor.thresholds.wounds` / `actor.thresholds.strain`.

### `tests/models/character-thresholds.test.mjs`
- Nouveau fichier dédié (216 lignes) qui verrouille :
  - Le contrat des méthodes de bonus (`_getWoundThresholdBonus`, `_getStrainThresholdBonus`)
  - L'absence du champ `thresholds` dans le schema
  - Le calcul métier complet : `wounds.threshold = brawn + species.woundThreshold.modifier`, `strain.threshold = willpower + species.strainThreshold.modifier`
  - La non-régression avec espèces absentes ou modificateurs manquants
  - L'isolation entre bonus wound et strain (non-contamination)

### `tests/models/character-specializations.test.mjs`
- Retrait du champ `thresholds` obsolète dans `buildCharacterData()`.

## Périmètre exclu

- `resources.wounds.threshold` / `resources.strain.threshold` : noms publics conservés.
- `resources.*.max = Math.ceil(1.5 * resources.*.threshold)` : inchangé.
- Données persistées `system.thresholds\* dans les pregens YAML : inchangées (deviennent legacy shape).

## Validation

```bash
pnpm vitest run tests/models/character-thresholds.test.mjs tests/models/character-specializations.test.mjs
```

Closes #394