### PR TITLE
feat(market): add affordable only filter to item display

### DIFF
--- a/documentation/plan/plan-affordableOnlyFilter.prompt.md
+++ b/documentation/plan/plan-affordableOnlyFilter.prompt.md
@@ -1,0 +1,45 @@
+# Plan: Filtre "Affordable Only" dans le Market
+
+Ajouter une case à cocher dans la barre d'outils du Market qui filtre les items affichés selon le pouvoir d'achat du personnage. Quand cochée, seuls les items accessibles avec le budget actuel sont visibles.
+
+## Steps
+
+1. Ajouter `affordableOnly: false` dans [`DEFAULT_VIEW_STATE`](module/applications/market/market-application.mjs) (ligne 35-43) et mettre à jour le typedef `MarketViewState`.
+
+2. Modifier [`#prepareCatalog()`](module/applications/market/market-application.mjs) (ligne 337-344) pour filtrer les items après l'annotation `canBuy` si `affordableOnly` est activé.
+
+3. Ajouter la checkbox dans la section `.market-toolbar__filters` du template [`market.hbs`](templates/market/market.hbs) (après ligne 71), avec liaison vers `viewState.affordableOnly`.
+
+4. Ajouter un event listener `change` sur la checkbox dans [`_onRender()`](module/applications/market/market-application.mjs) (vers ligne 600) pour mettre à jour `_viewState.affordableOnly` et re-render.
+
+5. Mettre à jour [`#onResetCatalog()`](module/applications/market/market-application.mjs) pour inclure la réinitialisation du filtre (automatique via spread de `DEFAULT_VIEW_STATE`).
+
+6. Ajouter les clés i18n dans [`en.json`](lang/en.json) et [`fr.json`](lang/fr.json) sous `MARKET.Toolbar.Filter.AffordableOnly*`.
+
+## Further Considerations
+
+1. **Visibilité conditionnelle** : La checkbox n'a de sens que si un buyer est actif. Faut-il la masquer ou la désactiver quand aucun personnage n'est sélectionné ? _Recommandation : la désactiver (disabled) pour indiquer son existence._
+
+2. **Compteur filtré** : Afficher le nombre d'items après filtrage "affordable" vs total pourrait être utile pour l'UX. Voulez-vous ajouter un indicateur visuel type "(12/45 items)" ?
+
+## Architecture Impact
+
+### Files to Modify
+
+- `module/applications/market/market-application.mjs` - typedef, state, filtering logic, event handlers
+- `templates/market/market.hbs` - checkbox HTML
+- `lang/en.json` - English labels
+- `lang/fr.json` - French labels
+
+### Files to Review (no changes expected)
+
+- `module/lib/market/purchase.mjs` - validation logic (reused as-is)
+- `module/config/market.mjs` - market configuration (reused as-is)
+
+## Implementation Strategy
+
+1. **Minimal state addition** - Add single boolean flag to `MarketViewState`
+2. **Filter after canBuy annotation** - Preserve existing purchase validation, filter only on display
+3. **Preserve existing UX** - Reuse existing filter patterns (select/checkbox event listeners, render on change)
+4. **i18n-first labels** - All user-facing text via localization keys
+5. **Conditional UI** - Checkbox disabled when no buyer actor selected

--- a/lang/en.json
+++ b/lang/en.json
@@ -1556,7 +1556,10 @@
         "TypeLabel": "Filter by type",
         "SourceLabel": "Filter by source",
         "AllTypes": "All types",
-        "AllSources": "All sources"
+        "AllSources": "All sources",
+        "AffordableOnly": "Affordable only",
+        "AffordableOnlyLabel": "Show only items within budget",
+        "AffordableOnlyTooltip": "Show only items the buyer can currently afford"
       },
       "Sort": {
         "Label": "Sort by",

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -1452,7 +1452,10 @@
         "TypeLabel": "Filtrer par type",
         "SourceLabel": "Filtrer par source",
         "AllTypes": "Tous les types",
-        "AllSources": "Toutes les sources"
+        "AllSources": "Toutes les sources",
+        "AffordableOnly": "Abordables uniquement",
+        "AffordableOnlyLabel": "Afficher uniquement les objets dans le budget",
+        "AffordableOnlyTooltip": "Afficher uniquement les objets que l'acheteur peut se permettre"
       },
       "Sort": {
         "Label": "Trier par",

--- a/module/applications/market/market-application.mjs
+++ b/module/applications/market/market-application.mjs
@@ -13,6 +13,7 @@ const { api } = foundry.applications
  * @property {string} filterType         Item type filter key, or '' for all types
  * @property {string} filterSource       Source type filter key, or '' for all sources
  * @property {string} filterRestriction  Restriction level filter key, or '' for all
+ * @property {boolean} affordableOnly    When true, only items the buyer can afford are shown
  * @property {string} sortBy             Sort field key: 'name' | 'price' | 'rarity'
  * @property {'asc'|'desc'} sortDirection  Sort direction
  * @property {string} activeMarketType   Active market type key (key of MARKET_TYPES)
@@ -37,6 +38,7 @@ const DEFAULT_VIEW_STATE = Object.freeze({
   filterType: '',
   filterSource: '',
   filterRestriction: '',
+  affordableOnly: false,
   sortBy: MARKET_SORT_FIELDS.name,
   sortDirection: 'asc',
   activeMarketType: DEFAULT_MARKET_TYPE,
@@ -325,16 +327,15 @@ export default class MarketApplicationV2 extends api.HandlebarsApplicationMixin(
     const totalCount = visibleEntries.length
 
     // 3. Apply search and filters
-    const { search, filterType, filterSource, filterRestriction, sortBy, sortDirection } = this._viewState
+    const { search, filterType, filterSource, filterRestriction, affordableOnly, sortBy, sortDirection } = this._viewState
     let filtered = filterBySearch(visibleEntries, search)
     filtered = filterByFilters(filtered, { filterType, filterSource, filterRestriction })
 
     // 4. Sort globally across all types
     const sorted = sortEntries(filtered, sortBy, sortDirection)
-    const filteredCount = sorted.length
 
     // 5. Annotate each entry with canBuy based on buyer affordability
-    const items = sorted.map((entry) => {
+    const annotated = sorted.map((entry) => {
       const validation = validatePurchase({ actor: buyer, entry })
       return {
         ...entry,
@@ -343,7 +344,11 @@ export default class MarketApplicationV2 extends api.HandlebarsApplicationMixin(
       }
     })
 
-    const hasActiveFilter = !!(search || filterType || filterSource || filterRestriction)
+    // 6. Apply affordableOnly filter after canBuy annotation (buyer must be present for this filter to take effect)
+    const items = affordableOnly && buyer !== null ? annotated.filter((entry) => entry.canBuy) : annotated
+
+    const filteredCount = items.length
+    const hasActiveFilter = !!(search || filterType || filterSource || filterRestriction || (affordableOnly && buyer !== null))
 
     return {
       items,
@@ -595,6 +600,15 @@ export default class MarketApplicationV2 extends api.HandlebarsApplicationMixin(
     if (restrictionSelect) {
       restrictionSelect.addEventListener('change', (event) => {
         this._viewState = { ...this._viewState, filterRestriction: event.currentTarget.value ?? '' }
+        this.render()
+      })
+    }
+
+    // Affordable only checkbox — only active when a buyer is set
+    const affordableOnlyCheckbox = html.querySelector('.market-toolbar__filter--affordable-only')
+    if (affordableOnlyCheckbox) {
+      affordableOnlyCheckbox.addEventListener('change', (event) => {
+        this._viewState = { ...this._viewState, affordableOnly: event.currentTarget.checked }
         this.render()
       })
     }

--- a/templates/market/market.hbs
+++ b/templates/market/market.hbs
@@ -69,6 +69,20 @@
           </option>
         {{/each}}
       </select>
+
+      <label class="market-toolbar__filter-label market-toolbar__filter-label--affordable-only"
+        data-tooltip="{{localize 'MARKET.Toolbar.Filter.AffordableOnlyTooltip'}}"
+        aria-label="{{localize 'MARKET.Toolbar.Filter.AffordableOnlyLabel'}}"
+      >
+        <input
+          type="checkbox"
+          class="market-toolbar__filter--affordable-only"
+          {{#if viewState.affordableOnly}}checked{{/if}}
+          {{#unless buyer}}disabled aria-disabled="true"{{/unless}}
+          aria-label="{{localize 'MARKET.Toolbar.Filter.AffordableOnlyLabel'}}"
+        />
+        {{localize "MARKET.Toolbar.Filter.AffordableOnly"}}
+      </label>
     </div>
 
     <div class="market-toolbar__sort">

--- a/tests/applications/market/market-application.test.mjs
+++ b/tests/applications/market/market-application.test.mjs
@@ -519,6 +519,88 @@ describe('MarketApplicationV2', () => {
   })
 
   /* -------------------------------------------- */
+  /*  Affordable-only filter                      */
+  /* -------------------------------------------- */
+
+  describe('affordableOnly filter', () => {
+    it('_viewState starts with affordableOnly=false', () => {
+      const app = new MarketApplicationV2()
+      expect(app._viewState.affordableOnly).toBe(false)
+    })
+
+    it('with affordableOnly=false, shows all items regardless of buyer budget', async () => {
+      const cheap = makeItem({ type: 'weapon', name: 'Cheap Blaster', price: 50 })
+      const expensive = makeItem({ type: 'weapon', name: 'Expensive Blaster', price: 9999 })
+      globalThis.game.items = makeItemsCollection([cheap, expensive])
+
+      const actor = { id: 'actor-1', name: 'Test', system: { credits: 100 } }
+      const app = new MarketApplicationV2()
+      app.setBuyerActor(actor)
+      app._viewState = { ...app._viewState, affordableOnly: false }
+      const context = await app._preparePartContext('catalog', {})
+
+      expect(context.catalog.filteredCount).toBe(2)
+    })
+
+    it('with affordableOnly=true and a buyer, shows only items the buyer can afford', async () => {
+      const cheap = makeItem({ type: 'weapon', name: 'Cheap Blaster', price: 50 })
+      const expensive = makeItem({ type: 'weapon', name: 'Expensive Blaster', price: 9999 })
+      globalThis.game.items = makeItemsCollection([cheap, expensive])
+
+      const actor = { id: 'actor-1', name: 'Test', system: { credits: 100 } }
+      const app = new MarketApplicationV2()
+      app.setBuyerActor(actor)
+      app._viewState = { ...app._viewState, affordableOnly: true }
+      const context = await app._preparePartContext('catalog', {})
+
+      expect(context.catalog.filteredCount).toBe(1)
+      expect(context.catalog.items[0].name).toBe('Cheap Blaster')
+    })
+
+    it('with affordableOnly=true but no buyer, shows all items (filter is a no-op)', async () => {
+      const cheap = makeItem({ type: 'weapon', name: 'Cheap Blaster', price: 50 })
+      const expensive = makeItem({ type: 'weapon', name: 'Expensive Blaster', price: 9999 })
+      globalThis.game.items = makeItemsCollection([cheap, expensive])
+
+      const app = new MarketApplicationV2()
+      // No buyer set — filter must not apply
+      app._viewState = { ...app._viewState, affordableOnly: true }
+      const context = await app._preparePartContext('catalog', {})
+
+      expect(context.catalog.filteredCount).toBe(2)
+    })
+
+    it('with affordableOnly=true and buyer who cannot afford any item, returns isFilteredEmpty=true', async () => {
+      const expensive = makeItem({ type: 'weapon', name: 'Expensive Blaster', price: 9999 })
+      globalThis.game.items = makeItemsCollection([expensive])
+
+      const actor = { id: 'actor-1', name: 'Test', system: { credits: 1 } }
+      const app = new MarketApplicationV2()
+      app.setBuyerActor(actor)
+      app._viewState = { ...app._viewState, affordableOnly: true }
+      const context = await app._preparePartContext('catalog', {})
+
+      expect(context.catalog.totalCount).toBe(1)
+      expect(context.catalog.filteredCount).toBe(0)
+      expect(context.catalog.isFilteredEmpty).toBe(true)
+    })
+
+    it('resetCatalog action resets affordableOnly to false', async () => {
+      globalThis.game.items = makeItemsCollection([])
+
+      const app = new MarketApplicationV2()
+      app._viewState = { ...app._viewState, affordableOnly: true }
+      app.render = vi.fn().mockResolvedValue(undefined)
+
+      const action = MarketApplicationV2.DEFAULT_OPTIONS.actions.resetCatalog
+      await action.call(app, {}, {})
+
+      expect(app._viewState.affordableOnly).toBe(false)
+      expect(app.render).toHaveBeenCalled()
+    })
+  })
+
+  /* -------------------------------------------- */
   /*  Sort                                        */
   /* -------------------------------------------- */
 


### PR DESCRIPTION
## Summary

- Add an “Affordable only” filter to the Market view so actors can limit listed items to those they can afford.
- Implements UI template change, application logic, i18n (en/fr) and unit tests.

## Context

This PR implements the filter described in the feature plan and tests. 

Closes #475

## Tests

- Unit tests added: tests/module/applications/market/market-application.test.mjs
- Not run (not requested).

## Notes

- Files changed: module/applications/market/market-application.mjs, templates/market/market.hbs, lang/en.json, lang/fr.json, tests/module/applications/market/market-application.test.mjs, documentation plan prompt added.
- Diff summary: 6 files changed, 167 insertions(+), 6 deletions(-).
