### PR TITLE
feat(market): add restriction level filter to market catalog

### DIFF
--- a/documentation/cadrage/market/feature-market-cadrage-metier.md
+++ b/documentation/cadrage/market/feature-market-cadrage-metier.md
@@ -4,11 +4,16 @@
 
 ### Besoin
 
-Le système doit proposer une fenêtre dédiée au marché, ouvrable depuis la feuille de personnage, dans un premier temps depuis l’onglet Inventory.
+Le système doit proposer une fenêtre dédiée au marché, ouvrable depuis la feuille de personnage, dans un premier temps
+depuis l’onglet Inventory.
 
-Cette fenêtre doit permettre au joueur ou au MJ de consulter les objets achetables disponibles dans le jeu, de les parcourir, de les filtrer et, à terme, de les acheter pour les ajouter à l’inventaire d’un personnage.
+Cette fenêtre doit permettre au joueur ou au MJ de consulter les objets achetables disponibles dans le jeu, de les
+parcourir, de les filtrer et, à terme, de les acheter pour les ajouter à l’inventaire d’un personnage.
 
-L’objectif n’est pas seulement d’afficher une liste d’items. L’objectif est de créer une expérience de marché crédible, pratique et immersive, adaptée à Star Wars FFG : crédits, disponibilité, rareté, restrictions locales, marchés légaux ou illégaux, vendeurs douteux, matériel militaire contrôlé, équipement courant, pièces récupérées, droïdes, armes, armures, véhicules ou services selon les phases retenues.
+L’objectif n’est pas seulement d’afficher une liste d’items. L’objectif est de créer une expérience de marché crédible,
+pratique et immersive, adaptée à Star Wars FFG : crédits, disponibilité, rareté, restrictions locales, marchés légaux ou
+illégaux, vendeurs douteux, matériel militaire contrôlé, équipement courant, pièces récupérées, droïdes, armes, armures,
+véhicules ou services selon les phases retenues.
 
 ## 2. Vision fonctionnelle
 
@@ -37,19 +42,23 @@ Il doit s’appuyer sur une logique métier séparée du reste de l’interface.
 
 Il doit intégrer progressivement un calcul de prix dépendant de la disponibilité, de la rareté et du contexte.
 
-Il doit être pensé pour une expérience moderne, claire, rapide à utiliser en table et visuellement cohérente avec Star Wars.
+Il doit être pensé pour une expérience moderne, claire, rapide à utiliser en table et visuellement cohérente avec Star
+Wars.
 
 ### Hors périmètre initial
 
 Le marché ne doit pas, dans une première version, chercher à simuler toute l’économie galactique.
 
-Il ne doit pas gérer immédiatement des stocks dynamiques par vendeur, sauf si cette notion est explicitement retenue pour une phase ultérieure.
+Il ne doit pas gérer immédiatement des stocks dynamiques par vendeur, sauf si cette notion est explicitement retenue
+pour une phase ultérieure.
 
 Il ne doit pas imposer un modèle unique de commerce pour toute la galaxie.
 
-Il ne doit pas mélanger dans une même première livraison l’achat, la vente, le troc, les services, les réparations, les commandes spéciales et le marché noir.
+Il ne doit pas mélanger dans une même première livraison l’achat, la vente, le troc, les services, les réparations, les
+commandes spéciales et le marché noir.
 
-Il ne doit pas être dépendant uniquement de la feuille de personnage, même s’il est ouvert depuis celle-ci dans la première phase.
+Il ne doit pas être dépendant uniquement de la feuille de personnage, même s’il est ouvert depuis celle-ci dans la
+première phase.
 
 ## 4. Principes métier
 
@@ -57,11 +66,13 @@ Il ne doit pas être dépendant uniquement de la feuille de personnage, même s�
 
 Tous les items du système ne sont pas destinés à être achetés.
 
-Certains items sont techniques, narratifs, uniques, liés à un PNJ, liés à une récompense, liés à un pouvoir, liés à un vaisseau précis, ou simplement non commercialisables.
+Certains items sont techniques, narratifs, uniques, liés à un PNJ, liés à une récompense, liés à un pouvoir, liés à un
+vaisseau précis, ou simplement non commercialisables.
 
 Le marché doit donc s’appuyer sur une règle d’éligibilité.
 
-Un item est affichable dans le marché uniquement s’il appartient à un type autorisé et s’il dispose des données minimales nécessaires à l’achat.
+Un item est affichable dans le marché uniquement s’il appartient à un type autorisé et s’il dispose des données
+minimales nécessaires à l’achat.
 
 ### 4.2. Le prix affiché n’est pas toujours le prix de base
 
@@ -97,7 +108,8 @@ Le système doit aider à automatiser, pas décider à la place du MJ.
 
 Le MJ doit pouvoir autoriser, masquer, restreindre, surclasser ou modifier les disponibilités et les prix.
 
-Dans Star Wars FFG, le commerce est fortement lié au contexte : un blaster n’a pas le même statut dans un astroport impérial, une enclave rebelle, une cantina de Tatooine ou un marché noir hutt.
+Dans Star Wars FFG, le commerce est fortement lié au contexte : un blaster n’a pas le même statut dans un astroport
+impérial, une enclave rebelle, une cantina de Tatooine ou un marché noir hutt.
 
 ## 5. Types d’items achetables
 
@@ -116,9 +128,11 @@ Pour éviter une première version trop large, le marché devrait commencer par 
 
 ### À traiter plus tard
 
-Les véhicules, vaisseaux, services, réparations, modifications, licences, faux papiers, informations, soins médicaux, cargaisons et marchandises devraient être traités dans des phases ultérieures.
+Les véhicules, vaisseaux, services, réparations, modifications, licences, faux papiers, informations, soins médicaux,
+cargaisons et marchandises devraient être traités dans des phases ultérieures.
 
-La raison est simple : ces éléments ne relèvent pas toujours d’un achat d’item classique. Ils impliquent souvent un contexte narratif, une disponibilité rare, une négociation, ou une intégration technique plus lourde.
+La raison est simple : ces éléments ne relèvent pas toujours d’un achat d’item classique. Ils impliquent souvent un
+contexte narratif, une disponibilité rare, une négociation, ou une intégration technique plus lourde.
 
 ## 6. Expérience utilisateur attendue
 
@@ -213,7 +227,8 @@ Sources possibles :
 
 Point à arbitrer : faut-il que le marché scanne toutes les sources disponibles ou seulement des sources configurées ?
 
-Recommandation : utiliser des sources configurées. Scanner tout automatiquement risque d’afficher des éléments non prévus, des doublons ou des items narratifs.
+Recommandation : utiliser des sources configurées. Scanner tout automatiquement risque d’afficher des éléments non
+prévus, des doublons ou des items narratifs.
 
 ### 7.3. Prix de base
 
@@ -268,7 +283,8 @@ La disponibilité décrit le fait qu’il soit accessible ici, maintenant, dans 
 
 ### 7.6. Achat
 
-L’achat ne doit pas être inclus dans la toute première étape si l’objectif est d’abord de cadrer, afficher et filtrer proprement.
+L’achat ne doit pas être inclus dans la toute première étape si l’objectif est d’abord de cadrer, afficher et filtrer
+proprement.
 
 Quand l’achat sera implémenté, il devra :
 
@@ -282,7 +298,8 @@ Quand l’achat sera implémenté, il devra :
 
 Point à arbitrer : l’achat doit-il créer une copie de l’item ou une référence à l’item source ?
 
-Recommandation métier : l’inventaire du personnage doit recevoir une instance propre de l’item acheté. Le marché est une source d’achat, pas un lien permanent vers l’objet catalogue.
+Recommandation métier : l’inventaire du personnage doit recevoir une instance propre de l’item acheté. Le marché est une
+source d’achat, pas un lien permanent vers l’objet catalogue.
 
 ## 8. Découpage projet recommandé
 
@@ -434,11 +451,13 @@ Valeur : le marché devient un moteur de jeu, pas seulement une boutique.
 
 Un simple tableau d’items ne sera pas suffisant.
 
-Le système doit rester pratique, mais il doit aussi sentir Star Wars : marché noir, pénurie, contrôle impérial, vendeurs douteux, récupération, rareté locale.
+Le système doit rester pratique, mais il doit aussi sentir Star Wars : marché noir, pénurie, contrôle impérial, vendeurs
+douteux, récupération, rareté locale.
 
 ### Risque 2 — Trop automatiser trop tôt
 
-Le calcul de prix, la disponibilité, l’achat, la négociation et les conséquences narratives peuvent vite devenir complexes.
+Le calcul de prix, la disponibilité, l’achat, la négociation et les conséquences narratives peuvent vite devenir
+complexes.
 
 Il faut livrer par étapes.
 
@@ -460,9 +479,11 @@ Recommandation : commencer par un catalogue global achetable, puis introduire le
 
 ### Risque 5 — Coupler trop fortement la feature à la feuille personnage
 
-Le marché peut être ouvert depuis la feuille, mais il ne doit pas être conçu comme une simple sous-fenêtre de l’inventaire.
+Le marché peut être ouvert depuis la feuille, mais il ne doit pas être conçu comme une simple sous-fenêtre de
+l’inventaire.
 
-À terme, il pourrait aussi être ouvert par le MJ, depuis un lieu, depuis une scène, depuis un vendeur, ou depuis une macro.
+À terme, il pourrait aussi être ouvert par le MJ, depuis un lieu, depuis une scène, depuis un vendeur, ou depuis une
+macro.
 
 ## 10. Arbitrages à prendre avant les issues
 
@@ -481,11 +502,13 @@ Le marché peut être ouvert depuis la feuille, mais il ne doit pas être conçu
 
 ### Epic — Market / Marché
 
-Créer une fonctionnalité de marché permettant de consulter, filtrer, valoriser et acheter des items achetables dans le système Star Wars FFG.
+Créer une fonctionnalité de marché permettant de consulter, filtrer, valoriser et acheter des items achetables dans le
+système Star Wars FFG.
 
 ### Issue 1 — Définir le modèle métier du Market
 
-But : stabiliser les notions de marché, item achetable, éligibilité, prix de base, prix final, disponibilité et source commerciale.
+But : stabiliser les notions de marché, item achetable, éligibilité, prix de base, prix final, disponibilité et source
+commerciale.
 
 ### Issue 2 — Ouvrir la fenêtre Market depuis l’inventaire
 
@@ -531,8 +554,10 @@ La première version doit être un catalogue achetable propre, rapide, filtrable
 
 La deuxième version doit intégrer un vrai moteur métier de prix et de disponibilité.
 
-La troisième version doit rendre le marché vivant : marchés locaux, vendeurs, rareté contextuelle, marché noir, conséquences narratives.
+La troisième version doit rendre le marché vivant : marchés locaux, vendeurs, rareté contextuelle, marché noir,
+conséquences narratives.
 
 Le cœur de la feature ne doit pas être “acheter un objet”.
 
-Le cœur de la feature doit être : “accéder à l’économie galactique depuis le personnage, avec des règles cohérentes, contrôlables et immersives”.
+Le cœur de la feature doit être : “accéder à l’économie galactique depuis le personnage, avec des règles cohérentes,
+contrôlables et immersives”.

--- a/documentation/plan/market/plan-compendiumSourceIntegration.prompt.md
+++ b/documentation/plan/market/plan-compendiumSourceIntegration.prompt.md
@@ -1,0 +1,537 @@
+# Plan : Intégration des sources Compendium dans le Market
+
+## Objectif
+
+Le Market ne charge actuellement que les items du monde (`game.items`). Ce plan étend le pipeline de données pour résoudre les items depuis les **compendiums Foundry** (`game.packs`) en plus des items du monde, en respectant la configuration des sources activées (`readMarketConfig`) et la stratégie de déduplication existante. Le but est de réaliser la **Phase 3 du cadrage métier** (sources configurables) et rendre le Market exploitable avec des données importées via OggDude.
+
+## Contexte & motivation
+
+### État actuel
+
+- `MarketApplicationV2.#prepareCatalog()` itère uniquement `game.items` (items du monde)
+- Les items des compendiums Foundry ne sont pas visibles dans le catalogue marchand
+- Le système de configuration (enabledSources, allowedItemTypes, dedupStrategy) existe mais n'est appliqué qu'aux items du monde
+- Les importations OggDude créent souvent des items dans des compendiums, qui restent invisibles au Market
+
+### Blocages et risques
+
+1. **Incompletude du catalogue** : Le Market parle uniquement des items du monde personnalisés, pas du contenu officiel/importé
+2. **Mélange de deux data flows** : Monde vs. Packs, sans normalisation commune ni déduplication
+3. **Configuration partielle** : `readMarketConfig()` n'a aucun effet si aucune source compendium n'est scannée
+4. **Performance** : Charger tous les documents compendium peut être coûteux — optimisation requise
+
+### Approche recommandée
+
+Créer un **adapter Foundry** qui résout les items depuis les packs selon la configuration, puis lever les items monde et compendium dans une **fonction domaine pure** qui applique les règles métier (éligibilité, déduplication, contexte de prix). Cette approche respecte la séparation pure domaine / adapter Foundry.
+
+## Étapes d'implémentation
+
+### 1. Créer [`module/lib/market/catalog-loader.mjs`](module/lib/market/catalog-loader.mjs)
+
+**Responsabilité** : Fonction pure domaine qui agrège les items du monde et des compendiums, applique les règles de normalisation et déduplication.
+
+**Signature** :
+
+```javascript
+/**
+ * Load the complete Market catalogue from world and compendium sources.
+ *
+ * Deep domain function: pure logic, no Foundry dependencies.
+ * Handles eligibility, deduplication, and price calculation.
+ *
+ * @param {Object} options
+ * @param {Array<RawItem>} options.worldItems         Raw items from game.items or fallback
+ * @param {Array<RawItem>} options.compendiumItems    Raw items from game.packs, with sourceType/sourceId
+ * @param {import('../../config/market.mjs').MarketConfig} options.config  Market runtime config
+ * @param {Partial<import('../../config/market.mjs').MarketContext>} options.marketContext  Price context
+ * @returns {import('./market-entry.mjs').MarketEntry[]}  Eligible, deduplicated, priced entries
+ */
+export function loadMarketCatalog({ worldItems, compendiumItems, config, marketContext }) {
+  // 1. Merge sources with proper source type tagging
+  const allRawItems = [
+    ...worldItems.map((item) => ({ ...item, _sourceType: 'world' })),
+    ...compendiumItems.map((item) => ({ ...item, _sourceType: 'compendium' })),
+  ]
+
+  // 2. Create market entries
+  const entries = allRawItems
+    .map((rawItem) => {
+      try {
+        return createMarketEntry(rawItem, { sourceType: rawItem._sourceType, sourceId: rawItem._sourceId ?? '' }, marketContext)
+      } catch (err) {
+        // Non-purchasable type: skip
+        return null
+      }
+    })
+    .filter(Boolean)
+
+  // 3. Filter by active config (enabledSources, allowedItemTypes)
+  const filtered = filterByActiveConfig(entries, config.enabledSources, config.allowedItemTypes)
+
+  // 4. Deduplicate per strategy
+  const deduplicated = filterDuplicates(filtered, config.dedupStrategy)
+
+  return deduplicated
+}
+```
+
+**Points clés** :
+
+- Accepte `worldItems` et `compendiumItems` comme arrays de `RawItem[]`
+- Chaque item est étiqueté avec `_sourceType` et `_sourceId` avant normalisation
+- Applique `createMarketEntry` → `filterByActiveConfig` → `filterDuplicates` dans l'ordre
+- N'a aucune dépendance Foundry — 100% testable avec des mocks d'objet
+
+### 2. Créer [`module/applications/market/compendium-source-adapter.mjs`](module/applications/market/compendium-source-adapter.mjs)
+
+**Responsabilité** : Adapter Foundry qui itère les packs, charge les items achetables, les normalise en `RawItem[]` avec métadonnées source.
+
+**Signature** :
+
+```javascript
+import { PURCHASABLE_ITEM_TYPES } from '../../config/market.mjs'
+import { logger } from '../../utils/logger.mjs'
+
+/**
+ * Load all purchasable items from Foundry compendium packs.
+ *
+ * Iterates game.packs, filters Item-type packs, loads index or documents,
+ * and converts each to a RawItem with sourceType='compendium' and sourceId=<pack-collection>.
+ *
+ * No eligibility checks here — that is done by the domain layer.
+ *
+ * @returns {Promise<Array<RawItem>>} Array of raw items from packs, ready for domain processing
+ */
+export async function loadCompendiumItems() {
+  const compendiumItems = []
+  const purchasableTypes = Object.keys(PURCHASABLE_ITEM_TYPES)
+
+  for (const pack of game.packs) {
+    // 1. Filter to Item packs only
+    if (pack.documentName !== 'Item') continue
+
+    // 2. Try to load via index first (cheaper than getDocuments)
+    let documents = []
+    try {
+      // Foundry v14+ supports getIndex with fields option
+      const index = await pack.getIndex({
+        fields: ['name', 'img', 'type', 'system.price', 'system.rarity', 'system.restrictionLevel', 'system.quality', 'system.availability'],
+      })
+      documents = Array.from(index.values())
+    } catch (err) {
+      logger.warn(`[Market] Could not load index from pack "${pack.collection}": ${err.message}`)
+      continue
+    }
+
+    // 3. Filter by purchasable type and normalize
+    for (const doc of documents) {
+      if (!purchasableTypes.includes(doc.type)) continue
+
+      compendiumItems.push({
+        uuid: doc.uuid ?? '',
+        name: doc.name ?? '',
+        img: doc.img ?? '',
+        type: doc.type,
+        basePrice: doc.system?.price ?? 0,
+        rarity: doc.system?.rarity ?? 0,
+        quality: doc.system?.quality ?? '',
+        restrictionLevel: doc.system?.restrictionLevel ?? '',
+        availability: doc.system?.availability ?? undefined,
+        nonPurchasable: false, // Packs don't expose item flags easily; use eligibility rules instead
+        broken: false,
+        _sourceId: pack.collection, // Pack collection ID for dedup + UI reference
+      })
+    }
+  }
+
+  logger.debug('[Market] Loaded compendium items', { count: compendiumItems.length })
+  return compendiumItems
+}
+```
+
+**Points clés** :
+
+- Utilise `pack.getIndex()` avec champs limités (optimisation pour les gros packs)
+- Filtre uniquement par type achetable ; les règles d'éligibilité seront appliquées côté domaine
+- Chaque item reçoit un `_sourceId` (collection pack) pour identification
+- Gestion d'erreur gracieuse : skip le pack sur erreur, continue
+- Logs de débogage pour instrumentation
+
+### 3. Modifier [`module/applications/market/market-application.mjs`](module/applications/market/market-application.mjs) — `#prepareCatalog`
+
+**Changement clé** : Remplacer la boucle `game.items` manuelle par un chemin qui charge world + compendium et passe à la fonction domaine.
+
+**Avant** :
+
+```javascript
+#prepareCatalog(buyer = null, buyerCredits = null) {
+  const activeMarketType = this._viewState.activeMarketType ?? DEFAULT_MARKET_TYPE
+
+  // 1. Build all eligible entries from game.items, using active market type for price calculation
+  const allEntries = []
+  const marketContext = { ...DEFAULT_MARKET_CONTEXT, marketType: activeMarketType }
+  for (const item of game.items) {
+    try {
+      const rawItem = itemToRawItem(item)
+      const entry = createMarketEntry(rawItem, { sourceType: 'world', sourceId: item.uuid ?? '' }, marketContext)
+      if (!entry.eligible) continue
+      allEntries.push(entry)
+    } catch (err) {
+      logger.debug(`[Market] Skipping item "${item.name}" (type="${item.type}"): ${err.message}`)
+    }
+  }
+  // ... rest of pipeline ...
+}
+```
+
+**Après** :
+
+```javascript
+async #prepareCatalog(buyer = null, buyerCredits = null) {
+  const activeMarketType = this._viewState.activeMarketType ?? DEFAULT_MARKET_TYPE
+  const marketContext = { ...DEFAULT_MARKET_CONTEXT, marketType: activeMarketType }
+  const marketConfig = readMarketConfig('swerpg')
+
+  // 1. Load world items
+  const worldItems = Array.from(game.items).map(item => itemToRawItem(item))
+
+  // 2. Load compendium items (async)
+  let compendiumItems = []
+  try {
+    compendiumItems = await loadCompendiumItems()
+  } catch (err) {
+    logger.warn('[Market] Could not load compendium items', err)
+  }
+
+  // 3. Delegate to domain loader (handles eligibility, dedup, config)
+  let allEntries
+  try {
+    allEntries = loadMarketCatalog({
+      worldItems,
+      compendiumItems,
+      config: marketConfig,
+      marketContext,
+    })
+  } catch (err) {
+    logger.error('[Market] Catalog loading failed', err)
+    allEntries = []
+  }
+
+  // 4. Apply market-type visibility rules (hide items whose availability is not allowed in this market)
+  const visibleEntries = allEntries.filter((entry) => {
+    const { visible } = resolveMarketCatalogVisibility(entry, activeMarketType)
+    return visible
+  })
+
+  // ... rest of pipeline unchanged (search, filters, sort, annotate, etc.) ...
+}
+```
+
+**Points clés** :
+
+- Make `#prepareCatalog` async pour supporter `loadCompendiumItems()`
+- Normaliser world items via `itemToRawItem` (existant)
+- Appeler `loadCompendiumItems()` (nouveau) pour packs
+- Passer les deux arrays au domaine via `loadMarketCatalog` (nouveau)
+- Gestion d'erreur non-bloquante pour chaque étape
+
+### 4. Ajouter le filtre par `restrictionLevel` dans le template [`templates/market/market.hbs`](templates/market/market.hbs)
+
+**Contexte** : Le `viewState` et les filtres métier existent déjà, mais le template manque le sélecteur `filterRestriction` dans la toolbar.
+
+**Ajouter dans la section `<div class="market-toolbar__filters">` (après filterSource)** :
+
+```handlebars
+<label for="market-filter-restriction" class="sr-only">{{localize "MARKET.Toolbar.Filter.RestrictionLabel"}}</label>
+<select id="market-filter-restriction" class="market-toolbar__filter market-toolbar__filter--restriction" aria-label="{{localize 'MARKET.Toolbar.Filter.RestrictionLabel'}}">
+  {{#each restrictionFilterOptions as |opt|}}
+    <option value="{{opt.value}}" {{#if (eq opt.value ../viewState.filterRestriction)}}selected{{/if}}>
+      {{localize opt.label}}
+    </option>
+  {{/each}}
+</select>
+```
+
+**Dans `market-application.mjs` — ajouter la fonction builder** :
+
+```javascript
+/**
+ * Build the list of restriction filter options.
+ * First entry is the "all restrictions" placeholder.
+ * @returns {Array<{value: string, label: string}>}
+ */
+#buildRestrictionFilterOptions() {
+  const allOption = { value: '', label: 'MARKET.Toolbar.Filter.AllRestrictions' }
+  // Hardcoded restrictions or scanned from catalogue data
+  const restrictionOptions = [
+    { value: 'restricted', label: 'MARKET.Restriction.Restricted' },
+    { value: 'illegal', label: 'MARKET.Restriction.Illegal' },
+    { value: 'licensed', label: 'MARKET.Restriction.Licensed' },
+  ]
+  return [allOption, ...restrictionOptions]
+}
+```
+
+**Exposer dans `_preparePartContext`** :
+
+```javascript
+context.restrictionFilterOptions = this.#buildRestrictionFilterOptions()
+```
+
+### 5. Écrire les tests unitaires
+
+#### 5a. [`tests/lib/market/catalog-loader.test.mjs`](tests/lib/market/catalog-loader.test.mjs)
+
+Tester la fonction domaine en isolation avec des mocks d'objet (pas de Foundry).
+
+```javascript
+import { describe, test, expect } from 'vitest'
+import { loadMarketCatalog } from '../../../module/lib/market/catalog-loader.mjs'
+import { DEFAULT_MARKET_CONFIG, DEFAULT_MARKET_CONTEXT } from '../../../module/config/market.mjs'
+
+describe('loadMarketCatalog', () => {
+  test('merges world and compendium items into a single catalogue', () => {
+    const worldItems = [{ uuid: 'world.1', name: 'Blaster', type: 'weapon', basePrice: 500, rarity: 0 }]
+    const compendiumItems = [{ uuid: 'pack.1', name: 'Rifle', type: 'weapon', basePrice: 1000, rarity: 1, _sourceId: 'swerpg.weapons' }]
+
+    const result = loadMarketCatalog({
+      worldItems,
+      compendiumItems,
+      config: DEFAULT_MARKET_CONFIG,
+      marketContext: DEFAULT_MARKET_CONTEXT,
+    })
+
+    expect(result).toHaveLength(2)
+    expect(result.map((e) => e.name)).toEqual(['Blaster', 'Rifle'])
+  })
+
+  test('filters by enabledSources config', () => {
+    // Config that only allows compendium, not world
+    const config = { ...DEFAULT_MARKET_CONFIG, enabledSources: ['compendium'] }
+    const worldItems = [{ uuid: 'world.1', name: 'Blaster', type: 'weapon', basePrice: 500 }]
+    const compendiumItems = [{ uuid: 'pack.1', name: 'Rifle', type: 'weapon', basePrice: 1000, _sourceId: 'swerpg.weapons' }]
+
+    const result = loadMarketCatalog({
+      worldItems,
+      compendiumItems,
+      config,
+      marketContext: DEFAULT_MARKET_CONTEXT,
+    })
+
+    expect(result).toHaveLength(1)
+    expect(result[0].name).toBe('Rifle')
+  })
+
+  test('deduplicates by prefer-compendium strategy', () => {
+    // Same weapon exists in world and compendium
+    const worldItems = [{ uuid: 'world.1', name: 'Blaster', type: 'weapon', basePrice: 500 }]
+    const compendiumItems = [{ uuid: 'pack.1', name: 'Blaster', type: 'weapon', basePrice: 500, _sourceId: 'swerpg.weapons' }]
+
+    const result = loadMarketCatalog({
+      worldItems,
+      compendiumItems,
+      config: DEFAULT_MARKET_CONFIG,
+      marketContext: DEFAULT_MARKET_CONTEXT,
+    })
+
+    expect(result).toHaveLength(1)
+    expect(result[0].sourceType).toBe('compendium') // Prefer compendium
+  })
+
+  test('skips ineligible items', () => {
+    const worldItems = [{ uuid: 'world.1', name: 'Broken Blaster', type: 'weapon', basePrice: 100, broken: true }]
+
+    const result = loadMarketCatalog({
+      worldItems,
+      compendiumItems: [],
+      config: DEFAULT_MARKET_CONFIG,
+      marketContext: DEFAULT_MARKET_CONTEXT,
+    })
+
+    expect(result).toHaveLength(0)
+  })
+})
+```
+
+#### 5b. [`tests/applications/market/compendium-source-adapter.test.mjs`](tests/applications/market/compendium-source-adapter.test.mjs)
+
+Tester l'adapter Foundry avec un mock de `game.packs`.
+
+```javascript
+import { describe, test, expect, beforeEach, afterEach, vi } from 'vitest'
+import { setupFoundryMock, teardownFoundryMock, addPacksMock } from '../../helpers/mock-foundry.mjs'
+import { loadCompendiumItems } from '../../../module/applications/market/compendium-source-adapter.mjs'
+
+describe('loadCompendiumItems', () => {
+  beforeEach(() => setupFoundryMock())
+  afterEach(() => teardownFoundryMock())
+
+  test('loads items from Item-type packs', async () => {
+    addPacksMock({
+      'swerpg.weapons': {
+        documentName: 'Item',
+        collection: 'swerpg.weapons',
+        documents: [
+          { id: 'w1', name: 'Blaster', type: 'weapon', system: { price: 500, rarity: 0 } },
+          { id: 'w2', name: 'Rifle', type: 'weapon', system: { price: 1000, rarity: 1 } },
+        ],
+      },
+    })
+
+    const result = await loadCompendiumItems()
+
+    expect(result).toHaveLength(2)
+    expect(result[0].name).toBe('Blaster')
+    expect(result[1]._sourceId).toBe('swerpg.weapons')
+  })
+
+  test('filters by purchasable item types', async () => {
+    addPacksMock({
+      'swerpg.weapons': {
+        documentName: 'Item',
+        documents: [
+          { id: 'w1', name: 'Blaster', type: 'weapon' },
+          { id: 't1', name: 'Talent', type: 'talent' }, // Should be skipped
+        ],
+      },
+    })
+
+    const result = await loadCompendiumItems()
+
+    expect(result).toHaveLength(1)
+    expect(result[0].type).toBe('weapon')
+  })
+
+  test('skips non-Item packs', async () => {
+    addPacksMock({
+      'swerpg.weapons': {
+        documentName: 'Item',
+        documents: [{ id: 'w1', name: 'Blaster', type: 'weapon' }],
+      },
+      'swerpg.actors': {
+        documentName: 'Actor',
+        documents: [{ id: 'a1', name: 'NPC', type: 'character' }],
+      },
+    })
+
+    const result = await loadCompendiumItems()
+
+    expect(result).toHaveLength(1)
+  })
+
+  test('handles pack load errors gracefully', async () => {
+    addPacksMock({
+      'swerpg.weapons': {
+        documentName: 'Item',
+        documents: [{ id: 'w1', name: 'Blaster', type: 'weapon' }],
+      },
+    })
+
+    // Simulate pack.getIndex() error
+    vi.spyOn(game.packs._values[0], 'getIndex').mockRejectedValueOnce(new Error('Mock error'))
+
+    const result = await loadCompendiumItems()
+
+    expect(result).toHaveLength(0) // Skip the failing pack, continue
+  })
+})
+```
+
+### 6. Mettre à jour les clés i18n
+
+#### En [`lang/en.json`](lang/en.json)
+
+```json
+{
+  "MARKET.Toolbar.Filter.RestrictionLabel": "Restriction Level",
+  "MARKET.Toolbar.Filter.AllRestrictions": "All Restrictions",
+  "MARKET.Restriction.Restricted": "Restricted",
+  "MARKET.Restriction.Illegal": "Illegal",
+  "MARKET.Restriction.Licensed": "Licensed"
+}
+```
+
+#### En [`lang/fr.json`](lang/fr.json)
+
+```json
+{
+  "MARKET.Toolbar.Filter.RestrictionLabel": "Restriction",
+  "MARKET.Toolbar.Filter.AllRestrictions": "Tous",
+  "MARKET.Restriction.Restricted": "Restreint",
+  "MARKET.Restriction.Illegal": "Illégal",
+  "MARKET.Restriction.Licensed": "Licencié"
+}
+```
+
+## Considérations avancées
+
+### 1. Optimisation du chargement des compendiums
+
+**Problème** : Charger tous les documents compendium peut être coûteux pour les gros packs.
+
+**Solution V1 (recommandée pour cette issue)** :
+
+- Utiliser `pack.getIndex()` avec champs limités (`fields: [...]`)
+- **Limitation** : Foundry v14+ doit supporter `getIndex({ fields: [...] })`. Si non supporté, passer à `pack.getIndex()` sans options, puis mapper les champs.
+- Fallback : charger via `pack.getDocuments()` seulement si nécessaire pour les packs non-indexés.
+
+**Solution V2 (future)** :
+
+- Ajouter un setting "Packs à scanner pour le Market" → seulement charger les packs explicitement activés
+- Utiliser un cache invalidé via hook `updateCompendium`
+
+### 2. Gestion des items avec des UUIDs brisés
+
+**Problème** : Si un item compendium est supprimé après indexation, son UUID est mort.
+
+**Solution** :
+
+- Les items non résolus ne peuvent pas être achetés (pas d'UUID valide)
+- Le filtre optionnel "missing-uuid" pourrait être exposé plus tard
+- Pour V1 : accepter les UUIDs tels quels, les achats en lire les erreurs
+
+### 3. Comportement de déduplication
+
+La déduplication `prefer-compendium` est la stratégie par défaut et logique :
+
+- Un item compendium "officiel" supplante un item world "maison" du même nom/type
+- Permet la mise à jour centralisée via re-import OggDude
+
+**Cas limites** :
+
+- Item compendium nommé "Blaster", item world aussi nommé "Blaster" → compendium gagne
+- Deux compendiums différents avec "Blaster" → dépend de l'ordre d'itération `game.packs` (deterministic mais non garanti)
+
+### 4. Asynchronicité de `#prepareCatalog`
+
+**Changement clé** : `#prepareCatalog` devient async (attendait le chargement compendium).
+
+**Impact** :
+
+- `_prepareContext` appelle déjà `#prepareCatalog` via `await`
+- Tous les usages doivent attendre la Promise
+- Les tests doivent être async
+
+## Définition de « done »
+
+Cette issue est complète quand :
+
+1. ✅ `module/lib/market/catalog-loader.mjs` existe, charge world+compendium, applique config/dedup
+2. ✅ `module/applications/market/compendium-source-adapter.mjs` existe, charge items packs efficacement
+3. ✅ `MarketApplicationV2.#prepareCatalog()` utilise les deux sources, respecte config
+4. ✅ Template `market.hbs` inclut sélecteur `filterRestriction` qui fonctionne
+5. ✅ Tests unitaires passent pour catalog-loader + source-adapter
+6. ✅ Clés i18n ajoutées (en.json + fr.json)
+7. ✅ Le Market affiche les items du monde ET les items compendium côte à côte
+8. ✅ Déduplication fonctionne (prefer-compendium par défaut)
+9. ✅ Logs + debug info actifs ([Market] logs visibles en debug mode)
+
+## Dépendances & références
+
+- [`feature-market-cadrage-metier.md`](../../cadrage/market/feature-market-cadrage-metier.md) — Vision métier Phase 3
+- [`module/config/market.mjs`](../../module/config/market.mjs) — Config, enums
+- [`module/lib/market/eligibility.mjs`](../../module/lib/market/eligibility.mjs) — Eligibility rules
+- [`module/lib/market/market-entry.mjs`](../../module/lib/market/market-entry.mjs) — MarketEntry factory
+- [`module/lib/market/source-resolver.mjs`](../../module/lib/market/source-resolver.mjs) — Dedup strategies
+- [`module/applications/market/market-application.mjs`](../../module/applications/market/market-application.mjs) — Main app (to modify)
+- Foundry VTT v14 API : `game.packs`, `pack.getIndex()`, `pack.getDocuments()`

--- a/documentation/plan/market/plan-marketCommerceRulesIntegration.prompt.md
+++ b/documentation/plan/market/plan-marketCommerceRulesIntegration.prompt.md
@@ -1,0 +1,300 @@
+# Plan : Intégration des règles de commerce et impact du type de marché
+
+**Source** : Cadrage `cadrage-regle-impact-type-de-market.md` — Synthèse MJ pour acheter, vendre et trouver des objets dans Star Wars: Aux Confins de l'Empire.
+
+**Objectif global** : Enrichir le Market existant avec les mécaniques narratives et contextuelles décrites dans le cadrage Edge : modificateurs de lieu, tests de disponibilité (Négociation/Pègre), vente/revente, résultats narratifs (Avantages/Menaces/Triomphe/Désastre).
+
+---
+
+## Plan d'implémentation
+
+### Contexte actuel
+
+Le Market actuel supporte :
+
+- 4 types de marché (`standard`, `local`, `specialized`, `black-market`) avec `priceModifier` et `allowedAvailability`
+- Calcul de prix : basePrice × (1 + availabilityMod + rarityMod × 0.1 + gmMod + marketTypeMod)
+- Validation d'achat (crédits suffisants)
+- Restriction des items par `restrictionLevel` (none/restricted/military/illegal)
+
+**Manque** :
+
+- Test de disponibilité (compétence Négociation/Pègre)
+- Modificateur de rareté par lieu (planète/région)
+- Mécanisme de revente/vente d'objets
+- Résultats narratifs appliqués au commerce
+- Coûts non-monétaires (dette, faveur, surveillance)
+
+---
+
+## Tranches verticales
+
+### Tranche 1 : Modificateur de rareté par lieu (planète/région)
+
+**Type** : AFK  
+**Bloqué par** : Aucun — peut démarrer immédiatement.
+
+**Objectif** : Ajouter un registre de types de lieux (`noyau`, `bordure`, `espaceSauvage`, etc.) avec un modificateur de rareté. Exposer dans `marketContext` et UI via sélecteur.
+
+**What to build**
+
+- Créer `module/config/market-locations.mjs` contenant un registre `MARKET_LOCATIONS` avec au minimum :
+  - `noyau`: modificateur rareté `−0.5` (items plus faciles à trouver)
+  - `bordure`: modificateur rareté `0` (neutralité)
+  - `espaceSauvage`: modificateur rareté `+1.5` (items rares deviennent plus rares)
+  - Champ optionnel description/label pour UI
+
+- Étendre `module/config/market.mjs` pour intégrer `MARKET_LOCATIONS` dans le `MarketContext` existant.
+- Ajouter `activeLocation` (string key) au `_viewState` de `MarketApplicationV2`.
+- Créer sélecteur UI (dropdown) pour changer de lieu. À chaque changement, recalculer rareté effective et rerendre catalogue.
+- Mettre à jour le price engine pour appliquer le modificateur de rareté du lieu.
+- Ajouter tests Vitest pour vérifier calcul rareté effective = rareté item + modifier lieu.
+
+**Acceptance criteria**
+
+- [ ] Registre `MARKET_LOCATIONS` créé et exposé via `SYSTEM.MARKET.LOCATIONS`
+- [ ] `MarketContext.activeLocation` défini et utilisé dans `computeMarketPrice()`
+- [ ] Sélecteur de lieu intégré à l'UI (dropdown avec description brève)
+- [ ] Prix et filtrage catalogue mis à jour en fonction du lieu actif
+- [ ] Tests Vitest pour calcul rareté et price impact
+- [ ] Clés i18n complètes (en.json, fr.json)
+
+**Blocked by**
+
+Aucun — peut démarrer immédiatement.
+
+---
+
+### Tranche 2 : Test de disponibilité (Négociation / Pègre)
+
+**Type** : HITL  
+**Bloqué par** : Tranche 1 (rareté contextuelle → seuil de test déterminé)
+
+**Objectif** : Avant l'achat, si la rareté effective dépasse un seuil, déclencher un test de compétence. Items légaux → Négociation. Items restreints → Pègre/Streetwise. Résultat autorise/interdit l'achat.
+
+**What to build**
+
+- Créer `module/lib/market/availability-check.mjs` (pur domaine) :
+  - Fonction `shouldRequireAvailabilityTest(rarity, restrictionLevel)` → booléen
+  - Fonction `buildAvailabilityTestConfig(rarity, restrictionLevel, marketLocation)` → { skill: string, dc: number, narrative: string }
+  - Seuils : rareté ≥ 4 → test requis ; rareté ≥ 8 → test très difficile
+  - Choix compétence : if restrictionLevel in [restricted/military/illegal] ? 'streetwise' : 'negotiation'
+
+- Créer dialog UI pour présenter le test avant l'achat.
+  - Afficher difficulté, compétence requise, description narrative
+  - Bouton "Tenter d'obtenir" → lancer test
+
+- Intégration dans `MarketApplicationV2` :
+  - Hook `#onBuyItem()` : avant d'accorder l'achat, vérifier si un test est requis
+  - Si requis, ouvrir dialog sans fermer le market
+  - Dialog lance test via le système dice pool existant
+- **HITL** : Décision d'architecture requise sur :
+  - Comment intégrer le dice pool du système?
+  - La dialog est-elle un ApplicationV2 séparé ou un render modal dans le Market?
+  - Comment passer les résultats du test au flow d'achat?
+
+**Acceptance criteria**
+
+- [ ] Logique pure `availablity-check.mjs` créée, testée sans Foundry
+- [ ] UI dialog créée (type ApplicationV2 ou modal)
+- [ ] Hook #onBuyItem() modifiée pour intercepter et tester
+- [ ] Dice pool intégré pour lancer test (exploit pattern existant système?)
+- [ ] Résultat test bloque ou autorise achat
+- [ ] Tests Vitest pour logique pure (thresholds, skill choice, DC calculation)
+- [ ] Clés i18n pour messages dialog
+
+**Blocked by**
+
+- Tranche 1 (pour rareté contextuelle)
+- **Décision architecurale** sur intégration dice pool ← HITL
+
+---
+
+### Tranche 3 : Résultats narratifs du test de commerce
+
+**Type** : AFK  
+**Bloqué par** : Tranche 2 (résultats du test disponibles)
+
+**Objectif** : Appliquer les résultats du test (Avantages/Menaces/Triomphe/Désastre) comme modificateurs prix et/ou conséquences narratives.
+
+**What to build**
+
+- Créer `module/lib/market/commerce-outcomes.mjs` :
+  - Fonction `computeCommerceOutcome(testResult, context)` → { priceModifier, narrativeKey, consequences: string[] }
+  - Résultats narratifs Edge :
+    - Succès : aucune conséquence
+    - Avantages : −10% prix, rabais appliqué, marchandise en bon état
+    - Menaces : +10% prix, délai, vendeur bavard, surveillance
+    - Triomphe : contact durable, objet supérieur, information bonus
+    - Désastre : arnaque, embuscade, objet tracé, intervention impériale
+
+- Intégrer dans le flow d'achat post-test :
+  - Appliquer `priceModifier` au prix final
+  - Afficher outcome narratif dans le chat ou notification
+  - Stocker conséquences (si applicable) pour suivi ultérieur
+
+- Création chat message pour documenter l'achat et ses conséquences narratives.
+
+**Acceptance criteria**
+
+- [ ] Logique pure `commerce-outcomes.mjs` créée et testée
+- [ ] Outcomes mappés pour Succès/Avantages(1+)/Menaces(1+)/Triomphe/Désastre
+- [ ] Prix réajusté selon outcome
+- [ ] Chat message généré avec détails achat + outcome
+- [ ] Clés i18n pour tous les outcomes
+- [ ] Tests Vitest pour logique outcome
+
+**Blocked by**
+
+- Tranche 2 (résultats test disponibles)
+
+---
+
+### Tranche 4 : Mécanisme de revente d'objets
+
+**Type** : AFK  
+**Bloqué par** : Aucun — peut démarrer en parallèle.
+
+**Objectif** : Acteur vend un item possédé. Prix de revente = % du basePrice selon résultat test Négociation (25%/50%/75%). Créditer l'acteur.
+
+**What to build**
+
+- Créer `module/lib/market/sell-valuation.mjs` (pur domaine) :
+  - Fonction `calculateSellValue(basePrice, condition, testResult?)` → number
+  - Règles : condition 'excellent' +10%, 'degraded' −25%
+  - Si test Négociation présent : 25% success / 50% +avantage / 75% triomphe
+
+- Créer UI "Mes articles à vendre" (onglet dans Market ou action séparée) :
+  - Lister items possédés (weapon/armor/gear) avec prix de base
+  - Afficher valeur de revente estimée (% du prix)
+  - Option : lancer test Négociation pour chercher meilleur prix
+  - Bouton "Vendre" → débiter l'item, créditer l'acteur
+
+- Intégrer dans `MarketApplicationV2` :
+  - Mode "seller" vs "buyer" toggable via bouton ou context
+  - Crédits additionnés/soustraits lors de vente
+
+**Acceptance criteria**
+
+- [ ] Logique `sell-valuation.mjs` créée, testée
+- [ ] UI "Mes articles" intégrée au Market (tab ou section)
+- [ ] Test Négociation lancé avant vente (optionnel/recommandé)
+- [ ] Item supprimé du inventaire, crédits augmentés
+- [ ] Tests Vitest pour logique valuation
+- [ ] Clés i18n
+
+**Blocked by**
+
+Aucun — peut démarrer immédiatement.
+
+---
+
+### Tranche 5 : Filtrage catalogue par légalité et niveau de restriction
+
+**Type** : AFK  
+**Bloqué par** : Tranche 1 (contexte de marché nécessaire pour logique filtrage)
+
+**Objectif** : Quand marché `standard` ou `local`, masquer items `restricted`/`military`/`illegal`. Quand `black-market`, tous visibles mais avec indicateur visuel. Ajouter filtre restriction dans toolbar.
+
+**What to build**
+
+- Créer fonction pure `isItemVisibleForMarket(item, marketType)` → booléen
+  - `standard`/`local` → masquer restricted/military/illegal
+  - `specialized` → afficher restricted/military mais épingler
+  - `black-market` → all visible
+
+- Intégrer logique de filtrage dans `#buildCatalogFromWorldItems()` (MarketApplicationV2)
+  - Appliquer filtre après autres critères d'éligibilité
+
+- Ajouter filtre restriction dans toolbar (dropdown) :
+  - Options : "Tous", "Légal", "Restreint"
+  - Interagit avec `marketType` (black-market masque l'option "Légal")
+
+- CSS/UI : visuellement distinguer items restreints (`badge RESTREINT`, couleur, icône ⚠️)
+
+**Acceptance criteria**
+
+- [ ] Fonction `isItemVisibleForMarket()` créée, testée
+- [ ] Filtrage intégré au catalogue rendering
+- [ ] Filtre restriction dans toolbar (dropdown)
+- [ ] Items restreints marqués visuellement (badge, couleur)
+- [ ] Tests Vitest pour logique filtrage
+- [ ] Pas de changement comportement pour `specialized` existing
+
+**Blocked by**
+
+- Tranche 1 (contexte marché et rareté)
+
+---
+
+### Tranche 6 : Intégration du coût narratif (dette, faveur, risque)
+
+**Type** : HITL  
+**Bloqué par** : Tranche 3 (outcomes narratifs disponibles)
+
+**Objectif** : Modéliser conséquences non-monétaires (dette envers Hutt, surveillance impériale…) comme effets persistants. Nécessite décision architecturale.
+
+**What to build**
+
+- **HITL — Décision d'architecture** :
+  - Structure de données : flags sur acteur + chat? Items narratifs (obligation-like)? ActiveEffects?
+  - Durée : persistent ou temporaire?
+  - Suivi : simple texte ou système de dettes/faveurs mécanique?
+
+- MVP post-décision :
+  - Ajouter flag acteur `market.lastNarrativeConsequences` (array de strings)
+  - Dans chat, afficher conséquences narratives
+  - Dashboard simple : "Vous avez une dette envers [Hutt]" affiché sur character sheet
+
+- Exemple conséquences :
+  - Achat black-market risqué → "Surveillance impériale déclenchée (test Discrétion requis?"
+  - Achat chez Hutt avec dette → "Obligation : faveur au Hutt"
+  - Revente arnaque → "Arnaqueur cherche vengeance"
+
+**Acceptance criteria**
+
+- [ ] **Décision architecturale prise** : structure de données définie
+- [ ] Conséquences stockées sur acteur
+- [ ] Dashboard/display sur sheet ou Market
+- [ ] Chat messages documentes conséquences
+- [ ] Tests Vitest pour logique pure
+- [ ] Clés i18n
+
+**Blocked by**
+
+- Tranche 3 (outcomes narratifs)
+- **Décision architecturale** ← HITL
+
+---
+
+## Considérations de design
+
+### 1. Ordem de mise en œuvre recommandée
+
+1. **Tranches 1 & 4** (indépendantes, livraison rapide)
+2. **Tranche 5** (dépend 1, améliore UX filtrage)
+3. **Tranches 2 & 3** (cœur des règles Edge, dépendent les unes des autres)
+4. **Tranche 6** (nice-to-have, dépend décision archi)
+
+### 2. Points HITL critiques
+
+- **Tranche 2** : Intégration dice pool — le système lance-t-il les tests via API existante?
+- **Tranche 6** : Modèle de données pour conséquences non-monétaires
+
+### 3. Granularité
+
+Toutes les tranches sont techniquement décomposables en sous-tranches (logique pure / UI / test). La granularité actuelle convient à un découpage vertical fin.
+
+---
+
+## Succès globaux
+
+- [ ] Modificateurs de lieu impactent rareté effective et tarification
+- [ ] Tests de disponibilité (Négociation/Pègre) peuvent être lancés avant achat
+- [ ] Résultats des tests appliquent modificateurs narratifs au commerce
+- [ ] Revente d'objets fonctionne avec valuation et Négociation optionnelle
+- [ ] Items restreints filtrés/affichés selon type de marché
+- [ ] Conséquences narratives tracées (decision archi prise)
+- [ ] Clés i18n complètes (en + fr)
+- [ ] Couverture tests Vitest ≥ 80% (logique pure)
+- [ ] Pas de breaking change sur Market existant

--- a/lang/en.json
+++ b/lang/en.json
@@ -1559,7 +1559,9 @@
         "AllSources": "All sources",
         "AffordableOnly": "Affordable only",
         "AffordableOnlyLabel": "Show only items within budget",
-        "AffordableOnlyTooltip": "Show only items the buyer can currently afford"
+        "AffordableOnlyTooltip": "Show only items the buyer can currently afford",
+        "RestrictionLabel": "Restriction Level",
+        "AllRestrictions": "All Restrictions"
       },
       "Sort": {
         "Label": "Sort by",
@@ -1574,6 +1576,11 @@
         "Label": "Reset",
         "Tooltip": "Reset filters and search"
       }
+    },
+    "Restriction": {
+      "Restricted": "Restricted",
+      "Illegal": "Illegal",
+      "Licensed": "Licensed"
     },
     "MarketType": {
       "SelectorLabel": "Market type",

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -1455,7 +1455,9 @@
         "AllSources": "Toutes les sources",
         "AffordableOnly": "Abordables uniquement",
         "AffordableOnlyLabel": "Afficher uniquement les objets dans le budget",
-        "AffordableOnlyTooltip": "Afficher uniquement les objets que l'acheteur peut se permettre"
+        "AffordableOnlyTooltip": "Afficher uniquement les objets que l'acheteur peut se permettre",
+        "RestrictionLabel": "Restriction",
+        "AllRestrictions": "Tous"
       },
       "Sort": {
         "Label": "Trier par",
@@ -1470,6 +1472,11 @@
         "Label": "Réinitialiser",
         "Tooltip": "Réinitialiser les filtres et la recherche"
       }
+    },
+    "Restriction": {
+      "Restricted": "Restreint",
+      "Illegal": "Illégal",
+      "Licensed": "Licencié"
     },
     "MarketType": {
       "SelectorLabel": "Type de marché",

--- a/module/applications/market/compendium-source-adapter.mjs
+++ b/module/applications/market/compendium-source-adapter.mjs
@@ -1,0 +1,59 @@
+import { PURCHASABLE_ITEM_TYPES } from '../../config/market.mjs'
+import { logger } from '../../utils/logger.mjs'
+
+/**
+ * Load all purchasable items from Foundry compendium packs.
+ *
+ * Iterates game.packs, filters Item-type packs, loads the index via getIndex(),
+ * and converts each matching document to a RawItem with sourceType='compendium'
+ * and sourceId=<pack-collection>.
+ *
+ * No eligibility checks here — that is done by the domain layer (catalog-loader).
+ *
+ * @returns {Promise<Array<import('../../lib/market/market-entry.mjs').RawItem>>}
+ *   Array of raw items from packs, ready for domain processing
+ */
+export async function loadCompendiumItems() {
+  const compendiumItems = []
+  const purchasableTypes = Object.keys(PURCHASABLE_ITEM_TYPES)
+
+  for (const pack of game.packs.values()) {
+    // 1. Filter to Item packs only
+    if (pack.documentName !== 'Item') continue
+
+    // 2. Load via index (cheaper than getDocuments for large packs)
+    let indexEntries = []
+    try {
+      const index = await pack.getIndex({
+        fields: ['name', 'img', 'type', 'system.price', 'system.rarity', 'system.restrictionLevel', 'system.quality', 'system.availability'],
+      })
+      indexEntries = Array.from(index.values())
+    } catch (err) {
+      logger.warn(`[Market] Could not load index from pack "${pack.collection}": ${err.message}`)
+      continue
+    }
+
+    // 3. Filter by purchasable type and normalize to RawItem shape
+    for (const doc of indexEntries) {
+      if (!purchasableTypes.includes(doc.type)) continue
+
+      compendiumItems.push({
+        uuid: doc.uuid ?? '',
+        name: doc.name ?? '',
+        img: doc.img ?? '',
+        type: doc.type,
+        basePrice: doc.system?.price ?? 0,
+        rarity: doc.system?.rarity ?? 0,
+        quality: doc.system?.quality ?? '',
+        restrictionLevel: doc.system?.restrictionLevel ?? '',
+        availability: doc.system?.availability ?? undefined,
+        nonPurchasable: false,
+        broken: false,
+        _sourceId: pack.collection,
+      })
+    }
+  }
+
+  logger.debug('[Market] Loaded compendium items', { count: compendiumItems.length })
+  return compendiumItems
+}

--- a/module/applications/market/market-application.mjs
+++ b/module/applications/market/market-application.mjs
@@ -1,6 +1,9 @@
 import { createMarketEntry, resolveMarketCatalogVisibility } from '../../lib/market/market-entry.mjs'
+import { loadMarketCatalog } from '../../lib/market/catalog-loader.mjs'
 import { validatePurchase } from '../../lib/market/purchase.mjs'
+import { readMarketConfig } from '../../lib/market/market-settings.mjs'
 import { PURCHASABLE_ITEM_TYPES, SOURCE_TYPES, DEFAULT_MARKET_CONTEXT, MARKET_TYPES, DEFAULT_MARKET_TYPE } from '../../config/market.mjs'
+import { loadCompendiumItems } from './compendium-source-adapter.mjs'
 import { logger } from '../../utils/logger.mjs'
 
 const { api } = foundry.applications
@@ -211,11 +214,12 @@ export default class MarketApplicationV2 extends api.HandlebarsApplicationMixin(
       const buyer = this._buyerActor
       const buyerCredits = buyer?.system?.creditBudget?.availableCredits ?? buyer?.system?.credits ?? null
 
-      context.catalog = this.#prepareCatalog(buyer, buyerCredits)
+      context.catalog = await this.#prepareCatalog(buyer, buyerCredits)
       context.viewState = { ...this._viewState }
       context.sortOptions = this.#buildSortOptions()
       context.typeFilterOptions = this.#buildTypeFilterOptions()
       context.sourceFilterOptions = this.#buildSourceFilterOptions()
+      context.restrictionFilterOptions = this.#buildRestrictionFilterOptions()
       context.marketTypeOptions = this.#buildMarketTypeOptions()
       context.buyer = buyer
         ? {
@@ -271,6 +275,21 @@ export default class MarketApplicationV2 extends api.HandlebarsApplicationMixin(
   }
 
   /**
+   * Build the list of restriction level filter options.
+   * First entry is the "all restrictions" placeholder.
+   * @returns {Array<{value: string, label: string}>}
+   */
+  #buildRestrictionFilterOptions() {
+    const allOption = { value: '', label: 'MARKET.Toolbar.Filter.AllRestrictions' }
+    const restrictionOptions = [
+      { value: 'restricted', label: 'MARKET.Restriction.Restricted' },
+      { value: 'illegal', label: 'MARKET.Restriction.Illegal' },
+      { value: 'licensed', label: 'MARKET.Restriction.Licensed' },
+    ]
+    return [allOption, ...restrictionOptions]
+  }
+
+  /**
    * Build the list of market type selector options from MARKET_TYPES.
    * @returns {Array<{value: string, label: string, description: string, uiVariant: string}>}
    */
@@ -286,11 +305,12 @@ export default class MarketApplicationV2 extends api.HandlebarsApplicationMixin(
   /* -------------------------------------------- */
 
   /**
-   * Build the filtered, sorted catalogue from World Items as a flat list.
-   * Pipeline: build all eligible entries → apply market-type visibility → apply search → apply filters → sort → annotate with canBuy.
+   * Build the filtered, sorted catalogue from World and Compendium Items as a flat list.
+   * Pipeline: load world+compendium items → domain catalog loader (eligibility, dedup, config)
+   *           → apply market-type visibility → apply search → apply filters → sort → annotate with canBuy.
    * @param {Actor|null} buyer        The buyer actor, or null when browsing without a character context.
    * @param {number|null} buyerCredits  The buyer's current credit balance (null when no buyer).
-   * @returns {{
+   * @returns {Promise<{
    *   items: import('../../lib/market/market-entry.mjs').MarketEntry[],
    *   isEmpty: boolean,
    *   isFilteredEmpty: boolean,
@@ -298,27 +318,39 @@ export default class MarketApplicationV2 extends api.HandlebarsApplicationMixin(
    *   filteredCount: number,
    *   activeMarketType: string,
    *   activeMarketDef: import('../../config/market.mjs').MarketTypeDefinition|null
-   * }}
+   * }>}
    */
-  #prepareCatalog(buyer = null, buyerCredits = null) {
+  async #prepareCatalog(buyer = null, buyerCredits = null) {
     const activeMarketType = this._viewState.activeMarketType ?? DEFAULT_MARKET_TYPE
-
-    // 1. Build all eligible entries from game.items, using active market type for price calculation
-    const allEntries = []
     const marketContext = { ...DEFAULT_MARKET_CONTEXT, marketType: activeMarketType }
-    for (const item of game.items) {
-      try {
-        const rawItem = itemToRawItem(item)
-        const entry = createMarketEntry(rawItem, { sourceType: 'world', sourceId: item.uuid ?? '' }, marketContext)
-        if (!entry.eligible) continue
-        allEntries.push(entry)
-      } catch (err) {
-        // createMarketEntry throws TypeError for non-purchasable item types — skip silently
-        logger.debug(`[Market] Skipping item "${item.name}" (type="${item.type}"): ${err.message}`)
-      }
+    const marketConfig = readMarketConfig('swerpg')
+
+    // 1. Load world items
+    const worldItems = Array.from(game.items).map((item) => itemToRawItem(item))
+
+    // 2. Load compendium items (async)
+    let compendiumItems = []
+    try {
+      compendiumItems = await loadCompendiumItems()
+    } catch (err) {
+      logger.warn('[Market] Could not load compendium items', err)
     }
 
-    // 2. Apply market-type visibility rules (hide items whose availability is not allowed in this market)
+    // 3. Delegate to domain loader (handles eligibility, config filtering, dedup)
+    let allEntries
+    try {
+      allEntries = loadMarketCatalog({
+        worldItems,
+        compendiumItems,
+        config: marketConfig,
+        marketContext,
+      })
+    } catch (err) {
+      logger.error('[Market] Catalog loading failed', err)
+      allEntries = []
+    }
+
+    // 4. Apply market-type visibility rules (hide items whose availability is not allowed in this market)
     const visibleEntries = allEntries.filter((entry) => {
       const { visible } = resolveMarketCatalogVisibility(entry, activeMarketType)
       return visible

--- a/module/lib/market/catalog-loader.mjs
+++ b/module/lib/market/catalog-loader.mjs
@@ -1,0 +1,53 @@
+import { filterByActiveConfig, filterDuplicates } from './source-resolver.mjs'
+import { createMarketEntry } from './market-entry.mjs'
+
+/**
+ * Load the complete Market catalogue from world and compendium sources.
+ *
+ * Deep domain function: pure logic, no Foundry dependencies.
+ * Handles eligibility, deduplication, and price calculation.
+ *
+ * Pipeline:
+ *  1. Tag each raw item with its source type (_sourceType).
+ *  2. Create a MarketEntry per item via createMarketEntry (throws for non-purchasable types → skip).
+ *  3. Filter to eligible entries only.
+ *  4. Apply active config (enabledSources, allowedItemTypes).
+ *  5. Deduplicate by strategy.
+ *
+ * @param {Object} options
+ * @param {Array<import('./market-entry.mjs').RawItem>} options.worldItems         Raw items from game.items or fallback
+ * @param {Array<import('./market-entry.mjs').RawItem>} options.compendiumItems    Raw items from game.packs, with _sourceId
+ * @param {import('../../config/market.mjs').MarketConfig} options.config          Market runtime config
+ * @param {Partial<import('../../config/market.mjs').MarketContext>} options.marketContext  Price context
+ * @returns {import('./market-entry.mjs').MarketEntry[]}  Eligible, deduplicated, priced entries
+ */
+export function loadMarketCatalog({ worldItems, compendiumItems, config, marketContext }) {
+  // 1. Merge sources with proper source type tagging
+  const allRawItems = [
+    ...worldItems.map((item) => ({ ...item, _sourceType: 'world' })),
+    ...compendiumItems.map((item) => ({ ...item, _sourceType: 'compendium' })),
+  ]
+
+  // 2. Create market entries — skip items whose type is not purchasable
+  const entries = allRawItems
+    .map((rawItem) => {
+      try {
+        // For world items, uuid is the source identifier; for compendium items, _sourceId (pack collection) is used.
+        const sourceId = rawItem._sourceType === 'compendium' ? (rawItem._sourceId ?? '') : (rawItem.uuid ?? '')
+        return createMarketEntry(rawItem, { sourceType: rawItem._sourceType, sourceId }, marketContext)
+      } catch {
+        // createMarketEntry throws TypeError for non-purchasable item types — skip silently
+        return null
+      }
+    })
+    .filter(Boolean)
+
+  // 3. Filter to eligible entries only
+  const eligible = entries.filter((entry) => entry.eligible)
+
+  // 4. Filter by active config (enabledSources, allowedItemTypes)
+  const filtered = filterByActiveConfig(eligible, config.enabledSources, config.allowedItemTypes)
+
+  // 5. Deduplicate per strategy
+  return filterDuplicates(filtered, config.dedupStrategy)
+}

--- a/module/lib/market/index.mjs
+++ b/module/lib/market/index.mjs
@@ -3,6 +3,7 @@ export { computeMarketPrice } from './pricing.mjs'
 export { calculateItemPrice } from './price-engine.mjs'
 export { resolveMarketSources, filterDuplicates, filterByActiveConfig, DEDUP_STRATEGIES } from './source-resolver.mjs'
 export { createMarketEntry, resolveMarketCatalogVisibility } from './market-entry.mjs'
+export { loadMarketCatalog } from './catalog-loader.mjs'
 export { validatePurchase } from './purchase.mjs'
 export {
   registerMarketSettings,

--- a/templates/market/market.hbs
+++ b/templates/market/market.hbs
@@ -70,6 +70,15 @@
         {{/each}}
       </select>
 
+      <label for="market-filter-restriction" class="sr-only">{{localize "MARKET.Toolbar.Filter.RestrictionLabel"}}</label>
+      <select id="market-filter-restriction" class="market-toolbar__filter market-toolbar__filter--restriction" aria-label="{{localize 'MARKET.Toolbar.Filter.RestrictionLabel'}}">
+        {{#each restrictionFilterOptions as |opt|}}
+          <option value="{{opt.value}}" {{#if (eq opt.value ../viewState.filterRestriction)}}selected{{/if}}>
+            {{localize opt.label}}
+          </option>
+        {{/each}}
+      </select>
+
       <label class="market-toolbar__filter-label market-toolbar__filter-label--affordable-only"
         data-tooltip="{{localize 'MARKET.Toolbar.Filter.AffordableOnlyTooltip'}}"
         aria-label="{{localize 'MARKET.Toolbar.Filter.AffordableOnlyLabel'}}"

--- a/tests/applications/market/compendium-source-adapter.test.mjs
+++ b/tests/applications/market/compendium-source-adapter.test.mjs
@@ -1,0 +1,231 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+
+import { addPacksMock, setupFoundryMock, teardownFoundryMock } from '../../helpers/mock-foundry.mjs'
+import { loadCompendiumItems } from '../../../module/applications/market/compendium-source-adapter.mjs'
+
+describe('loadCompendiumItems', () => {
+  beforeEach(() => {
+    setupFoundryMock()
+  })
+
+  afterEach(() => {
+    teardownFoundryMock()
+    vi.resetModules()
+  })
+
+  /* -------------------------------------------- */
+  /*  Basic loading                               */
+  /* -------------------------------------------- */
+
+  test('returns empty array when there are no packs', async () => {
+    // game.packs is already an empty Map from setupFoundryMock
+    const result = await loadCompendiumItems()
+    expect(result).toEqual([])
+  })
+
+  test('loads purchasable items from an Item-type pack', async () => {
+    addPacksMock({
+      'swerpg.weapons': {
+        documentName: 'Item',
+        collection: 'swerpg.weapons',
+        documents: [
+          { id: 'w1', name: 'Blaster', type: 'weapon', system: { price: 500, rarity: 0, availability: 'available' } },
+          { id: 'w2', name: 'Rifle', type: 'weapon', system: { price: 1000, rarity: 1, availability: 'rare' } },
+        ],
+      },
+    })
+
+    const result = await loadCompendiumItems()
+
+    expect(result).toHaveLength(2)
+    expect(result[0].name).toBe('Blaster')
+    expect(result[1].name).toBe('Rifle')
+  })
+
+  test('sets _sourceId to the pack collection on each item', async () => {
+    addPacksMock({
+      'swerpg.weapons': {
+        documentName: 'Item',
+        collection: 'swerpg.weapons',
+        documents: [{ id: 'w1', name: 'Blaster', type: 'weapon', system: { price: 500 } }],
+      },
+    })
+
+    const result = await loadCompendiumItems()
+
+    expect(result).toHaveLength(1)
+    expect(result[0]._sourceId).toBe('swerpg.weapons')
+  })
+
+  test('maps system fields to RawItem shape correctly', async () => {
+    addPacksMock({
+      'swerpg.weapons': {
+        documentName: 'Item',
+        collection: 'swerpg.weapons',
+        documents: [
+          {
+            id: 'w1',
+            name: 'Blaster',
+            type: 'weapon',
+            system: { price: 750, rarity: 3, quality: 'superior', restrictionLevel: 'restricted', availability: 'rare' },
+          },
+        ],
+      },
+    })
+
+    const result = await loadCompendiumItems()
+
+    expect(result).toHaveLength(1)
+    const item = result[0]
+    expect(item.name).toBe('Blaster')
+    expect(item.type).toBe('weapon')
+    expect(item.basePrice).toBe(750)
+    expect(item.rarity).toBe(3)
+    expect(item.quality).toBe('superior')
+    expect(item.restrictionLevel).toBe('restricted')
+    expect(item.availability).toBe('rare')
+    expect(item.nonPurchasable).toBe(false)
+    expect(item.broken).toBe(false)
+  })
+
+  /* -------------------------------------------- */
+  /*  Type filtering                              */
+  /* -------------------------------------------- */
+
+  test('filters out non-purchasable item types (e.g. talent)', async () => {
+    addPacksMock({
+      'swerpg.mixed': {
+        documentName: 'Item',
+        collection: 'swerpg.mixed',
+        documents: [
+          { id: 'w1', name: 'Blaster', type: 'weapon', system: { price: 500 } },
+          { id: 't1', name: 'Force Sensitive', type: 'talent', system: {} },
+          { id: 'a1', name: 'Light Armor', type: 'armor', system: { price: 300 } },
+        ],
+      },
+    })
+
+    const result = await loadCompendiumItems()
+
+    expect(result).toHaveLength(2)
+    const types = result.map((item) => item.type)
+    expect(types).toContain('weapon')
+    expect(types).toContain('armor')
+    expect(types).not.toContain('talent')
+  })
+
+  test('filters out career item type', async () => {
+    addPacksMock({
+      'swerpg.items': {
+        documentName: 'Item',
+        collection: 'swerpg.items',
+        documents: [
+          { id: 'c1', name: 'Smuggler', type: 'career', system: {} },
+          { id: 'g1', name: 'Medpac', type: 'gear', system: { price: 25 } },
+        ],
+      },
+    })
+
+    const result = await loadCompendiumItems()
+
+    expect(result).toHaveLength(1)
+    expect(result[0].type).toBe('gear')
+  })
+
+  /* -------------------------------------------- */
+  /*  Non-Item packs                              */
+  /* -------------------------------------------- */
+
+  test('skips non-Item packs (e.g. Actor packs)', async () => {
+    addPacksMock({
+      'swerpg.weapons': {
+        documentName: 'Item',
+        collection: 'swerpg.weapons',
+        documents: [{ id: 'w1', name: 'Blaster', type: 'weapon', system: { price: 500 } }],
+      },
+      'swerpg.actors': {
+        documentName: 'Actor',
+        collection: 'swerpg.actors',
+        documents: [{ id: 'a1', name: 'NPC', type: 'character' }],
+      },
+    })
+
+    const result = await loadCompendiumItems()
+
+    // Only the weapon from the Item pack, not the actor
+    expect(result).toHaveLength(1)
+    expect(result[0].name).toBe('Blaster')
+  })
+
+  /* -------------------------------------------- */
+  /*  Error handling                              */
+  /* -------------------------------------------- */
+
+  test('skips a pack gracefully when getIndex throws', async () => {
+    addPacksMock({
+      'swerpg.weapons': {
+        documentName: 'Item',
+        collection: 'swerpg.weapons',
+        documents: [{ id: 'w1', name: 'Blaster', type: 'weapon', system: { price: 500 } }],
+      },
+    })
+
+    // Override getIndex to simulate a pack error
+    const pack = globalThis.game.packs.get('swerpg.weapons')
+    pack.getIndex = vi.fn().mockRejectedValue(new Error('Pack index unavailable'))
+
+    const result = await loadCompendiumItems()
+
+    // Failing pack is skipped; no items returned
+    expect(result).toHaveLength(0)
+  })
+
+  test('loads items from multiple Item packs', async () => {
+    addPacksMock({
+      'swerpg.weapons': {
+        documentName: 'Item',
+        collection: 'swerpg.weapons',
+        documents: [{ id: 'w1', name: 'Blaster', type: 'weapon', system: { price: 500 } }],
+      },
+      'swerpg.gear': {
+        documentName: 'Item',
+        collection: 'swerpg.gear',
+        documents: [
+          { id: 'g1', name: 'Medpac', type: 'gear', system: { price: 25 } },
+          { id: 'g2', name: 'Stims', type: 'gear', system: { price: 10 } },
+        ],
+      },
+    })
+
+    const result = await loadCompendiumItems()
+
+    expect(result).toHaveLength(3)
+    const names = result.map((item) => item.name)
+    expect(names).toContain('Blaster')
+    expect(names).toContain('Medpac')
+    expect(names).toContain('Stims')
+  })
+
+  test('uses empty string fallback for missing system fields', async () => {
+    addPacksMock({
+      'swerpg.weapons': {
+        documentName: 'Item',
+        collection: 'swerpg.weapons',
+        documents: [
+          // Minimal doc with no system data
+          { id: 'w1', name: 'Mystery Weapon', type: 'weapon' },
+        ],
+      },
+    })
+
+    const result = await loadCompendiumItems()
+
+    expect(result).toHaveLength(1)
+    const item = result[0]
+    expect(item.basePrice).toBe(0)
+    expect(item.rarity).toBe(0)
+    expect(item.quality).toBe('')
+    expect(item.restrictionLevel).toBe('')
+    expect(item.availability).toBeUndefined()
+  })
+})

--- a/tests/helpers/mock-foundry.mjs
+++ b/tests/helpers/mock-foundry.mjs
@@ -780,6 +780,7 @@ export function addPacksMock(packs = {}) {
       index,
       contents: documents,
       getDocument: vi.fn(async (docId) => documents.find((d) => (d.id ?? d._id) === docId) ?? undefined),
+      getIndex: vi.fn(async (_options) => index),
     }
     globalThis.game.packs.set(id, packObj)
   }

--- a/tests/lib/market/catalog-loader.test.mjs
+++ b/tests/lib/market/catalog-loader.test.mjs
@@ -1,0 +1,267 @@
+import { describe, expect, test } from 'vitest'
+
+import { DEFAULT_MARKET_CONFIG, DEFAULT_MARKET_CONTEXT } from '../../../module/config/market.mjs'
+import { loadMarketCatalog } from '../../../module/lib/market/catalog-loader.mjs'
+
+/* -------------------------------------------- */
+/*  Helpers                                     */
+/* -------------------------------------------- */
+
+/**
+ * Minimal world RawItem fixture.
+ * @param {object} [overrides]
+ */
+function makeWorldItem(overrides = {}) {
+  return {
+    uuid: overrides.uuid ?? 'world.test-1',
+    name: overrides.name ?? 'Test Blaster',
+    type: overrides.type ?? 'weapon',
+    basePrice: overrides.basePrice ?? 500,
+    rarity: overrides.rarity ?? 0,
+    availability: overrides.availability ?? 'available',
+    nonPurchasable: overrides.nonPurchasable ?? false,
+    broken: overrides.broken ?? false,
+    ...overrides,
+  }
+}
+
+/**
+ * Minimal compendium RawItem fixture.
+ * @param {object} [overrides]
+ */
+function makeCompendiumItem(overrides = {}) {
+  return {
+    uuid: overrides.uuid ?? 'pack.test-1',
+    name: overrides.name ?? 'Test Rifle',
+    type: overrides.type ?? 'weapon',
+    basePrice: overrides.basePrice ?? 1000,
+    rarity: overrides.rarity ?? 1,
+    availability: overrides.availability ?? 'available',
+    nonPurchasable: overrides.nonPurchasable ?? false,
+    broken: overrides.broken ?? false,
+    _sourceId: overrides._sourceId ?? 'swerpg.weapons',
+    ...overrides,
+  }
+}
+
+/* -------------------------------------------- */
+/*  Tests                                       */
+/* -------------------------------------------- */
+
+describe('loadMarketCatalog', () => {
+  test('merges world and compendium items into a single catalogue', () => {
+    const worldItems = [makeWorldItem({ uuid: 'world.1', name: 'Blaster', type: 'weapon', basePrice: 500 })]
+    const compendiumItems = [makeCompendiumItem({ uuid: 'pack.1', name: 'Rifle', type: 'weapon', basePrice: 1000, _sourceId: 'swerpg.weapons' })]
+
+    const result = loadMarketCatalog({
+      worldItems,
+      compendiumItems,
+      config: DEFAULT_MARKET_CONFIG,
+      marketContext: DEFAULT_MARKET_CONTEXT,
+    })
+
+    expect(result).toHaveLength(2)
+    const names = result.map((e) => e.name)
+    expect(names).toContain('Blaster')
+    expect(names).toContain('Rifle')
+  })
+
+  test('tags world items with sourceType="world"', () => {
+    const worldItems = [makeWorldItem({ uuid: 'world.1', name: 'Blaster' })]
+
+    const result = loadMarketCatalog({
+      worldItems,
+      compendiumItems: [],
+      config: DEFAULT_MARKET_CONFIG,
+      marketContext: DEFAULT_MARKET_CONTEXT,
+    })
+
+    expect(result).toHaveLength(1)
+    expect(result[0].sourceType).toBe('world')
+  })
+
+  test('tags compendium items with sourceType="compendium"', () => {
+    const compendiumItems = [makeCompendiumItem({ uuid: 'pack.1', name: 'Rifle' })]
+
+    const result = loadMarketCatalog({
+      worldItems: [],
+      compendiumItems,
+      config: DEFAULT_MARKET_CONFIG,
+      marketContext: DEFAULT_MARKET_CONTEXT,
+    })
+
+    expect(result).toHaveLength(1)
+    expect(result[0].sourceType).toBe('compendium')
+  })
+
+  test('skips items with non-purchasable types silently', () => {
+    const worldItems = [
+      makeWorldItem({ type: 'talent', name: 'Force Sensitive', basePrice: 0 }),
+      makeWorldItem({ type: 'weapon', name: 'Blaster', basePrice: 500 }),
+    ]
+
+    const result = loadMarketCatalog({
+      worldItems,
+      compendiumItems: [],
+      config: DEFAULT_MARKET_CONFIG,
+      marketContext: DEFAULT_MARKET_CONTEXT,
+    })
+
+    expect(result).toHaveLength(1)
+    expect(result[0].name).toBe('Blaster')
+  })
+
+  test('skips ineligible items (broken=true)', () => {
+    const worldItems = [makeWorldItem({ name: 'Broken Blaster', type: 'weapon', basePrice: 100, broken: true })]
+
+    const result = loadMarketCatalog({
+      worldItems,
+      compendiumItems: [],
+      config: DEFAULT_MARKET_CONFIG,
+      marketContext: DEFAULT_MARKET_CONTEXT,
+    })
+
+    expect(result).toHaveLength(0)
+  })
+
+  test('skips ineligible items (nonPurchasable=true)', () => {
+    const worldItems = [makeWorldItem({ name: 'Excluded Item', type: 'weapon', basePrice: 100, nonPurchasable: true })]
+
+    const result = loadMarketCatalog({
+      worldItems,
+      compendiumItems: [],
+      config: DEFAULT_MARKET_CONFIG,
+      marketContext: DEFAULT_MARKET_CONTEXT,
+    })
+
+    expect(result).toHaveLength(0)
+  })
+
+  test('filters by enabledSources config (only compendium)', () => {
+    const config = { ...DEFAULT_MARKET_CONFIG, enabledSources: ['compendium'] }
+    const worldItems = [makeWorldItem({ uuid: 'world.1', name: 'Blaster', type: 'weapon', basePrice: 500 })]
+    const compendiumItems = [makeCompendiumItem({ uuid: 'pack.1', name: 'Rifle', type: 'weapon', basePrice: 1000, _sourceId: 'swerpg.weapons' })]
+
+    const result = loadMarketCatalog({
+      worldItems,
+      compendiumItems,
+      config,
+      marketContext: DEFAULT_MARKET_CONTEXT,
+    })
+
+    expect(result).toHaveLength(1)
+    expect(result[0].name).toBe('Rifle')
+    expect(result[0].sourceType).toBe('compendium')
+  })
+
+  test('filters by enabledSources config (only world)', () => {
+    const config = { ...DEFAULT_MARKET_CONFIG, enabledSources: ['world'] }
+    const worldItems = [makeWorldItem({ uuid: 'world.1', name: 'Blaster', type: 'weapon', basePrice: 500 })]
+    const compendiumItems = [makeCompendiumItem({ uuid: 'pack.1', name: 'Rifle', type: 'weapon', basePrice: 1000, _sourceId: 'swerpg.weapons' })]
+
+    const result = loadMarketCatalog({
+      worldItems,
+      compendiumItems,
+      config,
+      marketContext: DEFAULT_MARKET_CONTEXT,
+    })
+
+    expect(result).toHaveLength(1)
+    expect(result[0].name).toBe('Blaster')
+    expect(result[0].sourceType).toBe('world')
+  })
+
+  test('filters by allowedItemTypes config (only armor)', () => {
+    const config = { ...DEFAULT_MARKET_CONFIG, allowedItemTypes: ['armor'] }
+    const worldItems = [
+      makeWorldItem({ uuid: 'world.1', name: 'Blaster', type: 'weapon', basePrice: 500 }),
+      makeWorldItem({ uuid: 'world.2', name: 'Light Armor', type: 'armor', basePrice: 300 }),
+    ]
+
+    const result = loadMarketCatalog({
+      worldItems,
+      compendiumItems: [],
+      config,
+      marketContext: DEFAULT_MARKET_CONTEXT,
+    })
+
+    expect(result).toHaveLength(1)
+    expect(result[0].name).toBe('Light Armor')
+    expect(result[0].itemType).toBe('armor')
+  })
+
+  test('deduplicates by prefer-compendium strategy (compendium entry wins)', () => {
+    // Same name+type in world and compendium
+    const worldItems = [makeWorldItem({ uuid: 'world.1', name: 'Blaster', type: 'weapon', basePrice: 500 })]
+    const compendiumItems = [makeCompendiumItem({ uuid: 'pack.1', name: 'Blaster', type: 'weapon', basePrice: 500, _sourceId: 'swerpg.weapons' })]
+
+    const result = loadMarketCatalog({
+      worldItems,
+      compendiumItems,
+      config: DEFAULT_MARKET_CONFIG,
+      marketContext: DEFAULT_MARKET_CONTEXT,
+    })
+
+    expect(result).toHaveLength(1)
+    expect(result[0].sourceType).toBe('compendium')
+  })
+
+  test('keep-all strategy retains both duplicates', () => {
+    const config = { ...DEFAULT_MARKET_CONFIG, dedupStrategy: 'keep-all' }
+    const worldItems = [makeWorldItem({ uuid: 'world.1', name: 'Blaster', type: 'weapon', basePrice: 500 })]
+    const compendiumItems = [makeCompendiumItem({ uuid: 'pack.1', name: 'Blaster', type: 'weapon', basePrice: 500, _sourceId: 'swerpg.weapons' })]
+
+    const result = loadMarketCatalog({
+      worldItems,
+      compendiumItems,
+      config,
+      marketContext: DEFAULT_MARKET_CONTEXT,
+    })
+
+    expect(result).toHaveLength(2)
+  })
+
+  test('returns empty array when both sources are empty', () => {
+    const result = loadMarketCatalog({
+      worldItems: [],
+      compendiumItems: [],
+      config: DEFAULT_MARKET_CONFIG,
+      marketContext: DEFAULT_MARKET_CONTEXT,
+    })
+
+    expect(result).toHaveLength(0)
+  })
+
+  test('sets sourceId from _sourceId on compendium items', () => {
+    const compendiumItems = [makeCompendiumItem({ uuid: 'pack.1', name: 'Rifle', _sourceId: 'swerpg.weapons' })]
+
+    const result = loadMarketCatalog({
+      worldItems: [],
+      compendiumItems,
+      config: DEFAULT_MARKET_CONFIG,
+      marketContext: DEFAULT_MARKET_CONTEXT,
+    })
+
+    expect(result[0].sourceId).toBe('swerpg.weapons')
+  })
+
+  test('all items from both sources are included when no duplicates and config allows all', () => {
+    const worldItems = [
+      makeWorldItem({ uuid: 'world.1', name: 'Blaster', type: 'weapon', basePrice: 100 }),
+      makeWorldItem({ uuid: 'world.2', name: 'Light Armor', type: 'armor', basePrice: 200 }),
+    ]
+    const compendiumItems = [
+      makeCompendiumItem({ uuid: 'pack.1', name: 'Vibro Knife', type: 'weapon', basePrice: 150, _sourceId: 'swerpg.weapons' }),
+      makeCompendiumItem({ uuid: 'pack.2', name: 'Medpac', type: 'gear', basePrice: 25, _sourceId: 'swerpg.gear' }),
+    ]
+
+    const result = loadMarketCatalog({
+      worldItems,
+      compendiumItems,
+      config: DEFAULT_MARKET_CONFIG,
+      marketContext: DEFAULT_MARKET_CONTEXT,
+    })
+
+    expect(result).toHaveLength(4)
+  })
+})


### PR DESCRIPTION
## Summary

- Add a restriction-level filter to the market catalog so items can be filtered by restriction/rarity per planetary region.
- Implement a compendium source adapter and a catalog loader, plus a Market application view to expose the feature in the UI.
- Add unit tests for the catalog loader and compendium source adapter and supporting documentation/plan notes.

## Context

This branch implements the market-side feature to filter catalog entries by restriction level and integrates a compendium source adapter to feed the catalog. Changes touch application code, domain lib, templates, translations and tests. No issue number was referenced in commits.

## Tests

- Not run (not requested).

## Notes

- Key files changed: module/applications/market/compendium-source-adapter.mjs, module/applications/market/market-application.mjs, module/lib/market/catalog-loader.mjs, templates/market/market.hbs, tests/applications/market/compendium-source-adapter.test.mjs, tests/lib/market/catalog-loader.test.mjs, documentation/plan/market/*.prompt.md, documentation/cadrage/market/feature-market-cadrage-metier.md, and translations (lang/en.json, lang/fr.json).
- Diff vs develop: 13 files changed, approximately 1574 insertions and 45 deletions (see diff stats).
