### PR TITLE
feat(market): replace type-based grouping with flat item list in catalog

### DIFF
--- a/.copilot-tracking/plans/plan-makeCharacterSheetAreasScrollable-v2.prompt.md
+++ b/.copilot-tracking/plans/plan-makeCharacterSheetAreasScrollable-v2.prompt.md
@@ -1,0 +1,155 @@
+# Plan: Fix Scrolling in Character Sheet Tabs (FoundryVTT v14+)
+
+## Problem
+
+The scrollable tab in Skills (and other tabs with `.scrollable`) is not activating. The `.scrollable` CSS rule exists (`overflow-y: auto; min-height: 0`), and the PART configuration has `scrollable: ['.scrollable']` set, but the scroll does not work.
+
+## Root Cause Analysis
+
+**The core issue**: Foundry ApplicationV2 ApplicationV2 flex layout chain breaks height constraint propagation:
+
+```
+.swerpg.sheet.actor (overflow: visible)
+  └─ .window-content (flex-direction: row, height: calc(100% - header), overflow: visible)  ← PROBLEM HERE
+       ├─ .sheet-sidebar (flex: 0 0 200px)
+       └─ .sheet-body (flex: 1, flex-direction: column, height: 100%, min-height: 0, overflow: hidden)
+            └─ .tab.skills.scrollable (flex: 1, min-height: 0, overflow-y: auto)  ← Should scroll
+```
+
+**Why overflow: visible breaks flex height constraint:**
+
+In CSS flex layouts, when a flex container has `overflow: visible` (the default), it does **not enforce** height constraints on its children. Content can overflow, and the flex container will expand to accommodate it rather than forcing children within bounds. This breaks the height propagation chain downward.
+
+The `.window-content` has `overflow: visible` intentionally — the `.sheet-tabs` (`<nav>`) elements are positioned absolutely at `right: -36px` and need to be visible outside the `.window-content` bounds.
+
+**Effect on scrollable tab:**
+
+1. `.sheet-body` has `height: 100%` which should = `.window-content`'s height
+2. But `.window-content` with `overflow: visible` doesn't actually enforce its height on Flex children
+3. `.sheet-body` grows to fit its content (all tabs, even hidden ones)
+4. The `.tab.skills` with `flex: 1` never gets a constrained height
+5. `overflow-y: auto` never activates because the container is never height-constrained
+
+## Solution
+
+**Separate the overflow axes on `.window-content`:**
+
+- Keep `overflow-x: visible` (allows tabs to protrude right)
+- Change `overflow-y` to `clip` or `hidden` (hard-constrains height, forces flex children to respect bounds)
+
+Using `overflow-y: clip` is preferable to `hidden` because `clip` doesn't create a scroll context — it just clips without allowing scroll, which is appropriate for a container that delegates scrolling to children via `scrollable: [...]`.
+
+## Implementation Changes
+
+### File: `styles/actor.less`
+
+#### Change 1: `.window-content` (line 57-65)
+
+Replace:
+
+```less
+.window-content {
+  display: flex;
+  flex-direction: row;
+  flex-wrap: nowrap;
+  gap: var(--margin-size);
+  height: calc(100% - var(--header-height));
+  padding: 0 var(--margin-size) var(--margin-size);
+  overflow: visible;
+}
+```
+
+With:
+
+```less
+.window-content {
+  display: flex;
+  flex-direction: row;
+  flex-wrap: nowrap;
+  gap: var(--margin-size);
+  height: calc(100% - var(--header-height));
+  padding: 0 var(--margin-size) var(--margin-size);
+  overflow-x: visible;
+  overflow-y: clip;
+}
+```
+
+#### Change 2: `.sheet-body` (line 77-86) — Already Applied
+
+Keep the previous fix (no change needed):
+
+```less
+.sheet-body {
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+  justify-content: flex-start;
+  gap: 1rem;
+  height: 100%;
+  min-height: 0;
+  overflow: hidden;
+}
+```
+
+This ensures:
+
+- `flex: 1` fills available space in the flex-row parent
+- `height: 100%` resolves to the (now properly constrained) `.window-content` height
+- `min-height: 0` allows flex children to shrink below their content size
+- `overflow: hidden` ensures child content is clipped if needed
+
+#### Change 3: `.tab.scrollable` (line 88-97) — Already Correct
+
+No changes needed:
+
+```less
+.tab {
+  position: relative;
+  flex: 1;
+  padding: 1.5rem 0 1rem;
+  gap: 1.5rem;
+
+  &.scrollable {
+    overflow-y: auto;
+    min-height: 0;
+  }
+}
+```
+
+This ensures:
+
+- `flex: 1` fills remaining space in `.sheet-body` flex-column
+- `overflow-y: auto` activates scroll when content > available height
+- `min-height: 0` allows further shrinking below content size
+
+## Expected Result After Fix
+
+✅ `.window-content` height is now properly constrained (via `overflow-y: clip`)
+✅ `.sheet-body` receives constrained parent height and propagates to tabs
+✅ `.tab.skills` (and other scrollable tabs) receive hard height constraint
+✅ `overflow-y: auto` on scrollable tabs now works because height is constrained
+✅ Tab scroll position persists via Foundry's `scrollable: [...]` mechanism
+✅ Tabs to the right (`.sheet-tabs`) still overflow visible via `overflow-x: visible`
+✅ No visual regression on other UI elements
+
+## Validation Steps
+
+1. Compile LESS: `pnpm run less`
+2. Open Character Sheet in Foundry v14+
+3. Navigate to Skills tab
+4. Attempt to scroll within the skills list
+5. Scroll should be active and smooth
+6. Navigate to another tab and back — scroll position should be preserved
+7. Check other tabs (Inventory, Talents, Effects) — all should scroll
+8. Right-side tab navigation buttons should remain visible (not clipped)
+
+## Browser Compatibility Note
+
+`overflow: clip` is supported in all modern browsers (Chrome 90+, Firefox 69+, Safari 15.4+, Edge 90+). For older browser support, use `overflow: hidden` instead (though this creates a scroll context, which is less clean but functionally equivalent).
+
+## Related Files
+
+- `module/applications/sheets/base-actor-sheet.mjs` — PARTS definition with `scrollable: ['.scrollable']` (already correct)
+- `templates/sheets/actor/body.hbs` — Template structure for body PART (already correct)
+- `templates/sheets/actor/skills.hbs` — Skills tab template with `.scrollable` class (already correct)
+- `styles/actor.less` — Main stylesheet for actor sheets (requires changes listed above)

--- a/documentation/plan/market/463-catalogue-market-liste-unique-plate.md
+++ b/documentation/plan/market/463-catalogue-market-liste-unique-plate.md
@@ -1,0 +1,129 @@
+# Catalogue Market : liste unique plate (suppression du regroupement par type)
+
+**Demande utilisateur** : ne plus séparer les items par type dans le Market, mais afficher une seule liste plate de tous les items en vente, avec la colonne Type et le filtre Type comme moyen principal de navigation.
+
+---
+
+## Contexte actuel
+
+Le Market regroupe les items par type (`weapon`, `armor`, `gear`) dans des sections visuelles distinctes (`market-group`). Chaque groupe a son en-tête, sa propre table, et sa propre itération dans le template. Le tri s'applique par groupe et non globalement.
+
+Le regroupement est implémenté dans :
+
+- `module/applications/market/market-application.mjs` — étape 6 de `#prepareCatalog()`, lignes 345-363
+- `templates/market/market.hbs` — boucle `{{#each catalog.groups}}`, lignes 116-178
+- `styles/market.less` — `.market-group`, `.market-group__header`, `.market-group__title`, lignes 169-245
+- `tests/applications/market/market-application.test.mjs` — nombreuses assertions sur `catalog.groups`
+
+---
+
+## Décisions UX
+
+- La colonne `Type` reste purement textuelle (pas de badge, pas d'icône par ligne).
+- Le filtre `Type` devient le moyen principal pour cibler une famille d'items.
+- Pas de séparateur visuel par famille d'items.
+
+---
+
+## Étapes d'implémentation
+
+### Étape 1 : Refondre la structure du catalogue côté application
+
+**Fichier** : `module/applications/market/market-application.mjs`
+
+**What** :
+
+- Dans `#prepareCatalog()`, supprimer l'étape 6 (groupement par type) — lignes 345-363
+- Retourner `catalog.items` comme liste plate triée
+- Supprimer `catalog.groups` du type de retour
+- Conserver les autres propriétés : `isEmpty`, `isFilteredEmpty`, `totalCount`, `filteredCount`, `activeMarketType`, `activeMarketDef`
+- Mettre à jour le JSDoc du retour (ligne 291)
+- Supprimer les imports/deps devenus inutiles si applicable (vérifier `PURCHASABLE_ITEM_TYPES` — encore utilisé par le filtre Type, donc à garder)
+
+**Why** : la structure `groups` est devenue un artefact visuel qui empêche le tri global et ajoute de la complexité inutile.
+
+### Étape 2 : Simplifier le template Market en un seul bloc
+
+**Fichier** : `templates/market/market.hbs`
+
+**What** :
+
+- Remplacer la boucle `{{#each catalog.groups as |group|}}`...`{{/each}}` par :
+  - un unique conteneur de table
+  - une boucle directe `{{#each catalog.items as |entry|}}` dans un seul `<tbody>`
+- Conserver les colonnes actuelles dans l'en-tête (`<th>`) : icône, nom, type, prix, rareté, restriction, achat
+- Afficher `entry.itemType` localisé comme aujourd'hui dans la colonne Type
+
+**Why** : une seule table = tri global, rendu plus simple, pas de duplication de structure.
+
+### Étape 3 : Nettoyer le CSS
+
+**Fichier** : `styles/market.less`
+
+**What** :
+
+- Supprimer ou rendre inutiles les blocs liés à `.market-group`, `.market-group__header`, `.market-group__title`
+- Conserver le style de table existant `.market-group__table` (renommer éventuellement en `.market-catalog__table` si pertinent, mais pas nécessaire)
+- Vérifier qu'aucun style de bordure/background ne dépend de l'encapsulation `.market-group`
+
+**Why** : les séparateurs visuels par groupe n'ont plus de sens.
+
+### Étape 4 : Recaler les tests sur une liste plate
+
+**Fichier** : `tests/applications/market/market-application.test.mjs`
+
+**What** :
+
+- Remplacer les assertions basées sur `catalog.groups[0].items[0]` par `catalog.items[0]`
+- Remplacer les assertions basées sur `catalog.groups.find(...)` par des vérifications directes
+- Réécrire ou supprimer les tests qui vérifient le comportement de groupement :
+  - `'groups eligible items by type'` → `'returns a flat item list with all types'`
+  - `'does not include groups with zero items'` → à supprimer (plus de notion de groupe)
+  - `'includes typeKey, label, icon in each group'` → à supprimer (la colonne Type est textuelle)
+- Conserver les tests métier :
+  - visibilité par marché
+  - calcul de prix / `priceResult`
+  - `canBuy` / `buyBlockedReason`
+  - recherche texte
+  - filtres type/source/restriction
+  - tri
+  - reset
+  - achat
+- Vérifier que le filtre Type fonctionne toujours sur la liste plate
+
+**Why** : les tests doivent valider le nouveau contrat sans régresser les fonctionnalités métier.
+
+---
+
+## Comportements attendus après changement
+
+- Le Market affiche une **seule table** contenant tous les items éligibles
+- Le **tri** (nom/prix/rareté) s'applique globalement à toute la liste
+- Le **filtre Type** permet d'isoler rapidement `weapon`, `armor` ou `gear`
+- La **recherche texte** s'applique sur la liste unique
+- Les **achats**, la **visibilité par marché** et les **états vides** ne changent pas
+
+---
+
+## Fichiers modifiés
+
+- `module/applications/market/market-application.mjs`
+- `templates/market/market.hbs`
+- `styles/market.less`
+- `tests/applications/market/market-application.test.mjs`
+
+---
+
+## Tradeoffs
+
+**Perdu** : séparateurs visuels par famille d'items, navigation par groupe.
+
+**Gagné** :
+
+- lecture plus compacte
+- tri global cohérent
+- UI plus simple
+- moins de duplication structurelle template/JS
+- suppression d'une étape de calcul dans le pipeline catalogue
+
+**Risque** : changement de contrat du contexte `catalog` (suppression de `groups`). Aucun autre consommateur applicatif connu. Propre.

--- a/module/applications/market/market-application.mjs
+++ b/module/applications/market/market-application.mjs
@@ -130,7 +130,8 @@ function sortEntries(entries, sortBy, direction) {
 
 /**
  * The Market application presents a read-only catalogue of World Items that are eligible for purchase.
- * Items are grouped by purchasable type (weapon, armor, gear).
+ * Items are displayed as a single flat list sorted globally. Type, source, and restriction filters
+ * allow navigation within the unified list.
  * The catalogue supports text search, type/source/restriction filters, and name/price/rarity sort.
  */
 export default class MarketApplicationV2 extends api.HandlebarsApplicationMixin(api.ApplicationV2) {
@@ -283,12 +284,12 @@ export default class MarketApplicationV2 extends api.HandlebarsApplicationMixin(
   /* -------------------------------------------- */
 
   /**
-   * Build the filtered, sorted, and grouped catalogue from World Items.
-   * Pipeline: build all eligible entries → apply market-type visibility → apply search → apply filters → sort → group → annotate with canBuy.
+   * Build the filtered, sorted catalogue from World Items as a flat list.
+   * Pipeline: build all eligible entries → apply market-type visibility → apply search → apply filters → sort → annotate with canBuy.
    * @param {Actor|null} buyer        The buyer actor, or null when browsing without a character context.
    * @param {number|null} buyerCredits  The buyer's current credit balance (null when no buyer).
    * @returns {{
-   *   groups: Array<{typeKey: string, label: string, icon: string, items: MarketEntry[]}>,
+   *   items: import('../../lib/market/market-entry.mjs').MarketEntry[],
    *   isEmpty: boolean,
    *   isFilteredEmpty: boolean,
    *   totalCount: number,
@@ -328,12 +329,12 @@ export default class MarketApplicationV2 extends api.HandlebarsApplicationMixin(
     let filtered = filterBySearch(visibleEntries, search)
     filtered = filterByFilters(filtered, { filterType, filterSource, filterRestriction })
 
-    // 4. Sort
+    // 4. Sort globally across all types
     const sorted = sortEntries(filtered, sortBy, sortDirection)
     const filteredCount = sorted.length
 
     // 5. Annotate each entry with canBuy based on buyer affordability
-    const annotated = sorted.map((entry) => {
+    const items = sorted.map((entry) => {
       const validation = validatePurchase({ actor: buyer, entry })
       return {
         ...entry,
@@ -342,30 +343,10 @@ export default class MarketApplicationV2 extends api.HandlebarsApplicationMixin(
       }
     })
 
-    // 6. Group by item type
-    /** @type {Map<string, import('../../lib/market/market-entry.mjs').MarketEntry[]>} */
-    const grouped = new Map()
-    for (const typeKey of Object.keys(PURCHASABLE_ITEM_TYPES)) {
-      grouped.set(typeKey, [])
-    }
-    for (const entry of annotated) {
-      const bucket = grouped.get(entry.itemType)
-      if (bucket) bucket.push(entry)
-    }
-
-    const groups = Object.entries(PURCHASABLE_ITEM_TYPES)
-      .map(([typeKey, typeCfg]) => ({
-        typeKey,
-        label: typeCfg.label,
-        icon: typeCfg.icon,
-        items: grouped.get(typeKey) ?? [],
-      }))
-      .filter((group) => group.items.length > 0)
-
     const hasActiveFilter = !!(search || filterType || filterSource || filterRestriction)
 
     return {
-      groups,
+      items,
       isEmpty: totalCount === 0,
       isFilteredEmpty: totalCount > 0 && filteredCount === 0 && hasActiveFilter,
       totalCount,

--- a/styles/market.less
+++ b/styles/market.less
@@ -163,49 +163,17 @@
 }
 
 /* ----------------------------------------- */
-/*  Market Groups                            */
+/*  Market Table                             */
 /* ----------------------------------------- */
 
-.market-group {
-  display: flex;
-  flex-direction: column;
-  gap: 0.5rem;
+.market-catalog__table {
   border: 1px solid var(--color-cool-4, rgba(120, 169, 194, 0.22));
   border-radius: 8px;
   overflow: hidden;
   background: rgba(12, 18, 27, 0.6);
-}
-
-.market-group__header {
-  display: flex;
-  align-items: center;
-  gap: 0.5rem;
-  padding: 0.6rem 1rem;
-  background: rgba(18, 28, 42, 0.85);
-  border-bottom: 1px solid var(--color-cool-4, rgba(120, 169, 194, 0.22));
-
-  i {
-    color: var(--color-secondary);
-    font-size: var(--font-size-14);
-    flex: none;
-  }
-}
-
-.market-group__title {
-  margin: 0;
-  font-family: var(--font-h1);
-  font-size: var(--font-size-14);
-  color: var(--color-primary);
-  font-weight: normal;
-}
-
-/* ----------------------------------------- */
-/*  Market Table                             */
-/* ----------------------------------------- */
-
-.market-group__table {
   width: 100%;
-  border-collapse: collapse;
+  border-collapse: separate;
+  border-spacing: 0;
   font-size: var(--font-size-13);
 
   thead tr {

--- a/styles/swerpg.css
+++ b/styles/swerpg.css
@@ -5161,49 +5161,22 @@ input[type='range'] {
   border: 0;
 }
 /* ----------------------------------------- */
-/*  Market Groups                            */
+/*  Market Table                             */
 /* ----------------------------------------- */
-.market-group {
-  display: flex;
-  flex-direction: column;
-  gap: 0.5rem;
+.market-catalog__table {
   border: 1px solid var(--color-cool-4, rgba(120, 169, 194, 0.22));
   border-radius: 8px;
   overflow: hidden;
   background: rgba(12, 18, 27, 0.6);
-}
-.market-group__header {
-  display: flex;
-  align-items: center;
-  gap: 0.5rem;
-  padding: 0.6rem 1rem;
-  background: rgba(18, 28, 42, 0.85);
-  border-bottom: 1px solid var(--color-cool-4, rgba(120, 169, 194, 0.22));
-}
-.market-group__header i {
-  color: var(--color-secondary);
-  font-size: var(--font-size-14);
-  flex: none;
-}
-.market-group__title {
-  margin: 0;
-  font-family: var(--font-h1);
-  font-size: var(--font-size-14);
-  color: var(--color-primary);
-  font-weight: normal;
-}
-/* ----------------------------------------- */
-/*  Market Table                             */
-/* ----------------------------------------- */
-.market-group__table {
   width: 100%;
-  border-collapse: collapse;
+  border-collapse: separate;
+  border-spacing: 0;
   font-size: var(--font-size-13);
 }
-.market-group__table thead tr {
+.market-catalog__table thead tr {
   background: rgba(10, 17, 26, 0.5);
 }
-.market-group__table th {
+.market-catalog__table th {
   padding: 0.35rem 0.75rem;
   text-align: left;
   color: var(--color-secondary);
@@ -5214,17 +5187,17 @@ input[type='range'] {
   border-bottom: 1px solid rgba(120, 169, 194, 0.15);
   white-space: nowrap;
 }
-.market-group__table tbody tr.market-item {
+.market-catalog__table tbody tr.market-item {
   cursor: pointer;
   transition: background 0.12s ease;
 }
-.market-group__table tbody tr.market-item:hover {
+.market-catalog__table tbody tr.market-item:hover {
   background: rgba(120, 169, 194, 0.08);
 }
-.market-group__table tbody tr.market-item:not(:last-child) {
+.market-catalog__table tbody tr.market-item:not(:last-child) {
   border-bottom: 1px solid rgba(120, 169, 194, 0.07);
 }
-.market-group__table td {
+.market-catalog__table td {
   padding: 0.4rem 0.75rem;
   color: var(--color-text, #d5e4f1);
   vertical-align: middle;

--- a/templates/market/market.hbs
+++ b/templates/market/market.hbs
@@ -113,68 +113,59 @@
       {{localize "MARKET.Catalog.EmptySearch"}}
     </p>
   {{else}}
-    {{#each catalog.groups as |group|}}
-      <section class="market-group">
-        <header class="market-group__header">
-          <i class="{{group.icon}}"></i>
-          <h3 class="market-group__title">{{localize group.label}}</h3>
-        </header>
-
-        <table class="market-group__table">
-          <thead>
-            <tr>
-              <th class="market-col--icon" aria-label="{{localize 'MARKET.Catalog.Column.Name'}}"></th>
-              <th class="market-col--name">{{localize "MARKET.Catalog.Column.Name"}}</th>
-              <th class="market-col--type">{{localize "MARKET.Catalog.Column.Type"}}</th>
-              <th class="market-col--price">{{localize "MARKET.Catalog.Column.Price"}}</th>
-              <th class="market-col--rarity">{{localize "MARKET.Catalog.Column.Rarity"}}</th>
-              <th class="market-col--restriction">{{localize "MARKET.Catalog.Column.Restriction"}}</th>
-              {{#if @root.buyer}}<th class="market-col--buy" aria-label="{{localize 'MARKET.Catalog.Column.Buy'}}"></th>{{/if}}
-            </tr>
-          </thead>
-          <tbody>
-            {{#each group.items as |entry|}}
-              <tr class="market-item" data-uuid="{{entry.uuid}}" data-action="openItem"
-                  data-tooltip="{{localize 'MARKET.Catalog.OpenSheet'}}">
-                <td class="market-col--icon">
-                  {{#if entry.img}}
-                    <img class="market-item__icon" src="{{entry.img}}" alt="{{entry.name}}" />
-                  {{/if}}
-                </td>
-                <td class="market-col--name">{{entry.name}}</td>
-                <td class="market-col--type">{{localize entry.itemType}}</td>
-                <td class="market-col--price">
-                  {{#if entry.priceResult.modifiers.length}}
-                    <span class="market-price market-price--modified"
-                      data-tooltip="{{localize 'MARKET.Price.BaseLabel'}}: {{entry.priceResult.basePrice}} → {{localize 'MARKET.Price.FinalLabel'}}: {{entry.priceResult.finalPrice}}"
-                      aria-label="{{localize 'MARKET.Price.FinalLabel'}}: {{entry.priceResult.finalPrice}}"
-                    >{{entry.priceResult.finalPrice}}</span>
-                  {{else}}
-                    <span class="market-price">{{entry.priceResult.finalPrice}}</span>
-                  {{/if}}
-                </td>
-                <td class="market-col--rarity">{{entry.rarity}}</td>
-                <td class="market-col--restriction">{{entry.restrictionLevel}}</td>
-                {{#if @root.buyer}}
-                  <td class="market-col--buy">
-                    <button
-                      type="button"
-                      class="market-item__buy {{#unless entry.canBuy}}market-item__buy--disabled{{/unless}}"
-                      data-action="buyItem"
-                      data-tooltip="{{localize 'MARKET.Purchase.BuyButton'}}"
-                      data-uuid="{{entry.uuid}}"
-                      {{#unless entry.canBuy}}disabled aria-disabled="true"{{/unless}}
-                      aria-label="{{localize 'MARKET.Purchase.BuyButton'}}"
-                    >
-                      <i class="fa-solid fa-coins" aria-hidden="true"></i>
-                    </button>
-                  </td>
-                {{/if}}
-              </tr>
-            {{/each}}
-          </tbody>
-        </table>
-      </section>
-    {{/each}}
+    <table class="market-catalog__table">
+      <thead>
+        <tr>
+          <th class="market-col--icon" aria-label="{{localize 'MARKET.Catalog.Column.Name'}}"></th>
+          <th class="market-col--name">{{localize "MARKET.Catalog.Column.Name"}}</th>
+          <th class="market-col--type">{{localize "MARKET.Catalog.Column.Type"}}</th>
+          <th class="market-col--price">{{localize "MARKET.Catalog.Column.Price"}}</th>
+          <th class="market-col--rarity">{{localize "MARKET.Catalog.Column.Rarity"}}</th>
+          <th class="market-col--restriction">{{localize "MARKET.Catalog.Column.Restriction"}}</th>
+          {{#if buyer}}<th class="market-col--buy" aria-label="{{localize 'MARKET.Catalog.Column.Buy'}}"></th>{{/if}}
+        </tr>
+      </thead>
+      <tbody>
+        {{#each catalog.items as |entry|}}
+          <tr class="market-item" data-uuid="{{entry.uuid}}" data-action="openItem"
+              data-tooltip="{{localize 'MARKET.Catalog.OpenSheet'}}">
+            <td class="market-col--icon">
+              {{#if entry.img}}
+                <img class="market-item__icon" src="{{entry.img}}" alt="{{entry.name}}" />
+              {{/if}}
+            </td>
+            <td class="market-col--name">{{entry.name}}</td>
+            <td class="market-col--type">{{localize entry.itemType}}</td>
+            <td class="market-col--price">
+              {{#if entry.priceResult.modifiers.length}}
+                <span class="market-price market-price--modified"
+                  data-tooltip="{{localize 'MARKET.Price.BaseLabel'}}: {{entry.priceResult.basePrice}} → {{localize 'MARKET.Price.FinalLabel'}}: {{entry.priceResult.finalPrice}}"
+                  aria-label="{{localize 'MARKET.Price.FinalLabel'}}: {{entry.priceResult.finalPrice}}"
+                >{{entry.priceResult.finalPrice}}</span>
+              {{else}}
+                <span class="market-price">{{entry.priceResult.finalPrice}}</span>
+              {{/if}}
+            </td>
+            <td class="market-col--rarity">{{entry.rarity}}</td>
+            <td class="market-col--restriction">{{entry.restrictionLevel}}</td>
+            {{#if ../buyer}}
+              <td class="market-col--buy">
+                <button
+                  type="button"
+                  class="market-item__buy {{#unless entry.canBuy}}market-item__buy--disabled{{/unless}}"
+                  data-action="buyItem"
+                  data-tooltip="{{localize 'MARKET.Purchase.BuyButton'}}"
+                  data-uuid="{{entry.uuid}}"
+                  {{#unless entry.canBuy}}disabled aria-disabled="true"{{/unless}}
+                  aria-label="{{localize 'MARKET.Purchase.BuyButton'}}"
+                >
+                  <i class="fa-solid fa-coins" aria-hidden="true"></i>
+                </button>
+              </td>
+            {{/if}}
+          </tr>
+        {{/each}}
+      </tbody>
+    </table>
   {{/if}}
 </div>

--- a/tests/applications/market/market-application.test.mjs
+++ b/tests/applications/market/market-application.test.mjs
@@ -195,7 +195,7 @@ describe('MarketApplicationV2', () => {
       const app = new MarketApplicationV2()
       const context = await app._preparePartContext('catalog', {})
 
-      expect(context.catalog.groups[0].items[0].canBuy).toBe(false)
+      expect(context.catalog.items[0].canBuy).toBe(false)
     })
 
     it('sets canBuy=true when buyer has sufficient credits', async () => {
@@ -207,7 +207,7 @@ describe('MarketApplicationV2', () => {
       app.setBuyerActor(actor)
       const context = await app._preparePartContext('catalog', {})
 
-      expect(context.catalog.groups[0].items[0].canBuy).toBe(true)
+      expect(context.catalog.items[0].canBuy).toBe(true)
     })
 
     it('sets canBuy=false when buyer has insufficient credits', async () => {
@@ -219,8 +219,8 @@ describe('MarketApplicationV2', () => {
       app.setBuyerActor(actor)
       const context = await app._preparePartContext('catalog', {})
 
-      expect(context.catalog.groups[0].items[0].canBuy).toBe(false)
-      expect(context.catalog.groups[0].items[0].buyBlockedReason).toBe('insufficient-credits')
+      expect(context.catalog.items[0].canBuy).toBe(false)
+      expect(context.catalog.items[0].buyBlockedReason).toBe('insufficient-credits')
     })
   })
 
@@ -229,7 +229,7 @@ describe('MarketApplicationV2', () => {
   /* -------------------------------------------- */
 
   describe('_preparePartContext — catalog', () => {
-    it('groups eligible items by type', async () => {
+    it('returns a flat item list with all types', async () => {
       const weaponItem = makeItem({ type: 'weapon', name: 'Blaster Pistol' })
       const armorItem = makeItem({ type: 'armor', name: 'Light Armor', basePrice: 200 })
       globalThis.game.items = makeItemsCollection([weaponItem, armorItem])
@@ -238,17 +238,12 @@ describe('MarketApplicationV2', () => {
       const context = await app._preparePartContext('catalog', {})
 
       expect(context.catalog.isEmpty).toBe(false)
-      expect(context.catalog.groups).toHaveLength(2)
+      expect(Array.isArray(context.catalog.items)).toBe(true)
+      expect(context.catalog.items).toHaveLength(2)
 
-      const weaponGroup = context.catalog.groups.find((g) => g.typeKey === 'weapon')
-      expect(weaponGroup).toBeDefined()
-      expect(weaponGroup.items).toHaveLength(1)
-      expect(weaponGroup.items[0].name).toBe('Blaster Pistol')
-
-      const armorGroup = context.catalog.groups.find((g) => g.typeKey === 'armor')
-      expect(armorGroup).toBeDefined()
-      expect(armorGroup.items).toHaveLength(1)
-      expect(armorGroup.items[0].name).toBe('Light Armor')
+      const names = context.catalog.items.map((e) => e.name)
+      expect(names).toContain('Blaster Pistol')
+      expect(names).toContain('Light Armor')
     })
 
     it('excludes items with non-purchasable types (e.g. talent)', async () => {
@@ -259,7 +254,7 @@ describe('MarketApplicationV2', () => {
       const context = await app._preparePartContext('catalog', {})
 
       expect(context.catalog.isEmpty).toBe(true)
-      expect(context.catalog.groups).toHaveLength(0)
+      expect(context.catalog.items).toHaveLength(0)
     })
 
     it('excludes ineligible items (nonPurchasable=true)', async () => {
@@ -289,32 +284,7 @@ describe('MarketApplicationV2', () => {
       const context = await app._preparePartContext('catalog', {})
 
       expect(context.catalog.isEmpty).toBe(true)
-      expect(context.catalog.groups).toHaveLength(0)
-    })
-
-    it('does not include groups with zero items', async () => {
-      // Only one weapon, no armor, no gear
-      const weaponItem = makeItem({ type: 'weapon' })
-      globalThis.game.items = makeItemsCollection([weaponItem])
-
-      const app = new MarketApplicationV2()
-      const context = await app._preparePartContext('catalog', {})
-
-      expect(context.catalog.groups.every((g) => g.items.length > 0)).toBe(true)
-      expect(context.catalog.groups.some((g) => g.typeKey === 'armor')).toBe(false)
-      expect(context.catalog.groups.some((g) => g.typeKey === 'gear')).toBe(false)
-    })
-
-    it('includes typeKey, label, icon in each group', async () => {
-      const item = makeItem({ type: 'gear', name: 'Medpac', basePrice: 25 })
-      globalThis.game.items = makeItemsCollection([item])
-
-      const app = new MarketApplicationV2()
-      const context = await app._preparePartContext('catalog', {})
-
-      const gearGroup = context.catalog.groups.find((g) => g.typeKey === 'gear')
-      expect(gearGroup.label).toBe('MARKET.ItemType.Gear')
-      expect(gearGroup.icon).toBe('fa-solid fa-toolbox')
+      expect(context.catalog.items).toHaveLength(0)
     })
 
     it('gear item with price 200 and rarity 1 should have non-zero basePrice and finalPrice', async () => {
@@ -335,11 +305,9 @@ describe('MarketApplicationV2', () => {
       const app = new MarketApplicationV2()
       const context = await app._preparePartContext('catalog', {})
 
-      const gearGroup = context.catalog.groups.find((g) => g.typeKey === 'gear')
-      expect(gearGroup).toBeDefined()
-      expect(gearGroup.items).toHaveLength(1)
+      expect(context.catalog.items).toHaveLength(1)
 
-      const entry = gearGroup.items[0]
+      const entry = context.catalog.items[0]
       expect(entry.basePrice).toBeGreaterThan(0)
       expect(entry.priceResult.finalPrice).toBeGreaterThan(0)
     })
@@ -351,7 +319,7 @@ describe('MarketApplicationV2', () => {
       const app = new MarketApplicationV2()
       const context = await app._preparePartContext('catalog', {})
 
-      const entry = context.catalog.groups[0].items[0]
+      const entry = context.catalog.items[0]
       expect(entry.sourceId).toBe('Item.myUuid')
       expect(entry.sourceType).toBe('world')
     })
@@ -363,7 +331,7 @@ describe('MarketApplicationV2', () => {
       const app = new MarketApplicationV2()
       const context = await app._preparePartContext('catalog', {})
 
-      const entry = context.catalog.groups[0].items[0]
+      const entry = context.catalog.items[0]
       expect(entry.priceResult).toBeDefined()
       expect(typeof entry.priceResult.finalPrice).toBe('number')
       expect(typeof entry.priceResult.basePrice).toBe('number')
@@ -421,9 +389,8 @@ describe('MarketApplicationV2', () => {
       app._viewState = { ...app._viewState, search: 'blaster' }
       const context = await app._preparePartContext('catalog', {})
 
-      const weaponGroup = context.catalog.groups.find((g) => g.typeKey === 'weapon')
-      expect(weaponGroup.items).toHaveLength(1)
-      expect(weaponGroup.items[0].name).toBe('Blaster Pistol')
+      expect(context.catalog.items).toHaveLength(1)
+      expect(context.catalog.items[0].name).toBe('Blaster Pistol')
     })
 
     it('is case-insensitive', async () => {
@@ -479,8 +446,7 @@ describe('MarketApplicationV2', () => {
       const context = await app._preparePartContext('catalog', {})
 
       expect(context.catalog.filteredCount).toBe(1)
-      const armorGroup = context.catalog.groups.find((g) => g.typeKey === 'armor')
-      expect(armorGroup).toBeUndefined()
+      expect(context.catalog.items.every((e) => e.itemType === 'weapon')).toBe(true)
     })
 
     it('empty filterType shows all types', async () => {
@@ -534,8 +500,7 @@ describe('MarketApplicationV2', () => {
 
       // Only the weapon named "Blaster Pistol" — armor is excluded by type, vibro by search
       expect(context.catalog.filteredCount).toBe(1)
-      const weaponGroup = context.catalog.groups.find((g) => g.typeKey === 'weapon')
-      expect(weaponGroup.items[0].name).toBe('Blaster Pistol')
+      expect(context.catalog.items[0].name).toBe('Blaster Pistol')
     })
 
     it('does not re-introduce items excluded by eligibility', async () => {
@@ -549,7 +514,7 @@ describe('MarketApplicationV2', () => {
       const context = await app._preparePartContext('catalog', {})
 
       expect(context.catalog.filteredCount).toBe(1)
-      expect(context.catalog.groups[0].items[0].name).toBe('Blaster')
+      expect(context.catalog.items[0].name).toBe('Blaster')
     })
   })
 
@@ -568,7 +533,7 @@ describe('MarketApplicationV2', () => {
       app._viewState = { ...app._viewState, sortBy: 'name', sortDirection: 'asc' }
       const context = await app._preparePartContext('catalog', {})
 
-      const names = context.catalog.groups[0].items.map((e) => e.name)
+      const names = context.catalog.items.map((e) => e.name)
       expect(names).toEqual([...names].sort((a, b) => a.localeCompare(b)))
     })
 
@@ -581,7 +546,7 @@ describe('MarketApplicationV2', () => {
       app._viewState = { ...app._viewState, sortBy: 'name', sortDirection: 'desc' }
       const context = await app._preparePartContext('catalog', {})
 
-      const names = context.catalog.groups[0].items.map((e) => e.name)
+      const names = context.catalog.items.map((e) => e.name)
       expect(names[0]).toBe('Z-6 Rotary Blaster')
       expect(names[1]).toBe('A-310 Rifle')
     })
@@ -597,7 +562,7 @@ describe('MarketApplicationV2', () => {
       app._viewState = { ...app._viewState, sortBy: 'price', sortDirection: 'asc' }
       const context = await app._preparePartContext('catalog', {})
 
-      const prices = context.catalog.groups[0].items.map((e) => e.priceResult.finalPrice)
+      const prices = context.catalog.items.map((e) => e.priceResult.finalPrice)
       expect(prices[0]).toBeLessThanOrEqual(prices[1])
     })
 
@@ -610,7 +575,7 @@ describe('MarketApplicationV2', () => {
       app._viewState = { ...app._viewState, sortBy: 'price', sortDirection: 'desc' }
       const context = await app._preparePartContext('catalog', {})
 
-      const prices = context.catalog.groups[0].items.map((e) => e.priceResult.finalPrice)
+      const prices = context.catalog.items.map((e) => e.priceResult.finalPrice)
       expect(prices[0]).toBeGreaterThanOrEqual(prices[1])
     })
 
@@ -625,7 +590,7 @@ describe('MarketApplicationV2', () => {
       app._viewState = { ...app._viewState, sortBy: 'price', sortDirection: 'asc' }
       const context = await app._preparePartContext('catalog', {})
 
-      const names = context.catalog.groups[0].items.map((e) => e.name)
+      const names = context.catalog.items.map((e) => e.name)
       // Item A (finalPrice=100) should come before Item B (finalPrice=120)
       expect(names[0]).toBe('Item A')
       expect(names[1]).toBe('Item B')
@@ -642,7 +607,7 @@ describe('MarketApplicationV2', () => {
       app._viewState = { ...app._viewState, sortBy: 'rarity', sortDirection: 'asc' }
       const context = await app._preparePartContext('catalog', {})
 
-      const rarities = context.catalog.groups[0].items.map((e) => e.rarity)
+      const rarities = context.catalog.items.map((e) => e.rarity)
       expect(rarities[0]).toBeLessThanOrEqual(rarities[1])
     })
   })
@@ -797,7 +762,7 @@ describe('MarketApplicationV2', () => {
 
       // Only commonItem should be visible
       expect(context.catalog.totalCount).toBe(1)
-      const names = context.catalog.groups[0]?.items.map((e) => e.name) ?? []
+      const names = context.catalog.items.map((e) => e.name)
       expect(names).toContain('Common Blaster')
       expect(names).not.toContain('Very Rare Weapon')
     })
@@ -817,7 +782,7 @@ describe('MarketApplicationV2', () => {
       app._viewState = { ...app._viewState, activeMarketType: 'black-market' }
       const blackMarketContext = await app._preparePartContext('catalog', {})
       expect(blackMarketContext.catalog.totalCount).toBe(1)
-      expect(blackMarketContext.catalog.groups[0].items[0].name).toBe('Restricted Blaster')
+      expect(blackMarketContext.catalog.items[0].name).toBe('Restricted Blaster')
     })
 
     it('local market excludes rare items', async () => {
@@ -830,7 +795,7 @@ describe('MarketApplicationV2', () => {
       const context = await app._preparePartContext('catalog', {})
 
       expect(context.catalog.totalCount).toBe(1)
-      const names = context.catalog.groups.flatMap((g) => g.items.map((e) => e.name))
+      const names = context.catalog.items.map((e) => e.name)
       expect(names).toContain('Common Armor')
       expect(names).not.toContain('Rare Blaster')
     })
@@ -850,7 +815,7 @@ describe('MarketApplicationV2', () => {
       app._viewState = { ...app._viewState, activeMarketType: 'specialized' }
       const specCtx = await app._preparePartContext('catalog', {})
       expect(specCtx.catalog.totalCount).toBe(1)
-      expect(specCtx.catalog.groups[0].items[0].name).toBe('Very Rare Blaster')
+      expect(specCtx.catalog.items[0].name).toBe('Very Rare Blaster')
     })
 
     it('black-market applies a price premium (+50%) compared to standard', async () => {
@@ -862,11 +827,11 @@ describe('MarketApplicationV2', () => {
 
       app._viewState = { ...app._viewState, activeMarketType: 'standard' }
       const stdCtx = await app._preparePartContext('catalog', {})
-      const stdPrice = stdCtx.catalog.groups[0].items[0].priceResult.finalPrice
+      const stdPrice = stdCtx.catalog.items[0].priceResult.finalPrice
 
       app._viewState = { ...app._viewState, activeMarketType: 'black-market' }
       const bmCtx = await app._preparePartContext('catalog', {})
-      const bmPrice = bmCtx.catalog.groups[0].items[0].priceResult.finalPrice
+      const bmPrice = bmCtx.catalog.items[0].priceResult.finalPrice
 
       expect(stdPrice).toBe(100)
       expect(bmPrice).toBe(150)
@@ -881,11 +846,11 @@ describe('MarketApplicationV2', () => {
 
       app._viewState = { ...app._viewState, activeMarketType: 'standard' }
       const stdCtx = await app._preparePartContext('catalog', {})
-      const stdPrice = stdCtx.catalog.groups[0].items[0].priceResult.finalPrice
+      const stdPrice = stdCtx.catalog.items[0].priceResult.finalPrice
 
       app._viewState = { ...app._viewState, activeMarketType: 'local' }
       const localCtx = await app._preparePartContext('catalog', {})
-      const localPrice = localCtx.catalog.groups[0].items[0].priceResult.finalPrice
+      const localPrice = localCtx.catalog.items[0].priceResult.finalPrice
 
       expect(stdPrice).toBe(100)
       expect(localPrice).toBe(90)
@@ -1090,7 +1055,7 @@ describe('MarketApplicationV2', () => {
       const context = await app._preparePartContext('catalog', {})
 
       expect(context.buyer.credits).toBe(400)
-      const entry = context.catalog.groups[0].items[0]
+      const entry = context.catalog.items[0]
       expect(entry.canBuy).toBe(false)
       expect(entry.buyBlockedReason).toBe('insufficient-credits')
     })


### PR DESCRIPTION
## Summary

- Replace grouped sections (weapon/armor/gear) with a single flat table in the market catalogue
- Make the type filter the primary navigation and provide a global sort for the list

## Context

Closes #472

Refer to documentation/plan/market/463-catalogue-market-liste-unique-plate.md for the implementation plan and rationale.

This branch contains a single commit implementing the flat item list UI and related style/template updates.

## Tests

- Not run (not requested).

## Notes

- Commits included: 1 commit (628f43f5 feat(market): implement flat item list in market without type grouping)
- Files changed: 7 files changed, 396 insertions(+), 234 deletions(-)
