### PR TITLE
feat(market): create initial Market application UI with world items catalog

### DIFF
--- a/documentation/plan/market/453-catalogue-market-depuis-les-items-du-monde.md
+++ b/documentation/plan/market/453-catalogue-market-depuis-les-items-du-monde.md
@@ -1,0 +1,194 @@
+# Catalogue Market depuis les items du monde
+
+**Issue** : [#453 — Catalogue Market depuis les items du monde](https://github.com/herveDarritchon/foundryvtt-swerpg/issues/453)
+
+**Dépend sur** : [#452 — Modèle métier du Market](https://github.com/herveDarritchon/foundryvtt-swerpg/issues/452) ✅ livré
+
+## Objectif
+
+Créer la première version UI de la fenêtre Market, alimentée par les `World Items` éligibles, sans achat ni filtres avancés. Réutiliser le contrat métier posé par `#452`.
+
+## Décisions de cadrage
+
+- Source unique : `game.items` (World Items, pas les compendiums)
+- Réutiliser `createMarketEntry()` + `evaluateEligibility()` de `#452` — pas de logique d'éligibilité locale
+- Catégories affichées : `weapon`, `armor`, `gear` (clés de `PURCHASABLE_ITEM_TYPES`)
+- Pas de filtres, pas de tri, pas d'achat — scope strictement consultatif
+- Créer le scaffold UI complet car rien n'existe encore (pas de `MarketApplicationV2`, pas de template, pas de style, pas de clés i18n)
+
+## État initial du code
+
+Ce qui existe déjà (issue #452) :
+
+- `module/config/market.mjs` — registres canoniques `PURCHASABLE_ITEM_TYPES`, `EXCLUDED_ITEM_TYPES`, `AVAILABILITY_STATUS`, `SOURCE_TYPES`
+- `module/lib/market/eligibility.mjs` — `evaluateEligibility()`
+- `module/lib/market/market-entry.mjs` — `createMarketEntry()`
+- `module/lib/market/pricing.mjs` — `computeMarketPrice()`
+- `module/lib/market/source-resolver.mjs` — `resolveMarketSources()`, `filterDuplicates()`
+- `module/lib/market/index.mjs` — réexport barrel
+- Exposition via `SYSTEM.MARKET`
+
+Ce qui manque et doit être créé :
+
+- `MarketApplicationV2` (ApplicationV2)
+- Template Handlebars `templates/market/` (nouveau dossier)
+- Styles LESS dans `styles/` pour le Market
+- Clés i18n `MARKET.*` dans `lang/en.json` et `lang/fr.json`
+- Tests unitaires sur la préparation de contexte et le formatage d'affichage
+
+## Étapes d'implémentation
+
+### 1. Créer le scaffold UI Market (ApplicationV2)
+
+**Fichiers à créer** :
+
+- `module/applications/market/market-application.mjs` — classe `MarketApplicationV2`
+- `templates/market/market.hbs` — template Handlebars principal
+- `styles/market.less` ou ajout dans `styles/swerpg.less`
+
+**Détails** :
+
+- `MarketApplicationV2` extends `api.HandlebarsApplicationMixin(api.ApplicationV2)`
+- `static DEFAULT_OPTIONS` : `id: 'market'`, `window: { title: 'MARKET.Title' }`, `tag: 'aside'`
+- `static PARTS` : `{ catalog: { template: 'templates/market/market.hbs' } }`
+- `static TABS` : vide pour l'instant (pas d'onglets)
+- Enregistrer l'application dans le code d'initialisation (hook `init` ou `ready`)
+
+### 2. Ajouter les clés i18n MARKET
+
+**Fichiers** : `lang/en.json`, `lang/fr.json`
+
+Clés minimales :
+
+- `MARKET.Title` — `"Market"`
+- `MARKET.Catalog.Empty` — `"No items available in the market."`
+- `MARKET.Catalog.Column.Name` — `"Name"`
+- `MARKET.Catalog.Column.Type` — `"Type"`
+- `MARKET.Catalog.Column.Price` — `"Price"`
+- `MARKET.Catalog.Column.Rarity` — `"Rarity"`
+- `MARKET.Catalog.Column.Restriction` — `"Restriction"`
+- `MARKET.Catalog.Group.Weapon` — `"Weapons"` (ou réutiliser `MARKET.ItemType.Weapon` déjà défini dans `#452`)
+- `MARKET.Catalog.Group.Armor` — `"Armor"`
+- `MARKET.Catalog.Group.Gear` — `"Gear"`
+- `MARKET.Catalog.OpenSheet` — `"Open item sheet"`
+
+### 3. Implémenter le catalogue world dans le contexte applicatif
+
+**Fichier** : `module/applications/market/market-application.mjs`
+
+**What** :
+
+- surcharger `_preparePartContext(partId, context)` pour la part `catalog`
+- interroger `game.items` (collection `items`)
+- pour chaque item, appeler `createMarketEntry()` du domaine `#452` :
+  - `sourceType: 'world'`
+  - `sourceId: 'world'` (ou l'UUID du document)
+- filtrer `entry.eligible === true`
+- grouper par `entry.itemType` en utilisant `PURCHASABLE_ITEM_TYPES` pour le libellé et l'icône
+- retourner `{ catalog: { groups: [...] } }` dans le contexte
+
+**API réelle** (pas `isItemPurchasable()` qui n'existe pas) :
+
+```js
+import { createMarketEntry } from '../../lib/market/market-entry.mjs'
+import { PURCHASABLE_ITEM_TYPES } from '../../config/market.mjs'
+
+for (const item of game.items) {
+  try {
+    const entry = createMarketEntry(item, { sourceType: 'world', sourceId: item.uuid })
+    if (entry.eligible) {
+      /* group by entry.itemType */
+    }
+  } catch (err) {
+    // createMarketEntry throw pour les types non autorisés -> skip
+  }
+}
+```
+
+**Validation visée** : le contexte produit `{ groups: [ { typeKey, label, icon, items: [...] }, ... ] }` sans items non éligibles.
+
+### 4. Rendre la liste groupée dans le template
+
+**Fichier** : `templates/market/market.hbs`
+
+**What** :
+
+- itérer les groupes, afficher un `<section>` par groupe avec titre + icône
+- tableau ou liste des items avec colonnes : icône, nom, type, prix, rareté, restriction
+- chaque ligne a `data-uuid="{{ uuid }}"` et `data-action="openItem"`
+- état vide : `<p>{{ localize "MARKET.Catalog.Empty" }}</p>` si aucun groupe n'a d'items
+- attributs `data-application-part="catalog"` pour le rattachement ApplicationV2
+
+**Validation visée** : la fenêtre Market affiche le catalogue groupé, lisible, avec état vide.
+
+### 5. Câbler l'ouverture de fiche item
+
+**Fichier** : `module/applications/market/market-application.mjs`
+
+**What** :
+
+- ajouter une méthode action `openItem(event)` avec décorateur `@action('openItem')` ou via `_onAction`
+- résoudre l'UUID via `fromUuid(uuid)` et appeler `item.sheet.render(true)`
+- gérer le cas où l'item n'existe plus (item supprimé entre-temps) → logger.warn
+
+### 6. Ajouter les styles LESS
+
+**Fichier** : `styles/market.less` (importé depuis `swerpg.less`)
+
+**What** :
+
+- styles pour `.market-catalog`, `.market-group`, `.market-item`, `.market-empty`
+- grille simple pour les colonnes (CSS grid ou table)
+- thème visuel cohérent avec le reste du système (variables CSS existantes)
+- pas de style complexe — réutiliser les tokens de design existants
+
+### 7. Enregistrer l'application et le point d'accès
+
+**Fichier** : hook `ready` dans `module/hooks/` ou dans un bloc d'initialisation
+
+**What** :
+
+- exposer un moyen d'ouvrir le Market : `game.system.swerpg.openMarket()` ou via une barre d'outils
+- créer une instance singleton ou la détruire à chaque fermeture
+
+**Validation visée** : l'utilisateur peut ouvrir la fenêtre Market depuis le jeu.
+
+### 8. Tests unitaires
+
+**Fichier** : `tests/applications/market/market-application.test.mjs` (nouveau)
+
+**What** :
+
+- tester `_preparePartContext` avec un mock Foundry (`setupFoundryMock`) :
+  - simuler `game.items` avec des items valides, invalides, non autorisés
+  - vérifier le groupement correct
+  - vérifier l'exclusion des items non éligibles
+  - vérifier l'état vide
+- tester l'action `openItem` :
+  - vérifier que `item.sheet.render(true)` est appelé avec le bon item
+  - vérifier le comportement avec un UUID invalide
+
+**Validation visée** : couverture du requêtage, du filtrage, du groupement, de l'affichage et de l'action d'ouverture.
+
+## Résultat attendu
+
+- `MarketApplicationV2` créée et fonctionnelle
+- La fenêtre Market affiche les items achetables du monde à partir de `game.items`
+- Les entrées sont regroupées par type achetable (`weapon`, `armor`, `gear`)
+- Chaque ligne affiche : icône, nom, type, prix, rareté, restriction
+- Un clic ouvre la fiche détaillée de l'item
+- Les items non éligibles (type interdit, nom manquant, prix manquant) sont exclus par le contrat `#452`
+- Le catalogue est prêt pour les filtres/tris de `#455`
+- Tests unitaires couvrant le contexte applicatif et l'interaction
+
+## Fichiers modifiés
+
+| Fichier                                                 | Action                             |
+| ------------------------------------------------------- | ---------------------------------- |
+| `module/applications/market/market-application.mjs`     | Créer                              |
+| `templates/market/market.hbs`                           | Créer                              |
+| `styles/market.less`                                    | Créer                              |
+| `styles/swerpg.less`                                    | Modifier (importer `market.less`)  |
+| `lang/en.json`                                          | Modifier (ajouter clés `MARKET.*`) |
+| `lang/fr.json`                                          | Modifier (ajouter clés `MARKET.*`) |
+| `tests/applications/market/market-application.test.mjs` | Créer                              |

--- a/lang/en.json
+++ b/lang/en.json
@@ -1458,6 +1458,7 @@
     "UnspecifiedAbbr": "Unsp."
   },
   "MARKET": {
+    "Title": "Market",
     "ItemType": {
       "Weapon": "Weapon",
       "Armor": "Armor",
@@ -1476,6 +1477,22 @@
       "Compendium": "Compendium",
       "World": "World",
       "Import": "Import"
+    },
+    "Catalog": {
+      "Empty": "No items available in the market.",
+      "OpenSheet": "Open item sheet",
+      "Column": {
+        "Name": "Name",
+        "Type": "Type",
+        "Price": "Price",
+        "Rarity": "Rarity",
+        "Restriction": "Restriction"
+      },
+      "Group": {
+        "Weapon": "Weapons",
+        "Armor": "Armor",
+        "Gear": "Gear"
+      }
     }
   }
 }

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -1354,6 +1354,7 @@
     "UnspecifiedAbbr": "N.spéc."
   },
   "MARKET": {
+    "Title": "Marché",
     "ItemType": {
       "Weapon": "Arme",
       "Armor": "Armure",
@@ -1372,6 +1373,22 @@
       "Compendium": "Compendium",
       "World": "Monde",
       "Import": "Import"
+    },
+    "Catalog": {
+      "Empty": "Aucun article disponible dans le marché.",
+      "OpenSheet": "Ouvrir la fiche de l'objet",
+      "Column": {
+        "Name": "Nom",
+        "Type": "Type",
+        "Price": "Prix",
+        "Rarity": "Rareté",
+        "Restriction": "Restriction"
+      },
+      "Group": {
+        "Weapon": "Armes",
+        "Armor": "Armures",
+        "Gear": "Équipements"
+      }
     }
   }
 }

--- a/module/applications/_module.mjs
+++ b/module/applications/_module.mjs
@@ -1,6 +1,7 @@
 // Config Apps
 export { default as ActionConfig } from './config/action.mjs'
 export { default as CharacterAuditLogApp } from './character-audit-log.mjs'
+export { default as MarketApplicationV2 } from './market/market-application.mjs'
 export { default as SkillConfig } from './config/skill.mjs'
 export { default as SpecializationTreeApp } from './specialization-tree-app.mjs'
 

--- a/module/applications/market/market-application.mjs
+++ b/module/applications/market/market-application.mjs
@@ -1,0 +1,159 @@
+import { createMarketEntry } from '../../lib/market/market-entry.mjs'
+import { PURCHASABLE_ITEM_TYPES } from '../../config/market.mjs'
+import { logger } from '../../utils/logger.mjs'
+
+const { api } = foundry.applications
+
+/* -------------------------------------------- */
+
+/**
+ * Extract the RawItem-shaped plain object from a Foundry Item document.
+ * Maps Foundry document paths (item.system.*) to the shape expected by createMarketEntry.
+ *
+ * @param {Item} item  A Foundry Item document
+ * @returns {import('../../lib/market/market-entry.mjs').RawItem}
+ */
+function itemToRawItem(item) {
+  const system = item.system ?? {}
+  return {
+    uuid: item.uuid ?? '',
+    name: item.name ?? '',
+    img: item.img ?? '',
+    type: item.type ?? '',
+    basePrice: system.price ?? 0,
+    rarity: system.rarity ?? 0,
+    quality: system.quality ?? '',
+    restrictionLevel: system.restrictionLevel ?? '',
+    availability: system.availability ?? undefined,
+    nonPurchasable: system.nonPurchasable === true,
+    broken: system.broken === true,
+  }
+}
+
+/**
+ * The Market application presents a read-only catalogue of World Items that are eligible for purchase.
+ * Items are grouped by purchasable type (weapon, armor, gear).
+ * No purchase, no filter, no sort — scope is strictly consultatif for #453.
+ */
+export default class MarketApplicationV2 extends api.HandlebarsApplicationMixin(api.ApplicationV2) {
+  /** @inheritDoc */
+  static DEFAULT_OPTIONS = {
+    id: 'market',
+    classes: ['swerpg', 'application', 'market'],
+    tag: 'aside',
+    window: {
+      title: 'MARKET.Title',
+      minimizable: true,
+      resizable: true,
+    },
+    position: {
+      width: 740,
+      height: 600,
+    },
+    actions: {
+      openItem: MarketApplicationV2.#onOpenItem,
+    },
+  }
+
+  /** @override */
+  static PARTS = {
+    catalog: {
+      template: 'systems/swerpg/templates/market/market.hbs',
+      scrollable: ['.market-catalog'],
+    },
+  }
+
+  /* -------------------------------------------- */
+
+  /** @override */
+  async _prepareContext(options) {
+    const context = await super._prepareContext(options)
+    return context
+  }
+
+  /* -------------------------------------------- */
+
+  /** @override */
+  async _preparePartContext(partId, context) {
+    if (partId === 'catalog') {
+      context.catalog = this.#prepareCatalog()
+    }
+    return context
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Build the grouped catalogue from World Items.
+   * Iterates game.items, calls createMarketEntry for each item, skips ineligible and non-purchasable types.
+   * @returns {{ groups: Array<{typeKey: string, label: string, icon: string, items: MarketEntry[]}>, isEmpty: boolean }}
+   */
+  #prepareCatalog() {
+    /** @type {Map<string, import('../../lib/market/market-entry.mjs').MarketEntry[]>} */
+    const grouped = new Map()
+
+    // Initialize groups in declared order (weapon, armor, gear)
+    for (const typeKey of Object.keys(PURCHASABLE_ITEM_TYPES)) {
+      grouped.set(typeKey, [])
+    }
+
+    for (const item of game.items) {
+      try {
+        const rawItem = itemToRawItem(item)
+        const entry = createMarketEntry(rawItem, { sourceType: 'world', sourceId: item.uuid ?? '' })
+        if (!entry.eligible) continue
+        const bucket = grouped.get(entry.itemType)
+        if (bucket) bucket.push(entry)
+      } catch (err) {
+        // createMarketEntry throws TypeError for non-purchasable item types — skip silently
+        logger.debug(`[Market] Skipping item "${item.name}" (type="${item.type}"): ${err.message}`)
+      }
+    }
+
+    const groups = Object.entries(PURCHASABLE_ITEM_TYPES)
+      .map(([typeKey, typeCfg]) => ({
+        typeKey,
+        label: typeCfg.label,
+        icon: typeCfg.icon,
+        items: grouped.get(typeKey) ?? [],
+      }))
+      .filter((group) => group.items.length > 0)
+
+    return { groups, isEmpty: groups.length === 0 }
+  }
+
+  /* -------------------------------------------- */
+  /*  Actions                                     */
+  /* -------------------------------------------- */
+
+  /**
+   * Open the item sheet for the clicked market entry.
+   * @this {MarketApplicationV2}
+   * @param {PointerEvent} event     The initiating click event
+   * @param {HTMLElement}  target    The element bearing data-action="openItem"
+   * @returns {Promise<void>}
+   */
+  static async #onOpenItem(event, target) {
+    const row = target.closest('[data-uuid]')
+    const uuid = row?.dataset?.uuid
+    if (!uuid) {
+      logger.warn('[Market] openItem action triggered without a data-uuid attribute')
+      return
+    }
+
+    let item
+    try {
+      item = await fromUuid(uuid)
+    } catch (err) {
+      logger.warn(`[Market] Could not resolve UUID "${uuid}": ${err.message}`)
+      return
+    }
+
+    if (!item) {
+      logger.warn(`[Market] Item with UUID "${uuid}" no longer exists (deleted or moved).`)
+      return
+    }
+
+    await item.sheet.render(true)
+  }
+}

--- a/styles/market.less
+++ b/styles/market.less
@@ -1,0 +1,174 @@
+/* ----------------------------------------- */
+/*  Market Application                       */
+/* ----------------------------------------- */
+
+.swerpg.application.market {
+  display: flex;
+  flex-direction: column;
+  min-height: 100%;
+
+  .window-content {
+    display: flex;
+    flex-direction: column;
+    flex: 1;
+    overflow: hidden;
+    padding: 0;
+  }
+}
+
+/* ----------------------------------------- */
+/*  Market Catalogue                         */
+/* ----------------------------------------- */
+
+.market-catalog {
+  flex: 1;
+  overflow-y: auto;
+  padding: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+/* Empty state */
+.market-empty {
+  display: grid;
+  place-items: center;
+  padding: 2rem;
+  color: var(--color-secondary);
+  text-align: center;
+  font-style: italic;
+}
+
+/* ----------------------------------------- */
+/*  Market Groups                            */
+/* ----------------------------------------- */
+
+.market-group {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  border: 1px solid var(--color-cool-4, rgba(120, 169, 194, 0.22));
+  border-radius: 8px;
+  overflow: hidden;
+  background: rgba(12, 18, 27, 0.6);
+}
+
+.market-group__header {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.6rem 1rem;
+  background: rgba(18, 28, 42, 0.85);
+  border-bottom: 1px solid var(--color-cool-4, rgba(120, 169, 194, 0.22));
+
+  i {
+    color: var(--color-secondary);
+    font-size: var(--font-size-14);
+    flex: none;
+  }
+}
+
+.market-group__title {
+  margin: 0;
+  font-family: var(--font-h1);
+  font-size: var(--font-size-14);
+  color: var(--color-primary);
+  font-weight: normal;
+}
+
+/* ----------------------------------------- */
+/*  Market Table                             */
+/* ----------------------------------------- */
+
+.market-group__table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: var(--font-size-13);
+
+  thead tr {
+    background: rgba(10, 17, 26, 0.5);
+  }
+
+  th {
+    padding: 0.35rem 0.75rem;
+    text-align: left;
+    color: var(--color-secondary);
+    font-size: var(--font-size-11);
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    border-bottom: 1px solid rgba(120, 169, 194, 0.15);
+    white-space: nowrap;
+  }
+
+  tbody tr.market-item {
+    cursor: pointer;
+    transition: background 0.12s ease;
+
+    &:hover {
+      background: rgba(120, 169, 194, 0.08);
+    }
+
+    &:not(:last-child) {
+      border-bottom: 1px solid rgba(120, 169, 194, 0.07);
+    }
+  }
+
+  td {
+    padding: 0.4rem 0.75rem;
+    color: var(--color-text, #d5e4f1);
+    vertical-align: middle;
+  }
+}
+
+/* ----------------------------------------- */
+/*  Market Table Columns                     */
+/* ----------------------------------------- */
+
+.market-col--icon {
+  width: 36px;
+  padding-left: 0.5rem !important;
+  padding-right: 0.25rem !important;
+}
+
+.market-col--name {
+  min-width: 160px;
+  font-weight: 500;
+  color: var(--color-primary);
+}
+
+.market-col--type {
+  width: 90px;
+  color: var(--color-secondary);
+  font-size: var(--font-size-12);
+  text-transform: capitalize;
+}
+
+.market-col--price {
+  width: 80px;
+  text-align: right;
+}
+
+.market-col--rarity {
+  width: 70px;
+  text-align: center;
+}
+
+.market-col--restriction {
+  width: 110px;
+  text-align: center;
+  font-size: var(--font-size-12);
+  color: var(--color-secondary);
+}
+
+/* ----------------------------------------- */
+/*  Market Item Icon                         */
+/* ----------------------------------------- */
+
+.market-item__icon {
+  width: 28px;
+  height: 28px;
+  object-fit: contain;
+  border-radius: 3px;
+  border: 1px solid rgba(120, 169, 194, 0.15);
+}

--- a/styles/swerpg.css
+++ b/styles/swerpg.css
@@ -5065,3 +5065,150 @@ input[type='range'] {
 .domain-status--error .fa-circle {
   color: #ff3333;
 }
+/* ----------------------------------------- */
+/*  Market Application                       */
+/* ----------------------------------------- */
+.swerpg.application.market {
+  display: flex;
+  flex-direction: column;
+  min-height: 100%;
+}
+.swerpg.application.market .window-content {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  overflow: hidden;
+  padding: 0;
+}
+/* ----------------------------------------- */
+/*  Market Catalogue                         */
+/* ----------------------------------------- */
+.market-catalog {
+  flex: 1;
+  overflow-y: auto;
+  padding: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+/* Empty state */
+.market-empty {
+  display: grid;
+  place-items: center;
+  padding: 2rem;
+  color: var(--color-secondary);
+  text-align: center;
+  font-style: italic;
+}
+/* ----------------------------------------- */
+/*  Market Groups                            */
+/* ----------------------------------------- */
+.market-group {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  border: 1px solid var(--color-cool-4, rgba(120, 169, 194, 0.22));
+  border-radius: 8px;
+  overflow: hidden;
+  background: rgba(12, 18, 27, 0.6);
+}
+.market-group__header {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.6rem 1rem;
+  background: rgba(18, 28, 42, 0.85);
+  border-bottom: 1px solid var(--color-cool-4, rgba(120, 169, 194, 0.22));
+}
+.market-group__header i {
+  color: var(--color-secondary);
+  font-size: var(--font-size-14);
+  flex: none;
+}
+.market-group__title {
+  margin: 0;
+  font-family: var(--font-h1);
+  font-size: var(--font-size-14);
+  color: var(--color-primary);
+  font-weight: normal;
+}
+/* ----------------------------------------- */
+/*  Market Table                             */
+/* ----------------------------------------- */
+.market-group__table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: var(--font-size-13);
+}
+.market-group__table thead tr {
+  background: rgba(10, 17, 26, 0.5);
+}
+.market-group__table th {
+  padding: 0.35rem 0.75rem;
+  text-align: left;
+  color: var(--color-secondary);
+  font-size: var(--font-size-11);
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  border-bottom: 1px solid rgba(120, 169, 194, 0.15);
+  white-space: nowrap;
+}
+.market-group__table tbody tr.market-item {
+  cursor: pointer;
+  transition: background 0.12s ease;
+}
+.market-group__table tbody tr.market-item:hover {
+  background: rgba(120, 169, 194, 0.08);
+}
+.market-group__table tbody tr.market-item:not(:last-child) {
+  border-bottom: 1px solid rgba(120, 169, 194, 0.07);
+}
+.market-group__table td {
+  padding: 0.4rem 0.75rem;
+  color: var(--color-text, #d5e4f1);
+  vertical-align: middle;
+}
+/* ----------------------------------------- */
+/*  Market Table Columns                     */
+/* ----------------------------------------- */
+.market-col--icon {
+  width: 36px;
+  padding-left: 0.5rem !important;
+  padding-right: 0.25rem !important;
+}
+.market-col--name {
+  min-width: 160px;
+  font-weight: 500;
+  color: var(--color-primary);
+}
+.market-col--type {
+  width: 90px;
+  color: var(--color-secondary);
+  font-size: var(--font-size-12);
+  text-transform: capitalize;
+}
+.market-col--price {
+  width: 80px;
+  text-align: right;
+}
+.market-col--rarity {
+  width: 70px;
+  text-align: center;
+}
+.market-col--restriction {
+  width: 110px;
+  text-align: center;
+  font-size: var(--font-size-12);
+  color: var(--color-secondary);
+}
+/* ----------------------------------------- */
+/*  Market Item Icon                         */
+/* ----------------------------------------- */
+.market-item__icon {
+  width: 28px;
+  height: 28px;
+  object-fit: contain;
+  border-radius: 3px;
+  border: 1px solid rgba(120, 169, 194, 0.15);
+}

--- a/styles/swerpg.less
+++ b/styles/swerpg.less
@@ -15,3 +15,4 @@
 @import './components/jauge.less';
 @import './components/defenses.less';
 @import './components/importer.less';
+@import 'market.less';

--- a/swerpg.mjs
+++ b/swerpg.mjs
@@ -70,6 +70,7 @@ Hooks.once('init', async function () {
     logger,
     methods: {
       generateId,
+      openMarket,
       packageCompendium,
       resetAllActorTalents,
       standardizeItemIds,
@@ -336,6 +337,9 @@ Hooks.once('setup', function () {
   // Create the dedicated specialization tree application
   game.system.specializationTreeApp = new applications.SpecializationTreeApp()
 
+  // Create the Market application singleton
+  game.system.marketApp = new applications.MarketApplicationV2()
+
   // Create Talent Tree canvas
   game.system.tree = new SwerpgTalentTree()
 
@@ -575,6 +579,17 @@ async function resetAllActorTalents() {
     }
     await actor.deleteEmbeddedDocuments('Item', Array.from(deleteIds))
   }
+}
+
+/* -------------------------------------------- */
+
+/**
+ * Open the Market application window.
+ * Reuses the singleton created during setup.
+ * @returns {Promise<MarketApplicationV2>}
+ */
+function openMarket() {
+  return game.system.marketApp.render({ force: true })
 }
 
 /* -------------------------------------------- */

--- a/templates/market/market.hbs
+++ b/templates/market/market.hbs
@@ -1,0 +1,45 @@
+{{!-- Market Catalogue — part: catalog --}}
+<div class="market-catalog" data-application-part="catalog">
+  {{#if catalog.isEmpty}}
+    <p class="market-empty">{{localize "MARKET.Catalog.Empty"}}</p>
+  {{else}}
+    {{#each catalog.groups as |group|}}
+      <section class="market-group">
+        <header class="market-group__header">
+          <i class="{{group.icon}}"></i>
+          <h3 class="market-group__title">{{localize group.label}}</h3>
+        </header>
+
+        <table class="market-group__table">
+          <thead>
+            <tr>
+              <th class="market-col--icon" aria-label="{{localize 'MARKET.Catalog.Column.Name'}}"></th>
+              <th class="market-col--name">{{localize "MARKET.Catalog.Column.Name"}}</th>
+              <th class="market-col--type">{{localize "MARKET.Catalog.Column.Type"}}</th>
+              <th class="market-col--price">{{localize "MARKET.Catalog.Column.Price"}}</th>
+              <th class="market-col--rarity">{{localize "MARKET.Catalog.Column.Rarity"}}</th>
+              <th class="market-col--restriction">{{localize "MARKET.Catalog.Column.Restriction"}}</th>
+            </tr>
+          </thead>
+          <tbody>
+            {{#each group.items as |entry|}}
+              <tr class="market-item" data-uuid="{{entry.uuid}}" data-action="openItem"
+                  title="{{localize 'MARKET.Catalog.OpenSheet'}}">
+                <td class="market-col--icon">
+                  {{#if entry.img}}
+                    <img class="market-item__icon" src="{{entry.img}}" alt="{{entry.name}}" />
+                  {{/if}}
+                </td>
+                <td class="market-col--name">{{entry.name}}</td>
+                <td class="market-col--type">{{localize entry.itemType}}</td>
+                <td class="market-col--price">{{entry.basePrice}}</td>
+                <td class="market-col--rarity">{{entry.rarity}}</td>
+                <td class="market-col--restriction">{{entry.restrictionLevel}}</td>
+              </tr>
+            {{/each}}
+          </tbody>
+        </table>
+      </section>
+    {{/each}}
+  {{/if}}
+</div>

--- a/tests/applications/market/market-application.test.mjs
+++ b/tests/applications/market/market-application.test.mjs
@@ -1,0 +1,272 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { setupFoundryMock, teardownFoundryMock } from '../../helpers/mock-foundry.mjs'
+
+/* -------------------------------------------- */
+/*  Helpers                                     */
+/* -------------------------------------------- */
+
+/**
+ * Build a minimal Foundry Item mock suitable for market tests.
+ * Uses item.system.price (the actual Foundry model field), not basePrice.
+ * @param {object} [overrides]
+ */
+function makeItem(overrides = {}) {
+  const systemOverrides = overrides.system ?? {}
+  return {
+    uuid: overrides.uuid ?? `Item.${Math.random().toString(36).slice(2, 8)}`,
+    name: overrides.name ?? 'Test Item',
+    img: overrides.img ?? 'icons/test.webp',
+    type: overrides.type ?? 'weapon',
+    system: {
+      // Foundry physical item model uses `price`, not `basePrice`
+      price: overrides.price ?? systemOverrides.price ?? 100,
+      rarity: overrides.rarity ?? systemOverrides.rarity ?? 2,
+      quality: overrides.quality ?? systemOverrides.quality ?? 'standard',
+      restrictionLevel: overrides.restrictionLevel ?? systemOverrides.restrictionLevel ?? 'none',
+      availability: overrides.availability ?? systemOverrides.availability ?? 'available',
+      nonPurchasable: overrides.nonPurchasable ?? systemOverrides.nonPurchasable ?? false,
+      broken: overrides.broken ?? systemOverrides.broken ?? false,
+      ...systemOverrides,
+    },
+    sheet: {
+      render: vi.fn(),
+    },
+  }
+}
+
+/**
+ * Build a mock game.items collection from an array of items.
+ * @param {object[]} items
+ */
+function makeItemsCollection(items) {
+  return {
+    [Symbol.iterator]() {
+      return items[Symbol.iterator]()
+    },
+  }
+}
+
+/* -------------------------------------------- */
+/*  Tests                                       */
+/* -------------------------------------------- */
+
+describe('MarketApplicationV2', () => {
+  let MarketApplicationV2
+
+  beforeEach(async () => {
+    setupFoundryMock({
+      translations: {
+        'MARKET.Title': 'Market',
+        'MARKET.Catalog.Empty': 'No items available in the market.',
+        'MARKET.Catalog.OpenSheet': 'Open item sheet',
+        'MARKET.Catalog.Column.Name': 'Name',
+        'MARKET.Catalog.Column.Type': 'Type',
+        'MARKET.Catalog.Column.Price': 'Price',
+        'MARKET.Catalog.Column.Rarity': 'Rarity',
+        'MARKET.Catalog.Column.Restriction': 'Restriction',
+      },
+    })
+    ;({ default: MarketApplicationV2 } = await import('../../../module/applications/market/market-application.mjs'))
+  })
+
+  afterEach(() => {
+    teardownFoundryMock()
+    vi.resetModules()
+  })
+
+  /* -------------------------------------------- */
+  /*  Constructor & static config                 */
+  /* -------------------------------------------- */
+
+  describe('static configuration', () => {
+    it('has id "market"', () => {
+      expect(MarketApplicationV2.DEFAULT_OPTIONS.id).toBe('market')
+    })
+
+    it('has a catalog PART', () => {
+      expect(MarketApplicationV2.PARTS).toHaveProperty('catalog')
+      expect(MarketApplicationV2.PARTS.catalog.template).toContain('market.hbs')
+    })
+
+    it('declares the openItem action', () => {
+      expect(MarketApplicationV2.DEFAULT_OPTIONS.actions).toHaveProperty('openItem')
+    })
+  })
+
+  /* -------------------------------------------- */
+  /*  #prepareCatalog via _preparePartContext     */
+  /* -------------------------------------------- */
+
+  describe('_preparePartContext — catalog', () => {
+    it('groups eligible items by type', async () => {
+      const weaponItem = makeItem({ type: 'weapon', name: 'Blaster Pistol' })
+      const armorItem = makeItem({ type: 'armor', name: 'Light Armor', basePrice: 200 })
+      globalThis.game.items = makeItemsCollection([weaponItem, armorItem])
+
+      const app = new MarketApplicationV2()
+      const context = await app._preparePartContext('catalog', {})
+
+      expect(context.catalog.isEmpty).toBe(false)
+      expect(context.catalog.groups).toHaveLength(2)
+
+      const weaponGroup = context.catalog.groups.find((g) => g.typeKey === 'weapon')
+      expect(weaponGroup).toBeDefined()
+      expect(weaponGroup.items).toHaveLength(1)
+      expect(weaponGroup.items[0].name).toBe('Blaster Pistol')
+
+      const armorGroup = context.catalog.groups.find((g) => g.typeKey === 'armor')
+      expect(armorGroup).toBeDefined()
+      expect(armorGroup.items).toHaveLength(1)
+      expect(armorGroup.items[0].name).toBe('Light Armor')
+    })
+
+    it('excludes items with non-purchasable types (e.g. talent)', async () => {
+      const talentItem = makeItem({ type: 'talent', name: 'Force Sensitive' })
+      globalThis.game.items = makeItemsCollection([talentItem])
+
+      const app = new MarketApplicationV2()
+      const context = await app._preparePartContext('catalog', {})
+
+      expect(context.catalog.isEmpty).toBe(true)
+      expect(context.catalog.groups).toHaveLength(0)
+    })
+
+    it('excludes ineligible items (nonPurchasable=true)', async () => {
+      const item = makeItem({ type: 'weapon', nonPurchasable: true })
+      globalThis.game.items = makeItemsCollection([item])
+
+      const app = new MarketApplicationV2()
+      const context = await app._preparePartContext('catalog', {})
+
+      expect(context.catalog.isEmpty).toBe(true)
+    })
+
+    it('excludes broken items', async () => {
+      const item = makeItem({ type: 'armor', broken: true })
+      globalThis.game.items = makeItemsCollection([item])
+
+      const app = new MarketApplicationV2()
+      const context = await app._preparePartContext('catalog', {})
+
+      expect(context.catalog.isEmpty).toBe(true)
+    })
+
+    it('returns isEmpty=true when game.items is empty', async () => {
+      globalThis.game.items = makeItemsCollection([])
+
+      const app = new MarketApplicationV2()
+      const context = await app._preparePartContext('catalog', {})
+
+      expect(context.catalog.isEmpty).toBe(true)
+      expect(context.catalog.groups).toHaveLength(0)
+    })
+
+    it('does not include groups with zero items', async () => {
+      // Only one weapon, no armor, no gear
+      const weaponItem = makeItem({ type: 'weapon' })
+      globalThis.game.items = makeItemsCollection([weaponItem])
+
+      const app = new MarketApplicationV2()
+      const context = await app._preparePartContext('catalog', {})
+
+      expect(context.catalog.groups.every((g) => g.items.length > 0)).toBe(true)
+      expect(context.catalog.groups.some((g) => g.typeKey === 'armor')).toBe(false)
+      expect(context.catalog.groups.some((g) => g.typeKey === 'gear')).toBe(false)
+    })
+
+    it('includes typeKey, label, icon in each group', async () => {
+      const item = makeItem({ type: 'gear', name: 'Medpac', basePrice: 25 })
+      globalThis.game.items = makeItemsCollection([item])
+
+      const app = new MarketApplicationV2()
+      const context = await app._preparePartContext('catalog', {})
+
+      const gearGroup = context.catalog.groups.find((g) => g.typeKey === 'gear')
+      expect(gearGroup.label).toBe('MARKET.ItemType.Gear')
+      expect(gearGroup.icon).toBe('fa-solid fa-toolbox')
+    })
+
+    it('uses item.uuid as sourceId in the market entry', async () => {
+      const item = makeItem({ type: 'weapon', uuid: 'Item.myUuid' })
+      globalThis.game.items = makeItemsCollection([item])
+
+      const app = new MarketApplicationV2()
+      const context = await app._preparePartContext('catalog', {})
+
+      const entry = context.catalog.groups[0].items[0]
+      expect(entry.sourceId).toBe('Item.myUuid')
+      expect(entry.sourceType).toBe('world')
+    })
+
+    it('does not mutate context for non-catalog parts', async () => {
+      const app = new MarketApplicationV2()
+      const context = { someExistingKey: 'value' }
+      const result = await app._preparePartContext('other', context)
+
+      expect(result).not.toHaveProperty('catalog')
+      expect(result.someExistingKey).toBe('value')
+    })
+  })
+
+  /* -------------------------------------------- */
+  /*  openItem action                             */
+  /* -------------------------------------------- */
+
+  describe('openItem action', () => {
+    it('calls item.sheet.render(true) with the resolved item', async () => {
+      const item = makeItem({ uuid: 'Item.openMe', type: 'weapon' })
+      globalThis.fromUuid = vi.fn().mockResolvedValue(item)
+
+      const app = new MarketApplicationV2()
+
+      // Simulate the action by calling the static method through the actions map
+      const action = MarketApplicationV2.DEFAULT_OPTIONS.actions.openItem
+      const row = { dataset: { uuid: 'Item.openMe' }, closest: vi.fn(() => ({ dataset: { uuid: 'Item.openMe' } })) }
+      // Build a minimal event and target matching the action signature
+      const event = {}
+      const target = { closest: vi.fn(() => row) }
+
+      await action.call(app, event, target)
+
+      expect(globalThis.fromUuid).toHaveBeenCalledWith('Item.openMe')
+      expect(item.sheet.render).toHaveBeenCalledWith(true)
+
+      delete globalThis.fromUuid
+    })
+
+    it('logs a warning when the UUID cannot be resolved (item deleted)', async () => {
+      globalThis.fromUuid = vi.fn().mockResolvedValue(null)
+
+      const app = new MarketApplicationV2()
+      const action = MarketApplicationV2.DEFAULT_OPTIONS.actions.openItem
+      const target = { closest: vi.fn(() => ({ dataset: { uuid: 'Item.gone' } })) }
+
+      // Should not throw
+      await expect(action.call(app, {}, target)).resolves.toBeUndefined()
+
+      delete globalThis.fromUuid
+    })
+
+    it('logs a warning when fromUuid throws', async () => {
+      globalThis.fromUuid = vi.fn().mockRejectedValue(new Error('Invalid UUID'))
+
+      const app = new MarketApplicationV2()
+      const action = MarketApplicationV2.DEFAULT_OPTIONS.actions.openItem
+      const target = { closest: vi.fn(() => ({ dataset: { uuid: 'bad-uuid' } })) }
+
+      await expect(action.call(app, {}, target)).resolves.toBeUndefined()
+
+      delete globalThis.fromUuid
+    })
+
+    it('logs a warning when no data-uuid is present', async () => {
+      const app = new MarketApplicationV2()
+      const action = MarketApplicationV2.DEFAULT_OPTIONS.actions.openItem
+      // closest returns element without uuid dataset
+      const target = { closest: vi.fn(() => ({ dataset: {} })) }
+
+      await expect(action.call(app, {}, target)).resolves.toBeUndefined()
+    })
+  })
+})


### PR DESCRIPTION
## Summary

- Add a new Market application UI that exposes world items as a catalog.
- Add templates, styles and i18n entries for the Market UI.
- Include a unit test for the Market application and documentation plan.

## Context

Closes #453

## Tests

- Not run (not requested).

## Notes

- Tests added: `tests/applications/market/market-application.test.mjs`
- Branch already pushed to origin; no existing PR found for this branch.
