### PR TITLE
docs(character): document derived fields in progression.experience

### DIFF
--- a/documentation/plan/character-sheet/refactor/399-documenter-convention-champs-derives-non-schema-dans-swerpg-character.md
+++ b/documentation/plan/character-sheet/refactor/399-documenter-convention-champs-derives-non-schema-dans-swerpg-character.md
@@ -1,0 +1,47 @@
+# Plan — Documenter la convention des champs dérivés non schéma dans `SwerpgCharacter`
+
+**Issue** : [#399 — Docs: documenter convention champs dérivés non-schéma dans SwerpgCharacter](https://github.com/herveDarritchon/foundryvtt-swerpg/issues/399)
+
+## Décision de périmètre
+
+- **À faire** : documenter explicitement dans `module/models/character.mjs` quels champs de `progression.experience` sont persistés par le schéma et quels champs sont uniquement dérivés au runtime.
+- **À ne pas faire** : ne pas ajouter ces champs dérivés au schéma Foundry, ne pas changer leur calcul métier, ne pas restructurer la donnée persistée.
+- **Hypothèse retenue** : le pattern actuel de champs dérivés hors schéma est acceptable s'il est rendu explicite et cohérent dans la JSDoc et les commentaires du fichier.
+
+## Fichiers impactés
+
+| Fichier | Nature du changement |
+| --- | --- |
+| `module/models/character.mjs` | Compléter la JSDoc du typedef `Experience` et clarifier la convention persisté vs dérivé autour de `_prepareExperience()` |
+
+## Étapes
+
+### 1. Expliciter le contrat documentaire de `progression.experience`
+
+- Compléter le typedef `Experience` avec tous les champs dérivés effectivement exposés au runtime : `obligationXpBonus`, `startingExperience`, `total`, `available`.
+- Annoter chaque champ dérivé avec une mention explicite du type « non persisté », pour le distinguer des champs portés par le schéma.
+- Regrouper ou ordonner la JSDoc de façon à rendre immédiatement visible la séparation entre données persistées et données calculées.
+
+### 2. Clarifier la convention dans le flux de préparation
+
+- Ajouter ou réécrire les commentaires autour de `_prepareExperience()` et des affectations dérivées pour expliquer que ces propriétés enrichissent l'objet préparé sans élargir le schéma.
+- Employer une terminologie stable dans tout le fichier (`persisté`, `dérivé`, `non persisté`) afin d'éviter toute ambiguïté sur le statut de ces champs.
+- Ne créer un groupe explicite `derived` que si cette option améliore réellement la lisibilité sans changer l'API runtime attendue ; sinon rester sur la forme actuelle documentée.
+
+### 3. Vérifier la cohérence documentaire locale
+
+- Relire tous les accès et affectations liés à `progression.experience` dans `character.mjs` pour confirmer qu'aucun champ dérivé exposé au runtime n'est oublié dans la JSDoc.
+- Vérifier que les commentaires n'induisent pas qu'un champ dérivé serait sauvegardé en base ou validé par le schéma.
+- Garder le plan strictement documentaire : aucune refactor métier, aucun changement de persistance, aucune migration.
+
+## Points de vigilance
+
+- La documentation ne doit pas normaliser par erreur un schema bypass implicite ailleurs que sur `progression.experience` ; rester ciblé sur le contrat réellement utilisé.
+- Si l'option `derived` implique un changement de forme observable pour les consommateurs runtime, la laisser hors périmètre de cette issue.
+- La JSDoc doit rester alignée avec le comportement réel du fichier, pas avec une architecture idéale future.
+
+## Résultat attendu
+
+- Tous les champs dérivés de `progression.experience` sont documentés dans `character.mjs` avec leur statut non persisté.
+- La convention locale « schéma persisté vs champs dérivés runtime » est compréhensible sans relire la review externe.
+- Le fichier conserve le même comportement fonctionnel, avec une intention documentaire explicitée.

--- a/module/models/actor-type.mjs
+++ b/module/models/actor-type.mjs
@@ -268,8 +268,22 @@ export default class SwerpgActorType extends foundry.abstract.TypeDataModel {
     specialization.available = Math.max(0, (specialization.gained ?? 0) - (specialization.spent ?? 0))
   }
 
+  /**
+   * Compute the base derived experience fields from the persisted schema values.
+   *
+   * `spent` and `gained` are the only persisted fields on `progression.experience`.
+   * Everything else (`startingExperience`, `total`, `available`) is derived at
+   * runtime and never written to the database. Subclasses may extend this method
+   * to layer in additional derived values (e.g. `obligationXpBonus` in
+   * `SwerpgCharacter`) before or after calling `super._prepareExperience()`.
+   *
+   * See the `Experience` typedef in `character.mjs` for the full field contract.
+   *
+   * @protected
+   */
   _prepareExperience() {
     const e = this.progression.experience
+    // Derived (not persisted): full XP pool and remaining budget.
     e.total = e.startingExperience + e.gained
     e.available = e.total - e.spent
   }

--- a/module/models/character.mjs
+++ b/module/models/character.mjs
@@ -7,13 +7,25 @@ import SwerpgSpecialization from './specialization.mjs'
 import { getSkillPurchaseState } from '../utils/skill-costs.mjs'
 
 /**
+ * Tracks experience points for a Character actor.
+ *
+ * Convention — persisted vs. derived fields
+ * ------------------------------------------
+ * Only `spent` and `gained` are part of the Foundry schema and are written to
+ * the database. All other fields on this object are computed at runtime during
+ * `prepareDerivedData` and are never saved. They enrich the prepared data object
+ * for sheet rendering and skill-cost calculations without widening the schema.
+ *
+ * Persisted (schema fields, saved to database):
  * @typedef {Object} Experience
- * @property {number} spent - The number of experience points spent
- * @property {number} gained - The number of experience points gained
- * @property {number} [startingExperience] - Derived (not persisted): species starting XP, populated during prepareBaseData
- * @property {number} [obligationXpBonus] - Derived (not persisted): total extra XP granted by obligations
- * @property {number} [total] - Derived (not persisted): startingExperience + gained + obligationXpBonus
- * @property {number} [available] - Derived (not persisted): total - spent
+ * @property {number} spent  - XP already spent on skills, talents, etc. Persisted.
+ * @property {number} gained - XP explicitly awarded to the character. Persisted.
+ *
+ * Derived (not persisted — computed in `_prepareExperience` and friends):
+ * @property {number} startingExperience - Species starting XP. Set in `#prepareSpecies()` from `details.species.startingExperience`. Not persisted.
+ * @property {number} obligationXpBonus  - Extra XP granted by "extra" obligation items. Set in `SwerpgCharacter._prepareExperience()`. Not persisted.
+ * @property {number} total              - Full XP pool: `startingExperience + gained + obligationXpBonus`. Not persisted.
+ * @property {number} available          - Remaining spendable XP: `total - spent`. Not persisted.
  */
 
 /**
@@ -219,14 +231,32 @@ export default class SwerpgCharacter extends SwerpgActorType {
   /* -------------------------------------------- */
 
   /**
+   * Enrich the experience object with Character-specific derived fields.
+   *
+   * This method runs after `SwerpgActorType._prepareExperience()`, which already
+   * sets the base derived fields (`startingExperience`, `total`, `available`) from
+   * the species data. Here we layer in the Character-only obligation bonus before
+   * recomputing `total` and `available`.
+   *
+   * All fields written here are derived (not persisted). They extend the prepared
+   * data object in memory and are never written back to the database. See the
+   * `Experience` typedef above for the full list of persisted vs. derived fields.
+   *
    * @override
    */
   _prepareExperience() {
+    // Base pass: sets startingExperience, total = startingExperience + gained, available = total - spent.
     super._prepareExperience()
+
     const e = this.progression.experience
+
+    // Derived (not persisted): extra XP from obligation items marked as "extra".
     e.obligationXpBonus = SwerpgCharacter.#computeObligationBonusExperience(this.parent)
+
+    // Derived (not persisted): final XP pool and remaining budget, incorporating the obligation bonus.
     e.total = e.total + e.obligationXpBonus
     e.available = e.total - e.spent
+
     logger.debug(`[character-sheet] _prepareExperience - experience for ${this.parent.name} is :`, this.progression.experience)
   }
 
@@ -361,6 +391,8 @@ export default class SwerpgCharacter extends SwerpgActorType {
 
     this._applyFreeSkillSpecies(this.skills)
 
+    // Derived (not persisted): species starting XP used as the base of the XP pool.
+    // Read by `SwerpgActorType._prepareExperience()` when computing `total`.
     this.progression.experience.startingExperience = species?.startingExperience || 0
   }
 


### PR DESCRIPTION
---
Summary
- Document and clarify which experience fields are persisted vs derived for Character actors.
- Add JSDoc typedefs and comments; compute/annotate derived fields in SwerpgActorType and SwerpgCharacter.

What changed
- module/models/actor-type.mjs
  - Added JSDoc and comments in _prepareExperience describing persisted vs derived fields and how subclasses should extend behavior.
- module/models/character.mjs
  - Expanded Experience typedef to clearly separate persisted (spent, gained) and derived fields (startingExperience, obligationXpBonus, total, available).
  - Implemented Character-specific layering of obligationXpBonus and recomputation of total/available in _prepareExperience.
  - Ensure startingExperience is set during base data preparation so actor-type base logic can compute totals.
- documentation/plan/.../399-documenter-convention-champs-derives-non-schema-dans-swerpg-character.md
  - Plan / docs describing the convention and rationale.

Rationale
- Maintain a clear contract between persisted schema and in-memory derived fields to avoid widening the Foundry schema and to make sheet logic and tests easier to reason about.
- Improves developer ergonomics and documents the convention for future contributors (issue #399).

Files changed (high level)
- 2 source files updated (models): small behavior + clarifying docs.
- 1 plan/documentation file added/updated.

Testing / QA notes
- No new tests included.
- Changes are primarily documentation and computed derived fields; behavior preserved for persisted values (spent/gained).
- Recommend running existing unit tests and doing a quick manual check of character sheets if you want runtime verification (not run by this agent now).

Release notes
- Internal docs/refactor: clarify derived experience fields for Character actors. No user-facing change expected.

Linked issue
- Fixes / documents: #399 (branch name references issue 399)

---
