### PR TITLE
feat(market): implement search, filter, and sort functionality in catalog

### DIFF
--- a/documentation/plan/market/456-moteur-de-prix-avec-modificateurs-rarete-disponibilite-contexte.md
+++ b/documentation/plan/market/456-moteur-de-prix-avec-modificateurs-rarete-disponibilite-contexte.md
@@ -1,0 +1,73 @@
+# Moteur de prix avec modificateurs (rareté, disponibilité, contexte)
+
+**Issue** : [#456 — Moteur de prix avec modificateurs (rareté, disponibilité, contexte)](https://github.com/herveDarritchon/foundryvtt-swerpg/issues/456)
+
+**Dépend sur** : [#455 — Recherche, filtres et tris du catalogue Market](https://github.com/herveDarritchon/foundryvtt-swerpg/issues/455)
+
+## Objectif
+
+Remplacer le calcul de prix historique dispersé par un moteur métier Market pur, modulaire et explicable, afin que chaque entrée du catalogue expose à la fois son prix final et la décomposition lisible des modificateurs appliqués.
+
+## Décisions de cadrage
+
+- Le contrat canonique devient `calculateItemPrice(itemData, marketContext) => { basePrice, finalPrice, modifiers }`, sans dépendance à `game`, `foundry` ou à l’UI.
+- Le moteur doit absorber l’existant de `module/lib/market/pricing.mjs` au lieu de recréer une deuxième logique de pricing parallèle.
+- Les modificateurs de rareté, disponibilité, contexte local / type de marché et override manuel MJ sont évalués comme étapes explicites, ordonnées et traçables.
+- L’UI Market consomme uniquement le résultat du moteur de prix ; elle ne recalcule jamais un pourcentage ou un total côté template.
+
+## Étapes d’implémentation
+
+### 1. Poser le contrat canonique du moteur de prix Market
+
+**Fichiers cibles** : `module/lib/market/price-engine.mjs`, `module/lib/market/index.mjs`, `module/config/market.mjs`, documentation technique Market pertinente.
+
+**What**
+
+- définir les types d’entrée/sortie du moteur : item normalisé, `marketContext`, structure `modifiers[]` avec `label`, `amount`, `reason` ;
+- formaliser les registres/constants métier utiles aux modificateurs de disponibilité et de contexte futur ;
+- décider explicitement la stratégie de migration depuis `pricing.mjs` : renommage, wrapper de compatibilité ou ré-export canonique unique.
+
+**Validation visée** : le projet dispose d’une seule API de calcul de prix Market, pure et extensible.
+
+### 2. Implémenter la composition des modificateurs et la migration depuis l’existant
+
+**Fichiers cibles** : `module/lib/market/price-engine.mjs`, `module/lib/market/pricing.mjs`, `module/models/physical.mjs`.
+
+**What**
+
+- encapsuler chaque modificateur dans une étape dédiée : rareté, disponibilité, contexte local / type de marché, modificateur manuel MJ ;
+- calculer `finalPrice` à partir de `basePrice` et de la somme canonique des modificateurs, avec garde-fous sur les cas limites et un résultat entier non négatif ;
+- faire déléguer `_preparePrice()` au nouveau moteur, ou supprimer la logique historique si toute la chaîne bascule sur l’API canonique.
+
+**Validation visée** : toute consommation du prix passe par le nouveau moteur, sans duplication ni formule legacy cachée.
+
+### 3. Brancher le moteur sur les entrées et le contexte du Market
+
+**Fichiers cibles** : `module/lib/market/market-entry.mjs`, `module/applications/market/market-application.mjs`, éventuels helpers Market ciblés.
+
+**What**
+
+- enrichir les entrées Market avec le `PriceResult` calculé à partir de l’item et du contexte courant ;
+- préparer un `marketContext` simple et stable pour cette tranche (`availability`, `marketType`, `manualModifier`), avec fallback déterministes tant que les marchés contextualisés ne sont pas encore livrés ;
+- faire converger le tri et l’affichage du catalogue sur le prix final calculé, pas uniquement sur `basePrice`.
+
+**Validation visée** : chaque entrée Market expose un prix final cohérent avec son contexte métier courant.
+
+### 4. Afficher la décomposition du prix et verrouiller la non-régression
+
+**Fichiers cibles** : `templates/market/market.hbs`, `lang/en.json`, `lang/fr.json`, `tests/lib/market/price-engine.test.mjs`, `tests/lib/market/pricing.test.mjs`, `tests/applications/market/market-application.test.mjs`.
+
+**What**
+
+- afficher dans la ligne d’item, un tooltip ou un expand la décomposition `prix de base -> modificateurs -> prix final` avec libellés localisés ;
+- couvrir par tests unitaires les modificateurs seuls et combinés, le modificateur manuel, les fallback de contexte et les bornes ;
+- couvrir côté application que le Market expose et rend bien le détail de prix attendu pour chaque item.
+
+**Validation visée** : l’utilisateur voit un prix expliqué, et les contrats de calcul / exposition sont verrouillés par tests ciblés.
+
+## Résultat attendu
+
+- `price-engine.mjs` devient la source de vérité du calcul de prix Market.
+- Le calcul historique de `physical.mjs` n’embarque plus sa propre formule.
+- Le Market affiche un prix final contextualisé et sa décomposition lisible.
+- Les futurs marchés contextualisés peuvent ajouter des modificateurs sans refonte de l’API de prix.

--- a/lang/en.json
+++ b/lang/en.json
@@ -1503,6 +1503,15 @@
         "Gear": "Gear"
       }
     },
+    "Price": {
+      "BaseLabel": "Base price",
+      "FinalLabel": "Final price",
+      "Modifier": {
+        "availability": "Availability",
+        "rarity": "Rarity",
+        "gmModifier": "GM adjustment"
+      }
+    },
     "Toolbar": {
       "Search": {
         "Label": "Search items",

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -1399,6 +1399,15 @@
         "Gear": "Équipements"
       }
     },
+    "Price": {
+      "BaseLabel": "Prix de base",
+      "FinalLabel": "Prix final",
+      "Modifier": {
+        "availability": "Disponibilité",
+        "rarity": "Rareté",
+        "gmModifier": "Ajustement MJ"
+      }
+    },
     "Toolbar": {
       "Search": {
         "Label": "Rechercher des objets",

--- a/module/applications/market/market-application.mjs
+++ b/module/applications/market/market-application.mjs
@@ -1,5 +1,5 @@
 import { createMarketEntry } from '../../lib/market/market-entry.mjs'
-import { PURCHASABLE_ITEM_TYPES, SOURCE_TYPES } from '../../config/market.mjs'
+import { PURCHASABLE_ITEM_TYPES, SOURCE_TYPES, DEFAULT_MARKET_CONTEXT } from '../../config/market.mjs'
 import { logger } from '../../utils/logger.mjs'
 
 const { api } = foundry.applications
@@ -112,7 +112,7 @@ function sortEntries(entries, sortBy, direction) {
     if (sortBy === MARKET_SORT_FIELDS.name) {
       cmp = a.name.localeCompare(b.name)
     } else if (sortBy === MARKET_SORT_FIELDS.price) {
-      cmp = a.basePrice - b.basePrice
+      cmp = a.priceResult.finalPrice - b.priceResult.finalPrice
     } else if (sortBy === MARKET_SORT_FIELDS.rarity) {
       cmp = a.rarity - b.rarity
     }
@@ -245,10 +245,11 @@ export default class MarketApplicationV2 extends api.HandlebarsApplicationMixin(
   #prepareCatalog() {
     // 1. Build all eligible entries from game.items
     const allEntries = []
+    const marketContext = { ...DEFAULT_MARKET_CONTEXT }
     for (const item of game.items) {
       try {
         const rawItem = itemToRawItem(item)
-        const entry = createMarketEntry(rawItem, { sourceType: 'world', sourceId: item.uuid ?? '' })
+        const entry = createMarketEntry(rawItem, { sourceType: 'world', sourceId: item.uuid ?? '' }, marketContext)
         if (!entry.eligible) continue
         allEntries.push(entry)
       } catch (err) {

--- a/module/config/market.mjs
+++ b/module/config/market.mjs
@@ -152,3 +152,34 @@ export const DEFAULT_MARKET_CONFIG = Object.freeze({
   allowedItemTypes: Object.freeze(Object.keys(PURCHASABLE_ITEM_TYPES)),
   dedupStrategy: 'prefer-compendium',
 })
+
+/* -------------------------------------------- */
+
+/**
+ * @typedef {Object} MarketContext
+ * @property {string}  availability    Availability key (one of AVAILABILITY_STATUS keys)
+ * @property {string}  marketType      Market type key: 'standard' | 'blackMarket' | 'imperial'
+ * @property {number}  manualModifier  Manual GM percentage modifier (-100 to +100), default 0
+ */
+
+/**
+ * Market types that affect pricing context.
+ * Additional market types can be registered in future tranches without breaking the API.
+ * @enum {string}
+ */
+export const MARKET_TYPES = Object.freeze({
+  standard: 'standard',
+  blackMarket: 'blackMarket',
+  imperial: 'imperial',
+})
+
+/**
+ * Default market context applied when none is provided to the price engine.
+ * Uses deterministic fallback values that produce no price modification beyond item data.
+ * @type {Readonly<MarketContext>}
+ */
+export const DEFAULT_MARKET_CONTEXT = Object.freeze({
+  availability: DEFAULT_AVAILABILITY,
+  marketType: MARKET_TYPES.standard,
+  manualModifier: 0,
+})

--- a/module/lib/market/index.mjs
+++ b/module/lib/market/index.mjs
@@ -1,5 +1,6 @@
 export { evaluateEligibility, ELIGIBILITY_REASONS } from './eligibility.mjs'
 export { computeMarketPrice } from './pricing.mjs'
+export { calculateItemPrice } from './price-engine.mjs'
 export { resolveMarketSources, filterDuplicates, filterByActiveConfig, DEDUP_STRATEGIES } from './source-resolver.mjs'
 export { createMarketEntry } from './market-entry.mjs'
 export {

--- a/module/lib/market/market-entry.mjs
+++ b/module/lib/market/market-entry.mjs
@@ -1,5 +1,6 @@
 import { PURCHASABLE_ITEM_TYPES, SOURCE_TYPES, DEFAULT_SOURCE_TYPE, DEFAULT_AVAILABILITY } from '../../config/market.mjs'
 import { evaluateEligibility } from './eligibility.mjs'
+import { calculateItemPrice } from './price-engine.mjs'
 
 /**
  * @typedef {Object} MarketEntry
@@ -14,6 +15,7 @@ import { evaluateEligibility } from './eligibility.mjs'
  * @property {string}      quality             Quality tier key
  * @property {string}      restrictionLevel    Restriction level key
  * @property {string}      availability        Computed availability status key
+ * @property {import('./price-engine.mjs').PriceResult} priceResult  Computed price with breakdown
  * @property {boolean}     eligible            Whether this entry passes all eligibility rules
  * @property {string|null} ineligibilityReason Machine-readable reason if not eligible, null otherwise
  */
@@ -49,15 +51,17 @@ import { evaluateEligibility } from './eligibility.mjs'
  * - `itemType` must be a key of PURCHASABLE_ITEM_TYPES (throws if not)
  * - `basePrice` is always a finite number >= 0
  * - `eligible` is deterministic for the same inputs
+ * - `priceResult` is always present and computed by the canonical price engine
  *
  * No Foundry dependencies — accepts plain objects only.
  *
- * @param {RawItem}    rawItem     The raw item data to normalize
- * @param {SourceInfo} sourceInfo  Source metadata for this item
+ * @param {RawItem}    rawItem       The raw item data to normalize
+ * @param {SourceInfo} sourceInfo    Source metadata for this item
+ * @param {Partial<import('../../config/market.mjs').MarketContext>} [marketContext]  Optional market context for price computation
  * @returns {MarketEntry}
  * @throws {TypeError} If itemType is not a key of PURCHASABLE_ITEM_TYPES
  */
-export function createMarketEntry(rawItem, sourceInfo) {
+export function createMarketEntry(rawItem, sourceInfo, marketContext = {}) {
   const itemType = rawItem.type ?? rawItem.itemType ?? ''
 
   if (!(itemType in PURCHASABLE_ITEM_TYPES)) {
@@ -74,6 +78,7 @@ export function createMarketEntry(rawItem, sourceInfo) {
 
   const rarity = Number.isFinite(rawItem.rarity) ? rawItem.rarity : 0
   const name = typeof rawItem.name === 'string' && rawItem.name.trim().length > 0 ? rawItem.name : 'unknown'
+  const availability = rawItem.availability ?? DEFAULT_AVAILABILITY
 
   const eligibilityItem = {
     itemType,
@@ -89,6 +94,8 @@ export function createMarketEntry(rawItem, sourceInfo) {
     sourceTypes: SOURCE_TYPES,
   })
 
+  const priceResult = calculateItemPrice({ basePrice, rarity, availability }, marketContext)
+
   return {
     uuid: rawItem.uuid ?? '',
     name,
@@ -100,7 +107,8 @@ export function createMarketEntry(rawItem, sourceInfo) {
     rarity,
     quality: rawItem.quality ?? '',
     restrictionLevel: rawItem.restrictionLevel ?? '',
-    availability: rawItem.availability ?? DEFAULT_AVAILABILITY,
+    availability,
+    priceResult,
     eligible,
     ineligibilityReason: reason,
   }

--- a/module/lib/market/price-engine.mjs
+++ b/module/lib/market/price-engine.mjs
@@ -1,0 +1,71 @@
+import { DEFAULT_MARKET_CONTEXT } from '../../config/market.mjs'
+import { computeMarketPrice } from './pricing.mjs'
+
+/**
+ * @typedef {Object} ItemData
+ * @property {number}  basePrice    Original item price from the data model (>= 0)
+ * @property {number}  rarity       Item rarity score (0–10)
+ * @property {string}  [availability]  Availability key — overrides context if provided
+ */
+
+/**
+ * @typedef {import('../../config/market.mjs').MarketContext} MarketContext
+ */
+
+/**
+ * @typedef {Object} PriceModifier
+ * @property {string} label    Machine key identifying the modifier source (e.g. 'availability', 'rarity', 'gmModifier')
+ * @property {number} modifier Fractional modifier value applied at this step
+ */
+
+/**
+ * @typedef {Object} PriceResult
+ * @property {number}           basePrice   Original base price
+ * @property {number}           finalPrice  Computed final price (integer >= 0)
+ * @property {PriceModifier[]}  modifiers   Ordered list of modifier steps for traceability
+ */
+
+/* -------------------------------------------- */
+
+/**
+ * Calculate the final Market price for an item given its data and a market context.
+ *
+ * This is the canonical API for all Market price computation. It delegates to
+ * `computeMarketPrice` from `pricing.mjs` and re-maps the result to the
+ * canonical `PriceResult` shape (`modifiers` instead of `breakdown`).
+ *
+ * Availability resolution order:
+ *   1. `itemData.availability` (item-level override)
+ *   2. `marketContext.availability` (context-level)
+ *   3. `DEFAULT_MARKET_CONTEXT.availability` (fallback)
+ *
+ * No Foundry dependencies — accepts plain objects only.
+ *
+ * @param {ItemData}      itemData       Normalised item data (plain object)
+ * @param {Partial<MarketContext>} [marketContext]  Optional market context; merged with defaults
+ * @returns {PriceResult}
+ * @throws {TypeError} If basePrice is not a finite non-negative number
+ * @throws {TypeError} If rarity is not a finite number
+ */
+export function calculateItemPrice(itemData, marketContext = {}) {
+  const ctx = { ...DEFAULT_MARKET_CONTEXT, ...marketContext }
+
+  // Item-level availability takes precedence over context
+  const availability = itemData.availability ?? ctx.availability
+
+  const pricingContext = {
+    basePrice: itemData.basePrice,
+    rarity: itemData.rarity,
+    availability,
+    gmModifier: ctx.manualModifier ?? 0,
+    marketType: ctx.marketType,
+  }
+
+  const { finalPrice, basePrice, breakdown } = computeMarketPrice(pricingContext)
+
+  return {
+    basePrice,
+    finalPrice,
+    modifiers: breakdown,
+  }
+}

--- a/templates/market/market.hbs
+++ b/templates/market/market.hbs
@@ -106,7 +106,16 @@
                 </td>
                 <td class="market-col--name">{{entry.name}}</td>
                 <td class="market-col--type">{{localize entry.itemType}}</td>
-                <td class="market-col--price">{{entry.basePrice}}</td>
+                <td class="market-col--price">
+                  {{#if entry.priceResult.modifiers.length}}
+                    <span class="market-price market-price--modified"
+                      title="{{localize 'MARKET.Price.BaseLabel'}}: {{entry.priceResult.basePrice}} → {{localize 'MARKET.Price.FinalLabel'}}: {{entry.priceResult.finalPrice}}"
+                      aria-label="{{localize 'MARKET.Price.FinalLabel'}}: {{entry.priceResult.finalPrice}}"
+                    >{{entry.priceResult.finalPrice}}</span>
+                  {{else}}
+                    <span class="market-price">{{entry.priceResult.finalPrice}}</span>
+                  {{/if}}
+                </td>
                 <td class="market-col--rarity">{{entry.rarity}}</td>
                 <td class="market-col--restriction">{{entry.restrictionLevel}}</td>
               </tr>

--- a/tests/applications/market/market-application.test.mjs
+++ b/tests/applications/market/market-application.test.mjs
@@ -233,6 +233,20 @@ describe('MarketApplicationV2', () => {
       expect(entry.sourceType).toBe('world')
     })
 
+    it('exposes priceResult on each catalog entry', async () => {
+      const item = makeItem({ type: 'weapon', price: 100, rarity: 0, availability: 'available' })
+      globalThis.game.items = makeItemsCollection([item])
+
+      const app = new MarketApplicationV2()
+      const context = await app._preparePartContext('catalog', {})
+
+      const entry = context.catalog.groups[0].items[0]
+      expect(entry.priceResult).toBeDefined()
+      expect(typeof entry.priceResult.finalPrice).toBe('number')
+      expect(typeof entry.priceResult.basePrice).toBe('number')
+      expect(Array.isArray(entry.priceResult.modifiers)).toBe(true)
+    })
+
     it('does not mutate context for non-catalog parts', async () => {
       const app = new MarketApplicationV2()
       const context = { someExistingKey: 'value' }
@@ -460,7 +474,7 @@ describe('MarketApplicationV2', () => {
       app._viewState = { ...app._viewState, sortBy: 'price', sortDirection: 'asc' }
       const context = await app._preparePartContext('catalog', {})
 
-      const prices = context.catalog.groups[0].items.map((e) => e.basePrice)
+      const prices = context.catalog.groups[0].items.map((e) => e.priceResult.finalPrice)
       expect(prices[0]).toBeLessThanOrEqual(prices[1])
     })
 
@@ -473,8 +487,25 @@ describe('MarketApplicationV2', () => {
       app._viewState = { ...app._viewState, sortBy: 'price', sortDirection: 'desc' }
       const context = await app._preparePartContext('catalog', {})
 
-      const prices = context.catalog.groups[0].items.map((e) => e.basePrice)
+      const prices = context.catalog.groups[0].items.map((e) => e.priceResult.finalPrice)
       expect(prices[0]).toBeGreaterThanOrEqual(prices[1])
+    })
+
+    it('sort by price uses finalPrice (not basePrice) — rarity-modified items sort on computed price', async () => {
+      // Item A: basePrice=100, rarity=0 → finalPrice=100
+      // Item B: basePrice=80, rarity=5 → finalPrice=80*(1+0.5)=120
+      const itemA = makeItem({ type: 'weapon', name: 'Item A', price: 100, rarity: 0 })
+      const itemB = makeItem({ type: 'weapon', name: 'Item B', price: 80, rarity: 5 })
+      globalThis.game.items = makeItemsCollection([itemA, itemB])
+
+      const app = new MarketApplicationV2()
+      app._viewState = { ...app._viewState, sortBy: 'price', sortDirection: 'asc' }
+      const context = await app._preparePartContext('catalog', {})
+
+      const names = context.catalog.groups[0].items.map((e) => e.name)
+      // Item A (finalPrice=100) should come before Item B (finalPrice=120)
+      expect(names[0]).toBe('Item A')
+      expect(names[1]).toBe('Item B')
     })
   })
 

--- a/tests/lib/market/market-entry.test.mjs
+++ b/tests/lib/market/market-entry.test.mjs
@@ -49,6 +49,39 @@ describe('createMarketEntry', () => {
       expect(entry.eligible).toBe(true)
       expect(entry.ineligibilityReason).toBeNull()
     })
+
+    test('exposes priceResult with basePrice, finalPrice, and modifiers', () => {
+      const entry = createMarketEntry(makeRawItem({ basePrice: 100, rarity: 0, availability: 'available' }), validSourceInfo)
+      expect(entry.priceResult).toBeDefined()
+      expect(entry.priceResult.basePrice).toBe(100)
+      expect(entry.priceResult.finalPrice).toBe(100)
+      expect(Array.isArray(entry.priceResult.modifiers)).toBe(true)
+    })
+
+    test('priceResult.finalPrice reflects rarity modifier', () => {
+      // rarity=5 → 10% * 5 = 50% → 100 * 1.5 = 150
+      const entry = createMarketEntry(makeRawItem({ basePrice: 100, rarity: 5, availability: 'available' }), validSourceInfo)
+      expect(entry.priceResult.finalPrice).toBe(150)
+    })
+
+    test('priceResult.finalPrice reflects availability modifier', () => {
+      // availability=rare → +25% → 100 * 1.25 = 125
+      const entry = createMarketEntry(makeRawItem({ basePrice: 100, rarity: 0, availability: 'rare' }), validSourceInfo)
+      expect(entry.priceResult.finalPrice).toBe(125)
+    })
+
+    test('priceResult.finalPrice reflects manualModifier from marketContext', () => {
+      // manualModifier=+50 → 100 * 1.5 = 150
+      const entry = createMarketEntry(makeRawItem({ basePrice: 100, rarity: 0, availability: 'available' }), validSourceInfo, { manualModifier: 50 })
+      expect(entry.priceResult.finalPrice).toBe(150)
+    })
+
+    test('priceResult is deterministic for the same inputs', () => {
+      const raw = makeRawItem()
+      const a = createMarketEntry(raw, validSourceInfo)
+      const b = createMarketEntry(raw, validSourceInfo)
+      expect(a.priceResult.finalPrice).toBe(b.priceResult.finalPrice)
+    })
   })
 
   describe('name normalization', () => {

--- a/tests/lib/market/price-engine.test.mjs
+++ b/tests/lib/market/price-engine.test.mjs
@@ -1,0 +1,196 @@
+import { describe, expect, it } from 'vitest'
+import { calculateItemPrice } from '../../../module/lib/market/price-engine.mjs'
+
+describe('calculateItemPrice', () => {
+  /* -------------------------------------------- */
+  /*  Return shape                                */
+  /* -------------------------------------------- */
+
+  describe('return shape', () => {
+    it('returns basePrice, finalPrice, and modifiers', () => {
+      const result = calculateItemPrice({ basePrice: 100, rarity: 0 })
+      expect(result).toHaveProperty('basePrice')
+      expect(result).toHaveProperty('finalPrice')
+      expect(result).toHaveProperty('modifiers')
+      expect(Array.isArray(result.modifiers)).toBe(true)
+    })
+
+    it('finalPrice is always an integer', () => {
+      const result = calculateItemPrice({ basePrice: 75, rarity: 3 })
+      expect(Number.isInteger(result.finalPrice)).toBe(true)
+    })
+
+    it('finalPrice is never negative', () => {
+      const result = calculateItemPrice({ basePrice: 100, rarity: 0 }, { manualModifier: -500 })
+      expect(result.finalPrice).toBeGreaterThanOrEqual(0)
+    })
+  })
+
+  /* -------------------------------------------- */
+  /*  Default context fallback                    */
+  /* -------------------------------------------- */
+
+  describe('default context fallback', () => {
+    it('uses DEFAULT_MARKET_CONTEXT when no context is provided', () => {
+      // With no modifiers (default availability=available, rarity=0, manualModifier=0)
+      const result = calculateItemPrice({ basePrice: 200, rarity: 0 })
+      expect(result.finalPrice).toBe(200)
+      expect(result.modifiers).toHaveLength(0)
+    })
+
+    it('uses DEFAULT_MARKET_CONTEXT when empty context is provided', () => {
+      const result = calculateItemPrice({ basePrice: 200, rarity: 0 }, {})
+      expect(result.finalPrice).toBe(200)
+    })
+
+    it('partial context is merged with defaults', () => {
+      // Only provide manualModifier — availability/marketType should still default
+      const result = calculateItemPrice({ basePrice: 100, rarity: 0 }, { manualModifier: 10 })
+      // 100 * (1 + 0.1) = 110
+      expect(result.finalPrice).toBe(110)
+    })
+  })
+
+  /* -------------------------------------------- */
+  /*  Availability resolution                     */
+  /* -------------------------------------------- */
+
+  describe('availability resolution', () => {
+    it('item-level availability overrides context availability', () => {
+      // Item has 'rare' availability (priceModifier=0.25), context has 'available' (0)
+      const result = calculateItemPrice({ basePrice: 100, rarity: 0, availability: 'rare' }, { availability: 'available' })
+      // Item overrides: 100 * (1 + 0.25) = 125
+      expect(result.finalPrice).toBe(125)
+    })
+
+    it('context availability is used when item has no availability', () => {
+      // No item availability — context provides 'restricted' (priceModifier=1.0)
+      const result = calculateItemPrice({ basePrice: 100, rarity: 0 }, { availability: 'restricted' })
+      // 100 * (1 + 1.0) = 200
+      expect(result.finalPrice).toBe(200)
+    })
+
+    it('defaults to available when neither item nor context sets availability', () => {
+      const result = calculateItemPrice({ basePrice: 100, rarity: 0 })
+      // No availability modifier
+      expect(result.finalPrice).toBe(100)
+    })
+  })
+
+  /* -------------------------------------------- */
+  /*  manualModifier (GM override)                */
+  /* -------------------------------------------- */
+
+  describe('manualModifier from context', () => {
+    it('+50 manual modifier adds 50% to base price', () => {
+      const result = calculateItemPrice({ basePrice: 100, rarity: 0 }, { manualModifier: 50 })
+      expect(result.finalPrice).toBe(150)
+    })
+
+    it('-50 manual modifier reduces price by 50%', () => {
+      const result = calculateItemPrice({ basePrice: 100, rarity: 0 }, { manualModifier: -50 })
+      expect(result.finalPrice).toBe(50)
+    })
+
+    it('-100 manual modifier clamps at 0', () => {
+      const result = calculateItemPrice({ basePrice: 100, rarity: 0 }, { manualModifier: -100 })
+      expect(result.finalPrice).toBe(0)
+    })
+
+    it('0 manual modifier produces no modifier step', () => {
+      const result = calculateItemPrice({ basePrice: 100, rarity: 0 }, { manualModifier: 0 })
+      const step = result.modifiers.find((m) => m.label === 'gmModifier')
+      expect(step).toBeUndefined()
+    })
+
+    it('non-zero manual modifier appears in modifiers array', () => {
+      const result = calculateItemPrice({ basePrice: 100, rarity: 0 }, { manualModifier: 25 })
+      const step = result.modifiers.find((m) => m.label === 'gmModifier')
+      expect(step).toBeDefined()
+      expect(step.modifier).toBeCloseTo(0.25)
+    })
+  })
+
+  /* -------------------------------------------- */
+  /*  Rarity modifier                             */
+  /* -------------------------------------------- */
+
+  describe('rarity modifier', () => {
+    it('applies 10% per rarity point', () => {
+      const result = calculateItemPrice({ basePrice: 100, rarity: 5 })
+      // 100 * (1 + 0.5) = 150
+      expect(result.finalPrice).toBe(150)
+    })
+
+    it('rarity=0 produces no rarity modifier step', () => {
+      const result = calculateItemPrice({ basePrice: 100, rarity: 0 })
+      const step = result.modifiers.find((m) => m.label === 'rarity')
+      expect(step).toBeUndefined()
+    })
+
+    it('rarity>0 appears in modifiers array', () => {
+      const result = calculateItemPrice({ basePrice: 100, rarity: 3 })
+      const step = result.modifiers.find((m) => m.label === 'rarity')
+      expect(step).toBeDefined()
+      expect(step.modifier).toBeCloseTo(0.3)
+    })
+  })
+
+  /* -------------------------------------------- */
+  /*  Combined modifiers                          */
+  /* -------------------------------------------- */
+
+  describe('combined modifiers', () => {
+    it('combines rarity + availability + manualModifier', () => {
+      // base=100, rarity=2 (0.2), availability=rare (0.25), manualModifier=10 (0.1)
+      // 100 * (1 + 0.25 + 0.2 + 0.1) = 155
+      const result = calculateItemPrice({ basePrice: 100, rarity: 2, availability: 'rare' }, { manualModifier: 10 })
+      expect(result.finalPrice).toBe(155)
+      expect(result.modifiers).toHaveLength(3)
+    })
+
+    it('basePrice=0 always yields finalPrice=0 regardless of modifiers', () => {
+      const result = calculateItemPrice({ basePrice: 0, rarity: 10, availability: 'blackMarket' }, { manualModifier: 100 })
+      expect(result.finalPrice).toBe(0)
+    })
+  })
+
+  /* -------------------------------------------- */
+  /*  Validation                                  */
+  /* -------------------------------------------- */
+
+  describe('validation', () => {
+    it('throws TypeError for negative basePrice', () => {
+      expect(() => calculateItemPrice({ basePrice: -1, rarity: 0 })).toThrow(TypeError)
+    })
+
+    it('throws TypeError for NaN basePrice', () => {
+      expect(() => calculateItemPrice({ basePrice: NaN, rarity: 0 })).toThrow(TypeError)
+    })
+
+    it('throws TypeError for NaN rarity', () => {
+      expect(() => calculateItemPrice({ basePrice: 100, rarity: NaN })).toThrow(TypeError)
+    })
+  })
+
+  /* -------------------------------------------- */
+  /*  Modifier key mapping                        */
+  /* -------------------------------------------- */
+
+  describe('modifier labels', () => {
+    it('availability modifier uses label "availability"', () => {
+      const result = calculateItemPrice({ basePrice: 100, rarity: 0, availability: 'rare' })
+      expect(result.modifiers.some((m) => m.label === 'availability')).toBe(true)
+    })
+
+    it('rarity modifier uses label "rarity"', () => {
+      const result = calculateItemPrice({ basePrice: 100, rarity: 2 })
+      expect(result.modifiers.some((m) => m.label === 'rarity')).toBe(true)
+    })
+
+    it('gmModifier step uses label "gmModifier"', () => {
+      const result = calculateItemPrice({ basePrice: 100, rarity: 0 }, { manualModifier: 20 })
+      expect(result.modifiers.some((m) => m.label === 'gmModifier')).toBe(true)
+    })
+  })
+})


### PR DESCRIPTION
## Summary

- Implement market search, filter and sort in catalogue.
- Add price engine with modifiers for rarity, availability and context.
- Add unit tests for market-entry and price-engine.

## Context

This branch implements the market feature used by the catalogue UI and price calculations.

Closes #456

## Tests

- Unit tests added and updated for market logic.

## Notes

- No lint/test/build was run by the PR creation agent.
