### PR TITLE
refactor(character): clarify semantics of wounds and strain thresholds

### DIFF
--- a/documentation/plan/character-sheet/refactor/400-clarifier-semantique-thresholds-wounds-strain-dans-swerpg-character.md
+++ b/documentation/plan/character-sheet/refactor/400-clarifier-semantique-thresholds-wounds-strain-dans-swerpg-character.md
@@ -1,0 +1,49 @@
+# Plan — Clarifier la sémantique des seuils `wounds/strain` dans `SwerpgCharacter`
+
+**Issue** : [#400 — Refactor: clarifier sémantique thresholds.wounds/strain dans SwerpgCharacter](https://github.com/herveDarritchon/foundryvtt-swerpg/issues/400)
+
+## Décision de périmètre
+
+- **À faire** : rendre explicite, dans le code et les tests, la différence entre le **bonus additif** fourni par l'espèce et le **seuil final** exposé dans `resources.wounds.threshold` / `resources.strain.threshold`.
+- **À ne pas faire** : ne pas renommer dans cette issue les champs persistés `details.species.woundThreshold` / `details.species.strainThreshold`, ne pas introduire de migration de données, ne pas modifier la règle métier de calcul des seuils.
+- **Hypothèse retenue** : depuis le retrait du stub runtime `thresholds.wounds/strain`, le besoin restant est un nettoyage sémantique ciblé, pas une refonte du schéma.
+
+## Fichiers impactés
+
+| Fichier | Nature du changement |
+| --- | --- |
+| `module/models/actor-type.mjs` | Clarifier le contrat entre helpers de bonus et calcul des seuils finaux |
+| `module/models/character.mjs` | Documenter la provenance du bonus d'espèce et la sémantique locale côté Character |
+| `tests/models/character-thresholds.test.mjs` | Aligner les libellés et assertions sur le contrat « bonus additif » vs « seuil final » |
+
+## Étapes
+
+### 1. Normaliser le vocabulaire autour du calcul des seuils
+
+- Vérifier dans `actor-type.mjs` et `character.mjs` qu'aucun nom local, commentaire ou JSDoc ne laisse entendre qu'un bonus additif serait lui-même un seuil absolu.
+- Employer systématiquement le vocabulaire `bonus` pour `_getWoundThresholdBonus()` / `_getStrainThresholdBonus()` et `threshold` pour la valeur finale écrite dans `resources.*.threshold`.
+- Ne conserver `threshold` que pour les ressources calculées ou pour la formule métier portée par l'espèce.
+
+### 2. Documenter explicitement la sémantique côté `SwerpgCharacter`
+
+- Ajouter une note claire près des hooks `_getWoundThresholdBonus()` / `_getStrainThresholdBonus()` indiquant que `details.species.*Threshold.modifier` représente la partie additive de la formule d'espèce, pas le seuil final du personnage.
+- Si nécessaire, clarifier en commentaire dans `#prepareSpecies()` ou `_prepareResources()` que le modèle Character ne stocke plus de champ intermédiaire `thresholds.wounds/strain`.
+- Garder inchangée l'API runtime observable : `resources.wounds.threshold` et `resources.strain.threshold` restent les valeurs absolues consommées par le reste du système.
+
+### 3. Verrouiller le contrat sémantique dans les tests
+
+- Renommer les blocs de tests et messages d'intention pour distinguer explicitement les **bonus d'espèce** des **seuils calculés**.
+- Ajouter ou ajuster une non-régression montrant que le bonus lu depuis l'espèce alimente bien le calcul, tandis que `resources.*.threshold` reste la sortie finale absolue.
+- Confirmer qu'aucun test ne repose encore sur l'ancien vocabulaire `thresholds.wounds/strain` comme donnée intermédiaire du modèle Character.
+
+## Points de vigilance
+
+- Ne pas transformer cette issue en migration de schéma : le renommage des champs persistés de l'espèce serait plus large et hors périmètre.
+- Ne pas casser la distinction entre la formule d'espèce (`modifier` + `abilityKey`) et la donnée calculée de l'acteur (`resources.*.threshold`).
+- Ne pas toucher à la règle existante `resources.*.max = Math.ceil(1.5 * resources.*.threshold)`.
+
+## Résultat attendu
+
+- La sémantique `bonus additif` vs `seuil final` est explicite et non ambiguë dans `SwerpgCharacter` et `SwerpgActorType`.
+- Aucun reliquat de vocabulaire trompeur `thresholds.wounds/strain` ne subsiste dans le flux Character concerné par l'issue.
+- Le comportement métier et la forme de données observée par les consommateurs restent inchangés.

--- a/module/models/actor-type.mjs
+++ b/module/models/actor-type.mjs
@@ -30,8 +30,14 @@ import { ENCUMBRANCE_BASE_BONUS } from '../config/progression.mjs'
 
 /**
  * @typedef {Object} DerivedAttributes
- * @property {number} woundThreshold Amount of Wounds a character can withstand before being knocked out.
- * @property {number} strainThreshold Amount of Strain a character can withstand before being stunned.
+ * @property {number} woundThreshold   Final wound threshold written to `resources.wounds.threshold`.
+ *   Equals brawn rank + the additive bonus returned by `_getWoundThresholdBonus()`.
+ *   Do not confuse with the bonus itself: the bonus is a partial additive value,
+ *   while this field holds the absolute threshold consumed by the rest of the system.
+ * @property {number} strainThreshold  Final strain threshold written to `resources.strain.threshold`.
+ *   Equals willpower rank + the additive bonus returned by `_getStrainThresholdBonus()`.
+ *   Do not confuse with the bonus itself: the bonus is a partial additive value,
+ *   while this field holds the absolute threshold consumed by the rest of the system.
  * @property {number} encumbranceThreshold Amount of Encumbrance a character can carry before being encumbered.
  * @property {DefenseAttributes} defense Determines how difficult it is to hit a character with an attack.
  * @property {number} soakValue Determines how much incoming damage a character can shrug off before being seriously wounded.
@@ -350,11 +356,17 @@ export default class SwerpgActorType extends foundry.abstract.TypeDataModel {
   /* -------------------------------------------- */
 
   /**
-   * Return the bonus to add to the wound threshold for this actor subtype.
+   * Return the additive wound bonus for this actor subtype.
+   *
+   * This value is combined with the brawn characteristic rank inside
+   * `#calculateWoundThreshold` to produce the **final** wound threshold
+   * written to `resources.wounds.threshold`. It is a partial contribution,
+   * not the absolute threshold itself.
+   *
    * Subclasses override this method to provide species or item-based bonuses.
    * The base implementation returns 0, which is correct for adversaries.
    *
-   * @returns {number} Non-negative bonus applied on top of the brawn characteristic.
+   * @returns {number} Additive bonus applied on top of the brawn characteristic rank.
    * @protected
    */
   _getWoundThresholdBonus() {
@@ -362,11 +374,17 @@ export default class SwerpgActorType extends foundry.abstract.TypeDataModel {
   }
 
   /**
-   * Return the bonus to add to the strain threshold for this actor subtype.
+   * Return the additive strain bonus for this actor subtype.
+   *
+   * This value is combined with the willpower characteristic rank inside
+   * `#calculateStrainThreshold` to produce the **final** strain threshold
+   * written to `resources.strain.threshold`. It is a partial contribution,
+   * not the absolute threshold itself.
+   *
    * Subclasses override this method to provide species or item-based bonuses.
    * The base implementation returns 0, which is correct for adversaries.
    *
-   * @returns {number} Non-negative bonus applied on top of the willpower characteristic.
+   * @returns {number} Additive bonus applied on top of the willpower characteristic rank.
    * @protected
    */
   _getStrainThresholdBonus() {

--- a/module/models/character.mjs
+++ b/module/models/character.mjs
@@ -263,12 +263,21 @@ export default class SwerpgCharacter extends SwerpgActorType {
   /* -------------------------------------------- */
 
   /**
-   * Return the wound threshold bonus sourced from the character's species.
-   * Reads `details.species.woundThreshold.modifier` and defaults to 0 when no
-   * species is set or the modifier is absent.
+   * Return the additive wound bonus sourced from the character's species.
+   *
+   * `details.species.woundThreshold.modifier` is the species-specific additive
+   * contribution to the wound threshold formula. It is **not** the final wound
+   * threshold — the absolute final value is computed in
+   * `SwerpgActorType.#calculateWoundThreshold` as:
+   *   `brawn rank + _getWoundThresholdBonus()`
+   * and written to `resources.wounds.threshold`.
+   *
+   * Note: there is no intermediate `thresholds.wounds` field on the Character
+   * model. The only runtime output consumed by the rest of the system is
+   * `resources.wounds.threshold`.
    *
    * @override
-   * @returns {number}
+   * @returns {number} Additive bonus from the species formula. Defaults to 0 when no species is set.
    */
   _getWoundThresholdBonus() {
     return this.details.species?.woundThreshold?.modifier ?? 0
@@ -277,12 +286,21 @@ export default class SwerpgCharacter extends SwerpgActorType {
   /* -------------------------------------------- */
 
   /**
-   * Return the strain threshold bonus sourced from the character's species.
-   * Reads `details.species.strainThreshold.modifier` and defaults to 0 when no
-   * species is set or the modifier is absent.
+   * Return the additive strain bonus sourced from the character's species.
+   *
+   * `details.species.strainThreshold.modifier` is the species-specific additive
+   * contribution to the strain threshold formula. It is **not** the final strain
+   * threshold — the absolute final value is computed in
+   * `SwerpgActorType.#calculateStrainThreshold` as:
+   *   `willpower rank + _getStrainThresholdBonus()`
+   * and written to `resources.strain.threshold`.
+   *
+   * Note: there is no intermediate `thresholds.strain` field on the Character
+   * model. The only runtime output consumed by the rest of the system is
+   * `resources.strain.threshold`.
    *
    * @override
-   * @returns {number}
+   * @returns {number} Additive bonus from the species formula. Defaults to 0 when no species is set.
    */
   _getStrainThresholdBonus() {
     return this.details.species?.strainThreshold?.modifier ?? 0
@@ -500,11 +518,13 @@ export default class SwerpgCharacter extends SwerpgActorType {
     super._prepareResources()
     const r = this.resources
 
-    // Wounds
+    // Wounds: max derived from the final wound threshold (resources.wounds.threshold).
+    // resources.wounds.threshold is set by _prepareDerivedAttributes via _getWoundThresholdBonus().
     r.wounds.max = Math.ceil(1.5 * r.wounds.threshold)
     r.wounds.value = Math.clamp(r.wounds.value, 0, r.wounds.max)
 
-    // Madness
+    // Strain: max derived from the final strain threshold (resources.strain.threshold).
+    // resources.strain.threshold is set by _prepareDerivedAttributes via _getStrainThresholdBonus().
     r.strain.max = Math.ceil(1.5 * r.strain.threshold)
     r.strain.value = Math.clamp(r.strain.value, 0, r.strain.max)
   }

--- a/tests/models/character-thresholds.test.mjs
+++ b/tests/models/character-thresholds.test.mjs
@@ -96,65 +96,88 @@ function buildMockParent() {
   }
 }
 
-describe('SwerpgCharacter — threshold bonus methods', () => {
-  describe('_getWoundThresholdBonus', () => {
-    test('returns species woundThreshold modifier when species is set', () => {
+/**
+ * Tests for the species additive bonus methods.
+ *
+ * These methods return a *partial additive contribution* from the species formula,
+ * not the final threshold. The final absolute values live in
+ * `resources.wounds.threshold` and `resources.strain.threshold` respectively.
+ * See the "threshold calculation contract" suites below for the end-to-end flow.
+ */
+describe('SwerpgCharacter — species additive bonus methods', () => {
+  describe('_getWoundThresholdBonus — returns the species additive wound bonus (not the final threshold)', () => {
+    test('returns species woundThreshold.modifier as the additive bonus when species is set', () => {
       const character = new SwerpgCharacter(buildCharacterData({ species: buildSpecies(10, 0) }))
       expect(character._getWoundThresholdBonus()).toBe(10)
     })
 
-    test('returns 0 when species is null', () => {
+    test('returns 0 (no bonus) when species is null', () => {
       const character = new SwerpgCharacter(buildCharacterData({ species: null }))
       expect(character._getWoundThresholdBonus()).toBe(0)
     })
 
-    test('returns 0 when species has no woundThreshold', () => {
+    test('returns 0 (no bonus) when species has no woundThreshold field', () => {
       const character = new SwerpgCharacter(buildCharacterData({ species: { characteristics: {}, freeSkills: new Set(), startingExperience: 0 } }))
       expect(character._getWoundThresholdBonus()).toBe(0)
     })
   })
 
-  describe('_getStrainThresholdBonus', () => {
-    test('returns species strainThreshold modifier when species is set', () => {
+  describe('_getStrainThresholdBonus — returns the species additive strain bonus (not the final threshold)', () => {
+    test('returns species strainThreshold.modifier as the additive bonus when species is set', () => {
       const character = new SwerpgCharacter(buildCharacterData({ species: buildSpecies(0, 8) }))
       expect(character._getStrainThresholdBonus()).toBe(8)
     })
 
-    test('returns 0 when species is null', () => {
+    test('returns 0 (no bonus) when species is null', () => {
       const character = new SwerpgCharacter(buildCharacterData({ species: null }))
       expect(character._getStrainThresholdBonus()).toBe(0)
     })
 
-    test('returns 0 when species has no strainThreshold', () => {
+    test('returns 0 (no bonus) when species has no strainThreshold field', () => {
       const character = new SwerpgCharacter(buildCharacterData({ species: { characteristics: {}, freeSkills: new Set(), startingExperience: 0 } }))
       expect(character._getStrainThresholdBonus()).toBe(0)
     })
   })
 })
 
-describe('SwerpgCharacter — threshold schema', () => {
-  test('defineSchema does not include a thresholds field', () => {
+describe('SwerpgCharacter — schema contract: no intermediate thresholds field', () => {
+  test('defineSchema does not expose a thresholds field — species bonuses and final thresholds are distinct', () => {
+    // The Character model has no intermediate `thresholds.wounds` or `thresholds.strain` field.
+    // Species additive bonuses feed _getWoundThresholdBonus()/_getStrainThresholdBonus(),
+    // which combine with characteristic ranks to produce resources.wounds.threshold / resources.strain.threshold.
     const schema = SwerpgCharacter.defineSchema()
     expect(schema).not.toHaveProperty('thresholds')
   })
 })
 
-describe('SwerpgCharacter — wound threshold calculation contract', () => {
-  test('wounds.threshold equals brawn + species woundThreshold modifier', () => {
-    // brawn base comes from species.characteristics.brawn (set to 3) after #prepareSpecies
+/**
+ * End-to-end contract tests for `resources.wounds.threshold`.
+ *
+ * The final wound threshold is the absolute value exposed to the rest of the
+ * system. It is distinct from the species additive bonus
+ * (`details.species.woundThreshold.modifier`) which is only a partial input.
+ *
+ * Formula: resources.wounds.threshold = brawn rank + _getWoundThresholdBonus()
+ *   where _getWoundThresholdBonus() = details.species.woundThreshold.modifier
+ */
+describe('SwerpgCharacter — final wound threshold calculation (resources.wounds.threshold)', () => {
+  test('final wound threshold = brawn rank + species additive wound bonus', () => {
+    // brawn base comes from species.characteristics.brawn (set to 3) after #prepareSpecies.
+    // The species wound bonus (10) is additive — resources.wounds.threshold is the sum, not the bonus alone.
     const species = buildSpecies(10, 0, { brawn: 3 })
     const character = new SwerpgCharacter(buildCharacterData({ species }))
     character.parent = buildMockParent()
 
     // prepareBaseData populates characteristic rank.value via #prepareSpecies, then
-    // _prepareDerivedAttributes reads rank.value and _getWoundThresholdBonus() to set the threshold
+    // prepareDerivedData calls _prepareDerivedAttributes which reads rank.value and
+    // _getWoundThresholdBonus() to write the final absolute threshold.
     character.prepareBaseData()
     character.prepareDerivedData()
 
     expect(character.resources.wounds.threshold).toBe(3 + 10)
   })
 
-  test('wounds.threshold equals brawn when species woundThreshold.modifier is 0', () => {
+  test('final wound threshold = brawn rank when species wound bonus is 0', () => {
     const species = buildSpecies(0, 0, { brawn: 4 })
     const character = new SwerpgCharacter(buildCharacterData({ species }))
     character.parent = buildMockParent()
@@ -165,8 +188,8 @@ describe('SwerpgCharacter — wound threshold calculation contract', () => {
     expect(character.resources.wounds.threshold).toBe(4)
   })
 
-  test('wounds.threshold equals brawn with non-zero strain modifier only', () => {
-    // wound modifier is 0 — the strain modifier (5) must not bleed into wound threshold
+  test('species strain bonus does not bleed into the final wound threshold', () => {
+    // wound bonus is 0 — the strain bonus (5) must not affect resources.wounds.threshold
     const species = buildSpecies(0, 5, { brawn: 2 })
     const character = new SwerpgCharacter(buildCharacterData({ species }))
     character.parent = buildMockParent()
@@ -178,9 +201,20 @@ describe('SwerpgCharacter — wound threshold calculation contract', () => {
   })
 })
 
-describe('SwerpgCharacter — strain threshold calculation contract', () => {
-  test('strain.threshold equals willpower + species strainThreshold modifier', () => {
-    // willpower base comes from species.characteristics.willpower (set to 3) after #prepareSpecies
+/**
+ * End-to-end contract tests for `resources.strain.threshold`.
+ *
+ * The final strain threshold is the absolute value exposed to the rest of the
+ * system. It is distinct from the species additive bonus
+ * (`details.species.strainThreshold.modifier`) which is only a partial input.
+ *
+ * Formula: resources.strain.threshold = willpower rank + _getStrainThresholdBonus()
+ *   where _getStrainThresholdBonus() = details.species.strainThreshold.modifier
+ */
+describe('SwerpgCharacter — final strain threshold calculation (resources.strain.threshold)', () => {
+  test('final strain threshold = willpower rank + species additive strain bonus', () => {
+    // willpower base comes from species.characteristics.willpower (set to 3) after #prepareSpecies.
+    // The species strain bonus (8) is additive — resources.strain.threshold is the sum, not the bonus alone.
     const species = buildSpecies(0, 8, { willpower: 3 })
     const character = new SwerpgCharacter(buildCharacterData({ species }))
     character.parent = buildMockParent()
@@ -191,7 +225,7 @@ describe('SwerpgCharacter — strain threshold calculation contract', () => {
     expect(character.resources.strain.threshold).toBe(3 + 8)
   })
 
-  test('strain.threshold equals willpower when species strainThreshold.modifier is 0', () => {
+  test('final strain threshold = willpower rank when species strain bonus is 0', () => {
     const species = buildSpecies(0, 0, { willpower: 4 })
     const character = new SwerpgCharacter(buildCharacterData({ species }))
     character.parent = buildMockParent()
@@ -202,8 +236,8 @@ describe('SwerpgCharacter — strain threshold calculation contract', () => {
     expect(character.resources.strain.threshold).toBe(4)
   })
 
-  test('strain.threshold equals willpower with non-zero wound modifier only', () => {
-    // strain modifier is 0 — the wound modifier (5) must not bleed into strain threshold
+  test('species wound bonus does not bleed into the final strain threshold', () => {
+    // strain bonus is 0 — the wound bonus (5) must not affect resources.strain.threshold
     const species = buildSpecies(5, 0, { willpower: 2 })
     const character = new SwerpgCharacter(buildCharacterData({ species }))
     character.parent = buildMockParent()


### PR DESCRIPTION
## Summary

- Clarify the semantic distinction between species additive bonuses and the final resource thresholds for wounds and strain.
- Update actor and character model documentation and tests to use "bonus" for species contributions and "threshold" for final runtime values.

## Context

This branch refactors `SwerpgActorType` and `SwerpgCharacter` to make explicit in code and tests that the species-provided values are additive bonuses and not the final thresholds. It aligns tests and documentation with the contract: final thresholds are exposed in `resources.wounds.threshold` and `resources.strain.threshold` and are computed as `characteristic rank + additive bonus`.

Closes #400

## Tests

- Updated unit tests under `tests/models/character-thresholds.test.mjs` to assert the additive bonus vs final threshold contract.
- Not run (not requested).

## Notes

- No runtime behavior change is intended; this is a semantic clarifying refactor and test alignment.
