### PR TITLE
refactor(character): correct initialization of SetField details.specializations

### DIFF
--- a/documentation/plan/character-sheet/refactor/396-corriger-l-initialisation-du-setfield-details-specializations-dans-swerpg-character.md
+++ b/documentation/plan/character-sheet/refactor/396-corriger-l-initialisation-du-setfield-details-specializations-dans-swerpg-character.md
@@ -1,0 +1,48 @@
+# Plan — Corriger l'initialisation du `SetField details.specializations` dans `SwerpgCharacter`
+
+**Issue** : [#396 — Refactor: corriger l'initialisation du SetField details.specializations dans SwerpgCharacter](https://github.com/herveDarritchon/foundryvtt-swerpg/issues/396)
+
+## Décision de périmètre
+
+- **À faire** : conserver `details.specializations` en `SetField`, corriger son contrat d'initialisation, puis simplifier les usages runtime devenus inutilement défensifs dans `character.mjs`.
+- **À ne pas faire** : ne pas remplacer le champ par un `ArrayField`, ne pas refondre la persistance des spécialisations, ne pas étendre la refactor aux autres collections du modèle.
+- **Hypothèse retenue** : Foundry sérialise correctement un `SetField` en tableau côté document, donc `initial: []` est la forme attendue pour l'initialisation canonique.
+
+## Fichiers impactés
+
+| Fichier | Nature du changement |
+| --- | --- |
+| `module/models/character.mjs` | Corriger les options du `SetField` et retirer les `Array.from(... || [])` devenus inutiles sur `details.specializations` |
+| `tests/models/character-specializations.test.mjs` | Verrouiller le contrat de schéma et la disponibilité d'un `Set` vide par défaut |
+
+## Étapes
+
+### 1. Stabiliser le contrat du champ `details.specializations`
+
+- Sur le `SetField` externe, définir explicitement `{ required: true, nullable: false, initial: [] }`.
+- Sur le `SchemaField` interne, retirer `nullable: true, initial: null` si ces options ne servent qu'à tolérer un état impossible pour une entrée d'un `Set`.
+- Conserver inchangée la structure métier des spécialisations (`specializationId`, `treeUuid`, `name`, `img`, `freeSkillRank`, `specializationSkills`, etc.).
+
+### 2. Simplifier les accès runtime dans `SwerpgCharacter`
+
+- Remplacer les usages `Array.from(this.details.specializations || [])` par `Array.from(this.details.specializations)` dans `#getFreeSkillStatus`, `#prepareSpecializations`, `acquireSpecialization` et `removeSpecialization`.
+- Ne retirer que la garde devenue inutile sur la collection racine `specializations` ; ne pas élargir la refactor aux gardes sur des sous-champs qui peuvent encore être absents dans les données métier.
+- Préserver le format de persistance actuel des updates (`'system.details.specializations': [...]`).
+
+### 3. Adapter les tests de contrat et de non-régression
+
+- Étendre le test de schéma pour vérifier que `details.specializations` reste un `SetField` avec `initial: []` et `nullable: false`.
+- Ajouter une non-régression qui construit un `SwerpgCharacter` sans `details.specializations` explicite et confirme que la préparation lit un `Set` vide sans fallback `|| []`.
+- Conserver les tests d'acquisition/suppression qui valident que les payloads d'update restent des tableaux d'objets sérialisables.
+
+## Points de vigilance
+
+- `SetField` reste le contrat du data model ; la simplification ne doit pas casser les composants UI Foundry qui s'appuient sur ce type.
+- La correction ne doit pas introduire de migration de données : la forme persistée attendue reste une collection d'objets de spécialisation.
+- Si un test applicatif de fiche repose sur `details.specializations` absent ou `null`, l'ajuster pour refléter le nouveau contrat canonique : collection toujours présente, éventuellement vide.
+
+## Résultat attendu
+
+- `details.specializations` est toujours initialisé comme un `Set` non nul.
+- `character.mjs` ne contient plus de `Array.from(this.details.specializations || [])`.
+- Les flux de spécialisation côté modèle conservent le même comportement fonctionnel et le même format de persistance.

--- a/module/models/character.mjs
+++ b/module/models/character.mjs
@@ -177,16 +177,14 @@ export default class SwerpgCharacter extends SwerpgActorType {
         { required: true, nullable: true, initial: null },
       ),
       specializations: new fields.SetField(
-        new fields.SchemaField(
-          {
-            specializationId: new fields.StringField({ required: false, blank: false, initial: undefined }),
-            treeUuid: new fields.DocumentUUIDField({ type: 'Item', required: false, nullable: true, initial: undefined }),
-            name: new fields.StringField({ blank: false }),
-            img: new fields.StringField(),
-            ...SwerpgSpecialization.defineSchema(),
-          },
-          { required: true, nullable: true, initial: null },
-        ),
+        new fields.SchemaField({
+          specializationId: new fields.StringField({ required: false, blank: false, initial: undefined }),
+          treeUuid: new fields.DocumentUUIDField({ type: 'Item', required: false, nullable: true, initial: undefined }),
+          name: new fields.StringField({ blank: false }),
+          img: new fields.StringField(),
+          ...SwerpgSpecialization.defineSchema(),
+        }),
+        { required: true, nullable: false, initial: [] },
       ),
       specialities: new fields.ArrayField(
         new fields.SchemaField({
@@ -428,7 +426,7 @@ export default class SwerpgCharacter extends SwerpgActorType {
     const career = this.details.career
     const isCareer = career ? Array.from(career.careerSkills || []).some((s) => s.id === skillId) : false
 
-    const specializations = Array.from(this.details.specializations || [])
+    const specializations = Array.from(this.details.specializations)
     const isSpecialization = specializations.some((spec) => Array.from(spec.specializationSkills || []).some((s) => s.id === skillId))
 
     return { isCareer, isSpecialization }
@@ -442,7 +440,7 @@ export default class SwerpgCharacter extends SwerpgActorType {
    */
   #prepareSpecializations() {
     let totalFreeRanks = 0
-    for (const specialization of Array.from(this.details.specializations || [])) {
+    for (const specialization of Array.from(this.details.specializations)) {
       totalFreeRanks += specialization?.freeSkillRank || 0
     }
 
@@ -557,7 +555,7 @@ export default class SwerpgCharacter extends SwerpgActorType {
       freeSkillRank: 0,
     }
 
-    const specializations = Array.from(this.details.specializations || [])
+    const specializations = Array.from(this.details.specializations)
     const updateData = {
       'system.details.specializations': [...specializations, acquiredSpecialization],
     }
@@ -582,7 +580,7 @@ export default class SwerpgCharacter extends SwerpgActorType {
    */
   async removeSpecialization(specializationKey) {
     const actor = this.parent
-    const specializations = Array.from(this.details.specializations || [])
+    const specializations = Array.from(this.details.specializations)
     const remaining = specializations.filter((spec) => {
       const key = spec.specializationId || spec.treeUuid || spec.name
       return key !== specializationKey

--- a/tests/models/character-specializations.test.mjs
+++ b/tests/models/character-specializations.test.mjs
@@ -2,7 +2,7 @@ import { describe, expect, test } from 'vitest'
 
 import SwerpgCharacter from '../../module/models/character.mjs'
 
-function buildCharacterData({ specializations } = {}) {
+function buildCharacterData({ specializations = new Set() } = {}) {
   const characteristicRank = { base: 1, trained: 0, bonus: 0, value: 1 }
 
   return {
@@ -44,6 +44,15 @@ describe('SwerpgCharacter — owned specializations', () => {
       expect(specializationSchema.treeUuid).toBeInstanceOf(foundry.data.fields.DocumentUUIDField)
       expect(specializationSchema.treeUuid.config.required).toBe(false)
       expect(specializationSchema.treeUuid.config.type).toBe('Item')
+    })
+
+    test('details.specializations is a SetField with required:true, nullable:false, and initial:[]', () => {
+      const specializationsField = SwerpgCharacter.defineSchema().details.schema.specializations
+
+      expect(specializationsField).toBeInstanceOf(foundry.data.fields.SetField)
+      expect(specializationsField.config.required).toBe(true)
+      expect(specializationsField.config.nullable).toBe(false)
+      expect(specializationsField.config.initial).toEqual([])
     })
   })
 
@@ -87,9 +96,24 @@ describe('SwerpgCharacter — owned specializations', () => {
       expect(character.progression.freeSkillRanks.specialization.gained).toBe(0)
     })
 
-    test('handles missing specializations without throwing', () => {
+    test('handles empty specializations without throwing', () => {
+      // The SetField contract guarantees a non-null Set; buildCharacterData defaults to new Set()
       const character = new SwerpgCharacter(buildCharacterData())
 
+      expect(() => character.prepareBaseData()).not.toThrow()
+      expect(character.progression.freeSkillRanks.specialization.gained).toBe(0)
+    })
+
+    test('details.specializations is a non-null Set when initialised with the canonical default', () => {
+      // buildCharacterData defaults to new Set(), reflecting the SetField initial:[] contract
+      const character = new SwerpgCharacter(buildCharacterData())
+
+      // The Set is always available — no || [] fallback needed in character.mjs
+      expect(character.details.specializations).toBeInstanceOf(Set)
+      expect(character.details.specializations).not.toBeNull()
+      expect(character.details.specializations.size).toBe(0)
+
+      // prepareBaseData must iterate the set directly without any fallback guard
       expect(() => character.prepareBaseData()).not.toThrow()
       expect(character.progression.freeSkillRanks.specialization.gained).toBe(0)
     })


### PR DESCRIPTION
## Summary

- Correct initialization of SetField.details.specializations in module/models/character.mjs
- Update test covering specializations: tests/models/character-specializations.test.mjs
- Add implementation plan: documentation/plan/character-sheet/refactor/396-corriger-l-initialisation-du-setfield-details-specializations-dans-swerpg-character.md

## Context

This branch fixes a refactor bug where the SetField used for character specializations was not initialized correctly, which could lead to incorrect runtime data in Character documents. The change is limited to the Character model implementation and the related unit test.

## Tests

- Not run (not requested).

## Notes

- Diff vs develop: module/models/character.mjs (modified), tests/models/character-specializations.test.mjs (modified), documentation/plan/... (added).
