### PR TITLE
fix(equipment): handle undefined weapon system properties to prevent crashes

### DIFF
--- a/module/documents/actor-mixins/equipment.mjs
+++ b/module/documents/actor-mixins/equipment.mjs
@@ -276,7 +276,7 @@ export const EquipmentMixin = (Base) =>
       const itemUpdates = [{ _id: weapon.id, 'system.equipped': true, 'system.slot': slot }]
       const actorUpdates = {}
 
-      let actionCost = weapon.system.properties.has('ambush') ? 0 : 1
+      let actionCost = weapon.system?.properties?.has('ambush') ? 0 : 1
       if (actionCost && this.talentIds.has('preparedness0000') && !this.system.status.hasMoved) {
         actionCost = 0
         foundry.utils.setProperty(actorUpdates, 'system.status.hasMoved', true)


### PR DESCRIPTION
## Summary

- Prevent crash when equipping a backpack weapon whose system properties are undefined

## Context

Closes #449

## Tests

- Not run (not requested).
