### PR TITLE
refactor(jsdoc): add missing parameter types in JSDoc comments

### DIFF
--- a/documentation/plan/core/refactor/438-ew2-completer-les-types-jsdoc-manquants.md
+++ b/documentation/plan/core/refactor/438-ew2-completer-les-types-jsdoc-manquants.md
@@ -1,0 +1,59 @@
+# EW2 — Compléter les types JSDoc manquants
+
+**Issue** : [#438 — EW2 — Compléter les types JSDoc manquants](https://github.com/herveDarritchon/foundryvtt-swerpg/issues/438)
+
+## Objectif
+
+Réduire le lot principal de warnings `jsdoc/require-param-type` du chantier `ESLint Warnings Reduction` en ajoutant uniquement des types JSDoc mécaniques, prudents et justifiables, sans changement comportemental ni invention de contrats métier incertains.
+
+## Décisions de cadrage
+
+- Limiter le périmètre aux occurrences remontées par `jsdoc/require-param-type` dans le scope déjà retenu pour la feature : `module/**/*.mjs`, `tests/**/*.mjs` et `swerpg.mjs`.
+- Prioriser les fichiers les plus denses en warnings pour obtenir une baisse visible du backlog sans disperser le lot.
+- Ajouter des types larges, observables et défendables (`string`, `number`, `boolean`, `object`, `Array<...>`, unions simples, nullable) plutôt que des types métier spéculatifs.
+- Réutiliser les typedefs, shapes et conventions JSDoc déjà présents quand ils existent localement, sans ouvrir de refactor documentaire transverse.
+- Exclure de ce lot les descriptions JSDoc manquantes, les paramètres mal nommés, les warnings de code et le chantier ADR-0018 `no-magic-numbers`.
+
+## Étapes d’implémentation
+
+### 1. Borner le lot EW2 et ordonner les fichiers
+
+**Fichiers cibles** : fichiers remontés par `jsdoc/require-param-type`, avec priorité aux modules les plus denses
+
+**What**
+
+- partir du baseline ESLint laissé par EW1 pour isoler uniquement les warnings `jsdoc/require-param-type` ;
+- regrouper les occurrences par fichier ou module cohérent afin de garder une revue lisible ;
+- confirmer avant modification quels cas relèvent d’un ajout mécanique de type et quels cas doivent rester hors lot si le contrat n’est pas suffisamment observable.
+
+**Validation visée** : le lot EW2 est borné, priorisé et ne mélange pas les warnings d’autres stories.
+
+### 2. Compléter les types JSDoc manquants sans élargir le contrat
+
+**Fichiers cibles** : uniquement les fichiers confirmés à l’étape 1
+
+**What**
+
+- ajouter les types manquants sur les paramètres signalés par ESLint ;
+- choisir le type le plus simple compatible avec l’usage réel visible localement, sans profiter du chantier pour renommer, restructurer ou documenter davantage que nécessaire ;
+- harmoniser au passage les formes JSDoc minimales nécessaires quand cela évite des incohérences locales dans un même bloc commenté.
+
+**Validation visée** : les warnings `jsdoc/require-param-type` disparaissent sur le lot traité sans création de documentation trompeuse.
+
+### 3. Stabiliser le résiduel et préparer EW3/EW5
+
+**Fichiers cibles** : fichiers modifiés EW2, rapport ESLint du lot
+
+**What**
+
+- relever les cas éventuellement exclus car nécessitant un arbitrage métier ou une clarification de contrat ;
+- laisser le terrain propre pour EW3 en n’ajoutant pas de descriptions éditoriales inutiles dans ce lot ;
+- consigner le résiduel attendu pour la revalidation globale EW5.
+
+**Validation visée** : EW2 ferme le lot mécanique des types JSDoc et laisse un résiduel clairement qualifié pour la suite.
+
+## Résultat attendu
+
+- Le backlog `jsdoc/require-param-type` baisse fortement sur le scope priorisé.
+- Les types ajoutés restent prudents, alignés sur le code observable et non spéculatifs.
+- Aucun warning hors périmètre EW2 n’est absorbé opportunistement dans ce chantier.

--- a/module/config/effects.mjs
+++ b/module/config/effects.mjs
@@ -9,11 +9,11 @@ export function getEffectId(label) {
 
 /**
  *
- * @param actor
- * @param target
- * @param root0
- * @param root0.ability
- * @param root0.damageType
+ * @param {object} actor
+ * @param {object} target
+ * @param {object} root0
+ * @param {string} root0.ability
+ * @param {string} root0.damageType
  */
 export function bleeding(actor, target, { ability = 'dexterity', damageType = 'piercing' } = {}) {
   return {
@@ -35,8 +35,8 @@ export function bleeding(actor, target, { ability = 'dexterity', damageType = 'p
 
 /**
  *
- * @param actor
- * @param target
+ * @param {object} actor
+ * @param {object} target
  */
 export function burning(actor, target) {
   return {
@@ -59,8 +59,8 @@ export function burning(actor, target) {
 
 /**
  *
- * @param actor
- * @param target
+ * @param {object} actor
+ * @param {object} target
  */
 export function chilled(actor, target) {
   return {
@@ -83,8 +83,8 @@ export function chilled(actor, target) {
 
 /**
  *
- * @param actor
- * @param target
+ * @param {object} actor
+ * @param {object} target
  */
 export function confusion(actor, target) {
   return {
@@ -107,8 +107,8 @@ export function confusion(actor, target) {
 
 /**
  *
- * @param actor
- * @param target
+ * @param {object} actor
+ * @param {object} target
  */
 export function corroding(actor, target) {
   return {
@@ -130,8 +130,8 @@ export function corroding(actor, target) {
 
 /**
  *
- * @param actor
- * @param target
+ * @param {object} actor
+ * @param {object} target
  */
 export function decay(actor, target) {
   return {
@@ -153,8 +153,8 @@ export function decay(actor, target) {
 
 /**
  *
- * @param actor
- * @param target
+ * @param {object} actor
+ * @param {object} target
  */
 export function entropy(actor, target) {
   return {
@@ -177,8 +177,8 @@ export function entropy(actor, target) {
 
 /**
  *
- * @param actor
- * @param target
+ * @param {object} actor
+ * @param {object} target
  */
 export function irradiated(actor, target) {
   return {
@@ -201,8 +201,8 @@ export function irradiated(actor, target) {
 
 /**
  *
- * @param actor
- * @param target
+ * @param {object} actor
+ * @param {object} target
  */
 export function mending(actor, target) {
   return {
@@ -223,8 +223,8 @@ export function mending(actor, target) {
 
 /**
  *
- * @param actor
- * @param target
+ * @param {object} actor
+ * @param {object} target
  */
 export function inspired(actor, target) {
   return {
@@ -245,8 +245,8 @@ export function inspired(actor, target) {
 
 /**
  *
- * @param actor
- * @param target
+ * @param {object} actor
+ * @param {object} target
  */
 export function poisoned(actor, target) {
   return {
@@ -268,8 +268,8 @@ export function poisoned(actor, target) {
 
 /**
  *
- * @param actor
- * @param target
+ * @param {object} actor
+ * @param {object} target
  */
 export function shocked(actor, target) {
   return {
@@ -292,8 +292,8 @@ export function shocked(actor, target) {
 
 /**
  *
- * @param actor
- * @param target
+ * @param {object} actor
+ * @param {object} target
  */
 export function staggered(actor, target) {
   return {

--- a/module/helpers/data/utilities.mjs
+++ b/module/helpers/data/utilities.mjs
@@ -9,10 +9,9 @@ const mandatoryHtml = { required: true, blank: false, textSearch: true }
 
 /**
  * Enrich the initialization schema with the initial value if it is not null or empty
- * @param initial.initial
- * @param initial {string|number|boolean} The initial value of the field
- * @param dataFieldConfiguration {{nullable: boolean,integer: boolean,required: boolean }|{blank: boolean,textSearch: boolean,initial: string,required: boolean }|{blank: boolean, trim: boolean, nullable: boolean, required: boolean}|{nullable: boolean, initial: number, integer: boolean, required: boolean}} The configuration of the field
- * @param initial.dataFieldConfiguration
+ * @param {object} root0
+ * @param {string|number|boolean|undefined} root0.initial The initial value of the field
+ * @param {object} root0.dataFieldConfiguration The configuration of the field
  * @private
  * @static
  * @function
@@ -28,7 +27,7 @@ export function _enrichDataFieldConfiguration({ initial = undefined, dataFieldCo
 
 /**
  * Check if the initial value is not null or empty
- * @param initial {string|number|boolean|undefined|null} The initial value of the field
+ * @param {string|number|boolean|undefined|null} initial The initial value of the field
  * @returns {boolean} True if the initial value is not null or empty
  */
 export function isNullOrEmpty(initial) {
@@ -49,13 +48,11 @@ export function isNullOrEmpty(initial) {
 
 /**
  * Build the localization prefix for the item
- * @param itemType.itemType
- * @param itemType {string} The type of the item for Localization (e.g. 'Base-Item', 'Combat-Item', 'Species-Item')
- * @param key {string} The key of the item for Localization (e.g. 'sources.page', 'attributes.requirement.key')
- * @param itemType.key
+ * @param {object} root0
+ * @param {string} root0.itemType The type of the item for Localization (e.g. 'Base-Item', 'Combat-Item', 'Species-Item')
+ * @param {string} root0.key The key of the item for Localization (e.g. 'sources.page', 'attributes.requirement.key')
  * @returns {string[]} The localization prefix
  * @private
- * @function
  * @function
  * @name _buildLocalizationPrefix
  * @example
@@ -67,16 +64,13 @@ export function _buildLocalizationPrefix({ itemType, key }) {
 }
 
 /**
- *  Create a new StringField with the requiredString properties set to false
- * @param itemType.initial
- *  @param itemType {string} The type of the item for Localization (e.g. 'Base-Item', 'Combat-Item', 'Species-Item')
- * @param key {string} The key of the item for Localization (e.g. 'sources.page', 'attributes.requirement.key')
- * @param initial {string} The initial value of the field (default is "")
- * @param itemType.itemType
- * @param itemType.key
+ * Create a new StringField with the requiredString properties set to false
+ * @param {object} root0
+ * @param {string} root0.itemType The type of the item for Localization (e.g. 'Base-Item', 'Combat-Item', 'Species-Item')
+ * @param {string} root0.key The key of the item for Localization (e.g. 'sources.page', 'attributes.requirement.key')
+ * @param {string} root0.initial The initial value of the field (default is "")
  * @returns {fields.StringField} A schema Field used to describe the structure and type of the data
  * @public
- * @function
  * @function
  * @name buildOptionalStringField
  */
@@ -97,14 +91,12 @@ export function buildOptionalStringField({ initial = '', itemType, key }) {
 }
 
 /**
- *  Create a new StringField  with the requiredString properties set to true
- * @param itemType.itemType
- *  @param itemType {string} The type of the item for Localization (e.g. 'Base-Item', 'Combat-Item', 'Species-Item')
- *  @param key {string} The key of the item for Localization (e.g. 'sources.page', 'attributes.requirement.key')
- * @param itemType.key
+ * Create a new StringField with the requiredString properties set to true
+ * @param {object} root0
+ * @param {string} root0.itemType The type of the item for Localization (e.g. 'Base-Item', 'Combat-Item', 'Species-Item')
+ * @param {string} root0.key The key of the item for Localization (e.g. 'sources.page', 'attributes.requirement.key')
  * @returns {fields.StringField} A schema Field used to describe the structure and type of the data
  * @public
- * @function
  * @function
  * @name buildMandatoryStringField
  */
@@ -125,19 +117,14 @@ export function buildMandatoryStringField({ itemType, key }) {
 
 /**
  * Create a new NumberField with the required properties set to false
- * @param initial.itemType
- * @param initial {number} The initial value of the field (default is 0)
- * @param itemType {string} The type of the item for Localization (e.g. 'Base-Item', 'Combat-Item', 'Species-Item')
- * @param key {string} The key of the item for Localization (e.g. 'sources.page', 'attributes.requirement.key')
- * @param min {number} The minimum value of the field (default is 0)
- * @param max {number} The maximum value of the field (default is 10)
- * @param initial.key
- * @param initial.initial
- * @param initial.min
- * @param initial.max
+ * @param {object} root0
+ * @param {string} root0.itemType The type of the item for Localization (e.g. 'Base-Item', 'Combat-Item', 'Species-Item')
+ * @param {string} root0.key The key of the item for Localization (e.g. 'sources.page', 'attributes.requirement.key')
+ * @param {number} root0.initial The initial value of the field (default is 0)
+ * @param {number} root0.min The minimum value of the field (default is 0)
+ * @param {number} root0.max The maximum value of the field (default is 10)
  * @returns {fields.NumberField} A schema Field used to describe the structure and type of the data
  * @public
- * @function
  * @function
  * @name buildOptionalIntegerField
  */
@@ -160,19 +147,14 @@ export function buildOptionalIntegerField({ itemType, key, initial = 0, min = 0,
 
 /**
  * Create a new NumberField with the required properties set to true
- * @param initial.itemType
- * @param initial {number} Initial value for the field (default is 0)
- * @param itemType {string} The type of the item for Localization (e.g. 'Base-Item', 'Combat-Item', 'Species-Item')
- * @param key {string} The key of the item for Localization (e.g. 'sources.page', 'attributes.requirement.key')
- * @param min {number} The minimum value of the field (default is 0)
- * @param max {number} The maximum value of the field (default is 10)
- * @param initial.key
- * @param initial.initial
- * @param initial.min
- * @param initial.max
+ * @param {object} root0
+ * @param {string} root0.itemType The type of the item for Localization (e.g. 'Base-Item', 'Combat-Item', 'Species-Item')
+ * @param {string} root0.key The key of the item for Localization (e.g. 'sources.page', 'attributes.requirement.key')
+ * @param {number} root0.initial Initial value for the field (default is 0)
+ * @param {number} root0.min The minimum value of the field (default is 0)
+ * @param {number} root0.max The maximum value of the field (default is 10)
  * @returns {fields.NumberField} A schema Field used to describe the structure and type of the data
  * @public
- * @function
  * @function
  * @name buildMandatoryIntegerField
  */
@@ -195,15 +177,12 @@ export function buildMandatoryIntegerField({ itemType, key, initial = 0, min = 0
 
 /**
  * Create a new BooleanField with the required properties set to false
- * @param initial.initial
- * @param initial  {boolean} The initial value of the field (default is false)
- * @param itemType {string} The type of the item for Localization (e.g. 'Base-Item', 'Combat-Item', 'Species-Item')
- * @param key {string} The key of the item for Localization (e.g. 'sources.page', 'attributes.requirement.key')
- * @param initial.itemType
- * @param initial.key
+ * @param {object} root0
+ * @param {boolean} root0.initial The initial value of the field (default is false)
+ * @param {string} root0.itemType The type of the item for Localization (e.g. 'Base-Item', 'Combat-Item', 'Species-Item')
+ * @param {string} root0.key The key of the item for Localization (e.g. 'sources.page', 'attributes.requirement.key')
  * @returns {fields.BooleanField} A schema Field used to describe the structure and type of the data
  * @public
- * @function
  * @function
  * @name buildOptionalBooleanField
  */
@@ -224,14 +203,11 @@ export function buildOptionalBooleanField({ initial = false, itemType, key }) {
 
 /**
  * Create a new BooleanField with the required properties set to true
- * @param initial {boolean} The initial value of the field (default is false)
- * @param initial.itemType
- * @param itemType {string} The type of the item for Localization (e.g. 'Base-Item', 'Combat-Item', 'Species-Item')
- * @param key {string} The key of the item for Localization (e.g. 'sources.page', 'attributes.requirement.key')
- * @param initial.key
+ * @param {object} root0
+ * @param {string} root0.itemType The type of the item for Localization (e.g. 'Base-Item', 'Combat-Item', 'Species-Item')
+ * @param {string} root0.key The key of the item for Localization (e.g. 'sources.page', 'attributes.requirement.key')
  * @returns {fields.BooleanField} A schema Field used to describe the structure and type of the data
  * @public
- * @function
  * @function
  * @name buildMandatoryBooleanField
  */
@@ -252,10 +228,10 @@ export function buildMandatoryBooleanField({ itemType, key }) {
 /**
  * Create a new StringField with the requiredString properties
  *
- * @param root0
- * @param root0.initial
- * @param root0.itemType
- * @param root0.key
+ * @param {object} root0
+ * @param {string} root0.initial
+ * @param {string} root0.itemType
+ * @param {string} root0.key
  * @returns {fields.HTMLField}
  */
 export function buildOptionalHtmlField({ initial = '', itemType, key }) {
@@ -275,9 +251,9 @@ export function buildOptionalHtmlField({ initial = '', itemType, key }) {
 
 /**
  *
- * @param root0
- * @param root0.itemType
- * @param root0.key
+ * @param {object} root0
+ * @param {string} root0.itemType
+ * @param {string} root0.key
  */
 export function buildMandatoryHtmlField({ itemType, key }) {
   const fields = foundry.data.fields
@@ -298,7 +274,7 @@ export function buildMandatoryHtmlField({ itemType, key }) {
 /**
  * Create a new SchemaField with the required properties set to false
  *
- * @param field {DataField} The field object inside the SchemaField
+ * @param {object} field The field object inside the SchemaField
  * @returns {fields.SchemaField} A schema Field used to describe the structure and type of the data
  */
 export function buildOptionalSchemaField(field = {}) {
@@ -308,10 +284,9 @@ export function buildOptionalSchemaField(field = {}) {
 
 /**
  * Create a new SchemaField with the required properties set to true
- * @param field {DataField} The field object inside the SchemaField
+ * @param {object} field The field object inside the SchemaField
  * @returns {fields.SchemaField} A schema Field used to describe the structure and type of the data
  * @public
- * @function
  * @function
  * @name mandatorySchemaField
  */
@@ -322,9 +297,9 @@ export function mandatorySchemaField(field = {}) {
 
 /**
  *
- * @param root0
- * @param root0.initial
- * @param root0.field
+ * @param {object} root0
+ * @param {Array} root0.initial
+ * @param {object} root0.field
  */
 export function buildOptionalSetField({ initial = [], field = {} }) {
   const fields = foundry.data.fields
@@ -333,10 +308,9 @@ export function buildOptionalSetField({ initial = [], field = {} }) {
 
 /**
  * Create a new SetField with the required properties set to true
- * @param field {DataField} The field object inside the SetField
+ * @param {object} field The field object inside the SetField
  * @returns {fields.SetField} A schema Field used to describe the structure and type of the data
  * @public
- * @function
  * @function
  * @name mandatorySetField
  */
@@ -348,10 +322,9 @@ export function mandatorySetField(field = {}) {
 /**
  * Create a new ArrayField with the required properties set to false
  *
- * @param initial.initial
- * @param initial {Array} The initial value of the field
- * @param field {DataField} The field object inside the ArrayField
- * @param initial.field
+ * @param {object} root0
+ * @param {Array} root0.initial The initial value of the field
+ * @param {object} root0.field The field object inside the ArrayField
  * @returns {fields.ArrayField} A schema Field used to describe the structure and type of the data
  */
 export function buildOptionalArrayField({ initial = [], field }) {
@@ -361,9 +334,8 @@ export function buildOptionalArrayField({ initial = [], field }) {
 /**
  * Create a new ArrayField with the required properties set to true
  *
- * @param initial {Array} The initial value of the field
- * @param initial.field
- * @param field {DataField} The field object
+ * @param {object} root0
+ * @param {object} root0.field The field object
  * @returns {fields.ArrayField} A schema Field used to describe the structure and type of the data
  */
 export function buildMandatoryArrayField({ field }) {

--- a/module/lib/talent-node/talent-node-progression.mjs
+++ b/module/lib/talent-node/talent-node-progression.mjs
@@ -84,11 +84,11 @@ export function processTalentNodeProgression(actor, specializationId, nodeId, ac
 
 /**
  *
- * @param actor
- * @param specializationId
- * @param tree
- * @param node
- * @param action
+ * @param {object} actor
+ * @param {string} specializationId
+ * @param {object} tree
+ * @param {object} node
+ * @param {NodeAction} action
  */
 function validatePurchase(actor, specializationId, tree, node, action) {
   const state = getNodeState(actor, specializationId, tree, node.nodeId)
@@ -105,11 +105,11 @@ function validatePurchase(actor, specializationId, tree, node, action) {
 
 /**
  *
- * @param actor
- * @param specializationId
- * @param tree
- * @param node
- * @param action
+ * @param {object} actor
+ * @param {string} specializationId
+ * @param {object} tree
+ * @param {object} node
+ * @param {NodeAction} action
  */
 function validateForget(actor, specializationId, tree, node, action) {
   const treeId = tree.id ?? tree._id
@@ -139,12 +139,12 @@ function validateForget(actor, specializationId, tree, node, action) {
 
 /**
  *
- * @param actor
- * @param specializationId
- * @param tree
- * @param node
- * @param action
- * @param costSign
+ * @param {object} actor
+ * @param {string} specializationId
+ * @param {object} tree
+ * @param {object} node
+ * @param {NodeAction} action
+ * @param {number} costSign
  */
 function buildSuccessResult(actor, specializationId, tree, node, action, costSign) {
   const treeId = tree.id ?? tree._id
@@ -189,11 +189,11 @@ function buildSuccessResult(actor, specializationId, tree, node, action, costSig
 
 /**
  * Determine whether a node is currently purchased by the actor.
- * @param actor
- * @param treeId
- * @param treeUuid
- * @param node
- * @param specializationId
+ * @param {object} actor
+ * @param {string} treeId
+ * @param {string|null} treeUuid
+ * @param {object} node
+ * @param {string} specializationId
  */
 function isPurchased(actor, treeId, treeUuid, node, specializationId) {
   const purchases = actor?.system?.progression?.talentPurchases
@@ -204,11 +204,11 @@ function isPurchased(actor, treeId, treeUuid, node, specializationId) {
 /**
  * Match a purchase record against a node identity.
  * Prefers UUID-based matching when both sides carry a UUID.
- * @param p
- * @param treeId
- * @param treeUuid
- * @param node
- * @param specializationId
+ * @param {object} p
+ * @param {string} treeId
+ * @param {string|null} treeUuid
+ * @param {object} node
+ * @param {string} specializationId
  */
 function matchesPurchase(p, treeId, treeUuid, node, specializationId) {
   const treeMatch = treeUuid && p.treeUuid ? p.treeUuid === treeUuid : p.treeId === treeId
@@ -222,10 +222,10 @@ function matchesPurchase(p, treeId, treeUuid, node, specializationId) {
  *
  * A node is a blocking dependent if there is a connection from targetNodeId
  * to that node AND the node is currently purchased.
- * @param actor
- * @param tree
- * @param targetNodeId
- * @param specializationId
+ * @param {object} actor
+ * @param {object} tree
+ * @param {string} targetNodeId
+ * @param {string} specializationId
  */
 function findBlockingDependents(actor, tree, targetNodeId, specializationId) {
   const connections = tree?.system?.connections
@@ -251,8 +251,8 @@ function findBlockingDependents(actor, tree, targetNodeId, specializationId) {
 
 /**
  *
- * @param actor
- * @param specializationId
+ * @param {object} actor
+ * @param {string} specializationId
  */
 function findSpecialization(actor, specializationId) {
   const specs = actor?.system?.details?.specializations
@@ -265,8 +265,8 @@ function findSpecialization(actor, specializationId) {
 
 /**
  *
- * @param tree
- * @param nodeId
+ * @param {object} tree
+ * @param {string} nodeId
  */
 function findNodeInTree(tree, nodeId) {
   const nodes = tree?.system?.nodes

--- a/module/lib/talent-node/talent-node-state.mjs
+++ b/module/lib/talent-node/talent-node-state.mjs
@@ -22,9 +22,9 @@ export const REASON_CODE = Object.freeze({
 
 /**
  *
- * @param state
- * @param reasonCode
- * @param details
+ * @param {string} state
+ * @param {string} reasonCode
+ * @param {object} details
  */
 function makeResult(state, reasonCode, details = {}) {
   return { state, reasonCode, details }
@@ -32,8 +32,8 @@ function makeResult(state, reasonCode, details = {}) {
 
 /**
  *
- * @param actor
- * @param specializationId
+ * @param {object} actor
+ * @param {string} specializationId
  */
 function isSpecializationOwned(actor, specializationId) {
   const specs = actor?.system?.details?.specializations
@@ -46,8 +46,8 @@ function isSpecializationOwned(actor, specializationId) {
 
 /**
  *
- * @param tree
- * @param nodeId
+ * @param {object} tree
+ * @param {string} nodeId
  */
 function findNode(tree, nodeId) {
   const nodes = tree?.system?.nodes
@@ -57,14 +57,14 @@ function findNode(tree, nodeId) {
 
 /**
  *
- * @param actor
- * @param treeId
- * @param nodeId
- * @param talentId
- * @param specializationId
- * @param root0
- * @param root0.treeUuid
- * @param root0.talentUuid
+ * @param {object} actor
+ * @param {string} treeId
+ * @param {string} nodeId
+ * @param {string} talentId
+ * @param {string} specializationId
+ * @param {object} root0
+ * @param {string|undefined} root0.treeUuid
+ * @param {string|undefined} root0.talentUuid
  */
 function hasPurchase(actor, treeId, nodeId, talentId, specializationId, { treeUuid, talentUuid } = {}) {
   const purchases = actor?.system?.progression?.talentPurchases
@@ -80,7 +80,7 @@ function hasPurchase(actor, treeId, nodeId, talentId, specializationId, { treeUu
 
 /**
  *
- * @param node
+ * @param {object} node
  */
 function hasValidFields(node) {
   if (!node.nodeId || !node.talentId) return false
@@ -91,7 +91,7 @@ function hasValidFields(node) {
 
 /**
  *
- * @param node
+ * @param {object} node
  */
 function missingFields(node) {
   const fields = []
@@ -104,7 +104,7 @@ function missingFields(node) {
 
 /**
  *
- * @param tree
+ * @param {object} tree
  */
 function isCompleteTree(tree) {
   const nodes = tree?.system?.nodes
@@ -120,9 +120,9 @@ function isCompleteTree(tree) {
 
 /**
  *
- * @param actor
- * @param tree
- * @param node
+ * @param {object} actor
+ * @param {object} tree
+ * @param {object} node
  */
 function isAccessible(actor, tree, node) {
   if (node.row === 1) return true
@@ -148,7 +148,7 @@ function isAccessible(actor, tree, node) {
 
 /**
  *
- * @param actor
+ * @param {object} actor
  */
 function getAvailableXp(actor) {
   const exp = actor?.system?.progression?.experience
@@ -159,10 +159,10 @@ function getAvailableXp(actor) {
 
 /**
  *
- * @param actor
- * @param specializationId
- * @param tree
- * @param nodeId
+ * @param {object} actor
+ * @param {string} specializationId
+ * @param {object} tree
+ * @param {string} nodeId
  */
 export function getNodeState(actor, specializationId, tree, nodeId) {
   if (!actor) {
@@ -233,9 +233,9 @@ export function getNodeState(actor, specializationId, tree, nodeId) {
 
 /**
  *
- * @param actor
- * @param specializationId
- * @param tree
+ * @param {object} actor
+ * @param {string} specializationId
+ * @param {object} tree
  */
 export function getTreeNodesStates(actor, specializationId, tree) {
   const map = new Map()

--- a/module/utils/audit-diff.mjs
+++ b/module/utils/audit-diff.mjs
@@ -8,7 +8,7 @@ import { getCanonicalSpecializationKey } from '../lib/specializations/owned-spec
 
 /**
  *
- * @param actor
+ * @param {object} actor
  */
 function captureSnapshot(actor) {
   const xp = actor.system?.progression?.experience
@@ -24,7 +24,7 @@ function captureSnapshot(actor) {
 
 /**
  *
- * @param newValue
+ * @param {number} newValue
  */
 function computeCharacteristicCost(newValue) {
   return newValue * 10
@@ -38,8 +38,8 @@ function computeCharacteristicCost(newValue) {
  * - currentValue = { base: 0, trained: 2, bonus: 0 }
  * - oldPartialValue = { trained: 1 }
  * - résultat = { base: 0, trained: 1, bonus: 0 }
- * @param oldPartialValue
- * @param currentValue
+ * @param {*} oldPartialValue
+ * @param {*} currentValue
  */
 function reconstructPreviousValue(oldPartialValue, currentValue) {
   if (oldPartialValue === undefined) return currentValue
@@ -62,14 +62,14 @@ function reconstructPreviousValue(oldPartialValue, currentValue) {
 
 /**
  *
- * @param root0
- * @param root0.type
- * @param root0.data
- * @param root0.xpDelta
- * @param root0.ts
- * @param root0.userId
- * @param root0.user
- * @param root0.snapshot
+ * @param {object} root0
+ * @param {string} root0.type
+ * @param {object} root0.data
+ * @param {number} root0.xpDelta
+ * @param {number} root0.ts
+ * @param {string} root0.userId
+ * @param {object|null} root0.user
+ * @param {object} root0.snapshot
  */
 function makeEntry({ type, data, xpDelta, ts, userId, user, snapshot }) {
   return {
@@ -91,13 +91,13 @@ function makeEntry({ type, data, xpDelta, ts, userId, user, snapshot }) {
 
 /**
  *
- * @param oldState
- * @param changes
- * @param actor
- * @param ts
- * @param userId
- * @param user
- * @param snapshot
+ * @param {object} oldState
+ * @param {object} changes
+ * @param {object} actor
+ * @param {number} ts
+ * @param {string} userId
+ * @param {object|null} user
+ * @param {object} snapshot
  */
 function detectSkillChanges(oldState, changes, actor, ts, userId, user, snapshot) {
   const entries = []
@@ -177,7 +177,7 @@ function detectSkillChanges(oldState, changes, actor, ts, userId, user, snapshot
 
 /**
  *
- * @param rank
+ * @param {object} rank
  */
 function getSkillTotalRank(rank) {
   return (rank.base ?? 0) + (rank.careerFree ?? 0) + (rank.specializationFree ?? 0) + (rank.trained ?? 0)
@@ -185,9 +185,9 @@ function getSkillTotalRank(rank) {
 
 /**
  *
- * @param skillId
- * @param _oldState
- * @param actor
+ * @param {string} skillId
+ * @param {object} _oldState
+ * @param {object} actor
  */
 function inferIsCareer(skillId, _oldState, actor) {
   return getCareerSkillIds(actor).has(skillId)
@@ -195,7 +195,7 @@ function inferIsCareer(skillId, _oldState, actor) {
 
 /**
  *
- * @param actor
+ * @param {object} actor
  */
 function getCareerSkillIds(actor) {
   const ids = new Set()
@@ -218,13 +218,13 @@ function getCareerSkillIds(actor) {
 
 /**
  *
- * @param oldState
- * @param changes
- * @param actor
- * @param ts
- * @param userId
- * @param user
- * @param snapshot
+ * @param {object} oldState
+ * @param {object} changes
+ * @param {object} actor
+ * @param {number} ts
+ * @param {string} userId
+ * @param {object|null} user
+ * @param {object} snapshot
  */
 function detectCharacteristicChanges(oldState, changes, actor, ts, userId, user, snapshot) {
   const entries = []
@@ -269,7 +269,7 @@ function detectCharacteristicChanges(oldState, changes, actor, ts, userId, user,
 
 /**
  *
- * @param rank
+ * @param {object} rank
  */
 function getCharacteristicTotalRank(rank) {
   return (rank.base ?? 0) + (rank.trained ?? 0) + (rank.bonus ?? 0)
@@ -277,13 +277,13 @@ function getCharacteristicTotalRank(rank) {
 
 /**
  *
- * @param oldState
- * @param changes
- * @param actor
- * @param ts
- * @param userId
- * @param user
- * @param snapshot
+ * @param {object} oldState
+ * @param {object} changes
+ * @param {object} actor
+ * @param {number} ts
+ * @param {string} userId
+ * @param {object|null} user
+ * @param {object} snapshot
  */
 function detectXpChanges(oldState, changes, actor, ts, userId, user, snapshot) {
   const entries = []
@@ -345,13 +345,13 @@ function detectXpChanges(oldState, changes, actor, ts, userId, user, snapshot) {
 
 /**
  *
- * @param oldState
- * @param changes
- * @param actor
- * @param ts
- * @param userId
- * @param user
- * @param snapshot
+ * @param {object} oldState
+ * @param {object} changes
+ * @param {object} actor
+ * @param {number} ts
+ * @param {string} userId
+ * @param {object|null} user
+ * @param {object} snapshot
  */
 function detectDetailChanges(oldState, changes, actor, ts, userId, user, snapshot) {
   const entries = []
@@ -406,8 +406,8 @@ function detectDetailChanges(oldState, changes, actor, ts, userId, user, snapsho
 
 /**
  *
- * @param oldState
- * @param changes
+ * @param {object} oldState
+ * @param {object} changes
  */
 function getXpDeltaFromChanges(oldState, changes) {
   const newSpent = changes.system?.progression?.experience?.spent
@@ -419,7 +419,7 @@ function getXpDeltaFromChanges(oldState, changes) {
 
 /**
  *
- * @param source
+ * @param {object} source
  */
 function getSpecArray(source) {
   const raw = source.system?.details?.specializations
@@ -432,7 +432,7 @@ function getSpecArray(source) {
 
 /**
  *
- * @param source
+ * @param {object} source
  */
 function buildSpecMap(source) {
   const specs = getSpecArray(source)
@@ -447,14 +447,14 @@ function buildSpecMap(source) {
 
 /**
  *
- * @param oldState
- * @param specializationChanges
- * @param actor
- * @param ts
- * @param userId
- * @param user
- * @param snapshot
- * @param batchXpDelta
+ * @param {object} oldState
+ * @param {object} specializationChanges
+ * @param {object} actor
+ * @param {number} ts
+ * @param {string} userId
+ * @param {object|null} user
+ * @param {object} snapshot
+ * @param {number} batchXpDelta
  */
 function detectSpecializationChanges(oldState, specializationChanges, actor, ts, userId, user, snapshot, batchXpDelta) {
   const entries = []
@@ -545,13 +545,13 @@ function detectSpecializationChanges(oldState, specializationChanges, actor, ts,
 
 /**
  *
- * @param oldState
- * @param changes
- * @param actor
- * @param ts
- * @param userId
- * @param user
- * @param snapshot
+ * @param {object} oldState
+ * @param {object} changes
+ * @param {object} actor
+ * @param {number} ts
+ * @param {string} userId
+ * @param {object|null} user
+ * @param {object} snapshot
  */
 function detectAdvancementChanges(oldState, changes, actor, ts, userId, user, snapshot) {
   if (changes.system?.advancement?.level === undefined) return []
@@ -580,10 +580,10 @@ function detectAdvancementChanges(oldState, changes, actor, ts, userId, user, sn
 
 /**
  *
- * @param oldState
- * @param changes
- * @param actor
- * @param userId
+ * @param {object} oldState
+ * @param {object} changes
+ * @param {object} actor
+ * @param {string} userId
  */
 export function composeEntries(oldState, changes, actor, userId) {
   try {

--- a/module/utils/audit-log.mjs
+++ b/module/utils/audit-log.mjs
@@ -20,7 +20,7 @@ const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms))
 
 /**
  *
- * @param changes
+ * @param {object} changes
  */
 function isOnlyAuditChange(changes) {
   const flat = _flattenObject(changes)
@@ -30,7 +30,7 @@ function isOnlyAuditChange(changes) {
 
 /**
  *
- * @param actor
+ * @param {object} actor
  */
 function isCharacterActor(actor) {
   return actor?.type === 'character'
@@ -38,7 +38,7 @@ function isCharacterActor(actor) {
 
 /**
  *
- * @param options
+ * @param {object} options
  */
 function isAuditInternalUpdate(options) {
   return options?.swerpgAuditLog === false
@@ -50,7 +50,7 @@ function isAuditInternalUpdate(options) {
 
 /**
  *
- * @param value
+ * @param {*} value
  */
 function cloneValue(value) {
   if (value === undefined) return undefined
@@ -92,7 +92,7 @@ function countPendingEntries() {
 
 /**
  *
- * @param incomingCount
+ * @param {number} incomingCount
  */
 function evictOldestIfNeeded(incomingCount = 1) {
   const overflow = countPendingEntries() + incomingCount - MAX_PENDING
@@ -122,8 +122,8 @@ function evictOldestIfNeeded(incomingCount = 1) {
 
 /**
  *
- * @param actor
- * @param userId
+ * @param {object} actor
+ * @param {string} userId
  */
 function getPendingKey(actor, userId) {
   return `${actor.uuid}:${userId}`
@@ -131,9 +131,9 @@ function getPendingKey(actor, userId) {
 
 /**
  *
- * @param actor
- * @param userId
- * @param entry
+ * @param {object} actor
+ * @param {string} userId
+ * @param {object} entry
  */
 function pushPendingEntry(actor, userId, entry) {
   const key = getPendingKey(actor, userId)
@@ -144,8 +144,8 @@ function pushPendingEntry(actor, userId, entry) {
 
 /**
  *
- * @param actor
- * @param userId
+ * @param {object} actor
+ * @param {string} userId
  */
 function shiftPendingEntry(actor, userId) {
   const key = getPendingKey(actor, userId)
@@ -162,7 +162,7 @@ function shiftPendingEntry(actor, userId) {
 
 /**
  *
- * @param path
+ * @param {string} path
  */
 function isDeletionPath(path) {
   return path.includes('.-=')
@@ -170,7 +170,7 @@ function isDeletionPath(path) {
 
 /**
  *
- * @param path
+ * @param {string} path
  */
 function getDeletionParentPath(path) {
   const segments = path.split('.')
@@ -181,8 +181,8 @@ function getDeletionParentPath(path) {
 
 /**
  *
- * @param source
- * @param changes
+ * @param {object} source
+ * @param {object} changes
  */
 function snapshotOldState(source, changes) {
   const oldState = {}
@@ -217,8 +217,8 @@ function snapshotOldState(source, changes) {
 
 /**
  *
- * @param actor
- * @param err
+ * @param {object} actor
+ * @param {Error} err
  */
 async function handleWriteError(actor, err) {
   logger.error(`[AuditLog] Write failed for actor "${actor.name}" (${actor.id})`, err)
@@ -248,8 +248,8 @@ async function handleWriteError(actor, err) {
 
 /**
  *
- * @param actor
- * @param entries
+ * @param {object} actor
+ * @param {object[]} entries
  */
 async function writeLogEntries(actor, entries) {
   if (!entries.length) return
@@ -320,10 +320,10 @@ export {
 
 /**
  *
- * @param actor
- * @param changes
- * @param options
- * @param userId
+ * @param {object} actor
+ * @param {object} changes
+ * @param {object} options
+ * @param {string} userId
  */
 export function onPreUpdateActor(actor, changes, options, userId) {
   if (isAuditInternalUpdate(options)) return
@@ -345,10 +345,10 @@ export function onPreUpdateActor(actor, changes, options, userId) {
 
 /**
  *
- * @param actor
- * @param changes
- * @param options
- * @param userId
+ * @param {object} actor
+ * @param {object} changes
+ * @param {object} options
+ * @param {string} userId
  */
 export function onUpdateActor(actor, changes, options, userId) {
   if (isAuditInternalUpdate(options)) return
@@ -371,10 +371,10 @@ export function onUpdateActor(actor, changes, options, userId) {
 
 /**
  *
- * @param item
- * @param data
- * @param options
- * @param userId
+ * @param {object} item
+ * @param {object} data
+ * @param {object} options
+ * @param {string} userId
  */
 function onCreateItem(item, data, options, userId) {
   if (item.parent?.type !== 'character') return
@@ -700,8 +700,8 @@ export function registerAuditLogHooks() {
 
 /**
  *
- * @param obj
- * @param prefix
+ * @param {object} obj
+ * @param {string} prefix
  */
 function _flattenObject(obj, prefix = '') {
   const result = {}
@@ -720,8 +720,8 @@ function _flattenObject(obj, prefix = '') {
 
 /**
  *
- * @param object
- * @param path
+ * @param {object} object
+ * @param {string} path
  */
 function _getProperty(object, path) {
   const keys = path.split('.')
@@ -735,9 +735,9 @@ function _getProperty(object, path) {
 
 /**
  *
- * @param object
- * @param path
- * @param value
+ * @param {object} object
+ * @param {string} path
+ * @param {*} value
  */
 function _setProperty(object, path, value) {
   const keys = path.split('.')


### PR DESCRIPTION
## Summary

- Add missing parameter types in JSDoc comments across multiple modules to improve IDE hints and documentation.
- Update docs file related to issue 438 (documentation/plan/core/refactor/438-ew2-completer-les-types-jsdoc-manquants.md).
- Change set touches config, helpers, talent-node logic and audit utilities.

## Context

Branch: fix/438-ew2-completer-les-types-jsdoc-manquants  
Target base: develop

Closes: #438

## Tests

- [x] `pnpm test` passed
- [x] `pnpm exec eslint module/ utils/ --quiet` passed

## Notes

- Commits included: 1 commit (fb118175 — refactor(jsdoc): add missing parameter types in JSDoc comments).
- Strictly mechanical addition of JSDoc param types only; no behavioral changes.
- Cases requiring business arbitration were excluded and will be handled in EW3 (#439) and EW5 (#441).
