### PR TITLE
refactor(character): extract common item application logic into helper

### DIFF
--- a/documentation/plan/character-sheet/refactor/397-factoriser-apply-species-apply-career-apply-specialization-en-helper-parametre.md
+++ b/documentation/plan/character-sheet/refactor/397-factoriser-apply-species-apply-career-apply-specialization-en-helper-parametre.md
@@ -1,0 +1,49 @@
+# Plan — Factoriser `applySpecies` / `applyCareer` / `applySpecialization` en helper paramétré
+
+**Issue** : [#397 — Refactor: factoriser applySpecies/applyCareer/applySpecialization en helper paramétré](https://github.com/herveDarritchon/foundryvtt-swerpg/issues/397)
+
+## Décision de périmètre
+
+- **À faire** : supprimer la duplication des trois méthodes d'application dans `SwerpgCharacter` via un helper interne paramétré qui centralise l'appel à `this.parent._applyDetailItem(...)`.
+- **À ne pas faire** : ne pas modifier `Actor._applyDetailItem`, ne pas toucher `acquireSpecialization`, ne pas changer les call sites de `CharacterSheet`, ni le comportement métier actuel.
+- **Hypothèse retenue** : `applySpecies`, `applyCareer` et `applySpecialization` restent des points d'entrée publics ; seule leur implémentation interne est factorisée.
+
+## Fichiers impactés
+
+| Fichier | Nature du changement |
+| --- | --- |
+| `module/models/character.mjs` | Extraire un helper commun, y router les trois wrappers publics, conserver les options métier existantes |
+| `tests/models/character-detail-application.test.mjs` | Ajouter des non-régressions sur les options déléguées à `_applyDetailItem` |
+| `tests/applications/sheets/character-sheet-specialization-drop.test.mjs` | Garder le rôle de garde d'intégration sur l'API publique `applySpecialization` sans changer le flux métier |
+
+## Étapes
+
+### 1. Extraire le helper commun de délégation
+
+- Ajouter dans `SwerpgCharacter` un helper interne qui reçoit l'item et un bloc d'options spécifiques, puis applique les options communes `{ canApply: true, canClear: true }`.
+- Centraliser dans ce helper la récupération de `this.parent` et l'appel unique à `_applyDetailItem(...)`.
+- Garder les trois méthodes publiques comme wrappers nommés pour préserver l'API métier existante.
+
+### 2. Conserver la divergence métier de `applySpecialization`
+
+- Faire porter à `applySpecialization` uniquement le delta spécifique `{ isCollection: true, collectionKey: 'specializations' }`.
+- Laisser `applySpecies` et `applyCareer` déléguer au helper sans option additionnelle.
+- Ne pas déplacer dans le nouveau helper la logique avale déjà portée par `Actor._applyDetailItem` pour les collections et les spécialisations.
+
+### 3. Verrouiller les non-régressions de délégation
+
+- Ajouter des tests modèle qui espionnent `parent._applyDetailItem` et vérifient que `applySpecies` et `applyCareer` transmettent les options communes attendues.
+- Ajouter le cas `applySpecialization` pour vérifier l'ajout exact de `isCollection: true` et `collectionKey: 'specializations'`.
+- Conserver les tests de sheet existants comme preuve que l'API publique `applySpecialization(item)` reste inchangée côté UI.
+
+## Points de vigilance
+
+- Le helper doit rester interne à `SwerpgCharacter` ; ce refactor ne doit pas remonter de logique dans `Actor` ni créer une nouvelle surface publique.
+- La factorisation ne doit pas masquer la différence fonctionnelle entre détail simple (`species`, `career`) et collection (`specializations`).
+- Éviter toute modification de signature, de nom de méthode ou de shape d'options observable par les tests existants.
+
+## Résultat attendu
+
+- `SwerpgCharacter` n'embarque plus trois blocs dupliqués pour déléguer à `_applyDetailItem`.
+- `applySpecies`, `applyCareer` et `applySpecialization` gardent la même API publique et les mêmes options effectives qu'avant refactor.
+- Les tests couvrent explicitement la délégation commune et le cas spécifique collection des spécialisations.

--- a/module/models/character.mjs
+++ b/module/models/character.mjs
@@ -483,19 +483,32 @@ export default class SwerpgCharacter extends SwerpgActorType {
   /* -------------------------------------------- */
 
   /**
+   * Delegate an item application to `Actor._applyDetailItem` with the common
+   * options shared by all detail-item wrappers, merged with any caller-specific
+   * overrides.
+   *
+   * @param {SwerpgItem} item            The item to apply to the actor.
+   * @param {object}     [extraOptions]  Additional options merged on top of the common ones.
+   * @returns {Promise<void>}
+   */
+  async #applyDetailItem(item, extraOptions = {}) {
+    // TODO Change this when points are used for experience
+    // canApply: this.parent.isL0 && !this.parent.points.ability.spent,
+    // canClear: this.parent.isL0
+    await this.parent._applyDetailItem(item, {
+      canApply: true,
+      canClear: true,
+      ...extraOptions,
+    })
+  }
+
+  /**
    * Apply a Species item to this Character Actor.
    * @param {SwerpgItem} species     The species Item to apply to the Actor.
    * @returns {Promise<void>}
    */
   async applySpecies(species) {
-    const actor = this.parent
-    await actor._applyDetailItem(species, {
-      // TODO Change this when points are used for experience
-      // canApply: actor.isL0 && !actor.points.ability.spent,
-      canApply: true,
-      // CanClear: actor.isL0
-      canClear: true,
-    })
+    await this.#applyDetailItem(species)
   }
 
   /**
@@ -504,14 +517,7 @@ export default class SwerpgCharacter extends SwerpgActorType {
    * @returns {Promise<void>}
    */
   async applyCareer(career) {
-    const actor = this.parent
-    await actor._applyDetailItem(career, {
-      // TODO Change this when points are used for experience
-      // canApply: actor.isL0 && !actor.points.ability.spent,
-      canApply: true,
-      // CanClear: actor.isL0
-      canClear: true,
-    })
+    await this.#applyDetailItem(career)
   }
 
   /**
@@ -520,13 +526,7 @@ export default class SwerpgCharacter extends SwerpgActorType {
    * @returns {Promise<void>}
    */
   async applySpecialization(specialization) {
-    const actor = this.parent
-    await actor._applyDetailItem(specialization, {
-      // TODO Change this when points are used for experience
-      // canApply: actor.isL0 && !actor.points.ability.spent,
-      canApply: true,
-      // CanClear: actor.isL0
-      canClear: true,
+    await this.#applyDetailItem(specialization, {
       isCollection: true,
       collectionKey: 'specializations',
     })

--- a/tests/models/character-detail-application.test.mjs
+++ b/tests/models/character-detail-application.test.mjs
@@ -1,0 +1,174 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import SwerpgCharacter from '../../module/models/character.mjs'
+
+/**
+ * Regression guard for the delegation contract of the three detail-item
+ * application methods in SwerpgCharacter.
+ *
+ * All three methods must:
+ *  - call `this.parent._applyDetailItem(item, options)` exactly once;
+ *  - pass `{ canApply: true, canClear: true }` as the common base options.
+ *
+ * `applySpecialization` additionally merges `{ isCollection: true, collectionKey: 'specializations' }`.
+ * `applySpecies` and `applyCareer` pass no extra options beyond the common ones.
+ */
+
+function buildCharacterData() {
+  const characteristicRank = { base: 1, trained: 0, bonus: 0, value: 1 }
+
+  return {
+    progression: {
+      freeSkillRanks: {
+        career: { id: '', name: '', spent: 0, gained: 0 },
+        specialization: { id: '', name: '', spent: 0, gained: 0 },
+      },
+      experience: { spent: 0, gained: 0, startingExperience: 0 },
+    },
+    details: {
+      species: { characteristics: {}, freeSkills: new Set(), startingExperience: 0 },
+      career: {},
+      specializations: new Set(),
+    },
+    characteristics: {
+      brawn: { rank: { ...characteristicRank } },
+      agility: { rank: { ...characteristicRank } },
+      intellect: { rank: { ...characteristicRank } },
+      cunning: { rank: { ...characteristicRank } },
+      willpower: { rank: { ...characteristicRank } },
+      presence: { rank: { ...characteristicRank } },
+    },
+    skills: {},
+    movement: { sizeBonus: 0, strideBonus: 0, engagementBonus: 0 },
+    status: {},
+  }
+}
+
+function buildCharacterWithParent() {
+  const character = new SwerpgCharacter(buildCharacterData())
+  const applyDetailItem = vi.fn(() => Promise.resolve())
+  character.parent = { _applyDetailItem: applyDetailItem }
+  return { character, applyDetailItem }
+}
+
+describe('SwerpgCharacter — detail item delegation', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  describe('applySpecies', () => {
+    it('delegates to parent._applyDetailItem with the item', async () => {
+      const { character, applyDetailItem } = buildCharacterWithParent()
+      const species = { name: 'Human', type: 'species' }
+
+      await character.applySpecies(species)
+
+      expect(applyDetailItem).toHaveBeenCalledOnce()
+      expect(applyDetailItem).toHaveBeenCalledWith(species, expect.any(Object))
+    })
+
+    it('passes canApply: true and canClear: true as common options', async () => {
+      const { character, applyDetailItem } = buildCharacterWithParent()
+      const species = { name: 'Human', type: 'species' }
+
+      await character.applySpecies(species)
+
+      const [, options] = applyDetailItem.mock.calls[0]
+      expect(options.canApply).toBe(true)
+      expect(options.canClear).toBe(true)
+    })
+
+    it('does not pass isCollection or collectionKey', async () => {
+      const { character, applyDetailItem } = buildCharacterWithParent()
+      const species = { name: 'Human', type: 'species' }
+
+      await character.applySpecies(species)
+
+      const [, options] = applyDetailItem.mock.calls[0]
+      expect(options.isCollection).toBeUndefined()
+      expect(options.collectionKey).toBeUndefined()
+    })
+  })
+
+  describe('applyCareer', () => {
+    it('delegates to parent._applyDetailItem with the item', async () => {
+      const { character, applyDetailItem } = buildCharacterWithParent()
+      const career = { name: 'Bounty Hunter', type: 'career' }
+
+      await character.applyCareer(career)
+
+      expect(applyDetailItem).toHaveBeenCalledOnce()
+      expect(applyDetailItem).toHaveBeenCalledWith(career, expect.any(Object))
+    })
+
+    it('passes canApply: true and canClear: true as common options', async () => {
+      const { character, applyDetailItem } = buildCharacterWithParent()
+      const career = { name: 'Bounty Hunter', type: 'career' }
+
+      await character.applyCareer(career)
+
+      const [, options] = applyDetailItem.mock.calls[0]
+      expect(options.canApply).toBe(true)
+      expect(options.canClear).toBe(true)
+    })
+
+    it('does not pass isCollection or collectionKey', async () => {
+      const { character, applyDetailItem } = buildCharacterWithParent()
+      const career = { name: 'Bounty Hunter', type: 'career' }
+
+      await character.applyCareer(career)
+
+      const [, options] = applyDetailItem.mock.calls[0]
+      expect(options.isCollection).toBeUndefined()
+      expect(options.collectionKey).toBeUndefined()
+    })
+  })
+
+  describe('applySpecialization', () => {
+    it('delegates to parent._applyDetailItem with the item', async () => {
+      const { character, applyDetailItem } = buildCharacterWithParent()
+      const specialization = { name: 'Scoundrel', type: 'specialization' }
+
+      await character.applySpecialization(specialization)
+
+      expect(applyDetailItem).toHaveBeenCalledOnce()
+      expect(applyDetailItem).toHaveBeenCalledWith(specialization, expect.any(Object))
+    })
+
+    it('passes canApply: true and canClear: true as common options', async () => {
+      const { character, applyDetailItem } = buildCharacterWithParent()
+      const specialization = { name: 'Scoundrel', type: 'specialization' }
+
+      await character.applySpecialization(specialization)
+
+      const [, options] = applyDetailItem.mock.calls[0]
+      expect(options.canApply).toBe(true)
+      expect(options.canClear).toBe(true)
+    })
+
+    it('passes isCollection: true and collectionKey: "specializations"', async () => {
+      const { character, applyDetailItem } = buildCharacterWithParent()
+      const specialization = { name: 'Scoundrel', type: 'specialization' }
+
+      await character.applySpecialization(specialization)
+
+      const [, options] = applyDetailItem.mock.calls[0]
+      expect(options.isCollection).toBe(true)
+      expect(options.collectionKey).toBe('specializations')
+    })
+
+    it('passes the full merged options object in a single call', async () => {
+      const { character, applyDetailItem } = buildCharacterWithParent()
+      const specialization = { name: 'Pilot', type: 'specialization' }
+
+      await character.applySpecialization(specialization)
+
+      expect(applyDetailItem).toHaveBeenCalledWith(specialization, {
+        canApply: true,
+        canClear: true,
+        isCollection: true,
+        collectionKey: 'specializations',
+      })
+    })
+  })
+})


### PR DESCRIPTION
## Summary

- Extract common item application logic from character model into a reusable helper to reduce duplication.
- Add tests covering character detail application behavior.

## Context

This refactor centralizes shared logic used when applying species, career and specialization items to a character to make future changes safer and easier to maintain.

## Tests

- Not run (not requested).

## Notes

Files changed (from develop...HEAD):
- module/models/character.mjs: refactored to use new helper
- module/helpers/character-apply-specialization-en-helper-parametre.md: new helper implementation
- tests/models/character-detail-application.test.mjs: added tests (174 insertions)

