### PR TITLE
refactor(jsdoc): add missing JSDoc descriptions for functions and methods

### DIFF
--- a/documentation/plan/core/refactor/432-ew3-rediger-les-descriptions-jsdoc-manquantes.md
+++ b/documentation/plan/core/refactor/432-ew3-rediger-les-descriptions-jsdoc-manquantes.md
@@ -1,0 +1,59 @@
+# EW3 — Rédiger les descriptions JSDoc manquantes
+
+**Issue** : [#432 — EW3 — Rédiger les descriptions JSDoc manquantes](https://github.com/herveDarritchon/foundryvtt-swerpg/issues/432)
+
+## Objectif
+
+Réduire le backlog de warnings `jsdoc/require-description` du chantier `ESLint Warnings Reduction` en ajoutant des descriptions JSDoc courtes, factuelles et strictement alignées sur le contrat observable, sans refactor fonctionnel ni réécriture éditoriale opportuniste.
+
+## Décisions de cadrage
+
+- Démarrer ce lot uniquement après EW2, afin de documenter des blocs JSDoc déjà remis au propre côté types et de limiter les reprises croisées.
+- Limiter le périmètre aux occurrences remontées par `jsdoc/require-description` dans le scope déjà retenu pour la feature : `module/**/*.mjs`, `tests/**/*.mjs` et `swerpg.mjs`.
+- Regrouper les corrections par modules cohérents pour garder des commits courts et des revues lisibles.
+- Rédiger des descriptions minimales, concrètes et observables, centrées sur la responsabilité du symbole documenté plutôt que sur son implémentation interne.
+- Exclure de ce lot les ajouts de types, les corrections de noms JSDoc, les warnings de code et tout refactor comportemental.
+
+## Étapes d’implémentation
+
+### 1. Borner le lot EW3 et constituer des batches relisibles
+
+**Fichiers cibles** : fichiers remontés par `jsdoc/require-description`, regroupés par module ou zone fonctionnelle cohérente
+
+**What**
+
+- repartir du baseline ESLint laissé après EW2 pour isoler uniquement les warnings `jsdoc/require-description` ;
+- classer les occurrences par lots de modules cohérents afin d'éviter un diff transverse illisible ;
+- identifier les cas simples à documenter et laisser hors lot les blocs dont le contrat observable reste ambigu.
+
+**Validation visée** : le périmètre EW3 est borné, ordonné et ne mélange pas les autres familles de warnings.
+
+### 2. Ajouter des descriptions JSDoc courtes et factuelles
+
+**Fichiers cibles** : uniquement les fichiers confirmés à l’étape 1
+
+**What**
+
+- compléter les descriptions manquantes sur les fonctions, méthodes, classes ou typedefs signalés ;
+- formuler chaque description à partir du comportement visible du symbole documenté, avec une phrase courte et non spéculative ;
+- éviter toute retouche non nécessaire du code, des signatures ou de la structure documentaire au-delà du strict besoin ESLint.
+
+**Validation visée** : les warnings `jsdoc/require-description` disparaissent sur le lot traité sans documentation trompeuse ni changement métier.
+
+### 3. Qualifier le résiduel et préparer la suite du chantier ESLint
+
+**Fichiers cibles** : fichiers modifiés EW3, rapport ESLint du lot
+
+**What**
+
+- relever les cas résiduels qui demanderaient un arbitrage de vocabulaire, de responsabilité ou de découpage hors du lot courant ;
+- vérifier que les descriptions ajoutées restent homogènes en ton, niveau de détail et granularité ;
+- laisser un résiduel clairement qualifié pour les lots suivants de réduction des warnings.
+
+**Validation visée** : EW3 ferme un lot documentaire propre, relisible et sans dérive de périmètre.
+
+## Résultat attendu
+
+- Le backlog `jsdoc/require-description` baisse nettement sur les modules priorisés.
+- Les descriptions ajoutées sont brèves, factuelles et alignées sur le contrat observable.
+- Aucun refactor fonctionnel ni warning hors périmètre EW3 n’est absorbé opportunistement dans ce chantier.

--- a/module/applications/character-audit-log.mjs
+++ b/module/applications/character-audit-log.mjs
@@ -107,7 +107,7 @@ export function getAuditLogFamily(type) {
 }
 
 /**
- *
+ * Return the locale string for date formatting based on the current i18n language.
  */
 function getAuditLogDateLocale() {
   const language = game.i18n?.lang
@@ -117,7 +117,7 @@ function getAuditLogDateLocale() {
 }
 
 /**
- *
+ * Format a Unix timestamp as a localized date-time string.
  * @param timestamp
  */
 function formatAuditLogTimestamp(timestamp) {
@@ -135,7 +135,7 @@ function formatAuditLogTimestamp(timestamp) {
 }
 
 /**
- *
+ * Format an XP delta value as a signed string with the "XP" suffix.
  * @param xpDelta
  */
 function formatAuditLogDelta(xpDelta) {
@@ -145,7 +145,7 @@ function formatAuditLogDelta(xpDelta) {
 }
 
 /**
- *
+ * Return the localized label for the given audit entry type, falling back to the UNKNOWN key.
  * @param type
  */
 function getAuditLogTypeLabel(type) {
@@ -154,7 +154,7 @@ function getAuditLogTypeLabel(type) {
 }
 
 /**
- *
+ * Return the display name for a value, localizing the fallback key when the value is absent or empty.
  * @param value
  * @param fallbackKey
  */
@@ -412,7 +412,7 @@ export default class CharacterAuditLogApp extends api.HandlebarsApplicationMixin
 /* -------------------------------------------- */
 
 /**
- *
+ * Escape a value for inclusion in a CSV cell, wrapping in double-quotes when the string contains commas, quotes, or line breaks.
  * @param value
  */
 export function escapeCsvCell(value) {
@@ -425,7 +425,7 @@ export function escapeCsvCell(value) {
 }
 
 /**
- *
+ * Return the display name of the first user with owner-level permission on the actor, or "unknown-player".
  * @param actor
  */
 export function getPrimaryOwnerName(actor) {
@@ -443,7 +443,7 @@ export function getPrimaryOwnerName(actor) {
 }
 
 /**
- *
+ * Convert a string to a lowercase slug safe for use in filenames.
  * @param str
  */
 function slugify(str) {
@@ -459,7 +459,7 @@ function slugify(str) {
 }
 
 /**
- *
+ * Build a dated CSV export filename from the actor's name and primary owner name.
  * @param actor
  */
 export function buildExportFilename(actor) {
@@ -470,7 +470,7 @@ export function buildExportFilename(actor) {
 }
 
 /**
- *
+ * Build the full CSV content for the actor's audit log, including the header row.
  * @param actor
  */
 export function buildCsvContent(actor) {

--- a/module/applications/config/skill.mjs
+++ b/module/applications/config/skill.mjs
@@ -95,6 +95,7 @@ export default class SkillConfig extends api.HandlebarsApplicationMixin(api.Docu
   /* -------------------------------------------- */
 
   /**
+   * Handle the selection of a skill progression path for the actor.
    * @this {SkillConfig}
    * @param {PointerEvent} event
    * @returns {Promise<void>}
@@ -109,6 +110,7 @@ export default class SkillConfig extends api.HandlebarsApplicationMixin(api.Docu
   /* -------------------------------------------- */
 
   /**
+   * Open the rules journal page for the configured skill.
    * @this {SkillConfig}
    * @param {PointerEvent} event
    * @returns {Promise<void>}
@@ -121,6 +123,7 @@ export default class SkillConfig extends api.HandlebarsApplicationMixin(api.Docu
   /* -------------------------------------------- */
 
   /**
+   * Decrease the actor's rank in the configured skill by one.
    * @this {SkillConfig}
    * @param {PointerEvent} event
    */
@@ -131,6 +134,7 @@ export default class SkillConfig extends api.HandlebarsApplicationMixin(api.Docu
   /* -------------------------------------------- */
 
   /**
+   * Increase the actor's rank in the configured skill by one.
    * @this {SkillConfig}
    * @param {PointerEvent} event
    */

--- a/module/applications/sheets/base-actor-sheet.mjs
+++ b/module/applications/sheets/base-actor-sheet.mjs
@@ -783,6 +783,7 @@ export default class SwerpgBaseActorSheet extends HBMixin(BaseActorSheetV2) {
   /* -------------------------------------------- */
 
   /**
+   * Open the sheet of the action item associated with the clicked element.
    * @this {SwerpgBaseActorSheet}
    * @param {PointerEvent} event
    * @returns {Promise<void>}
@@ -797,6 +798,7 @@ export default class SwerpgBaseActorSheet extends HBMixin(BaseActorSheetV2) {
   /* -------------------------------------------- */
 
   /**
+   * Toggle the favorite state of an action on the actor.
    * @this {SwerpgBaseActorSheet}
    * @param {PointerEvent} event
    * @returns {Promise<void>}
@@ -812,6 +814,7 @@ export default class SwerpgBaseActorSheet extends HBMixin(BaseActorSheetV2) {
   /* -------------------------------------------- */
 
   /**
+   * Execute the action identified by the clicked element on the actor.
    * @this {SwerpgBaseActorSheet}
    * @param {PointerEvent} event
    * @returns {Promise<void>}
@@ -824,6 +827,7 @@ export default class SwerpgBaseActorSheet extends HBMixin(BaseActorSheetV2) {
   /* -------------------------------------------- */
 
   /**
+   * Open the item creation dialog for the actor, defaulting to the weapon type.
    * @this {SwerpgBaseActorSheet}
    * @param {PointerEvent} event
    * @returns {Promise<void>}
@@ -854,6 +858,7 @@ export default class SwerpgBaseActorSheet extends HBMixin(BaseActorSheetV2) {
   /* -------------------------------------------- */
 
   /**
+   * Open the sheet of the item associated with the clicked element.
    * @this {SwerpgBaseActorSheet}
    * @param {PointerEvent} event
    * @returns {Promise<void>}
@@ -867,6 +872,7 @@ export default class SwerpgBaseActorSheet extends HBMixin(BaseActorSheetV2) {
   /* -------------------------------------------- */
 
   /**
+   * Toggle the equipped state of an armor or weapon item on the actor.
    * @this {SwerpgBaseActorSheet}
    * @param {PointerEvent} event
    * @returns {Promise<void>}
@@ -1010,6 +1016,7 @@ export default class SwerpgBaseActorSheet extends HBMixin(BaseActorSheetV2) {
   /* -------------------------------------------- */
 
   /**
+   * Open the ActiveEffect creation dialog for the actor.
    * @this {SwerpgBaseActorSheet}
    * @param {PointerEvent} event
    * @returns {Promise<void>}
@@ -1022,6 +1029,7 @@ export default class SwerpgBaseActorSheet extends HBMixin(BaseActorSheetV2) {
   /* -------------------------------------------- */
 
   /**
+   * Open the deletion confirmation dialog for the ActiveEffect associated with the clicked element.
    * @this {SwerpgBaseActorSheet}
    * @param {PointerEvent} event
    * @returns {Promise<void>}
@@ -1034,6 +1042,7 @@ export default class SwerpgBaseActorSheet extends HBMixin(BaseActorSheetV2) {
   /* -------------------------------------------- */
 
   /**
+   * Open the sheet of the ActiveEffect associated with the clicked element.
    * @this {SwerpgBaseActorSheet}
    * @param {PointerEvent} event
    * @returns {Promise<void>}
@@ -1046,6 +1055,7 @@ export default class SwerpgBaseActorSheet extends HBMixin(BaseActorSheetV2) {
   /* -------------------------------------------- */
 
   /**
+   * Toggle the disabled state of the ActiveEffect associated with the clicked element.
    * @this {SwerpgBaseActorSheet}
    * @param {PointerEvent} event
    * @returns {Promise<void>}

--- a/module/applications/sheets/career.mjs
+++ b/module/applications/sheets/career.mjs
@@ -65,6 +65,7 @@ export default class CareerSheet extends SwerpgBaseItemSheet {
   /* -------------------------------------------- */
 
   /**
+   * Toggle a skill's career status on the item when the corresponding checkbox is clicked.
    * @this {SwerpgBaseActorSheet}
    * @param {PointerEvent} event
    * @returns {Promise<void>}

--- a/module/applications/sheets/specialization.mjs
+++ b/module/applications/sheets/specialization.mjs
@@ -60,6 +60,7 @@ export default class SpecializationSheet extends SwerpgBaseItemSheet {
   /* -------------------------------------------- */
 
   /**
+   * Toggle a skill's specialization status on the item when the corresponding checkbox is clicked.
    * @this {SwerpgBaseActorSheet}
    * @param {PointerEvent} event
    * @returns {Promise<void>}

--- a/module/applications/specialization-tree-app.mjs
+++ b/module/applications/specialization-tree-app.mjs
@@ -307,6 +307,7 @@ export default class SpecializationTreeApp extends api.HandlebarsApplicationMixi
   /* ═══════════════════════════════════════════════════════════════ */
 
   /**
+   * Reset the tree renderer viewport to its default position and zoom.
    * @param event
    * @param _target
    * @returns {Promise<void>}
@@ -317,6 +318,7 @@ export default class SpecializationTreeApp extends api.HandlebarsApplicationMixi
   }
 
   /**
+   * Set the selected specialization tree key from the clicked tab and trigger a re-render.
    * @param event
    * @param target
    * @returns {Promise<void>}
@@ -330,6 +332,7 @@ export default class SpecializationTreeApp extends api.HandlebarsApplicationMixi
   }
 
   /**
+   * Zoom the tree renderer in by one step.
    * @param event
    * @param _target
    * @returns {Promise<void>}
@@ -340,6 +343,7 @@ export default class SpecializationTreeApp extends api.HandlebarsApplicationMixi
   }
 
   /**
+   * Zoom the tree renderer out by one step.
    * @param event
    * @param _target
    * @returns {Promise<void>}
@@ -444,6 +448,7 @@ export default class SpecializationTreeApp extends api.HandlebarsApplicationMixi
   }
 
   /**
+   * Trigger the primary action (purchase or forget) for the currently selected detail node.
    * @param event
    * @param _target
    * @returns {Promise<void>}
@@ -456,6 +461,7 @@ export default class SpecializationTreeApp extends api.HandlebarsApplicationMixi
   }
 
   /**
+   * Hide the node detail panel.
    * @param event
    * @param _target
    * @returns {Promise<void>}
@@ -466,6 +472,7 @@ export default class SpecializationTreeApp extends api.HandlebarsApplicationMixi
   }
 
   /**
+   * Remove a specialization from the actor after evaluating whether removal is permitted.
    * @param event
    * @param target
    * @returns {Promise<void>}

--- a/module/applications/specialization-tree/actionable-node-view-model.mjs
+++ b/module/applications/specialization-tree/actionable-node-view-model.mjs
@@ -71,6 +71,7 @@ export function actionableNodeViewModel({ renderNode, actor, specializationId, t
 }
 
 /**
+ * Build an ActionRef descriptor for a talent node, resolving tree identity and node position.
  * @param {string} specializationId
  * @param {object|null} tree
  * @param {object} renderNode

--- a/module/applications/specialization-tree/pixi-tree-renderer.mjs
+++ b/module/applications/specialization-tree/pixi-tree-renderer.mjs
@@ -662,6 +662,7 @@ export class PixiTreeRenderer {
   }
 
   /**
+   * Extract the canvas pointer position from a PIXI federated pointer event, or return null when unavailable.
    * @param {PIXI.FederatedPointerEvent} event
    * @returns {{ x: number, y: number }|null}
    */

--- a/module/canvas/talent-tree-talent.mjs
+++ b/module/canvas/talent-tree-talent.mjs
@@ -45,6 +45,7 @@ export default class SwerpgTalentTreeTalent extends SwerpgTalentIcon {
   /* -------------------------------------------- */
 
   /**
+   * Handle a left-click on a talent node to trigger a purchase action (deprecated V1 path).
    * @param event
    * @deprecated Crucible legacy — choice wheel left-click purchase.
    *   V1 Edge uses specialization-tree-app.mjs with purchaseTalentNode().

--- a/module/canvas/talent-tree.mjs
+++ b/module/canvas/talent-tree.mjs
@@ -526,7 +526,7 @@ export default class SwerpgTalentTree extends PIXI.Container {
 
     // Recursive testing function
     /**
-     *
+     * Process a batch of talent nodes, updating their accessibility state and queuing child nodes for the next pass.
      * @param nodes
      * @param accessible
      */

--- a/module/chat.mjs
+++ b/module/chat.mjs
@@ -1,7 +1,7 @@
 import SwerpgAction from './models/action.mjs'
 
 /**
- *
+ * Add SWERPG context menu options to the chat log, allowing GMs to set difficulty or confirm actions.
  * @param html
  * @param options
  */
@@ -93,7 +93,7 @@ export async function onCreateChatMessage(message, data, options, userId) {
 /* -------------------------------------------- */
 
 /**
- *
+ * Return true if the chat message carries a SWERPG action flag.
  * @param message
  */
 function isSwerpgActionMessage(message) {

--- a/module/config/effects.mjs
+++ b/module/config/effects.mjs
@@ -8,7 +8,7 @@ export function getEffectId(label) {
 }
 
 /**
- *
+ * Build the ActiveEffect data for the Bleeding condition, dealing piercing damage over time.
  * @param {object} actor
  * @param {object} target
  * @param {object} root0
@@ -34,7 +34,7 @@ export function bleeding(actor, target, { ability = 'dexterity', damageType = 'p
 }
 
 /**
- *
+ * Build the ActiveEffect data for the Burning condition, dealing fire damage over time to health and morale.
  * @param {object} actor
  * @param {object} target
  */
@@ -58,7 +58,7 @@ export function burning(actor, target) {
 }
 
 /**
- *
+ * Build the ActiveEffect data for the Chilled condition, applying cold damage and the slowed status.
  * @param {object} actor
  * @param {object} target
  */
@@ -82,7 +82,7 @@ export function chilled(actor, target) {
 }
 
 /**
- *
+ * Build the ActiveEffect data for the Confusion condition, dealing psychic morale damage and applying the disoriented status.
  * @param {object} actor
  * @param {object} target
  */
@@ -106,7 +106,7 @@ export function confusion(actor, target) {
 }
 
 /**
- *
+ * Build the ActiveEffect data for the Corroding condition, dealing acid damage over three turns.
  * @param {object} actor
  * @param {object} target
  */
@@ -129,7 +129,7 @@ export function corroding(actor, target) {
 }
 
 /**
- *
+ * Build the ActiveEffect data for the Decay condition, dealing corruption damage over three turns.
  * @param {object} actor
  * @param {object} target
  */
@@ -152,7 +152,7 @@ export function decay(actor, target) {
 }
 
 /**
- *
+ * Build the ActiveEffect data for the Entropy condition, dealing void damage and applying the frightened status.
  * @param {object} actor
  * @param {object} target
  */
@@ -176,7 +176,7 @@ export function entropy(actor, target) {
 }
 
 /**
- *
+ * Build the ActiveEffect data for the Irradiated condition, dealing radiant damage to both health and morale.
  * @param {object} actor
  * @param {object} target
  */
@@ -200,7 +200,7 @@ export function irradiated(actor, target) {
 }
 
 /**
- *
+ * Build the ActiveEffect data for the Mending condition, restoring health each turn.
  * @param {object} actor
  * @param {object} target
  */
@@ -222,7 +222,7 @@ export function mending(actor, target) {
 }
 
 /**
- *
+ * Build the ActiveEffect data for the Inspired condition, restoring morale each turn.
  * @param {object} actor
  * @param {object} target
  */
@@ -244,7 +244,7 @@ export function inspired(actor, target) {
 }
 
 /**
- *
+ * Build the ActiveEffect data for the Poisoned condition, dealing poison damage over six turns.
  * @param {object} actor
  * @param {object} target
  */
@@ -267,7 +267,7 @@ export function poisoned(actor, target) {
 }
 
 /**
- *
+ * Build the ActiveEffect data for the Shocked condition, dealing electricity morale damage and applying the staggered status.
  * @param {object} actor
  * @param {object} target
  */
@@ -291,7 +291,7 @@ export function shocked(actor, target) {
 }
 
 /**
- *
+ * Build the ActiveEffect data for the Staggered condition, applying the staggered status for one turn.
  * @param {object} actor
  * @param {object} target
  */

--- a/module/config/qualities.mjs
+++ b/module/config/qualities.mjs
@@ -65,7 +65,7 @@ export const OGGDUDE_QUALITY_MAP = {
 }
 
 /**
- *
+ * Return the quality configuration entry matching the given key, or undefined when not found.
  * @param key
  */
 export function getQualityConfig(key) {

--- a/module/dice/action-use-dialog.mjs
+++ b/module/dice/action-use-dialog.mjs
@@ -98,7 +98,7 @@ export default class ActionUseDialog extends StandardCheckDialog {
   /* -------------------------------------------- */
 
   /**
-   *
+   * Prepare and annotate the list of action targets with CSS class and tooltip derived from their error state.
    * @returns {ActionUseTarget[]}
    */
   #prepareTargets() {

--- a/module/helpers/data/itemSchema.mjs
+++ b/module/helpers/data/itemSchema.mjs
@@ -10,7 +10,7 @@ import SwerpgCombatItemData from '../../data/combat-item.mjs'
 import { buildQualitySchema } from '../../models/qualities-schema.mjs'
 
 /**
- *
+ * Build the SchemaField for item starting attributes including wound/strain thresholds, defense, soak, experience, and force rating.
  * @param fields
  */
 export function buildAttributesSchema(fields) {
@@ -70,7 +70,7 @@ export function buildAttributesSchema(fields) {
 }
 
 /**
- *
+ * Build the standard requirement SchemaField including armor, non-career, and soak constraints on top of the base schema.
  * @param fields
  * @param extraFields
  */
@@ -101,7 +101,7 @@ export function buildStandardRequirementSchema(fields, extraFields = {}) {
 }
 
 /**
- *
+ * Build the base requirement SchemaField with career and specialization boolean flags, merging any extra fields.
  * @param fields
  * @param extraFields
  */
@@ -127,7 +127,7 @@ export function buildBaseRequirementSchema(fields, extraFields = {}) {
 }
 
 /**
- *
+ * Build a requirement schema extended with melee, brawl, and lightsaber wielding constraints.
  * @param fields
  */
 export function buildRequirementSchemaWithExtraFields(fields) {
@@ -148,7 +148,7 @@ export function buildRequirementSchemaWithExtraFields(fields) {
 }
 
 /**
- *
+ * Build the SetField schema for skill modifiers, extending talent modifiers with isCareer and skillType fields.
  * @param fields
  */
 export function buildSkillModifiersSchema(fields) {
@@ -165,7 +165,7 @@ export function buildSkillModifiersSchema(fields) {
 }
 
 /**
- *
+ * Build the SetField schema for talent modifiers, each entry carrying rank range, limit, and requirement fields.
  * @param fields
  * @param extraFields
  */
@@ -198,7 +198,7 @@ export function buildTalentModifiersSchema(fields, extraFields = {}) {
 }
 
 /**
- *
+ * Build the ArrayField schema for item qualities using the quality schema definition.
  * @param fields
  */
 export function buildQualitiesSchema(fields) {
@@ -206,7 +206,7 @@ export function buildQualitiesSchema(fields) {
 }
 
 /**
- *
+ * Build the SetField schema for weapon modifiers including unarmed, skill key, damage, crit, range, and quality fields.
  * @param fields
  * @param extraFields
  */
@@ -266,7 +266,7 @@ export function buildWeaponModifiersSchema(fields, extraFields = {}) {
 }
 
 /**
- *
+ * Build the weapon modifiers schema extended with range and baseMods fields.
  * @param fields
  */
 export function buildWeaponModifiersSchemaWithExtraSchema(fields) {

--- a/module/helpers/data/utilities.mjs
+++ b/module/helpers/data/utilities.mjs
@@ -250,7 +250,7 @@ export function buildOptionalHtmlField({ initial = '', itemType, key }) {
 }
 
 /**
- *
+ * Build a mandatory HTMLField with localized label and hint derived from the item type and key.
  * @param {object} root0
  * @param {string} root0.itemType
  * @param {string} root0.key
@@ -296,7 +296,7 @@ export function mandatorySchemaField(field = {}) {
 }
 
 /**
- *
+ * Build an optional SetField with the given element field and initial value.
  * @param {object} root0
  * @param {Array} root0.initial
  * @param {object} root0.field

--- a/module/helpers/foundry/compendium-folders.mjs
+++ b/module/helpers/foundry/compendium-folders.mjs
@@ -21,7 +21,7 @@ const OGGDUDE_COMPENDIUM_FOLDERS = {
 }
 
 /**
- *
+ * Return the first folder matching the given name, document type, and optional parent folder ID.
  * @param name
  * @param type
  * @param parentId
@@ -35,7 +35,7 @@ function findFolderByNameTypeAndParent(name, type, parentId = null) {
 }
 
 /**
- *
+ * Find an existing folder matching the given name, type, and parent, or create it when absent.
  * @param root0
  * @param root0.name
  * @param root0.type
@@ -57,7 +57,7 @@ async function getOrCreateFolder({ name, type, color, parentId = null }) {
 }
 
 /**
- *
+ * Ensure the compendium pack is placed in the correct OggDude import folder group, creating folders as needed.
  * @param pack
  * @param elementType
  */

--- a/module/helpers/server/directory/file.mjs
+++ b/module/helpers/server/directory/file.mjs
@@ -19,7 +19,7 @@
 import { logger } from '../../../utils/logger.mjs'
 
 /**
- *
+ * Create a subdirectory under the given path on the Foundry data storage.
  * @param path
  * @param target
  */

--- a/module/importer/items/career-ogg-dude.mjs
+++ b/module/importer/items/career-ogg-dude.mjs
@@ -201,7 +201,7 @@ export function mapCareerSkills(rawCodes = [], { strict = false } = {}) {
 }
 
 /**
- *
+ * Resolve the primary source reference from a raw OggDude career XML node.
  * @param xmlCareer
  */
 function resolveCareerSource(xmlCareer) {
@@ -227,7 +227,7 @@ function resolveCareerSource(xmlCareer) {
 }
 
 /**
- *
+ * Extract source name and page number from a single OggDude source entry node.
  * @param entry
  */
 function extractCareerSourceEntry(entry) {
@@ -251,7 +251,7 @@ function extractCareerSourceEntry(entry) {
 }
 
 /**
- *
+ * Convert a raw OggDude career description with markup tags to sanitized HTML, appending source attribution.
  * @param rawDescription
  * @param sourceInfo
  */
@@ -288,7 +288,7 @@ function buildCareerDescription(rawDescription, sourceInfo) {
 }
 
 /**
- *
+ * Append a formatted source attribution paragraph to the given HTML sections array when source info is present.
  * @param sections
  * @param sourceInfo
  */
@@ -304,7 +304,7 @@ function appendSourceSection(sections, sourceInfo) {
 }
 
 /**
- *
+ * Convert OggDude bracket-style markup tags in a career description string to equivalent HTML tags.
  * @param description
  */
 function convertCareerMarkupToHtml(description) {
@@ -374,7 +374,7 @@ function convertCareerMarkupToHtml(description) {
 }
 
 /**
- *
+ * Escape HTML special characters in a string, using Foundry's utility when available.
  * @param value
  */
 function escapeHtmlSafe(value) {

--- a/module/importer/items/combat-item-mapper.mjs
+++ b/module/importer/items/combat-item-mapper.mjs
@@ -1,7 +1,7 @@
 import OggDudeImporter from '../oggDude.mjs'
 
 /**
- *
+ * Map an OggDude XML weapon modifier node to a flat weapon modifier object.
  * @param xmlWeaponModifier
  */
 export function buildWeaponModifiers(xmlWeaponModifier) {
@@ -32,7 +32,7 @@ export function buildWeaponModifiers(xmlWeaponModifier) {
 }
 
 /**
- *
+ * Map an OggDude XML die modifier node to a flat die modifier object.
  * @param dieModifier
  */
 function _buildDieModifier(dieModifier) {
@@ -56,7 +56,7 @@ function _buildDieModifier(dieModifier) {
 }
 
 /**
- *
+ * Map an OggDude XML base mod node to a flat mod object including nested die modifiers.
  * @param mod
  */
 export function buildMod(mod) {

--- a/module/importer/items/duty-ogg-dude.mjs
+++ b/module/importer/items/duty-ogg-dude.mjs
@@ -6,7 +6,7 @@ import { resetDutyImportStats, incrementDutyImportStat, getDutyImportStats } fro
 import { sanitizeDescription } from '../utils/text.mjs'
 
 /**
- *
+ * Map an array of raw OggDude duty XML objects to Foundry item data objects.
  * @param duties
  */
 export function dutyMapper(duties) {
@@ -105,7 +105,7 @@ export function dutyMapper(duties) {
 export { getDutyImportStats }
 
 /**
- *
+ * Build the import context for OggDude duty data, including JSON payload and image references.
  * @param zip
  * @param groupByDirectory
  * @param groupByType

--- a/module/importer/items/specialization-tree-ogg-dude.mjs
+++ b/module/importer/items/specialization-tree-ogg-dude.mjs
@@ -5,7 +5,7 @@ import { getSpecializationTreeImportStats, resetSpecializationTreeImportStats } 
 import { specializationTreeMapper } from '../mappers/oggdude-specialization-tree-mapper.mjs'
 
 /**
- *
+ * Build a talent lookup map keyed by system ID or OggDude key from the active Foundry world items.
  */
 function buildTalentByIdFromWorld() {
   if (typeof game === 'undefined' || !game.items) return new Map()
@@ -30,7 +30,7 @@ function buildTalentByIdFromWorld() {
 }
 
 /**
- *
+ * Build a talent lookup map keyed by system ID or OggDude key from all loaded compendium packs.
  */
 function buildTalentByIdFromCompendium() {
   if (typeof game === 'undefined' || !game.packs) return new Map()
@@ -61,7 +61,7 @@ function buildTalentByIdFromCompendium() {
 }
 
 /**
- *
+ * Merge the world talent index with the compendium talent index, giving priority to world entries.
  */
 function buildTalentIndex() {
   const worldIndex = buildTalentByIdFromWorld()
@@ -115,6 +115,7 @@ function buildMergedTalentIndex(importSession) {
 }
 
 /**
+ * Build the import context for OggDude specialization tree data, resolving talent references via world, compendium, and session indexes.
  * @param zip
  * @param groupByDirectory
  * @param groupByType

--- a/module/importer/items/species-ogg-dude.mjs
+++ b/module/importer/items/species-ogg-dude.mjs
@@ -157,7 +157,7 @@ function collectNestedOptionSkillModifiers(xmlSpecies) {
 }
 
 /**
- *
+ * Extract all skill modifiers from the Options list of a single species choice node.
  * @param choice
  */
 function extractOptionsSkillModifiers(choice) {
@@ -168,7 +168,7 @@ function extractOptionsSkillModifiers(choice) {
 }
 
 /**
- *
+ * Extract all skill modifier entries from a single species option node.
  * @param opt
  */
 function extractSkillModifiersFromOption(opt) {

--- a/module/importer/items/weapon-ogg-dude.mjs
+++ b/module/importer/items/weapon-ogg-dude.mjs
@@ -31,7 +31,7 @@ import {
 const DEFAULT_QUALITY_COUNT = 1
 
 /**
- *
+ * Parse a raw quality count value and return a positive integer, defaulting to 1 when invalid.
  * @param value
  */
 function coerceQualityCount(value) {
@@ -40,7 +40,7 @@ function coerceQualityCount(value) {
 }
 
 /**
- *
+ * Split a delimited string on semicolons, commas, or slashes and return a trimmed, non-empty array.
  * @param input
  */
 function normalizeDelimitedValues(input) {
@@ -57,7 +57,7 @@ function normalizeDelimitedValues(input) {
 }
 
 /**
- *
+ * Normalize a raw category value or array to a trimmed, non-empty string array.
  * @param rawCategories
  */
 function normalizeCategoryValues(rawCategories) {
@@ -104,7 +104,7 @@ function normalizeSizeValue(value) {
 }
 
 /**
- *
+ * Extract source book name and page number from a raw OggDude source node.
  * @param source
  */
 function extractSourceInfo(source) {

--- a/module/importer/mappers/oggdude-specialization-tree-mapper.mjs
+++ b/module/importer/mappers/oggdude-specialization-tree-mapper.mjs
@@ -19,7 +19,7 @@ import {
 } from '../utils/specialization-tree-import-utils.mjs'
 
 /**
- *
+ * Wrap a value in an array if it is not already an array, normalizing objects and strings to single-element arrays.
  * @param value
  */
 function asArray(value) {
@@ -30,7 +30,7 @@ function asArray(value) {
 }
 
 /**
- *
+ * Return the trimmed string value, logging a warning when the value is absent or not a string.
  * @param label
  * @param value
  */
@@ -44,7 +44,7 @@ function readMandatoryString(label, value) {
 }
 
 /**
- *
+ * Return the value if it is a string, or an empty string otherwise.
  * @param value
  */
 function readOptionalString(value) {
@@ -52,7 +52,7 @@ function readOptionalString(value) {
 }
 
 /**
- *
+ * Return the first non-empty trimmed string found among the provided values, or an empty string when none qualify.
  * @param {...any} values
  */
 function readFirstString(...values) {
@@ -67,7 +67,7 @@ function readFirstString(...values) {
 }
 
 /**
- *
+ * Build lookup maps from raw node keys and row/column coordinates to normalized node IDs.
  * @param nodes
  */
 function buildNodeReferenceMaps(nodes) {
@@ -85,7 +85,7 @@ function buildNodeReferenceMaps(nodes) {
 }
 
 /**
- *
+ * Resolve a raw connection endpoint reference to a canonical node ID using the provided reference maps.
  * @param rawReference
  * @param maps
  */
@@ -106,7 +106,7 @@ function resolveConnectionEndpoint(rawReference, maps) {
 }
 
 /**
- *
+ * Extract connection entries declared on a single node, resolving endpoints and recording invalid connections.
  * @param rawNode
  * @param currentNodeId
  * @param maps
@@ -136,7 +136,7 @@ function extractNodeConnectionEntries(rawNode, currentNodeId, maps) {
 }
 
 /**
- *
+ * Extract connection entries declared at the specialization level, resolving from/to endpoints and recording invalid connections.
  * @param xmlSpecialization
  * @param maps
  */
@@ -168,7 +168,7 @@ function extractGlobalConnectionEntries(xmlSpecialization, maps) {
 }
 
 /**
- *
+ * Extract raw node entries from a talent-rows-style specialization XML block.
  * @param xmlSpecialization
  */
 function extractNodesFromRows(xmlSpecialization) {
@@ -214,7 +214,7 @@ function extractNodesFromRows(xmlSpecialization) {
 }
 
 /**
- *
+ * Derive the tree row index from a node XP cost value, returning null when the cost does not map to a valid row.
  * @param cost
  */
 function computeRowFromCost(cost) {
@@ -226,7 +226,7 @@ function computeRowFromCost(cost) {
 }
 
 /**
- *
+ * Extract raw node entries from a flat Nodes/TalentNodes list in the specialization XML block.
  * @param xmlSpecialization
  */
 function extractNodesFromFlatList(xmlSpecialization) {
@@ -247,7 +247,7 @@ function extractNodesFromFlatList(xmlSpecialization) {
 }
 
 /**
- *
+ * Select and return raw node entries from a specialization XML block, preferring row-based extraction over the flat-list format.
  * @param xmlSpecialization
  */
 function extractRawNodeEntries(xmlSpecialization) {
@@ -257,7 +257,7 @@ function extractRawNodeEntries(xmlSpecialization) {
 }
 
 /**
- *
+ * Detect the structural format of the specialization XML input block (talent-rows-keys, talent-rows-columns, flat-list, or unknown).
  * @param xmlSpecialization
  */
 function detectInputFormat(xmlSpecialization) {
@@ -290,7 +290,7 @@ function detectInputFormat(xmlSpecialization) {
 }
 
 /**
- *
+ * Parse and normalize all node entries from the specialization XML, validating positions and costs.
  * @param xmlSpecialization
  * @param specializationId
  */
@@ -332,7 +332,7 @@ function normalizeNodes(xmlSpecialization, specializationId) {
 }
 
 /**
- *
+ * Remove duplicate connection entries, keeping only the first occurrence of each from→to:type combination.
  * @param connections
  */
 function dedupeConnections(connections) {
@@ -350,7 +350,7 @@ function dedupeConnections(connections) {
 }
 
 /**
- *
+ * Derive Right and Down directional connections from node direction flags in talent-rows-keys format.
  * @param nodes
  */
 function extractDirectionalConnections(nodes) {
@@ -390,7 +390,7 @@ function extractDirectionalConnections(nodes) {
 }
 
 /**
- *
+ * Map an array of raw OggDude specialization XML objects to Foundry specialization tree item data.
  * @param specializations
  * @param root0
  * @param root0.talentById

--- a/module/importer/mappings/oggdude-gear-utils.mjs
+++ b/module/importer/mappings/oggdude-gear-utils.mjs
@@ -5,7 +5,7 @@ import { getQualityConfig } from '../../config/qualities.mjs'
 const BRAWN_BASED_SKILLS = new Set(['melee', 'meleeheavy', 'meleelight', 'brawl', 'lightsaber'])
 
 /**
- *
+ * Return the value wrapped in an array if it is not already an array, or an empty array for falsy values.
  * @param value
  */
 function ensureArray(value) {
@@ -16,7 +16,7 @@ function ensureArray(value) {
 }
 
 /**
- *
+ * Parse a value as an integer, returning the fallback when the result is NaN.
  * @param value
  * @param fallback
  */
@@ -29,7 +29,7 @@ function parseInteger(value, fallback = 0) {
 }
 
 /**
- *
+ * Convert a PascalCase key to camelCase by lowercasing the first character.
  * @param key
  */
 function toCamelCase(key) {
@@ -40,7 +40,7 @@ function toCamelCase(key) {
 }
 
 /**
- *
+ * Convert a raw key or enum value to a title-cased human-readable label.
  * @param value
  */
 function humanizeLabel(value) {
@@ -61,7 +61,7 @@ function humanizeLabel(value) {
 }
 
 /**
- *
+ * Map a raw OggDude range string to the canonical SWERPG range value using the weapon range map.
  * @param range
  */
 function normalizeRangeValue(range) {
@@ -91,7 +91,7 @@ function normalizeRangeValue(range) {
 }
 
 /**
- *
+ * Return true if the skill key corresponds to a brawn-based combat skill.
  * @param skillKey
  */
 function isBrawnSkill(skillKey) {
@@ -105,7 +105,7 @@ function isBrawnSkill(skillKey) {
 }
 
 /**
- *
+ * Build a display label for weapon damage, using "Brawn" notation for brawn-based skills.
  * @param baseDamage
  * @param bonusDamage
  * @param skillKey
@@ -133,7 +133,7 @@ function formatDamageLabel(baseDamage, bonusDamage, skillKey) {
 }
 
 /**
- *
+ * Sanitize an OggDude gear description string using the same rules as weapon descriptions.
  * @param description
  */
 export function sanitizeOggDudeGearDescription(description) {
@@ -141,7 +141,7 @@ export function sanitizeOggDudeGearDescription(description) {
 }
 
 /**
- *
+ * Extract source book name and page number from an OggDude source field.
  * @param source
  */
 export function extractGearSourceInfo(source) {
@@ -162,7 +162,7 @@ export function extractGearSourceInfo(source) {
 }
 
 /**
- *
+ * Format an extracted source info object as a display string, appending the page number when available.
  * @param root0
  * @param root0.name
  * @param root0.page
@@ -178,7 +178,7 @@ export function formatGearSourceLine({ name, page }) {
 }
 
 /**
- *
+ * Convert a gear category label to a normalized lowercase underscore-separated slug, defaulting to "general".
  * @param value
  */
 export function slugifyGearCategory(value) {
@@ -197,7 +197,7 @@ export function slugifyGearCategory(value) {
 }
 
 /**
- *
+ * Extract and normalize base modification entries from an OggDude BaseMods XML node.
  * @param baseModsNode
  */
 export function extractBaseMods(baseModsNode) {
@@ -290,7 +290,7 @@ export function extractBaseMods(baseModsNode) {
 }
 
 /**
- *
+ * Extract the primary weapon profile from an OggDude WeaponModifiers XML node, including damage, crit, range, and qualities.
  * @param weaponModifiersNode
  */
 export function extractWeaponProfile(weaponModifiersNode) {
@@ -398,7 +398,7 @@ export function extractWeaponProfile(weaponModifiersNode) {
 }
 
 /**
- *
+ * Compose the full gear item description by assembling base text, source line, base mods, and weapon use sections.
  * @param root0
  * @param root0.baseDescription
  * @param root0.sourceLine

--- a/module/importer/mappings/oggdude-talent-prerequisite-map.mjs
+++ b/module/importer/mappings/oggdude-talent-prerequisite-map.mjs
@@ -79,7 +79,7 @@ function mapOggDudeSkillToSystem(oggDudeSkillCode) {
 
 // Mapping minimal selon TUs
 /**
- *
+ * Map an OggDude characteristic name to its system key, or return null when unrecognized.
  * @param k
  */
 function mapCharacteristicKey(k) {
@@ -95,7 +95,7 @@ function mapCharacteristicKey(k) {
 }
 
 /**
- *
+ * Map an OggDude skill identifier to its normalized lowercase system key.
  * @param k
  */
 function mapSkillKey(k) {

--- a/module/importer/oggDude.mjs
+++ b/module/importer/oggDude.mjs
@@ -203,7 +203,7 @@ function buildContextRegistry() {
 }
 
 /**
- *
+ * Return the import statistics payload for the given domain identifier.
  * @param domain
  */
 function getDomainStatsPayload(domain) {
@@ -601,6 +601,7 @@ export default class OggDudeImporter {
   }
 
   /**
+   * Load an OggDude zip archive and return its entries keyed by path.
    * @param file : File (Zip file path) from OGGDude https://www.swrpgcommunity.com/gm-resources/apps-dice-utilities/oggdudes-generator
    * @returns {Promise<{[p: string]: JSZip.JSZipObject}>}
    */

--- a/module/importer/utils/career-import-utils.mjs
+++ b/module/importer/utils/career-import-utils.mjs
@@ -12,7 +12,7 @@ const careerStats = new ImportStats({
 })
 
 /**
- *
+ * Reset all career import counters and skill details to zero.
  */
 export function resetCareerImportStats() {
   careerStats.reset({
@@ -22,7 +22,7 @@ export function resetCareerImportStats() {
 }
 
 /**
- *
+ * Increment a named career import counter by the given amount.
  * @param key
  * @param amount
  */
@@ -31,7 +31,7 @@ export function incrementCareerImportStat(key, amount = 1) {
 }
 
 /**
- *
+ * Record an unknown skill code encountered during career import.
  * @param code
  */
 export function addCareerUnknownSkill(code) {
@@ -39,7 +39,7 @@ export function addCareerUnknownSkill(code) {
 }
 
 /**
- *
+ * Return the current career import statistics snapshot.
  */
 export function getCareerImportStats() {
   return careerStats.getStats()

--- a/module/importer/utils/duty-import-utils.mjs
+++ b/module/importer/utils/duty-import-utils.mjs
@@ -5,14 +5,14 @@ import { ImportStats } from './import-stats.mjs'
 const dutyStats = new ImportStats()
 
 /**
- *
+ * Reset all duty import counters to zero.
  */
 export function resetDutyImportStats() {
   dutyStats.reset()
 }
 
 /**
- *
+ * Increment a named duty import counter by the given amount.
  * @param key
  * @param amount
  */
@@ -21,7 +21,7 @@ export function incrementDutyImportStat(key, amount = 1) {
 }
 
 /**
- *
+ * Return the current duty import statistics snapshot.
  */
 export function getDutyImportStats() {
   return dutyStats.getStats()

--- a/module/importer/utils/gear-import-utils.mjs
+++ b/module/importer/utils/gear-import-utils.mjs
@@ -12,7 +12,7 @@ const gearStats = new ImportStats({
 })
 
 /**
- *
+ * Reset all gear import counters and category details to zero.
  */
 export function resetGearImportStats() {
   gearStats.reset({
@@ -21,7 +21,7 @@ export function resetGearImportStats() {
 }
 
 /**
- *
+ * Increment a named gear import counter by the given amount.
  * @param key
  * @param amount
  */
@@ -30,7 +30,7 @@ export function incrementGearImportStat(key, amount = 1) {
 }
 
 /**
- *
+ * Record an unknown category code encountered during gear import.
  * @param code
  */
 export function addGearUnknownCategory(code) {
@@ -38,7 +38,7 @@ export function addGearUnknownCategory(code) {
 }
 
 /**
- *
+ * Return the current gear import statistics snapshot.
  */
 export function getGearImportStats() {
   return gearStats.getStats()

--- a/module/importer/utils/global-import-metrics.mjs
+++ b/module/importer/utils/global-import-metrics.mjs
@@ -25,7 +25,7 @@ const _runtime = {
 // For tests and reset scenarios we expose a reset helper so consumers (tests) can
 // ensure a clean state between runs.
 /**
- *
+ * Reset the internal runtime metrics, optionally preserving the last successful import stats.
  * @param preserveLastImportStats
  */
 export function resetRuntimeMetrics(preserveLastImportStats = false) {
@@ -39,7 +39,7 @@ export function resetRuntimeMetrics(preserveLastImportStats = false) {
 }
 
 /**
- *
+ * Record the global import start timestamp using performance.now when available.
  */
 export function markGlobalStart() {
   _runtime.globalStart = typeof performance !== 'undefined' && typeof performance.now === 'function' ? performance.now() : Date.now()
@@ -47,7 +47,7 @@ export function markGlobalStart() {
 }
 
 /**
- *
+ * Record the global import end timestamp and log the overall duration.
  */
 export function markGlobalEnd() {
   _runtime.globalEnd = typeof performance !== 'undefined' && typeof performance.now === 'function' ? performance.now() : Date.now()
@@ -56,7 +56,7 @@ export function markGlobalEnd() {
 }
 
 /**
- *
+ * Store the import archive size in bytes when the provided value is a non-negative finite number.
  * @param size
  */
 export function markArchiveSize(size) {
@@ -66,7 +66,7 @@ export function markArchiveSize(size) {
 }
 
 /**
- *
+ * Record the start timestamp for the given import domain.
  * @param domain
  */
 export function recordDomainStart(domain) {
@@ -75,7 +75,7 @@ export function recordDomainStart(domain) {
 }
 
 /**
- *
+ * Record the end timestamp for the given import domain when its entry exists in the runtime map.
  * @param domain
  */
 export function recordDomainEnd(domain) {
@@ -131,7 +131,7 @@ export function getAllImportStats() {
 }
 
 /**
- *
+ * Invoke fn and return its result, returning a zero-filled stats object if an error is thrown.
  * @param fn
  */
 function safeCall(fn) {
@@ -196,7 +196,7 @@ export { aggregateImportMetrics as getGlobalImportMetrics }
 // ---- Format helpers (human readable) ---------------------------------
 
 /**
- *
+ * Format a byte count as a human-readable string with the appropriate unit.
  * @param bytes
  * @param decimals
  */
@@ -209,7 +209,7 @@ function _formatBytes(bytes, decimals = 2) {
 }
 
 /**
- *
+ * Format a duration in milliseconds as a human-readable string, showing seconds when the value exceeds 1000.
  * @param ms
  */
 function _formatDurationMs(ms) {
@@ -222,7 +222,7 @@ function _formatDurationMs(ms) {
 }
 
 /**
- *
+ * Format a 0–1 ratio as a percentage string with the given number of decimal places.
  * @param value
  * @param decimals
  */
@@ -232,7 +232,7 @@ function _formatPercent(value, decimals = 2) {
 }
 
 /**
- *
+ * Format a numeric value as a string, returning integers without a decimal point.
  * @param value
  * @param decimals
  */

--- a/module/importer/utils/import-session.mjs
+++ b/module/importer/utils/import-session.mjs
@@ -174,7 +174,7 @@ export function topologicalSort(pipelines) {
   const cycleDetails = []
 
   /**
-   *
+   * Recursively visit a node to produce a topologically sorted order, detecting cycles.
    * @param id
    */
   function visit(id) {

--- a/module/importer/utils/motivation-import-utils.mjs
+++ b/module/importer/utils/motivation-import-utils.mjs
@@ -8,14 +8,14 @@ const motivationCategoryStats = new ImportStats()
 // --- Motivation ---
 
 /**
- *
+ * Reset all motivation import counters to zero.
  */
 export function resetMotivationImportStats() {
   motivationStats.reset()
 }
 
 /**
- *
+ * Increment a named motivation import counter by the given amount.
  * @param key
  * @param amount
  */
@@ -24,7 +24,7 @@ export function incrementMotivationImportStat(key, amount = 1) {
 }
 
 /**
- *
+ * Return the current motivation import statistics snapshot.
  */
 export function getMotivationImportStats() {
   return motivationStats.getStats()
@@ -33,14 +33,14 @@ export function getMotivationImportStats() {
 // --- Motivation Category ---
 
 /**
- *
+ * Reset all motivation-category import counters to zero.
  */
 export function resetMotivationCategoryImportStats() {
   motivationCategoryStats.reset()
 }
 
 /**
- *
+ * Increment a named motivation-category import counter by the given amount.
  * @param key
  * @param amount
  */
@@ -49,7 +49,7 @@ export function incrementMotivationCategoryImportStat(key, amount = 1) {
 }
 
 /**
- *
+ * Return the current motivation-category import statistics snapshot.
  */
 export function getMotivationCategoryImportStats() {
   return motivationCategoryStats.getStats()

--- a/module/importer/utils/specialization-import-utils.mjs
+++ b/module/importer/utils/specialization-import-utils.mjs
@@ -49,7 +49,7 @@ export function addSpecializationRejectionReason(reason) {
 }
 
 /**
- *
+ * Record an unknown skill code encountered during specialization import.
  * @param code
  */
 export function addSpecializationUnknownSkill(code) {

--- a/module/importer/utils/specialization-tree-import-utils.mjs
+++ b/module/importer/utils/specialization-tree-import-utils.mjs
@@ -8,7 +8,7 @@ const specializationTreeStats = new ImportStats({
 })
 
 /**
- *
+ * Reset all specialization tree import counters and detail lists to their initial zero values.
  */
 export function resetSpecializationTreeImportStats() {
   specializationTreeStats.reset({
@@ -20,7 +20,7 @@ export function resetSpecializationTreeImportStats() {
 }
 
 /**
- *
+ * Increment a named statistic counter for the current specialization tree import run.
  * @param key
  * @param amount
  */
@@ -29,7 +29,7 @@ export function incrementSpecializationTreeImportStat(key, amount = 1) {
 }
 
 /**
- *
+ * Record a rejection reason string for the current specialization tree import run.
  * @param reason
  */
 export function addSpecializationTreeRejectionReason(reason) {
@@ -37,7 +37,7 @@ export function addSpecializationTreeRejectionReason(reason) {
 }
 
 /**
- *
+ * Record a missing-cost detail entry for a node that could not be mapped to a cost value.
  * @param detail
  */
 export function addSpecializationTreeMissingCost(detail) {
@@ -45,7 +45,7 @@ export function addSpecializationTreeMissingCost(detail) {
 }
 
 /**
- *
+ * Record an unresolved-talent detail entry for a node whose talent could not be resolved.
  * @param detail
  */
 export function addSpecializationTreeUnresolvedTalent(detail) {
@@ -53,7 +53,7 @@ export function addSpecializationTreeUnresolvedTalent(detail) {
 }
 
 /**
- *
+ * Record a detail entry for a talent node whose UUID could not be resolved to a compendium item.
  * @param detail
  */
 export function addSpecializationTreeTalentUuidNotResolved(detail) {
@@ -61,7 +61,7 @@ export function addSpecializationTreeTalentUuidNotResolved(detail) {
 }
 
 /**
- *
+ * Record an invalid-connection detail entry for a node connection that could not be resolved.
  * @param detail
  */
 export function addSpecializationTreeInvalidConnection(detail) {
@@ -69,14 +69,14 @@ export function addSpecializationTreeInvalidConnection(detail) {
 }
 
 /**
- *
+ * Return the accumulated statistics for the current specialization tree import run.
  */
 export function getSpecializationTreeImportStats() {
   return specializationTreeStats.getStats()
 }
 
 /**
- *
+ * Merge base specialization stats with specialization-tree stats into a single combined object.
  * @param baseStats
  * @param treeStats
  */
@@ -95,7 +95,7 @@ export function getCombinedSpecializationImportStats(baseStats = {}, treeStats =
 }
 
 /**
- *
+ * Normalize a raw specialization key into a lowercase hyphenated identifier.
  * @param rawKey
  */
 export function normalizeSpecializationTreeId(rawKey) {
@@ -107,7 +107,7 @@ export function normalizeSpecializationTreeId(rawKey) {
 }
 
 /**
- *
+ * Build a canonical node identifier string from a positive integer row and column, returning null for invalid inputs.
  * @param row
  * @param column
  */
@@ -117,7 +117,7 @@ export function normalizeNodeId(row, column) {
 }
 
 /**
- *
+ * Parse a raw value as a positive integer, returning null when the result is not a positive integer.
  * @param rawValue
  */
 export function parsePositiveInteger(rawValue) {
@@ -126,7 +126,7 @@ export function parsePositiveInteger(rawValue) {
 }
 
 /**
- *
+ * Parse a raw value as a non-negative integer, returning null when the result is negative or not an integer.
  * @param rawValue
  */
 export function parseNonNegativeInteger(rawValue) {
@@ -135,7 +135,7 @@ export function parseNonNegativeInteger(rawValue) {
 }
 
 /**
- *
+ * Normalize a raw connection type string to a lowercase trimmed value, returning undefined for non-string inputs.
  * @param rawValue
  */
 export function normalizeConnectionType(rawValue) {
@@ -149,7 +149,7 @@ export function normalizeConnectionType(rawValue) {
 }
 
 /**
- *
+ * Return true if the nodeId string already matches the canonical "rNcN" node reference format.
  * @param nodeId
  */
 export function isResolvedNodeReference(nodeId) {
@@ -157,7 +157,7 @@ export function isResolvedNodeReference(nodeId) {
 }
 
 /**
- *
+ * Build a diagnostics object for a specialization tree import result, combining warnings and completeness flags.
  * @param warnings
  * @param unresolved
  * @param options

--- a/module/importer/utils/species-import-utils.mjs
+++ b/module/importer/utils/species-import-utils.mjs
@@ -11,7 +11,7 @@ const speciesStats = new ImportStats({
 })
 
 /**
- *
+ * Reset all species import counters and talent details to zero.
  */
 export function resetSpeciesImportStats() {
   speciesStats.reset({
@@ -20,7 +20,7 @@ export function resetSpeciesImportStats() {
 }
 
 /**
- *
+ * Increment a named species import counter by the given amount.
  * @param key
  * @param amount
  */
@@ -29,7 +29,7 @@ export function incrementSpeciesImportStat(key, amount = 1) {
 }
 
 /**
- *
+ * Record an unknown talent code encountered during species import.
  * @param code
  */
 export function addSpeciesUnknownTalent(code) {
@@ -37,7 +37,7 @@ export function addSpeciesUnknownTalent(code) {
 }
 
 /**
- *
+ * Return the current species import statistics snapshot.
  */
 export function getSpeciesImportStats() {
   return speciesStats.getStats()

--- a/module/importer/utils/talent-import-utils.mjs
+++ b/module/importer/utils/talent-import-utils.mjs
@@ -126,7 +126,7 @@ export function generateTalentKey(name) {
 }
 
 /**
- *
+ * Build a talent import diagnostics object summarizing warnings and unresolved reference status.
  * @param warnings
  * @param unresolved
  */

--- a/module/lib/jauges/abstract-jauge.mjs
+++ b/module/lib/jauges/abstract-jauge.mjs
@@ -15,6 +15,7 @@ export class AbstractJauge {
   }
 
   /**
+   * Build and return the display data object for this gauge.
    * @returns {JaugeDisplayData}
    */
   create() {

--- a/module/lib/talent-node/talent-node-forget.mjs
+++ b/module/lib/talent-node/talent-node-forget.mjs
@@ -94,7 +94,7 @@ function auditTalentNode(actor, operation, status, data) {
 }
 
 /**
- *
+ * Await an audit promise and log any rejection as an error without propagating it.
  * @param promise
  * @param ctx
  * @param prefix

--- a/module/lib/talent-node/talent-node-progression.mjs
+++ b/module/lib/talent-node/talent-node-progression.mjs
@@ -83,7 +83,7 @@ export function processTalentNodeProgression(actor, specializationId, nodeId, ac
 // ---------------------------------------------------------------------------
 
 /**
- *
+ * Validate that the node is in AVAILABLE state and return the purchase success result or a failure reason.
  * @param {object} actor
  * @param {string} specializationId
  * @param {object} tree
@@ -104,7 +104,7 @@ function validatePurchase(actor, specializationId, tree, node, action) {
 // ---------------------------------------------------------------------------
 
 /**
- *
+ * Validate that the node is purchased and has no blocking dependents, returning the forget success result or a failure reason.
  * @param {object} actor
  * @param {string} specializationId
  * @param {object} tree
@@ -138,7 +138,7 @@ function validateForget(actor, specializationId, tree, node, action) {
 // ---------------------------------------------------------------------------
 
 /**
- *
+ * Build the success result payload for a purchase or forget action, computing updated purchases and XP spent.
  * @param {object} actor
  * @param {string} specializationId
  * @param {object} tree
@@ -250,7 +250,7 @@ function findBlockingDependents(actor, tree, targetNodeId, specializationId) {
 }
 
 /**
- *
+ * Find and return the specialization object on the actor matching the given specializationId, or null if absent.
  * @param {object} actor
  * @param {string} specializationId
  */
@@ -264,7 +264,7 @@ function findSpecialization(actor, specializationId) {
 }
 
 /**
- *
+ * Find and return the node with the given nodeId within the tree, or null if not found.
  * @param {object} tree
  * @param {string} nodeId
  */

--- a/module/lib/talent-node/talent-node-purchase.mjs
+++ b/module/lib/talent-node/talent-node-purchase.mjs
@@ -92,7 +92,7 @@ function auditTalentNode(actor, operation, status, data) {
 }
 
 /**
- *
+ * Await an audit promise and log any rejection as an error without propagating it.
  * @param promise
  * @param ctx
  * @param prefix

--- a/module/lib/talent-node/talent-node-state.mjs
+++ b/module/lib/talent-node/talent-node-state.mjs
@@ -21,7 +21,7 @@ export const REASON_CODE = Object.freeze({
 })
 
 /**
- *
+ * Build a structured node state result object.
  * @param {string} state
  * @param {string} reasonCode
  * @param {object} details
@@ -31,7 +31,7 @@ function makeResult(state, reasonCode, details = {}) {
 }
 
 /**
- *
+ * Return true if the actor currently owns the specialization identified by specializationId.
  * @param {object} actor
  * @param {string} specializationId
  */
@@ -45,7 +45,7 @@ function isSpecializationOwned(actor, specializationId) {
 }
 
 /**
- *
+ * Find and return the node with the given nodeId within the tree's nodes array, or undefined if not found.
  * @param {object} tree
  * @param {string} nodeId
  */
@@ -56,7 +56,7 @@ function findNode(tree, nodeId) {
 }
 
 /**
- *
+ * Return true if the actor has a recorded purchase matching the given tree, node, talent, and specialization.
  * @param {object} actor
  * @param {string} treeId
  * @param {string} nodeId
@@ -79,7 +79,7 @@ function hasPurchase(actor, treeId, nodeId, talentId, specializationId, { treeUu
 }
 
 /**
- *
+ * Return true if the node has all mandatory fields populated with valid values.
  * @param {object} node
  */
 function hasValidFields(node) {
@@ -90,7 +90,7 @@ function hasValidFields(node) {
 }
 
 /**
- *
+ * Return the list of mandatory field names that are absent or null on the node.
  * @param {object} node
  */
 function missingFields(node) {
@@ -103,7 +103,7 @@ function missingFields(node) {
 }
 
 /**
- *
+ * Return true if the tree has non-empty nodes and connections arrays and carries no unresolved import flags.
  * @param {object} tree
  */
 function isCompleteTree(tree) {
@@ -119,7 +119,7 @@ function isCompleteTree(tree) {
 }
 
 /**
- *
+ * Return true if the node is accessible: either it is on row 1, or at least one predecessor node is purchased.
  * @param {object} actor
  * @param {object} tree
  * @param {object} node
@@ -147,7 +147,7 @@ function isAccessible(actor, tree, node) {
 }
 
 /**
- *
+ * Return the actor's available XP from the progression data, computing it from gained minus spent when not directly stored.
  * @param {object} actor
  */
 function getAvailableXp(actor) {
@@ -158,7 +158,7 @@ function getAvailableXp(actor) {
 }
 
 /**
- *
+ * Return the computed state of a single talent node for the given actor and specialization context.
  * @param {object} actor
  * @param {string} specializationId
  * @param {object} tree
@@ -232,7 +232,7 @@ export function getNodeState(actor, specializationId, tree, nodeId) {
 }
 
 /**
- *
+ * Compute the state of every node in the tree for the given actor and specialization, returning a map keyed by nodeId.
  * @param {object} actor
  * @param {string} specializationId
  * @param {object} tree

--- a/module/lib/talent-node/talent-reference-resolver.mjs
+++ b/module/lib/talent-node/talent-reference-resolver.mjs
@@ -27,7 +27,7 @@ function isTalentActivationActive(activation) {
 }
 
 /**
- *
+ * Resolve a talent item from world items or compendium packs using its normalized business key.
  * @param normalizedKey
  */
 function resolveTalentByBusinessKey(normalizedKey) {

--- a/module/lib/talent-node/talent-tree-resolver.mjs
+++ b/module/lib/talent-node/talent-tree-resolver.mjs
@@ -1,7 +1,7 @@
 import { logger } from '../../utils/logger.mjs'
 
 /**
- *
+ * Find the specialization tree item that matches the given specialization data by name or slug.
  * @param specData
  */
 export function findTreeForSpecialization(specData) {

--- a/module/lib/talents/talent-cost-calculator.mjs
+++ b/module/lib/talents/talent-cost-calculator.mjs
@@ -43,6 +43,7 @@ export default class TalentCostCalculator {
   }
 
   /**
+   * Compute the XP cost to train a skill to the given rank.
    * @param rank
    * @deprecated Crucible legacy
    */
@@ -51,6 +52,7 @@ export default class TalentCostCalculator {
   }
 
   /**
+   * Compute the XP refund for forgetting a skill at the given rank.
    * @param rank
    * @deprecated Crucible legacy
    */

--- a/module/models/qualities-schema.mjs
+++ b/module/models/qualities-schema.mjs
@@ -1,5 +1,5 @@
 /**
- *
+ * Build the SchemaField definition for a single item quality entry, including key, rank, hasRank, active, and source fields.
  */
 export function buildQualitySchema() {
   const fields = foundry.data.fields

--- a/module/settings/OggDudeDataImporter.mjs
+++ b/module/settings/OggDudeDataImporter.mjs
@@ -535,7 +535,7 @@ export class OggDudeDataImporter extends HandlebarsApplicationMixin(ApplicationV
   /* -------------------------------------------- */
 
   /**
-   *
+   * Handle clicks on the load-zip button by reading the selected file and initiating the import pipeline.
    * @param {Event} event  The originating click event
    * @private
    */

--- a/module/settings/models/OggDudeDataElement.mjs
+++ b/module/settings/models/OggDudeDataElement.mjs
@@ -90,7 +90,7 @@ class OggDudeDataElement {
   static directory = 'directory'
 
   /**
-   *
+   * Initialize an OggDudeDataElement from the given zip entry metadata.
    * @param {ZipEntry} zipEntry Object the zip entry object
    */
   constructor(zipEntry = {}) {

--- a/module/socket.mjs
+++ b/module/socket.mjs
@@ -1,7 +1,7 @@
 import StandardCheck from './dice/standard-check.mjs'
 
 /**
- *
+ * Handle an incoming socket event by dispatching to the appropriate dice-check or contest handler.
  * @param root0
  * @param root0.action
  * @param root0.data

--- a/module/utils/audit-diff.mjs
+++ b/module/utils/audit-diff.mjs
@@ -7,7 +7,7 @@ import { getCanonicalSpecializationKey } from '../lib/specializations/owned-spec
 /* -------------------------------------------- */
 
 /**
- *
+ * Capture the current XP and free skill rank values from the actor's progression data.
  * @param {object} actor
  */
 function captureSnapshot(actor) {
@@ -23,7 +23,7 @@ function captureSnapshot(actor) {
 }
 
 /**
- *
+ * Compute the XP cost of increasing a characteristic to newValue.
  * @param {number} newValue
  */
 function computeCharacteristicCost(newValue) {
@@ -61,7 +61,7 @@ function reconstructPreviousValue(oldPartialValue, currentValue) {
 /* -------------------------------------------- */
 
 /**
- *
+ * Build a structured audit log entry with a generated ID and schema version.
  * @param {object} root0
  * @param {string} root0.type
  * @param {object} root0.data
@@ -90,7 +90,7 @@ function makeEntry({ type, data, xpDelta, ts, userId, user, snapshot }) {
 /* -------------------------------------------- */
 
 /**
- *
+ * Detect skill rank changes between old state and applied changes and return the corresponding audit entries.
  * @param {object} oldState
  * @param {object} changes
  * @param {object} actor
@@ -176,7 +176,7 @@ function detectSkillChanges(oldState, changes, actor, ts, userId, user, snapshot
 }
 
 /**
- *
+ * Compute the total skill rank by summing all rank sub-fields.
  * @param {object} rank
  */
 function getSkillTotalRank(rank) {
@@ -184,7 +184,7 @@ function getSkillTotalRank(rank) {
 }
 
 /**
- *
+ * Return true if the skill is a career skill for the actor, based on career and specialization data.
  * @param {string} skillId
  * @param {object} _oldState
  * @param {object} actor
@@ -194,7 +194,7 @@ function inferIsCareer(skillId, _oldState, actor) {
 }
 
 /**
- *
+ * Collect all career skill IDs for the actor, including those from active specializations.
  * @param {object} actor
  */
 function getCareerSkillIds(actor) {
@@ -217,7 +217,7 @@ function getCareerSkillIds(actor) {
 }
 
 /**
- *
+ * Detect characteristic rank increases between old state and applied changes and return the corresponding audit entries.
  * @param {object} oldState
  * @param {object} changes
  * @param {object} actor
@@ -268,7 +268,7 @@ function detectCharacteristicChanges(oldState, changes, actor, ts, userId, user,
 }
 
 /**
- *
+ * Compute the total characteristic rank by summing base, trained, and bonus sub-fields.
  * @param {object} rank
  */
 function getCharacteristicTotalRank(rank) {
@@ -276,7 +276,7 @@ function getCharacteristicTotalRank(rank) {
 }
 
 /**
- *
+ * Detect XP spend, refund, grant, or remove events from progression changes and return the corresponding audit entries.
  * @param {object} oldState
  * @param {object} changes
  * @param {object} actor
@@ -344,7 +344,7 @@ function detectXpChanges(oldState, changes, actor, ts, userId, user, snapshot) {
 }
 
 /**
- *
+ * Detect species, career, and specialization changes in the details block and return the corresponding audit entries.
  * @param {object} oldState
  * @param {object} changes
  * @param {object} actor
@@ -405,7 +405,7 @@ function detectDetailChanges(oldState, changes, actor, ts, userId, user, snapsho
 }
 
 /**
- *
+ * Compute the XP delta from the experience spent change, returning 0 when no spent value is present in the changes.
  * @param {object} oldState
  * @param {object} changes
  */
@@ -418,7 +418,7 @@ function getXpDeltaFromChanges(oldState, changes) {
 }
 
 /**
- *
+ * Return the specializations on a source object as a plain array, regardless of the underlying storage type.
  * @param {object} source
  */
 function getSpecArray(source) {
@@ -431,7 +431,7 @@ function getSpecArray(source) {
 }
 
 /**
- *
+ * Build a map from canonical specialization key to specialization object for the given source.
  * @param {object} source
  */
 function buildSpecMap(source) {
@@ -446,7 +446,7 @@ function buildSpecMap(source) {
 }
 
 /**
- *
+ * Detect specialization additions and removals from the specialization changes block and return the corresponding audit entries.
  * @param {object} oldState
  * @param {object} specializationChanges
  * @param {object} actor
@@ -544,7 +544,7 @@ function detectSpecializationChanges(oldState, specializationChanges, actor, ts,
 }
 
 /**
- *
+ * Detect level advancement changes and return the corresponding audit entry when the level differs.
  * @param {object} oldState
  * @param {object} changes
  * @param {object} actor
@@ -579,7 +579,7 @@ function detectAdvancementChanges(oldState, changes, actor, ts, userId, user, sn
 /* -------------------------------------------- */
 
 /**
- *
+ * Compose all audit log entries from a set of actor changes, dispatching to per-domain detectors.
  * @param {object} oldState
  * @param {object} changes
  * @param {object} actor

--- a/module/utils/audit-log.mjs
+++ b/module/utils/audit-log.mjs
@@ -19,7 +19,7 @@ const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms))
 /* -------------------------------------------- */
 
 /**
- *
+ * Return true if the changes object only modifies the audit log flag path.
  * @param {object} changes
  */
 function isOnlyAuditChange(changes) {
@@ -29,7 +29,7 @@ function isOnlyAuditChange(changes) {
 }
 
 /**
- *
+ * Return true if the actor document is of type "character".
  * @param {object} actor
  */
 function isCharacterActor(actor) {
@@ -37,7 +37,7 @@ function isCharacterActor(actor) {
 }
 
 /**
- *
+ * Return true if the update options flag this as an internal audit log write.
  * @param {object} options
  */
 function isAuditInternalUpdate(options) {
@@ -49,7 +49,7 @@ function isAuditInternalUpdate(options) {
 /* -------------------------------------------- */
 
 /**
- *
+ * Deep-clone a value using Foundry utilities when available, falling back to structuredClone.
  * @param {*} value
  */
 function cloneValue(value) {
@@ -62,7 +62,7 @@ function cloneValue(value) {
 /* -------------------------------------------- */
 
 /**
- *
+ * Remove expired pending entries from the pending state map and warn when the total count is high.
  */
 function pruneExpiredPending() {
   const now = Date.now()
@@ -82,7 +82,7 @@ function pruneExpiredPending() {
 }
 
 /**
- *
+ * Return the total number of pending state entries across all actor/user queues.
  */
 function countPendingEntries() {
   let count = 0
@@ -91,7 +91,7 @@ function countPendingEntries() {
 }
 
 /**
- *
+ * Evict the oldest pending entries when the pending map would exceed MAX_PENDING after adding incomingCount new entries.
  * @param {number} incomingCount
  */
 function evictOldestIfNeeded(incomingCount = 1) {
@@ -121,7 +121,7 @@ function evictOldestIfNeeded(incomingCount = 1) {
 /* -------------------------------------------- */
 
 /**
- *
+ * Build the composite map key for a pending entry keyed by actor UUID and user ID.
  * @param {object} actor
  * @param {string} userId
  */
@@ -130,7 +130,7 @@ function getPendingKey(actor, userId) {
 }
 
 /**
- *
+ * Append an old-state entry to the pending queue for the given actor and user.
  * @param {object} actor
  * @param {string} userId
  * @param {object} entry
@@ -143,7 +143,7 @@ function pushPendingEntry(actor, userId, entry) {
 }
 
 /**
- *
+ * Remove and return the oldest pending entry for the given actor and user, or undefined when the queue is empty.
  * @param {object} actor
  * @param {string} userId
  */
@@ -161,7 +161,7 @@ function shiftPendingEntry(actor, userId) {
 /* -------------------------------------------- */
 
 /**
- *
+ * Return true if the dot-notation path contains a Foundry deletion segment (".-=").
  * @param {string} path
  */
 function isDeletionPath(path) {
@@ -169,7 +169,7 @@ function isDeletionPath(path) {
 }
 
 /**
- *
+ * Return the dot-notation path of the parent object targeted by a Foundry deletion segment, or null when not found.
  * @param {string} path
  */
 function getDeletionParentPath(path) {
@@ -180,7 +180,7 @@ function getDeletionParentPath(path) {
 }
 
 /**
- *
+ * Capture the old values of every path present in changes from the document source, handling deletion paths.
  * @param {object} source
  * @param {object} changes
  */
@@ -216,7 +216,7 @@ function snapshotOldState(source, changes) {
 /* -------------------------------------------- */
 
 /**
- *
+ * Log a write failure, notify the user, and send a GM whisper with the error details.
  * @param {object} actor
  * @param {Error} err
  */
@@ -247,7 +247,7 @@ async function handleWriteError(actor, err) {
 /* -------------------------------------------- */
 
 /**
- *
+ * Append audit entries to the actor's log flag, trimming to the configured max, with retry on failure.
  * @param {object} actor
  * @param {object[]} entries
  */
@@ -279,7 +279,7 @@ async function writeLogEntries(actor, entries) {
 }
 
 /**
- *
+ * Read the configured maximum number of audit log entries from game settings, defaulting to 500.
  */
 function readMaxLogEntries() {
   try {
@@ -319,7 +319,7 @@ export {
 /* -------------------------------------------- */
 
 /**
- *
+ * Capture the old actor state before an update and push it to the pending queue.
  * @param {object} actor
  * @param {object} changes
  * @param {object} options
@@ -344,7 +344,7 @@ export function onPreUpdateActor(actor, changes, options, userId) {
 }
 
 /**
- *
+ * Compare the applied changes against the previously captured state and write the resulting audit entries.
  * @param {object} actor
  * @param {object} changes
  * @param {object} options
@@ -370,7 +370,7 @@ export function onUpdateActor(actor, changes, options, userId) {
 /* -------------------------------------------- */
 
 /**
- *
+ * Record a talent purchase audit entry when a talent item is created on a character actor.
  * @param {object} item
  * @param {object} data
  * @param {object} options
@@ -686,7 +686,7 @@ async function sendChatForAuditEntries(actor, entries) {
 /* -------------------------------------------- */
 
 /**
- *
+ * Register Foundry hooks for the audit log subsystem.
  */
 export function registerAuditLogHooks() {
   Hooks.on('preUpdateActor', onPreUpdateActor)
@@ -699,7 +699,7 @@ export function registerAuditLogHooks() {
 /* -------------------------------------------- */
 
 /**
- *
+ * Recursively flatten a nested object into dot-notation key/value pairs.
  * @param {object} obj
  * @param {string} prefix
  */
@@ -719,7 +719,7 @@ function _flattenObject(obj, prefix = '') {
 }
 
 /**
- *
+ * Retrieve the value at a dot-notation path from a nested object, returning undefined when any segment is missing.
  * @param {object} object
  * @param {string} path
  */
@@ -734,7 +734,7 @@ function _getProperty(object, path) {
 }
 
 /**
- *
+ * Set the value at a dot-notation path on a nested object, creating intermediate objects as needed.
  * @param {object} object
  * @param {string} path
  * @param {*} value
@@ -755,7 +755,7 @@ function _setProperty(object, path, value) {
 /* -------------------------------------------- */
 
 /**
- *
+ * Clear all pending old-state entries from the map (used for testing and reset scenarios).
  */
 function flushPending() {
   pendingOldStates.clear()

--- a/module/utils/foundry/compendium-utils.mjs
+++ b/module/utils/foundry/compendium-utils.mjs
@@ -1,7 +1,7 @@
 import { getOggDudePackConfig } from '../oggdude-mapping-config.mjs'
 
 /**
- *
+ * Retrieve the compendium pack for the given OggDude element type, returning a result object with pack, config, and reason fields.
  * @param type
  */
 export function getCharacterCreationCompendiumPack(type) {

--- a/module/utils/oggdude-mapping-config.mjs
+++ b/module/utils/oggdude-mapping-config.mjs
@@ -62,7 +62,7 @@ const OGGDUDE_PACKS_BY_TYPE = {
 }
 
 /**
- *
+ * Return the compendium pack configuration for the given OggDude element type, throwing when the type is unsupported.
  * @param elementType
  */
 export function getOggDudePackConfig(elementType) {

--- a/module/utils/storage/storage-strategy.mjs
+++ b/module/utils/storage/storage-strategy.mjs
@@ -6,7 +6,7 @@ import { CompendiumItemStorageTarget } from './compendium-item-storage-target.mj
 import { organizeCompendiumPack } from '../../helpers/foundry/compendium-folders.mjs'
 
 /**
- *
+ * Create and return the appropriate storage target (world folder or compendium pack) for the given OggDude import mode.
  * @param root0
  * @param root0.mode
  * @param root0.elementType

--- a/module/utils/xml2json.js
+++ b/module/utils/xml2json.js
@@ -6,7 +6,7 @@
 	Web:     https://github.com/henrikingo/xml2json
 */
 /**
- *
+ * Return an XML-to-JSON translation utility object with methods to parse XML nodes into plain JS objects.
  */
 export function xml2json_translator() {
   var X = {
@@ -208,7 +208,7 @@ export function xml2json_translator() {
 }
 
 /**
- *
+ * Convert an XML DOM node to a JSON string representation using the xml2json_translator.
  * @param xml
  * @param tab
  */

--- a/swerpg.mjs
+++ b/swerpg.mjs
@@ -423,7 +423,7 @@ Hooks.on('getSceneControlButtons', (controls) => {
 
 /* -------------------------------------------- */
 /**
- *
+ * Preload all Handlebars partial templates used by the system.
  */
 async function preloadHandlebarsTemplates() {
   const templatePaths = [
@@ -512,7 +512,7 @@ async function standardizeItemIds() {
 }
 
 /**
- *
+ * Register development-only Foundry hooks that keep talent data synchronized during authoring.
  */
 function registerDevelopmentHooks() {
   Hooks.on('preCreateItem', (item, data, options, user) => {
@@ -563,7 +563,7 @@ async function syncTalents(force = false) {
 /* -------------------------------------------- */
 
 /**
- *
+ * Delete all non-species talent items from every actor in the world.
  */
 async function resetAllActorTalents() {
   for (const actor of game.actors) {


### PR DESCRIPTION
## Summary

- Add missing JSDoc descriptions for functions and methods across the codebase.
- Changes span 58 files with +311 insertions and -221 deletions (refactor/documentation edits).
- Intention: documentation-only refactor (no intentional behavior change).

## Context

Commits on branch (develop..HEAD):
- 391ddb35 refactor(jsdoc): add missing JSDoc descriptions for functions and methods

## Tests

- Not run (not requested).

## Notes

- Worktree was clean before creating the PR; no additional commit was necessary.
- Branch is named `fix/432-ew3-rediger-les-descriptions-jsdoc-manquantes` and is tracked by `origin`.
- Reviewers should verify JSDoc accuracy and suggest textual improvements where needed.

