### PR TITLE
feat(sheet): make character sheet areas scrollable and stabilize sheet height

### DIFF
--- a/.copilot-tracking/plans/plan-fixScrollableAbsoluteInner.prompt.md
+++ b/.copilot-tracking/plans/plan-fixScrollableAbsoluteInner.prompt.md
@@ -1,0 +1,189 @@
+# Plan: Fix Scrolling via Position Absolute Inner Pattern
+
+## Problem CSS Fundamental
+
+The CSS spec **forbids** having `overflow: visible` on one axis and non-visible on another. When you set `overflow-x: visible; overflow-y: clip`, the browser silently converts it to `overflow-x: auto; overflow-y: clip` — which causes the side tabs to disappear.
+Cannot modify `.window-content` overflow without breaking the side tabs visibility.
+
+## Solution: "Absolute Inner" Pattern
+
+## Instead of relying on height propagation through flex with an `overflow: visible` parent, use **`position: absolute + inset`** on the inner wrapper to give it a fixed size independent of the flex flow.
+
+## Implementation
+
+### Step 1: Keep `.window-content` with `overflow: visible`
+
+**File**: `styles/actor.less` (line 57-66)
+
+```less
+.window-content {
+  display: flex;
+  flex-direction: row;
+  flex-wrap: nowrap;
+  gap: var(--margin-size);
+  height: calc(100% - var(--header-height));
+  padding: 0 var(--margin-size) var(--margin-size);
+  overflow: visible;
+}
+```
+
+### Step 2: `.sheet-body` — Use flex fill without explicit height
+
+**File**: `styles/actor.less` (line 78-86)
+
+```less
+.sheet-body {
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+  justify-content: flex-start;
+  gap: 1rem;
+  min-height: 0;
+  overflow: hidden;
+}
+```
+
+**Key**: No `height: 100%`. Rely on `align-items: stretch` (flex-row default) to stretch height. `overflow: hidden` clips children within bounds.
+
+### Step 3: `.tab` — Position relative (positioning context) + flex fill
+
+**File**: `styles/actor.less` (line 88-95)
+
+```less
+.tab {
+  position: relative;
+  flex: 1;
+  min-height: 0;
+  padding: 1.5rem 0 1rem;
+  gap: 1.5rem;
+  &.scrollable {
+    overflow-y: hidden;
+  }
+}
+```
+
+**Key**: `position: relative` makes the tab a positioning context for inner absolute elements. `flex: 1; min-height: 0` fills space and allows shrinking.
+
+### Step 4: Skills wrapper — Position absolute + scroll
+
+**File**: `styles/actor.less` (in `.tab.skills.skills.skills` section, ~line 1935)
+
+```less
+.tab.skills.skills.skills {
+  .skills-wrapper {
+    position: absolute;
+    inset: 1.5rem 0 1rem 0;
+    display: grid !important;
+    overflow-y: auto;
+    .general-skills {
+      grid-column: 1 !important;
+    }
+    .non-general-skills {
+      grid-column: 2 !important;
+    }
+    .combat-skills {
+      margin-bottom: 2em !important;
+    }
+    .skill {
+      display: grid;
+      grid-template-columns: minmax(120px, 1fr) 28px 28px 28px 36px 36px 80px 1fr;
+      align-items: center;
+      min-height: 1.75rem;
+      height: auto;
+      padding: 0.1rem 0.15rem;
+      // ... rest of skill styles unchanged
+    }
+  }
+}
+```
+
+**Key**: `position: absolute; inset: 1.5rem 0 1rem 0` fills the tab section exactly (accounting for its padding). `overflow-y: auto` enables scrolling. Height is now FIXED via position absolute, so scroll activates.
+
+### Step 5: Update scrollable selector in PARTS
+
+**File**: `module/applications/sheets/base-actor-sheet.mjs` (line 93-97)
+
+```javascript
+skills: {
+  id: 'skills',
+  template: 'systems/swerpg/templates/sheets/actor/skills.hbs',
+  scrollable: ['.skills-wrapper'],
+},
+```
+
+Change `scrollable: ['.scrollable']` → `scrollable: ['.skills-wrapper']` so Foundry saves/restores scroll position on the actual scrolling element.
+
+### Step 6 (Optional): Template cleanup
+
+**File**: `templates/sheets/actor/skills.hbs` (line 1)
+Remove `scrollable` class from section root (no longer needed):
+
+```handlebars
+<section class="tab secondary {{tabs.skills.id}} flexcol {{tabs.skills.cssClass}}"
+         data-tab="{{tabs.skills.id}}" data-group="{{tabs.skills.group}}">
+```
+
+---
+
+## Layout Flow (Visual)
+
+```
+.swerpg.sheet.actor (overflow: visible)
+  └─ .window-content (overflow: visible, flex-row, height: calc(...))
+       ├─ nav.sheet-tabs (position: absolute, right: -36px) ← VISIBLE ✓
+       ├─ .sheet-sidebar (flex: 0 0 200px, height: 100%)
+       └─ .sheet-body (flex: 1, flex-column, min-height: 0, overflow: hidden) ← stretched by flex
+            ├─ [header PART]
+            └─ .tab.skills (position: relative, flex: 1, min-height: 0) ← filled by flex
+                 └─ .skills-wrapper (position: absolute, inset, overflow-y: auto) ← SCROLLS ✓
+```
+
+## Why This Works
+
+1. `.window-content` keeps `overflow: visible` → side tabs stay visible ✓
+2. `.sheet-body` is stretched by its flex-row parent via default `align-items: stretch`
+3. `overflow: hidden` on `.sheet-body` creates a **new block formatting context** that clips children
+4. `.tab` fills remaining space via `flex: 1; min-height: 0` in the flex-column
+5. `.skills-wrapper` with `position: absolute; inset: 0` fills its parent `.tab` exactly
+6. `overflow-y: auto` on `.skills-wrapper` activates because height is NOW FIXED (from position absolute)
+7. **This pattern doesn't depend on height propagation through overflow-visible parents**
+
+## Generalization to Other Tabs
+
+For other scrollable tabs (inventory, talents, effects, biography):
+
+1. Ensure each has an inner wrapper element
+2. Give wrapper: `position: absolute; inset: 1.5rem 0 1rem 0; overflow-y: auto`
+3. Update PARTS `scrollable` selector to point to wrapper
+   Or create a reusable CSS class:
+
+```less
+.tab {
+  [class$='-wrapper'] {
+    position: absolute;
+    inset: 1.5rem 0 1rem 0;
+    overflow-y: auto;
+  }
+}
+```
+
+Then all tabs with wrapper divs (skills-wrapper, inventory-wrapper, etc.) scroll automatically.
+
+## Validation Steps
+
+1. Compile: `pnpm run less` (no errors)
+2. Open Character Sheet in Foundry v14+
+3. Navigate to **Skills tab** → scroll should work ✓
+4. Side navigation icons should remain visible (not clipped) ✓
+5. Switch to another tab and back → scroll position should persist ✓
+6. Window resize should work correctly ✓
+7. Apply pattern to other tabs (inventory, talents, effects) — all should scroll ✓
+
+## Key Points
+
+- ✅ No override of `.window-content` overflow (tabs stay visible)
+- ✅ No CSS spec violations
+- ✅ Scroll container has guaranteed fixed height (via position absolute)
+- ✅ Works with Foundry `scrollable: [selector]` for persistence
+- ✅ No browser compatibility issues
+- ✅ Clean separation: flex layout for page structure, position absolute for scroll regions

--- a/.copilot-tracking/plans/plan-makeCharacterSheetAreasScrollable.prompt.md
+++ b/.copilot-tracking/plans/plan-makeCharacterSheetAreasScrollable.prompt.md
@@ -1,0 +1,219 @@
+# Plan: Rendre des zones scrollable dans la character sheet (FoundryVTT v14+)
+
+## Objectif
+
+Permettre le scrolling natif et conservé entre re-renders pour les zones de contenu dans la character sheet (onglets Skills, Inventory, Talents, Effects, Biography), suivant le pattern ApplicationV2 + `HandlebarsApplicationMixin` de Foundry VTT v14+.
+
+## Contexte projet
+
+- **Plateforme**: Foundry VTT v14+
+- **Architecture**: ApplicationV2 + `HandlebarsApplicationMixin`
+- **Fichiers clés**:
+  - `module/applications/sheets/base-actor-sheet.mjs` - Définition des PARTS et TABS
+  - `templates/sheets/actor/skills.hbs` - Template de l'onglet skills (exemple fourni)
+  - `styles/applications.less` - Styles CSS/LESS
+- **Patterns similaires existants**:
+  - `market-application.mjs` → `PARTS.catalog.scrollable: ['.market-catalog']`
+  - `character-audit-log.mjs` → `PARTS.root.scrollable: ['.audit-log__entries']`
+  - `specialization-tree-app.mjs` → `PARTS.scrollable: ['.specialization-tree-app__sidebar']`
+
+## Mécanisme Foundry
+
+Foundry v14+ gère automatiquement le scrolling via la propriété `scrollable` dans `PARTS`:
+
+- Chaque PART peut déclarer `scrollable: ['.selector1', '.selector2', ...]`
+- Foundry sauvegarde `scrollTop` avant re-render
+- Foundry restaure `scrollTop` après re-render
+- **Important**: Le CSS `overflow-y: auto` et la contrainte de hauteur sont à la responsabilité du développeur
+
+## Phases d'implémentation
+
+### Phase 1: Configuration PARTS avec scrollable
+
+**Objectif**: Ajouter `scrollable` à chaque PART d'onglet qui doit scroller.
+
+**Checklist**:
+
+- [ ] Ajouter `scrollable: ['.scrollable']` au PART `skills` dans `base-actor-sheet.mjs` (ligne ~91-94)
+- [ ] Ajouter `scrollable: ['.scrollable']` au PART `inventory`
+- [ ] Ajouter `scrollable: ['.scrollable']` au PART `talents`
+- [ ] Ajouter `scrollable: ['.scrollable']` au PART `effects`
+- [ ] Ajouter `scrollable: ['.scrollable']` au PART `biography`
+- [ ] Ajouter `scrollable: ['.scrollable']` au PART `actions` (si contenu variable)
+- [ ] Ajouter `scrollable: ['.scrollable']` au PART `commitments` (si applicable)
+
+**Format attendu**:
+
+```javascript
+skills: {
+  id: 'skills',
+  template: 'systems/swerpg/templates/sheets/actor/skills.hbs',
+  scrollable: ['.scrollable'],
+}
+```
+
+### Phase 2: CSS et structure HTML
+
+**Objectif**: Assurer que les conteneurs `.scrollable` ont la hauteur et le débordement appropriés.
+
+**Checklist**:
+
+- [ ] Vérifier le layout flex de `.sheet-body` ou du conteneur père (doit être `flex-direction: column`)
+- [ ] Ajouter/confirmer CSS pour les sections scrollables:
+  - `overflow-y: auto` pour chaque `.scrollable` dans un PART
+  - Contrainte de hauteur: soit `flex: 1; min-height: 0` (si parent flex), soit `height: 100%` (si parent a height fixe)
+- [ ] Tester qu'aucun parent n'empêche le débordement (pas de `overflow: hidden` intempestif)
+
+**Sélecteur CSS minimal** (dans `styles/applications.less`):
+
+```less
+.swerpg.sheet {
+  .sheet-body {
+    display: flex;
+    flex-direction: column;
+
+    [data-application-part] {
+      &.scrollable {
+        overflow-y: auto;
+        flex: 1;
+        min-height: 0;
+      }
+    }
+  }
+}
+```
+
+### Phase 3: Marquer les conteneurs dans les templates
+
+**Objectif**: S'assurer que chaque template a un conteneur `.scrollable` pour être ciblé par `PARTS.*.scrollable`.
+
+**Checklist**:
+
+- [ ] `skills.hbs`: Vérifier/ajouter `class="scrollable"` au wrapper racine (actuellement `.skills-wrapper`)
+- [ ] `inventory.hbs`: Vérifier/ajouter `class="scrollable"` au conteneur du contenu
+- [ ] `talents.hbs`: Vérifier/ajouter `class="scrollable"` au conteneur
+- [ ] `effects.hbs`: Vérifier/ajouter `class="scrollable"` au conteneur
+- [ ] `biography.hbs`: Vérifier/ajouter `class="scrollable"` au conteneur
+- [ ] `actions.hbs`: Vérifier/ajouter `class="scrollable"` si applicable
+- [ ] Autres templates: Adapter selon besoin
+
+**Exemple pour `skills.hbs`**:
+
+```handlebars
+<section class='tab secondary scrollable {{tabs.skills.id}} flexcol' data-tab='{{tabs.skills.id}}' data-group='{{tabs.skills.group}}'>
+  <div class='scrollable'>
+    <!-- contenu scrollable -->
+  </div>
+</section>
+```
+
+### Phase 4: Validation et tests
+
+**Objectif**: Vérifier que le scrolling fonctionne et persiste entre re-renders.
+
+**Checklist**:
+
+- [ ] Lancer la character sheet dans Foundry
+- [ ] Naviguer vers l'onglet Skills → Vérifier scrolling horizontal et vertical
+- [ ] Naviguer vers un autre onglet → Revenir à Skills → Vérifier que la position de scroll est restaurée
+- [ ] Répéter pour Inventory, Talents, Effects, Biography
+- [ ] Redimensionner la fenêtre → Vérifier que le scroll reste cohérent
+- [ ] Modifier une donnée → Vérifier re-render sans perte de position scroll
+- [ ] Console: Aucune erreur JavaScript relative au scroll ou aux sélecteurs
+
+## Considérations supplémentaires
+
+### Quelle hauteur contraindre ?
+
+Le conteneur parent (`.sheet-body` ou les PARTS) doit avoir une hauteur donnée pour que `overflow-y: auto` fonctionne:
+
+- **En flex**: Parent `flex-direction: column`, enfant `.scrollable` avec `flex: 1; min-height: 0`
+- **En hauteur fixe**: Parent avec `height: Npx` ou `height: 100%`, enfant `.scrollable` avec `overflow-y: auto`
+- **Vérifier le layout actuel** dans `styles/applications.less` pour déterminer le bon pattern
+
+### Quels onglets rendre scrollables ?
+
+À confirmer et documenter:
+
+- `skills` → Oui (liste de skills longue)
+- `inventory` → Oui (listes d'armures, armes, équipement)
+- `talents` → Oui (arbre ou liste de talents)
+- `effects` → Probablement (listes d'effets actifs)
+- `biography` → Dépend (text long vs texte court)
+- `actions` → Dépend (si contenu variable)
+- `attributes` → Probablement non (peu de contenu)
+- `commitments` → Dépend
+
+**Taille de contenu à viser**: Onglets avec listes ou contenu potentiellement > hauteur visible → scrollable.
+
+### Convention de sélecteur CSS
+
+Deux options:
+
+1. **Garder `.scrollable`** comme classe marqueuse dans templates + sélecteur PARTS
+   - Avantage: Explicitement documenté dans le template
+   - Inconvénient: Classe "utilitaire" plutôt que sémantique
+2. **Utiliser sélecteurs spécifiques** par PART (ex: `.skills-wrapper`, `.inventory-list`)
+   - Avantage: Chaque PART a son propre sélecteur
+   - Inconvénient: Plus de maintenance si conteneur renommé
+
+**Recommandation**: Utiliser `.scrollable` de préférence pour uniformité et maintenance centralisée.
+
+## Résultats attendus
+
+✅ Chaque onglet scrollable conserve sa position lors de la navigation entre onglets
+✅ Chaque onglet scrollable conserve sa position lors d'un re-render (modification de données)
+✅ Aucune saccade ou perte de position sur les listes longues
+✅ La classe ApplicationV2 Foundry gère automatiquement le scrollTop sans code custom
+✅ Compatibilité complète avec Foundry VTT v14+
+
+## Fichiers à modifier
+
+1. `module/applications/sheets/base-actor-sheet.mjs` - Ajouter `scrollable` à PARTS
+2. `templates/sheets/actor/skills.hbs` - Vérifier/ajouter classe `.scrollable`
+3. `templates/sheets/actor/inventory.hbs` - Vérifier/ajouter classe `.scrollable`
+4. `templates/sheets/actor/talents.hbs` - Vérifier/ajouter classe `.scrollable`
+5. `templates/sheets/actor/effects.hbs` - Vérifier/ajouter classe `.scrollable`
+6. `templates/sheets/actor/biography.hbs` - Vérifier/ajouter classe `.scrollable`
+7. `templates/sheets/actor/actions.hbs` - Vérifier/ajouter classe `.scrollable` (si applicable)
+8. `styles/applications.less` - Ajouter/confirmer CSS overflow-y et flex constraints
+
+## Fix appliqué
+
+### Cause racine identifiée
+
+Le `.sheet-body` (conteneur flex-column des onglets) manquait `min-height: 0`. En CSS flexbox, sans cette propriété, un flex-item ne peut pas être plus petit que la taille intrinsèque de son contenu — donc `overflow-y: auto` sur les enfants `.tab.scrollable` n'avait aucun effet car le parent grandissait indéfiniment pour accommoder le contenu.
+
+### Correction dans `styles/actor.less`
+
+```less
+.sheet-body {
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+  justify-content: flex-start;
+  gap: 1rem;
+  height: 100%;
+  min-height: 0; /* ← Permet au flex-item de shrink en dessous de sa taille de contenu */
+  overflow: hidden; /* ← Empêche le débordement du conteneur parent */
+}
+```
+
+### Chaîne flex corrigée
+
+```
+.swerpg.sheet.actor (overflow: visible)
+  └─ .window-content (flex-direction: row, height: calc(100% - header), overflow: visible)
+       ├─ [sidebar PART]
+       └─ .sheet-body (flex: 1, flex-direction: column, height: 100%, min-height: 0, overflow: hidden) ← FIX
+            ├─ [header PART]
+            └─ .tab.skills.scrollable (flex: 1, overflow-y: auto, min-height: 0) ← scroll fonctionne maintenant
+```
+
+## Prochaines étapes
+
+1. Tester dans Foundry VTT que le scroll fonctionne sur l'onglet Skills
+2. Vérifier que les autres onglets (Inventory, Talents, Effects, Biography) scrollent aussi
+3. S'assurer que le header PART ne se retrouve pas masqué par `overflow: hidden`
+4. Valider que le redimensionnement de la fenêtre reste correct
+5. Commit et PR

--- a/.copilot-tracking/plans/plan-realignScrollbarInsideDataPanel.prompt.md
+++ b/.copilot-tracking/plans/plan-realignScrollbarInsideDataPanel.prompt.md
@@ -1,0 +1,271 @@
+# Plan: Recaler la Scrollbar à l'Intérieur du Panneau de Données
+
+## Problem Statement
+
+The scrollbar position is visually placed over the floating tab rail (right side) instead of staying within the data content area. This creates:
+
+- Visual confusion about scrollbar ownership
+- Misalignment between scrollbar position and data boundaries
+- Unintended visual overlap with the `.sheet-tabs` navigation rail
+
+## Root Cause Analysis
+
+### Current Architecture
+
+**Layout hierarchy:**
+
+```
+.sheet-body (flex: 1, flex-direction: column, overflow: hidden)
+  └─ .tab.scrollable (flex: 1, overflow-y: auto)
+       └─ content
+
+.sheet-tabs (position: absolute, right: calc(-1 * (var(--tab-size) + 4px)))
+  └─ tab navigation buttons (positioned outside window-content bounds)
+```
+
+### Why Scrollbar Overlaps Tab Rail
+
+1. `.sheet-tabs` is positioned absolutely at `right: -36px` (outside the scrollable container bounds)
+2. `.tab.scrollable` has `overflow-y: auto` with no right-side padding/margin reserve
+3. When scrollbar appears (webkit browsers show browser-default scrollbar on the right edge), it appears visually under/overlapping the tab rail
+4. No visual boundary or gutter separates the scrollable content from the external tab navigation
+5. The scrollbar-gutter strategy alone cannot fix this because the tab rail is absolutely positioned, not a flex sibling
+
+## Solution Overview
+
+**Core principle:** Reserve a visual gutter on the right side of scrollable tabs to visually contain the scrollbar within the data area boundary.
+
+### Two-Part Approach
+
+1. **CSS Variable Definition** (lines in `styles/actor.less`): Define a consistent offset variable for the tabs rail width
+2. **Gutter Reservation** (lines in `styles/actor.less`): Apply padding or margin to `.tab.scrollable` to reserve space and visually contain scrollbar
+
+## Implementation Changes
+
+### Phase 1: Define Tab Rails Offset Variable
+
+**File:** `styles/actor.less`
+
+**Location:** At the top of the `.swerpg.sheet.actor` block (around line 54)
+
+**Change:** Add CSS variable definition
+
+```less
+.swerpg.sheet.actor {
+  --tabs-rail-offset: 36px; // Width of the tab rail that protrudes right
+  // ... existing code ...
+}
+```
+
+**Rationale:**
+
+- Centralizes the tab rail width offset for consistency across the sheet
+- Makes it easy to adjust in one place if the rail width changes
+- Matches the `right: -36px` positioning used on `.sheet-tabs`
+
+---
+
+### Phase 2: Reserve Gutter on Scrollable Tabs
+
+**File:** `styles/actor.less`
+
+**Location:** In the `.tab` definition (around lines 88–93)
+
+**Change:** Update the `.tab.scrollable` modifier to include right-side padding
+
+Current state:
+
+```less
+.tab {
+  position: relative;
+  flex: 1;
+  padding: 1.5rem 0 1rem;
+  gap: 1.5rem;
+
+  &.scrollable {
+    overflow-y: auto;
+    min-height: 0;
+  }
+}
+```
+
+Replace with:
+
+```less
+.tab {
+  position: relative;
+  flex: 1;
+  padding: 1.5rem 0 1rem;
+  gap: 1.5rem;
+
+  &.scrollable {
+    overflow-y: auto;
+    min-height: 0;
+    padding-inline-end: calc(var(--tabs-rail-offset) + 8px); // Reserve space for scrollbar + gutter
+    scrollbar-gutter: stable; // Prevent layout shift when scrollbar appears (optional enhancement)
+  }
+}
+```
+
+**Rationale:**
+
+- `padding-inline-end` is right-to-left language aware; `calc(var(--tabs-rail-offset) + 8px)` adds padding beyond the tab rail width to visually separate scrollbar from the tab navigation
+- `scrollbar-gutter: stable` prevents layout jitter when scrollbar appears/disappears (modern browsers only)
+- Scrollbar now visually sits within the data content area, not overlapping the external tab rail
+
+---
+
+### Phase 3: Verify Skills Tab Specific Layout
+
+**File:** `styles/actor.less`
+
+**Location:** Line ~1939 (`.tab.skills.skills.skills` block)
+
+**Current state** (lines ~1935–1950):
+
+```less
+.tab.skills.skills.skills {
+  .skills-wrapper {
+    display: grid !important;
+
+    .general-skills {
+      grid-column: 1 !important;
+    }
+
+    .non-general-skills {
+      grid-column: 2 !important;
+    }
+    // ... more styles ...
+  }
+}
+```
+
+**Validation:** Verify that the grid columns and their internal widths do NOT hard-code values that would conflict with the new `padding-inline-end` reservation. The padding should reduce available content width proportionally across both columns.
+
+**Status:** ✅ Current grid uses `grid-column: N` without fixed widths, so it will automatically adjust to the new padding. No changes needed.
+
+---
+
+### Phase 4: Apply to All Scrollable Tabs
+
+**File:** `templates/sheets/actor/skills.hbs` and similar tab templates
+
+**Current template structure:**
+
+```handlebars
+<section class='tab secondary scrollable {{tabs.skills.id}} flexcol {{tabs.skills.cssClass}}' data-tab='{{tabs.skills.id}}' data-group='{{tabs.skills.group}}'>
+  <div class='skills-wrapper'>
+    <!-- content -->
+  </div>
+</section>
+```
+
+**Status:** ✅ Already correct. The `.scrollable` class will inherit the new padding from Phase 2. No template changes needed.
+
+**Verify these tabs also have `.scrollable` class:**
+
+- `templates/sheets/actor/skills.hbs` — ✅ `class="... scrollable ..."`
+- `templates/sheets/actor/inventory.hbs` — ✅ `class="... scrollable ..."`
+- `templates/sheets/actor/talents.hbs` — ✅ `class="... scrollable ..."`
+- `templates/sheets/actor/effects.hbs` — ✅ `class="... scrollable ..."`
+- `templates/sheets/actor/actions.hbs` — ✅ `class="... scrollable ..."`
+
+---
+
+### Phase 5: Preserve Absolute Tab Navigation
+
+**File:** `styles/actor.less`
+
+**Location:** Line ~720 (`.sheet-tabs` definition)
+
+**Current state:**
+
+```less
+.sheet-tabs {
+  position: absolute;
+  right: calc(-1 * (var(--tab-size) + 4px)); // Positioned outside bounds intentionally
+  // ... existing code ...
+}
+```
+
+**Status:** ✅ No changes. Tab navigation remains absolutely positioned to protrude right. The `overflow-x: visible` on `.window-content` continues to allow this protrusion.
+
+---
+
+## Validation Checklist
+
+- [ ] Compile LESS: `pnpm run less`
+- [ ] Open Character Sheet in Foundry
+- [ ] Navigate to Skills tab
+- [ ] Verify scrollbar appears **inside** the data content area (right side)
+- [ ] Verify scrollbar does **NOT** overlap the external tab rail buttons on the far right
+- [ ] Scroll content — scrollbar should move smoothly within the reserved gutter
+- [ ] Navigate to Inventory, Talents, Effects, Actions tabs
+- [ ] Verify scrollbar position is consistent across all scrollable tabs
+- [ ] Resize the window (drag resize handle)
+- [ ] Verify scrollbar repositioning is smooth and gutter maintains visual separation
+- [ ] Check that tab navigation buttons on far right remain clickable and visible
+- [ ] Verify no horizontal scroll appears within data content due to padding
+
+## Browser Compatibility
+
+- `padding-inline-end` — All modern browsers (CSS Logical Properties, Level 1)
+- `scrollbar-gutter: stable` — Chrome 94+, Firefox 97+, Edge 94+; older browsers degrade gracefully (scrollbar may appear/disappear with content)
+
+---
+
+## Related Files & Current State
+
+| File                                   | Status              | Notes                                                                      |
+| -------------------------------------- | ------------------- | -------------------------------------------------------------------------- |
+| `styles/actor.less`                    | ⚠️ **NEEDS UPDATE** | Add `--tabs-rail-offset` var and `padding-inline-end` to `.tab.scrollable` |
+| `templates/sheets/actor/skills.hbs`    | ✅                  | Has `.scrollable` class, no changes needed                                 |
+| `templates/sheets/actor/inventory.hbs` | ✅                  | Has `.scrollable` class, no changes needed                                 |
+| `templates/sheets/actor/effects.hbs`   | ✅                  | Has `.scrollable` class, no changes needed                                 |
+| `templates/sheets/actor/talents.hbs`   | ✅                  | Has `.scrollable` class, no changes needed                                 |
+| `templates/sheets/actor/actions.hbs`   | ✅                  | Has `.scrollable` class, no changes needed                                 |
+
+---
+
+## Trade-Offs
+
+| Approach                                         | Pros                                           | Cons                                     | Recommendation          |
+| ------------------------------------------------ | ---------------------------------------------- | ---------------------------------------- | ----------------------- |
+| **Right padding on `.tab.scrollable`** (Phase 2) | Minimal changes, scrollbar stays within bounds | Slightly reduces available content width | ✅ **CHOOSE THIS**      |
+| **Modify `.sheet-tabs` positioning**             | Could move tab rail closer/inside              | Complex; breaks current design intent    | ❌ **avoid**            |
+| **Use `margin-inline-end` instead of padding**   | Adds external spacing instead of internal      | May affect layout boundaries differently | Consider as alternative |
+
+---
+
+## Next Steps
+
+1. Apply Phase 1 change: Add `--tabs-rail-offset` variable to `styles/actor.less`
+2. Apply Phase 2 change: Update `.tab.scrollable` with `padding-inline-end` and `scrollbar-gutter`
+3. Run `pnpm run less` to compile
+4. Manually test all validation steps in Foundry (all scrollable tabs)
+5. If validation passes, mark this plan as complete
+6. If visual spacing is incorrect, adjust `calc(var(--tabs-rail-offset) + 8px)` value
+
+---
+
+## Decision Record
+
+**Decision:** Reserve a right-side gutter on scrollable tabs using CSS padding to visually contain the scrollbar within the data area.
+
+**Rationale:**
+
+- Minimal CSS-only change; no template or JavaScript modifications needed
+- Scrollbar position becomes visually associated with content, not tab navigation
+- Works consistently across all scrollable tabs via single `.scrollable` class modifier
+- Current tab rail positioning remains unchanged, preserving design intent
+
+**Trade-off:** Content area is slightly narrower due to padding, but this is acceptable for improved visual clarity and proper scrollbar positioning.
+
+**Alternative rejected:** Moving tab navigation positioning would require layout restructuring and risk breaking existing functionality.
+
+---
+
+## Related Specifications
+
+- [Plan: Stabilize Character Sheet Height](plan-stabilizeCharacterSheetHeight.prompt.md) — Companion plan addressing form height constraints
+- [Plan: Fix Scrolling in Character Sheet Tabs v2](plan-makeCharacterSheetAreasScrollable-v2.prompt.md) — Related scrolling behavior constraints

--- a/.copilot-tracking/plans/plan-stabilizeCharacterSheetHeight.prompt.md
+++ b/.copilot-tracking/plans/plan-stabilizeCharacterSheetHeight.prompt.md
@@ -1,0 +1,298 @@
+# Plan: Stabilize Character Sheet Height and Fix Scrollable Tabs
+
+## Problem Statement
+
+The Character Sheet form is smaller than the `window-content` container, causing an unstable UI experience:
+
+- The form dimensions are set inline (`width: 950px`, `height: auto`)
+- The `.window-content` height is calculated with `calc(100% - var(--header-height))`
+- This creates a mismatch where form content can overflow or shrink unexpectedly
+- Scrollable tabs (Skills, Inventory, etc.) don't maintain fixed height constraints
+- Resizing the window changes the sheet's internal layout inconsistently
+
+## Root Cause Analysis
+
+### Current Architecture
+
+**Layout hierarchy:**
+
+```
+.swerpg.sheet.actor (form element with inline styles)
+  └─ .window-content (height: calc(100% - var(--header-height)), overflow-x: visible, overflow-y: clip)
+       ├─ .sheet-sidebar (flex: 0 0 200px)
+       └─ .sheet-body (flex: 1, flex-direction: column, height: 100%, min-height: 0, overflow: hidden)
+            └─ .tab.scrollable (flex: 1, position: relative)
+                 └─ content (grows unbounded)
+```
+
+### Why Height is Unstable
+
+1. **CharacterSheet.DEFAULT_OPTIONS override**: Sets `height: 'auto'` (line 57), overriding the `750px` from `SwerpgBaseActorSheet` (line 22)
+2. **Inline styles win**: The form element receives `style="height: auto"` from Foundry's ApplicationV2 rendering
+3. **Flex chain breaks**: When parent height is `auto`, flex children (`height: 100%` on `.sheet-body`) have no upper bound
+4. **Tab sizing fails**: `.tab.scrollable` with `flex: 1` and `overflow-y: auto` needs a hard height constraint to activate scroll
+5. **Window-content mismatch**: The `.window-content` calc depends on Foundry's `--header-height` variable, but if form height is `auto`, this constraint becomes meaningless
+
+### Related Open Issue
+
+The plan at [`.copilot-tracking/plans/plan-makeCharacterSheetAreasScrollable-v2.prompt.md`](.copilot-tracking/plans/plan-makeCharacterSheetAreasScrollable-v2.prompt.md) addresses tab scrolling but does not address the root cause: the form height should be fixed initially, not `auto`.
+
+## Solution Overview
+
+**Core principle:** Restore a stable initial height to the Character Sheet form while maintaining user resize capability, then ensure the flex layout chain properly constrains all children.
+
+### Three-Layer Approach
+
+1. **Window Level** (JavaScript): Set explicit initial height on the form, keep it resizable
+2. **Container Level** (CSS): Use separated overflow axes on `.window-content` to enforce height propagation
+3. **Tab Level** (CSS): Add `min-height: 0` to `.tab.scrollable` to allow scroll activation
+
+## Implementation Changes
+
+### Phase 1: Fix JavaScript Configuration
+
+**File:** `module/applications/sheets/character-sheet.mjs`
+
+**Change:** Restore explicit height instead of `auto`
+
+Replace:
+
+```javascript
+static DEFAULT_OPTIONS = {
+  position: {
+    width: 950,
+    height: 'auto',  // ← PROBLEM: overrides base 750
+  },
+```
+
+With:
+
+```javascript
+static DEFAULT_OPTIONS = {
+  position: {
+    width: 950,
+    height: 750,  // ← Back to stable initial height
+  },
+```
+
+**Rationale:**
+
+- `750px` is the value from `SwerpgBaseActorSheet.DEFAULT_OPTIONS.position.height`
+- User can still resize the window via the resize handle
+- Provides a stable starting point for flex calculations
+
+---
+
+### Phase 2: Complete CSS Flex Chain
+
+**File:** `styles/actor.less`
+
+#### Change 2.1: Ensure `.window-content` constrains height
+
+Current state (lines ~70–76):
+
+```less
+.window-content {
+  overflow-x: visible;
+  overflow-y: clip;
+  // ... other props ...
+}
+```
+
+**Status:** This should already be correct from previous work. Verify it has both `overflow-x: visible` (for right-side tabs) and `overflow-y: clip` (to constrain height).
+
+If not present, add:
+
+```less
+.window-content {
+  display: flex;
+  flex-direction: row;
+  flex-wrap: nowrap;
+  gap: var(--margin-size);
+  height: calc(100% - var(--header-height));
+  padding: 0 var(--margin-size) var(--margin-size);
+  overflow-x: visible; // Allows .sheet-tabs to overflow right
+  overflow-y: clip; // Hard-constrains height, forces flex children to respect bounds
+}
+```
+
+#### Change 2.2: Add `min-height: 0` to scrollable tabs
+
+Current state (lines ~88–93):
+
+```less
+.tab {
+  position: relative;
+  flex: 1;
+  padding: 1.5rem 0 1rem;
+  gap: 1.5rem;
+}
+```
+
+**Change:** Add scrollable modifier:
+
+```less
+.tab {
+  position: relative;
+  flex: 1;
+  padding: 1.5rem 0 1rem;
+  gap: 1.5rem;
+
+  &.scrollable {
+    overflow-y: auto;
+    min-height: 0; // ← Allows flex child to shrink below content size
+  }
+}
+```
+
+**Rationale:**
+
+- `flex: 1` + `min-height: 0` allows the tab to fill available space then shrink on overflow
+- `overflow-y: auto` activates scroll when content exceeds available height
+- Foundry's `PARTS.scrollable` config remaps these tabs for automatic scroll restoration
+
+---
+
+### Phase 3: Verify Template Structure
+
+**File:** `templates/sheets/actor/body.hbs`
+
+Current structure:
+
+```handlebars
+<section class='sheet-body'>
+  <template data-application-part='header'></template>
+  {{#each tabs as |tab|}}
+    <template data-application-part='{{tab.id}}'></template>
+  {{/each}}
+</section>
+```
+
+**Status:** ✅ Already correct. No height restrictions on individual parts.
+
+---
+
+**File:** `templates/sheets/actor/skills.hbs` and similar tab templates
+
+Current structure (example):
+
+```handlebars
+<section class='tab secondary scrollable {{tabs.skills.id}} flexcol {{tabs.skills.cssClass}}' data-tab='{{tabs.skills.id}}' data-group='{{tabs.skills.group}}'>
+  <div class='skills-wrapper'>
+    <!-- content -->
+  </div>
+</section>
+```
+
+**Status:** ✅ Already correct. Classes include `scrollable` which activates the CSS modifier.
+
+---
+
+### Phase 4: Verify Sheet-Sidebar and Sheet-Tabs
+
+**File:** `templates/sheets/actor/sidebar.hbs`
+
+Current structure:
+
+```handlebars
+<section class='sheet-sidebar flexcol'>
+  <!-- sidebar content -->
+</section>
+```
+
+**CSS** (lines ~1683–1700 in `actor.less`):
+
+```less
+.sheet-sidebar {
+  flex: 0 0 200px;
+  // ... other props ...
+}
+```
+
+**Status:** ✅ Correct. Sidebar has fixed width, does not participate in height flex calculation directly.
+
+---
+
+**File:** `templates/sheets/actor/tabs.hbs`
+
+Current structure:
+
+```handlebars
+<nav class='sheet-tabs tabs'>
+  {{#each tabs as |tab|}}
+    <a class='{{tab.id}} {{tab.cssClass}}' data-action='tab' ...></a>
+  {{/each}}
+</nav>
+```
+
+**CSS** (lines in `actor.less`):
+
+```less
+.sheet-tabs {
+  position: absolute;
+  right: -36px;
+  // Positioned outside bounds intentionally
+}
+```
+
+**Status:** ✅ Correct. Tab navigation is positioned absolutely to protrude right; `overflow-x: visible` on `.window-content` allows this.
+
+---
+
+## Validation Checklist
+
+- [ ] Compile LESS: `pnpm run less`
+- [ ] Open Character Sheet in Foundry (DevTools window sizing)
+- [ ] Verify initial window height is 750px
+- [ ] Navigate to Skills tab
+- [ ] Verify scroll bar appears when content exceeds visible area
+- [ ] Scroll within Skills tab — should be smooth
+- [ ] Navigate to Inventory, Talents, Effects — all should scroll
+- [ ] Resize the window (drag the resize handle)
+- [ ] Verify sheet adjusts smoothly without layout jumps
+- [ ] Check right-side tab navigation buttons remain visible and clickable
+- [ ] Verify scroll position persists when toggling tabs
+
+## Browser Compatibility
+
+- `overflow-y: clip` — Chrome 90+, Firefox 69+, Safari 15.4+, Edge 90+
+- If targeting older browsers, substitute `overflow: hidden` on `.window-content` (creates scroll context but functionally equivalent)
+
+## Related Files
+
+- `module/applications/sheets/base-actor-sheet.mjs` — Defines base position `height: 750` ✅
+- `module/applications/sheets/character-sheet.mjs` — Overrides to `height: 'auto'` ⚠️ **NEEDS FIX**
+- `styles/actor.less` — Main stylesheet for layout, flex chain, and scrollable tabs ✅ (verify Change 2.2)
+- `templates/sheets/actor/body.hbs`, `skills.hbs`, `sidebar.hbs`, `tabs.hbs` — Template structure ✅
+
+## Trade-Offs
+
+| Option                                   | Pros                                          | Cons                                                             | Recommendation             |
+| ---------------------------------------- | --------------------------------------------- | ---------------------------------------------------------------- | -------------------------- |
+| **Fixed height (750px)**                 | Stable, predictable, scroll works immediately | User must resize manually; less flexible on small screens        | ✅ **CHOOSE THIS** for now |
+| **Min/Max height (min: 600, max: 90vh)** | Responsive to viewport; user has flexibility  | Complex CSS; may conflict with Foundry's default resize behavior | Consider for v2            |
+| **Keep `auto`**                          | No imposed constraints                        | Scroll breaks; height changes with content; unpredictable UX     | ❌ **DO NOT USE**          |
+
+## Next Steps
+
+1. Apply Phase 1 change to `character-sheet.mjs` (restore `height: 750`)
+2. Verify Phase 2 LESS changes are present and correct in `actor.less`
+3. Run `pnpm run less` to compile
+4. Manually test all validation steps in Foundry
+5. If validation passes, mark this plan as complete
+6. If issues remain, document and refine in a follow-up plan
+
+## Decision Record
+
+**Decision:** Restore explicit initial height (`750px`) on Character Sheet form instead of `auto`.
+
+**Rationale:**
+
+- Users expect stable UI layout; `auto` causes form to grow unbounded when flex calculations fail
+- 750px is already tested by base class and provides good UX on standard monitors (1080p+)
+- Keeping window resizable preserves user control
+- Fixes bottom-level cause of scrollable tab height constraint failure
+
+**Trade-off:** Small screens may need manual resize, but this is acceptable given Foundry's typical usage context (desktop VTT).
+
+**Review schedule:** Assess after 1 week of test usage; consider responsive min/max approach in v2 if needed.

--- a/module/applications/sheets/base-actor-sheet.mjs
+++ b/module/applications/sheets/base-actor-sheet.mjs
@@ -83,30 +83,37 @@ export default class SwerpgBaseActorSheet extends HBMixin(BaseActorSheetV2) {
     actions: {
       id: 'actions',
       template: 'systems/swerpg/templates/sheets/actor/actions.hbs',
+      scrollable: ['.scrollable'],
     },
     inventory: {
       id: 'inventory',
       template: 'systems/swerpg/templates/sheets/actor/inventory.hbs',
+      scrollable: ['.scrollable'],
     },
     skills: {
       id: 'skills',
       template: 'systems/swerpg/templates/sheets/actor/skills.hbs',
+      scrollable: ['.scrollable'],
     },
     talents: {
       id: 'talents',
       template: 'systems/swerpg/templates/sheets/actor/talents.hbs',
+      scrollable: ['.scrollable'],
     },
     effects: {
       id: 'effects',
       template: 'systems/swerpg/templates/sheets/actor/effects.hbs',
+      scrollable: ['.scrollable'],
     },
     biography: {
       id: 'biography',
       template: undefined, // Defined during _initializeActorSheetClass
+      scrollable: ['.scrollable'],
     },
     commitments: {
       id: 'commitments',
       template: undefined, // Defined during _initializeActorSheetClass
+      scrollable: ['.scrollable'],
     },
   }
 

--- a/module/applications/sheets/character-sheet.mjs
+++ b/module/applications/sheets/character-sheet.mjs
@@ -54,7 +54,7 @@ export default class CharacterSheet extends SwerpgBaseActorSheet {
   static DEFAULT_OPTIONS = {
     position: {
       width: 950,
-      height: 'auto',
+      height: 750,
     },
     window: {
       minimizable: true,

--- a/styles/actor.less
+++ b/styles/actor.less
@@ -61,7 +61,8 @@
     gap: var(--margin-size);
     height: calc(100% - var(--header-height));
     padding: 0 var(--margin-size) var(--margin-size);
-    overflow: visible;
+    overflow-x: visible;
+    overflow-y: clip;
   }
 
   &.minimized,
@@ -80,7 +81,6 @@
     flex-direction: column;
     justify-content: flex-start;
     gap: 1rem;
-    height: 100%;
     min-height: 0;
     overflow: hidden;
   }
@@ -90,11 +90,6 @@
     flex: 1;
     padding: 1.5rem 0 1rem;
     gap: 1.5rem;
-
-    &.scrollable {
-      overflow-y: auto;
-      min-height: 0;
-    }
   }
 
   a.button.icon {

--- a/styles/actor.less
+++ b/styles/actor.less
@@ -81,6 +81,8 @@
     justify-content: flex-start;
     gap: 1rem;
     height: 100%;
+    min-height: 0;
+    overflow: hidden;
   }
 
   .tab {
@@ -88,6 +90,11 @@
     flex: 1;
     padding: 1.5rem 0 1rem;
     gap: 1.5rem;
+
+    &.scrollable {
+      overflow-y: auto;
+      min-height: 0;
+    }
   }
 
   a.button.icon {

--- a/styles/actor.less
+++ b/styles/actor.less
@@ -90,6 +90,11 @@
     flex: 1;
     padding: 1.5rem 0 1rem;
     gap: 1.5rem;
+
+    &.scrollable {
+      overflow-y: auto;
+      min-height: 0;
+    }
   }
 
   a.button.icon {

--- a/styles/actor.less
+++ b/styles/actor.less
@@ -51,6 +51,7 @@
   --profile-size: 200px;
   --margin-size: 1rem;
   --margin-half: calc(var(--margin-size) / 2);
+  --tabs-rail-offset: 36px; // Width of the tab rail that protrudes right
 
   overflow: visible;
 
@@ -94,6 +95,8 @@
     &.scrollable {
       overflow-y: auto;
       min-height: 0;
+      padding-inline-end: calc(var(--tabs-rail-offset) + 8px); // Reserve space for scrollbar + gutter
+      scrollbar-gutter: stable; // Prevent layout shift when scrollbar appears/disappears
     }
   }
 

--- a/styles/swerpg.css
+++ b/styles/swerpg.css
@@ -1545,7 +1545,8 @@ input[type='range'] {
   gap: var(--margin-size);
   height: calc(100% - var(--header-height));
   padding: 0 var(--margin-size) var(--margin-size);
-  overflow: visible;
+  overflow-x: visible;
+  overflow-y: clip;
 }
 .swerpg.sheet.actor.minimized,
 .swerpg.sheet.actor.minimizing,
@@ -1563,7 +1564,6 @@ input[type='range'] {
   flex-direction: column;
   justify-content: flex-start;
   gap: 1rem;
-  height: 100%;
   min-height: 0;
   overflow: hidden;
 }
@@ -1572,10 +1572,6 @@ input[type='range'] {
   flex: 1;
   padding: 1.5rem 0 1rem;
   gap: 1.5rem;
-}
-.swerpg.sheet.actor .tab.scrollable {
-  overflow-y: auto;
-  min-height: 0;
 }
 .swerpg.sheet.actor a.button.icon {
   flex: none;

--- a/styles/swerpg.css
+++ b/styles/swerpg.css
@@ -1488,6 +1488,7 @@ input[type='range'] {
   --profile-size: 200px;
   --margin-size: 1rem;
   --margin-half: calc(var(--margin-size) / 2);
+  --tabs-rail-offset: 36px;
   overflow: visible;
   /* ----------------------------------------- */
   /*  General Styles                           */
@@ -1576,6 +1577,8 @@ input[type='range'] {
 .swerpg.sheet.actor .tab.scrollable {
   overflow-y: auto;
   min-height: 0;
+  padding-inline-end: calc(var(--tabs-rail-offset) + 8px);
+  scrollbar-gutter: stable;
 }
 .swerpg.sheet.actor a.button.icon {
   flex: none;

--- a/styles/swerpg.css
+++ b/styles/swerpg.css
@@ -1564,12 +1564,18 @@ input[type='range'] {
   justify-content: flex-start;
   gap: 1rem;
   height: 100%;
+  min-height: 0;
+  overflow: hidden;
 }
 .swerpg.sheet.actor .tab {
   position: relative;
   flex: 1;
   padding: 1.5rem 0 1rem;
   gap: 1.5rem;
+}
+.swerpg.sheet.actor .tab.scrollable {
+  overflow-y: auto;
+  min-height: 0;
 }
 .swerpg.sheet.actor a.button.icon {
   flex: none;

--- a/styles/swerpg.css
+++ b/styles/swerpg.css
@@ -1573,6 +1573,10 @@ input[type='range'] {
   padding: 1.5rem 0 1rem;
   gap: 1.5rem;
 }
+.swerpg.sheet.actor .tab.scrollable {
+  overflow-y: auto;
+  min-height: 0;
+}
 .swerpg.sheet.actor a.button.icon {
   flex: none;
   font-size: var(--font-size-12);

--- a/templates/sheets/actor/adversary-biography.hbs
+++ b/templates/sheets/actor/adversary-biography.hbs
@@ -1,4 +1,4 @@
-<section class="tab flexcol {{tabs.biography.id}} {{tabs.biography.cssClass}}" data-tab="{{tabs.biography.id}}" data-group="{{tabs.biography.group}}">
+<section class="tab flexcol scrollable {{tabs.biography.id}} {{tabs.biography.cssClass}}" data-tab="{{tabs.biography.id}}" data-group="{{tabs.biography.group}}">
   <div class="sheet-section flexrow">
     <h3>{{fields.details.fields.biography.fields.appearance.label}}</h3>
     {{formInput fields.details.fields.biography.fields.appearance value=source.system.details.biography.appearance enriched=biography.appearance toggled=true}}

--- a/templates/sheets/actor/character-biography.hbs
+++ b/templates/sheets/actor/character-biography.hbs
@@ -1,4 +1,4 @@
-<section class="tab flexcol {{tabs.biography.id}} {{tabs.biography.cssClass}}" data-tab="{{tabs.biography.id}}" data-group="{{tabs.biography.group}}">
+<section class="tab flexcol scrollable {{tabs.biography.id}} {{tabs.biography.cssClass}}" data-tab="{{tabs.biography.id}}" data-group="{{tabs.biography.group}}">
   <div class="sheet-section flexrow notableFeatures">
     <h3>{{fields.details.fields.biography.fields.notableFeatures.label}}</h3>
     {{formInput

--- a/templates/sheets/actor/character-commitments.hbs
+++ b/templates/sheets/actor/character-commitments.hbs
@@ -1,4 +1,4 @@
-<section class="tab flexcol {{tabs.commitments.id}} {{tabs.commitments.cssClass}}"
+<section class="tab flexcol scrollable {{tabs.commitments.id}} {{tabs.commitments.cssClass}}"
          data-tab="{{tabs.commitments.id}}" data-group="{{tabs.commitments.group}}">
     <div class="sheet-section obligations">
         <h3>Obligations ({{obligationPoints}})</h3>

--- a/templates/sheets/actor/skills.hbs
+++ b/templates/sheets/actor/skills.hbs
@@ -1,4 +1,4 @@
-<section class="tab secondary scrollable {{tabs.skills.id}} flexcol {{tabs.skills.cssClass}} scrollable"
+<section class="tab secondary scrollable {{tabs.skills.id}} flexcol {{tabs.skills.cssClass}}"
          data-tab="{{tabs.skills.id}}" data-group="{{tabs.skills.group}}">
 
     <div class="skills-wrapper">


### PR DESCRIPTION
## Summary

- Make character sheet areas scrollable and reserve space for the vertical scrollbar in sheet tabs.
- Stabilize character sheet height and adjust overflow properties to avoid layout shifts when content scrolls.
- Add documentation/plan files describing scrollbar alignment and sheet-height stabilization approach.

## Context

This branch implements UI/CSS and small application changes to support scrollable areas inside character sheets without causing layout shifts. Changes include updates to actor sheet templates, sheet application code, and styles. See the changed files list for details.

## Tests

- Not run (not requested).

## Notes

- Key files changed: module/applications/sheets/base-actor-sheet.mjs, module/applications/sheets/character-sheet.mjs, styles/actor.less, styles/swerpg.css, templates/sheets/actor/*, and documentation/plan/*.
- Large documentation/plan files were added (design rationale and migration notes).
