### PR TITLE
feat(market): add Phase 9 market settings and price modifiers

### DIFF
--- a/documentation/plan/market/plan-marketAdvancedGMConfiguration.prompt.md
+++ b/documentation/plan/market/plan-marketAdvancedGMConfiguration.prompt.md
@@ -1,0 +1,514 @@
+# Plan d'Implémentation — Phase 9 — Configuration avancée & panneau de contrôle MJ du Market
+
+**Statut**: Planned  
+**Version**: 1.0  
+**Date de création**: 2026-05-30  
+**Responsable**: SWERPG Dev Team  
+**Portée**: Fournir aux MJ une interface complète pour configurer les sources, types achetables, exclusions manuelles, et modificateurs de prix du Market  
+**Lié à**: Issue #481 (Phase 8 rareté contextuelle par lieu)
+
+---
+
+## 1. Executive Summary
+
+L'issue #482 vise à **donner aux MJ le contrôle total sur la configuration du Market** via une interface dédiée intégrée aux settings du monde Foundry.
+
+### État actuel
+
+- Phases 0–8 ✅ complètes (catalogue, filtres, pricing, achat, marchés contextualisés, négociation, conséquences, rareté locale)
+- Configuration backend ✅ existe (`market-settings.mjs`, registres `PURCHASABLE_ITEM_TYPES`, `SOURCE_TYPES`, `MARKET_TYPES`)
+- **Gap identifié** : Aucune UI d'administration MJ — configuration doit être faite via console ou JSON
+- Impact : MJ ne peut pas facilement gérer les sources, types visibles, ou exclusions manuelles en table
+
+### Objectif principal
+
+Créer un **Market Settings Panel** permettant au MJ de :
+
+1. **Gérer les sources** : configurer quels packs/sources sont scrutés par le Market
+2. **Gérer les types achetables** : autoriser/refuser weapon, armor, gear sélectivement
+3. **Exclure des items manuellement** : marquer items spécifiques comme « non achetables »
+4. **Appliquer des modificateurs globaux** : modifier le prix de base de toutes les armes, armures, etc.
+5. **Configurer les marchés locaux** : définir les rareté-modifiers par planète/lieu
+6. **Tester le catalogue** : aperçu en temps réel des items visibles après filtres appliqués
+
+### Bénéfices
+
+- ✅ MJ en contrôle sans technicité
+- ✅ Prévention d'items non-désirés dans le catalogue
+- ✅ Flexibilité narrative (marché local pauvre vs riche)
+- ✅ Débogage et diagnostic facile du Market
+- ✅ Meilleure expérience de jeu immersive via configuration contextuelle
+
+---
+
+## 2. Vision et Principes Métier — Phase 9
+
+### 2.1 Principes directeurs (du cadrage métier, section 4.4)
+
+1. **Le MJ doit garder le contrôle** : jamais d'automatisation obligatoire ou invisible
+2. **Configuration = propositions système, pas ordres** : le MJ voit ce qui est proposé, valide ou ajuste
+3. **Configurations persistantes** : enregistrées en settings monde, pas en session
+4. **Pas de couplage à une seule vue** : la configuration doit affecter le Market où qu'il soit ouvert
+5. **Diagnostic et auditabilité** : l'UI montre ce qui a été filtré et pourquoi
+
+### 2.2 Modèle de configuration cible
+
+```javascript
+// Existing: module/config/market.mjs → DEFAULT_MARKET_CONFIG
+// + new: Market Settings Panel UI stores per-world
+
+MarketWorldConfig = {
+  enabledSources: ['compendium', 'world'], // Source types actifs
+  allowedItemTypes: ['weapon', 'armor', 'gear'], // Types achetables
+  dedupStrategy: 'prefer-compendium', // Résolution des doublons
+
+  // NEW in Phase 9:
+  excludedItemIds: ['item-uuid-1', 'item-uuid-2'], // Items explicitement exclus
+  typeModifiers: {
+    // Modifiers globaux par type
+    weapon: { priceModifier: 0.1 }, // +10% armes
+    armor: { priceModifier: -0.05 }, // -5% armures
+  },
+
+  locationConfigs: {
+    // Rareté par lieu
+    'Mos Eisley': {
+      planetId: 'Tatooine',
+      preferredMarketType: 'standard',
+      rarityModifiers: { weapon: +1, armor: 0 },
+    },
+    'Core Worlds': {
+      regionId: 'Noyau',
+      preferredMarketType: 'standard',
+      rarityModifiers: { weapon: -1 },
+    },
+  },
+
+  lastUpdated: '2026-05-30T12:00:00Z',
+}
+```
+
+### 2.3 Architecture UI cible
+
+**Location** : Foundry World Settings → System → Market
+
+**Pages/Sections** :
+
+1. **Sources & Types** (tab)
+   - Checkboxes : enabledSources (compendium, world)
+   - Checkboxes : allowedItemTypes (weapon, armor, gear)
+   - Select : dedupStrategy (prefer-compendium, prefer-newest, keep-all)
+
+2. **Prix & Modificateurs** (tab)
+   - Table : type → priceModifier (% or + value)
+   - Global price modifier input
+
+3. **Exclusions manuelles** (tab)
+   - Search/filter itemIds
+   - Button "Add excluded item" → open item searcher
+   - List of excluded items with delete button
+
+4. **Lieux & Rareté contextuelle** (tab)
+   - List of configured locations
+   - Edit location : name, planetId, regionId, rarityModifiers per type
+   - Add/delete location buttons
+
+5. **Aperçu & Diagnostic** (tab)
+   - Button "Scan Market" → shows current visible items count
+   - Button "Export config as JSON"
+   - Button "Reset to defaults"
+
+---
+
+## 3. Architecture Technique — Phase 9
+
+### 3.1 Fichiers existants
+
+```javascript
+module/lib/market/market-settings.mjs
+  ← readMarketConfig()         ✅ Lis settings
+  ← registerMarketSettings()   ✅ Enregistre settings
+  ← Doit être étendu pour nouvelles clés
+
+module/config/market.mjs
+  ← PURCHASABLE_ITEM_TYPES     ✅
+  ← SOURCE_TYPES               ✅
+  ← DEFAULT_MARKET_CONFIG      ✅
+  ← Doit exposer constantes pour panel
+```
+
+### 3.2 Fichiers à créer
+
+```javascript
+// NEW:
+module/applications/settings/market-settings-panel.mjs
+  ← ApplicationV2 pour l'UI
+  ← Onglets : sources, prix, exclusions, lieux, diagnostic
+
+module/lib/market/location-config.mjs
+  ← Logique métier pour gérer locations & rareté contextuelle
+  ← Validation, defaults, persistence
+
+tests/applications/settings/market-settings-panel.test.mjs
+  ← Tests UI save/load
+  ← Tests validation config
+
+tests/lib/market/location-config.test.mjs
+  ← Tests métier lieux
+```
+
+### 3.3 Settings nouvelles
+
+```javascript
+// module/lib/market/market-settings.mjs → Ajouter:
+
+export const SETTING_MARKET_EXCLUDED_ITEMS = 'marketExcludedItems'
+export const SETTING_MARKET_TYPE_MODIFIERS = 'marketTypeModifiers'
+export const SETTING_MARKET_LOCATION_CONFIGS = 'marketLocationConfigs'
+export const SETTING_MARKET_GLOBAL_PRICE_MOD = 'marketGlobalPriceModifier'
+
+export function registerMarketSettingsPhase9() {
+  game.settings.register(systemId, SETTING_MARKET_EXCLUDED_ITEMS, {
+    name: 'SWERPG.SETTINGS.MARKET_EXCLUDED_ITEMS_NAME',
+    hint: 'SWERPG.SETTINGS.MARKET_EXCLUDED_ITEMS_HINT',
+    scope: 'world',
+    config: false, // ← Config via panel, not checkboxes
+    type: String,
+    default: JSON.stringify([]),
+  })
+  // ... register other settings
+}
+
+export function readMarketExcludedItems(systemId) {
+  const raw = game.settings.get(systemId, SETTING_MARKET_EXCLUDED_ITEMS)
+  return JSON.parse(raw ?? '[]')
+}
+
+export async function writeMarketExcludedItems(systemId, items) {
+  return game.settings.set(systemId, SETTING_MARKET_EXCLUDED_ITEMS, JSON.stringify(items))
+}
+```
+
+### 3.4 Integration existante
+
+```javascript
+// module/applications/market/market-application.mjs
+// Utilise readMarketConfig() → ajouter readMarketExcludedItems() check
+
+// module/lib/market/catalog-loader.mjs
+// Ajouter filtre exclusions:
+
+function loadMarketCatalog({ worldItems, compendiumItems, config, marketContext, excludedIds }) {
+  const allRawItems = [
+    ...worldItems.map((item) => ({ ...item, _sourceType: 'world' })),
+    ...compendiumItems.map((item) => ({ ...item, _sourceType: 'compendium' })),
+  ].filter((item) => !excludedIds.includes(item.uuid))
+  // ... rest of logic
+}
+```
+
+---
+
+## 4. Étapes d'implémentation
+
+### Phase 9.1 — Scaffold Settings Panel + Sources & Types
+
+**Objectif** : Créer la classe ApplicationV2 du panel settings avec les deux premiers onglets (sources, types).
+
+| Task   | Description                                             | Priority |
+| ------ | ------------------------------------------------------- | -------- |
+| TASK-1 | Créer `market-settings-panel.mjs` class ApplicationV2   | High     |
+| TASK-2 | Implémenter onglet "Sources & Types" (checkboxes)       | High     |
+| TASK-3 | Implémenter onglet "Diagnostic" (scan + export)         | High     |
+| TASK-4 | Ajouter bouton settings depuis Market ou system startup | High     |
+| TASK-5 | Tests unitaires ApplicationV2 basic rendering           | Medium   |
+
+**Success Criteria** :
+
+- ✅ Panel ouvre depuis Foundry settings without error
+- ✅ Checkboxes reflect `readMarketConfig()`
+- ✅ Click save → stores to settings via `game.settings.set()`
+- ✅ Scan button shows current catalogue count
+
+---
+
+### Phase 9.2 — Exclusions manuelles
+
+**Objectif** : Ajouter onglet exclusions + mettre à jour `catalog-loader.mjs` pour les filtrer.
+
+| Task    | Description                                                | Priority |
+| ------- | ---------------------------------------------------------- | -------- |
+| TASK-6  | Créer `location-config.mjs` domain logic                   | High     |
+| TASK-7  | Implémenter onglet "Exclusions manuelles"                  | High     |
+| TASK-8  | Ajouter item searcher dialog pour ajouter exclusion        | Medium   |
+| TASK-9  | Mettre à jour `catalog-loader.mjs` pour filtrer exclusions | High     |
+| TASK-10 | Tests exclusions filtering                                 | High     |
+
+**Success Criteria** :
+
+- ✅ Excluded items ne s'affichent pas dans le Market
+- ✅ Add/delete buttons fonctionnent
+- ✅ Exclusions persistent après reload
+
+---
+
+### Phase 9.3 — Prix & Modificateurs
+
+**Objectif** : Ajouter onglet modificateurs de prix par type + global.
+
+| Task    | Description                                      | Priority |
+| ------- | ------------------------------------------------ | -------- |
+| TASK-11 | Implémenter onglet "Prix & Modificateurs"        | High     |
+| TASK-12 | Ajouter table type → priceModifier               | High     |
+| TASK-13 | Intégrer global modifier dans `price-engine.mjs` | High     |
+| TASK-14 | Tests prix engine avec modifiers                 | High     |
+
+**Success Criteria** :
+
+- ✅ +10% armor modifier applique d'augmentation à tous les prix armorure
+- ✅ Global -5% applique à tous les items
+- ✅ Market affiche prix final correct avec explication
+
+---
+
+### Phase 9.4 — Configuration lieux & rareté contextuelle
+
+**Objectif** : Onglet complet pour gérer rareté par lieu (intégration Phase 8).
+
+| Task    | Description                                        | Priority |
+| ------- | -------------------------------------------------- | -------- |
+| TASK-15 | Implémenter onglet "Lieux & Rareté"                | High     |
+| TASK-16 | Ajouter UI add/edit/delete location                | High     |
+| TASK-17 | Intégrer dans Market pour filtre location actuelle | Medium   |
+| TASK-18 | Tests location-based rarity filtering              | Medium   |
+
+**Success Criteria** :
+
+- ✅ MJ crée « Mos Eisley » avec weapon +2 rarity
+- ✅ Market filtre items selon location active
+
+---
+
+### Phase 9.5 — Tests E2E + Documentation
+
+**Objectif** : Tests complets panel + docs utilisateur.
+
+| Task    | Description                                           | Priority |
+| ------- | ----------------------------------------------------- | -------- |
+| TASK-19 | E2E tests : open panel → modify config → check Market | High     |
+| TASK-20 | Documentation utilisateur (comment configurer Market) | High     |
+| TASK-21 | i18n keys pour tous onglets panel                     | High     |
+| TASK-22 | Audit et stabilisation                                | Medium   |
+
+---
+
+## 5. Integration Points
+
+### 5.1 ApplicationV2 pattern
+
+```javascript
+export default class MarketSettingsPanel extends api.HandlebarsApplicationMixin(api.ApplicationV2) {
+  static DEFAULT_OPTIONS = {
+    id: 'market-settings-panel',
+    classes: ['swerpg', 'application', 'market-settings-panel'],
+    window: {
+      title: 'MARKET.Settings.Title',
+      minimizable: true,
+      resizable: true,
+    },
+    position: { width: 700, height: 600 },
+    form: { submitOnChange: true },
+    actions: {
+      addExcludedItem: MarketSettingsPanel.#onAddExcludedItem,
+      removeExcludedItem: MarketSettingsPanel.#onRemoveExcludedItem,
+      scanCatalog: MarketSettingsPanel.#onScanCatalog,
+      resetDefaults: MarketSettingsPanel.#onResetDefaults,
+    },
+  }
+
+  static PARTS = {
+    header: { template: 'systems/swerpg/templates/settings/market-header.hbs' },
+    tabs: { template: 'systems/swerpg/templates/settings/market-tabs.hbs' },
+    sources: { template: 'systems/swerpg/templates/settings/market-sources.hbs' },
+    exclusions: { template: 'systems/swerpg/templates/settings/market-exclusions.hbs' },
+    prices: { template: 'systems/swerpg/templates/settings/market-prices.hbs' },
+    locations: { template: 'systems/swerpg/templates/settings/market-locations.hbs' },
+    diagnostic: { template: 'systems/swerpg/templates/settings/market-diagnostic.hbs' },
+  }
+
+  async _prepareContext(options) {
+    const context = await super._prepareContext(options)
+    context.config = readMarketConfig(game.system.id)
+    context.excludedItems = readMarketExcludedItems(game.system.id)
+    context.typeModifiers = readMarketTypeModifiers(game.system.id)
+    context.locationConfigs = readMarketLocationConfigs(game.system.id)
+    context.purchasableTypes = PURCHASABLE_ITEM_TYPES
+    context.sourcesTypes = SOURCE_TYPES
+    return context
+  }
+
+  async _onSubmitForm(event, form, formData) {
+    const pureData = this._processFormData(event, form, formData)
+    // Save to settings
+    await writeMarketConfig(game.system.id, pureData.config)
+    await writeMarketExcludedItems(game.system.id, pureData.excludedItems)
+    await writeMarketTypeModifiers(game.system.id, pureData.typeModifiers)
+    ui.notifications.info('Market settings saved')
+    // Trigger Market refresh if open
+    const market = Object.values(ui.windows).find((w) => w.constructor.name === 'MarketApplicationV2')
+    if (market) await market.render()
+  }
+
+  static async #onAddExcludedItem(event, target) {
+    // Open item searcher, then add UUID to excluded list
+  }
+
+  static async #onScanCatalog(event, target) {
+    // Load catalog with current config, show count
+  }
+}
+```
+
+### 5.2 i18n keys
+
+```json
+{
+  "MARKET.Settings.Title": "Market Configuration",
+  "MARKET.Settings.Tabs.Sources": "Sources & Types",
+  "MARKET.Settings.Tabs.Exclusions": "Exclusions",
+  "MARKET.Settings.Tabs.Prices": "Price Modifiers",
+  "MARKET.Settings.Tabs.Locations": "Locations & Rarity",
+  "MARKET.Settings.Tabs.Diagnostic": "Diagnostic",
+  "MARKET.Settings.Sources.EnabledSources": "Enabled Sources",
+  "MARKET.Settings.Sources.AllowedTypes": "Allowed Item Types",
+  "MARKET.Settings.Exclusions.ManuallyExcluded": "Manually Excluded Items",
+  "MARKET.Settings.Exclusions.AddItem": "Add Excluded Item",
+  "MARKET.Settings.Prices.TypeModifiers": "Price Modifiers by Type",
+  "MARKET.Settings.Prices.Global": "Global Price Modifier (%)",
+  "MARKET.Settings.Locations.ConfiguredLocations": "Configured Market Locations",
+  "MARKET.Settings.Locations.AddLocation": "Add Location",
+  "MARKET.Settings.Diagnostic.ScanCatalog": "Scan Current Catalog",
+  "MARKET.Settings.Diagnostic.Export": "Export Configuration",
+  "MARKET.Settings.Diagnostic.ResetDefaults": "Reset to Defaults"
+}
+```
+
+---
+
+## 6. Dependencies
+
+- `module/applications/market/market-application.mjs` — existing, will be updated
+- `module/lib/market/catalog-loader.mjs` — update to filter exclusions
+- `module/lib/market/price-engine.mjs` — update to apply type modifiers
+- `module/lib/market/market-settings.mjs` — extend with new settings keys
+- Foundry v14 API : `game.settings`, ApplicationV2, Handlebars templates
+
+---
+
+## 7. Files & Artifacts
+
+### New Files
+
+| File                                                         | Purpose                              |
+| ------------------------------------------------------------ | ------------------------------------ |
+| `module/applications/settings/market-settings-panel.mjs`     | Main ApplicationV2 panel             |
+| `module/lib/market/location-config.mjs`                      | Domain logic for location management |
+| `templates/settings/market-header.hbs`                       | Header template                      |
+| `templates/settings/market-tabs.hbs`                         | Tabs container                       |
+| `templates/settings/market-sources.hbs`                      | Sources & types tab                  |
+| `templates/settings/market-exclusions.hbs`                   | Exclusions tab                       |
+| `templates/settings/market-prices.hbs`                       | Price modifiers tab                  |
+| `templates/settings/market-locations.hbs`                    | Locations & rarity tab               |
+| `templates/settings/market-diagnostic.hbs`                   | Diagnostic tab                       |
+| `tests/applications/settings/market-settings-panel.test.mjs` | UI tests                             |
+| `tests/lib/market/location-config.test.mjs`                  | Domain logic tests                   |
+
+### Modified Files
+
+| File                                                | Changes                                       |
+| --------------------------------------------------- | --------------------------------------------- |
+| `module/lib/market/market-settings.mjs`             | Add new setting keys + getters/setters        |
+| `module/lib/market/catalog-loader.mjs`              | Add excludedIds filter                        |
+| `module/lib/market/price-engine.mjs`                | Add type modifiers + global modifier          |
+| `module/applications/market/market-application.mjs` | Read excluded items, refresh on config change |
+| `module/applications/_module.mjs`                   | Export new MarketSettingsPanel class          |
+| `styles/applications.less`                          | Add styles for panel                          |
+
+---
+
+## 8. Testing Strategy
+
+### Unit Tests (Vitest)
+
+- `location-config.test.mjs` : validation, defaults, merging
+- `market-settings-panel.test.mjs` : basic ApplicationV2 rendering, data binding
+
+### Integration Tests (Vitest + mock Foundry)
+
+- Settings save/load cycle
+- Exclusions filtering in catalog-loader
+- Price modifiers applied correctly
+
+### E2E Tests (Playwright)
+
+- Open panel from Market → modify sources → check re-render
+- Add excluded item → verify disappears from catalog
+- Apply price modifier → verify price changes
+
+---
+
+## 9. Risks & Assumptions
+
+| Risk                                                | Mitigation                                                  |
+| --------------------------------------------------- | ----------------------------------------------------------- |
+| Configuration complexity overwhelms MJ              | UX-first design with explanatory text and sensible defaults |
+| Performance : scanning large catalog for diagnostic | Async scan, progress bar, cache results                     |
+| Settings data structure changes                     | Version migrations + fallback to defaults                   |
+| Accidentally breaking existing config (Phase 8+)    | Backward-compatibility checks, defaults                     |
+
+---
+
+## 10. Success Criteria
+
+✅ **Functional Requirements** :
+
+- MJ can open Market Settings Panel from Foundry settings
+- MJ can enable/disable sources, item types
+- MJ can manually exclude specific items (items disappear from Market)
+- MJ can apply global & per-type price modifiers (prices reflect changes)
+- MJ can configure locations with rarity modifiers (filtered per location)
+- MJ can scan catalog and see count of visible items
+
+✅ **Non-Functional Requirements** :
+
+- No console errors or warnings
+- Settings persist across reload
+- Changes reflect in Market immediately
+- Full i18n for all UI strings
+- Tests cover 80%+ code paths
+- E2E basic workflows passing
+
+✅ **Documentation** :
+
+- User tutorial : how to configure
+- Developer API : extending location configs
+
+---
+
+## 11. Related Specifications
+
+- [`feature-market-cadrage-metier.md`](../../cadrage/market/feature-market-cadrage-metier.md) — Section 4.4 « Le MJ doit garder le contrôle »
+- [`feature-market-cadrage-metier.md`](../../cadrage/market/feature-market-cadrage-metier.md) — Section 7.2 « Sources configurables »
+- [`plan-marketAdvancedRarityContextualization.prompt.md`](./plan-marketAdvancedRarityContextualization.prompt.md) — Phase 8 location configs
+- Foundry VTT v14 Settings API : https://foundryvtt.com/api/
+- ApplicationV2 reference : https://foundryvtt.com/api/classes/client.applications.ApplicationV2.html
+
+---
+
+## 12. Suggestions de raffinement (optional)
+
+1. **Settings synchronisation multi-joueurs** : considérer `updateWorldTime` hook pour refesh Market si config change par autre MJ client
+2. **Presets configurés** : « Standard Galactic », « Coruscant Core », « Outer Rim Low Tech »
+3. **Audit trail** : log des modifications de config (qui, quand, quoi changé)
+4. **Templated location configs** : templates maritimes/désertiques/urbains avec presets
+5. **Market locale override** : allow player à surcharger via flag « current location » pendant session

--- a/lang/en.json
+++ b/lang/en.json
@@ -342,6 +342,14 @@
   "SWERPG.SETTINGS.MARKET_ALLOWED_ITEM_TYPES_HINT": "JSON array of item type keys visible in the Market (e.g. [\"weapon\",\"armor\",\"gear\"]). All purchasable types are allowed by default.",
   "SWERPG.SETTINGS.MARKET_DEDUP_STRATEGY_NAME": "Market deduplication strategy",
   "SWERPG.SETTINGS.MARKET_DEDUP_STRATEGY_HINT": "How to handle duplicate items across sources. Options: prefer-compendium, prefer-newest, keep-all.",
+  "SWERPG.SETTINGS.MARKET_EXCLUDED_ITEMS_NAME": "Market manually excluded items",
+  "SWERPG.SETTINGS.MARKET_EXCLUDED_ITEMS_HINT": "JSON array of item UUIDs manually excluded from the Market by the GM.",
+  "SWERPG.SETTINGS.MARKET_TYPE_MODIFIERS_NAME": "Market per-type price modifiers",
+  "SWERPG.SETTINGS.MARKET_TYPE_MODIFIERS_HINT": "JSON object mapping item types to their fractional price modifier (e.g. {\"weapon\":{\"priceModifier\":0.1}}).",
+  "SWERPG.SETTINGS.MARKET_GLOBAL_PRICE_MOD_NAME": "Market global price modifier",
+  "SWERPG.SETTINGS.MARKET_GLOBAL_PRICE_MOD_HINT": "Global percentage modifier applied to all Market item prices (e.g. 10 = +10%, -5 = -5%).",
+  "SWERPG.SETTINGS.MARKET_LOCATION_CONFIGS_NAME": "Market location configurations",
+  "SWERPG.SETTINGS.MARKET_LOCATION_CONFIGS_HINT": "JSON object mapping location names to their rarity and market-type configuration.",
   "ADVERSARY.ThreatMinion": "Minion",
   "ADVERSARY.ThreatNormal": "Normal",
   "ADVERSARY.ThreatElite": "Elite",
@@ -1700,6 +1708,84 @@
       },
       "Negotiable": {
         "Tooltip": "Price negotiable"
+      }
+    },
+    "Settings": {
+      "Title": "Market Configuration",
+      "Subtitle": "Configure sources, prices, exclusions, and locations for the Market.",
+      "MenuName": "Market Configuration",
+      "MenuHint": "Configure which items appear in the Market, their prices, and location-based rarity.",
+      "MenuLabel": "Configure Market",
+      "Save": "Save Settings",
+      "Cancel": "Cancel",
+      "Close": "Close",
+      "SavedSuccess": "Market settings saved successfully.",
+      "SaveError": "Failed to save Market settings.",
+      "Tabs": {
+        "Sources": "Sources & Types",
+        "Prices": "Price Modifiers",
+        "Exclusions": "Exclusions",
+        "Locations": "Locations & Rarity",
+        "Diagnostic": "Diagnostic"
+      },
+      "Sources": {
+        "EnabledSources": "Enabled Sources",
+        "EnabledSourcesHint": "Select which item sources are scanned by the Market.",
+        "AllowedTypes": "Allowed Item Types",
+        "AllowedTypesHint": "Select which item types can appear in the Market.",
+        "DedupStrategy": "Deduplication Strategy",
+        "DedupStrategyHint": "How to handle items that appear in multiple sources.",
+        "DedupPreferCompendium": "Prefer Compendium (recommended)",
+        "DedupPreferNewest": "Prefer Newest",
+        "DedupKeepAll": "Keep All Duplicates"
+      },
+      "Prices": {
+        "Global": "Global Price Modifier",
+        "GlobalHint": "Apply a percentage modifier to all Market item prices. Positive values raise prices; negative values lower them.",
+        "GlobalLabel": "Global modifier",
+        "TypeModifiers": "Per-Type Price Modifiers",
+        "TypeModifiersHint": "Set an additional percentage modifier per item type. These stack with the global modifier.",
+        "TypeColumn": "Item Type",
+        "ModifierColumn": "Modifier"
+      },
+      "Exclusions": {
+        "ManuallyExcluded": "Manually Excluded Items",
+        "ManuallyExcludedHint": "Items listed here will never appear in the Market catalogue, regardless of source or type.",
+        "AddItem": "Add Excluded Item",
+        "AddItemTitle": "Add Item to Exclusion List",
+        "AddItemHint": "Enter the UUID of the item to exclude from the Market.",
+        "UuidLabel": "Item UUID",
+        "RemoveItem": "Remove from exclusion list",
+        "AlreadyExcluded": "This item is already excluded from the Market.",
+        "Empty": "No items are manually excluded."
+      },
+      "Locations": {
+        "ConfiguredLocations": "Configured Market Locations",
+        "ConfiguredLocationsHint": "Define locations with custom rarity modifiers for the Market.",
+        "AddLocation": "Add Location",
+        "AddLocationTitle": "Add Market Location",
+        "NameLabel": "Location Name",
+        "NamePlaceholder": "e.g. Mos Eisley",
+        "RemoveLocation": "Remove location",
+        "AlreadyExists": "A location named \"{name}\" already exists.",
+        "Empty": "No locations configured."
+      },
+      "Diagnostic": {
+        "CatalogScan": "Catalog Scan",
+        "CatalogScanHint": "Scan the Market catalogue with the current configuration and display the number of visible items.",
+        "ScanCatalog": "Scan Current Catalog",
+        "ScanResult": "Visible items in current catalog:",
+        "ScanError": "Catalog scan failed — check the browser console for details.",
+        "ExportTitle": "Export Configuration",
+        "ExportHint": "Export the full Market configuration as JSON (copied to clipboard).",
+        "Export": "Export Configuration",
+        "ExportCopied": "Market configuration copied to clipboard.",
+        "ResetTitle": "Reset to Defaults",
+        "ResetHint": "This will erase all custom Market settings and restore the system defaults. This action cannot be undone.",
+        "ResetDefaults": "Reset to Defaults",
+        "ResetConfirm": "Reset all settings",
+        "ResetContent": "Are you sure you want to reset all Market settings to their defaults? This will remove all exclusions, price modifiers, and location configurations.",
+        "ResetSuccess": "Market settings reset to defaults."
       }
     }
   }

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -311,6 +311,14 @@
   "SWERPG.AUDIT_LOG.EXPORT_FAILED": "Échec de l'export du journal d'évolution du personnage.",
   "SWERPG.SETTINGS.AUDIT_LOG_MAX_ENTRIES_NAME": "Nombre max d'entrées du journal",
   "SWERPG.SETTINGS.AUDIT_LOG_MAX_ENTRIES_HINT": "Nombre maximum d'entrées dans le journal d'évolution du personnage (100-5000). Les plus anciennes sont supprimées en premier lorsque la limite est dépassée.",
+  "SWERPG.SETTINGS.MARKET_EXCLUDED_ITEMS_NAME": "Objets exclus manuellement du marché",
+  "SWERPG.SETTINGS.MARKET_EXCLUDED_ITEMS_HINT": "Tableau JSON d'UUIDs d'objets manuellement exclus du marché par le MJ.",
+  "SWERPG.SETTINGS.MARKET_TYPE_MODIFIERS_NAME": "Modificateurs de prix par type pour le marché",
+  "SWERPG.SETTINGS.MARKET_TYPE_MODIFIERS_HINT": "Objet JSON associant les types d'objets à leur modificateur de prix fractionnaire (ex. {\"weapon\":{\"priceModifier\":0.1}}).",
+  "SWERPG.SETTINGS.MARKET_GLOBAL_PRICE_MOD_NAME": "Modificateur de prix global du marché",
+  "SWERPG.SETTINGS.MARKET_GLOBAL_PRICE_MOD_HINT": "Modificateur de pourcentage global appliqué à tous les prix du marché (ex. 10 = +10%, -5 = -5%).",
+  "SWERPG.SETTINGS.MARKET_LOCATION_CONFIGS_NAME": "Configurations des lieux du marché",
+  "SWERPG.SETTINGS.MARKET_LOCATION_CONFIGS_HINT": "Objet JSON associant les noms de lieux à leur configuration de rareté et de type de marché.",
   "SWERPG.SETTINGS.MARKET_ENABLED_SOURCES_NAME": "Sources actives du marché",
   "SWERPG.SETTINGS.MARKET_ENABLED_SOURCES_HINT": "Tableau JSON des types de sources actives dans le marché (ex. [\"compendium\",\"world\"]). Toutes les sources sont activées par défaut.",
   "SWERPG.SETTINGS.MARKET_ALLOWED_ITEM_TYPES_NAME": "Types d'objets autorisés dans le marché",
@@ -1596,6 +1604,84 @@
       },
       "Negotiable": {
         "Tooltip": "Prix négociable"
+      }
+    },
+    "Settings": {
+      "Title": "Configuration du marché",
+      "Subtitle": "Configurez les sources, prix, exclusions et lieux du marché.",
+      "MenuName": "Configuration du marché",
+      "MenuHint": "Configurez les articles visibles dans le marché, leurs prix et la rareté selon les lieux.",
+      "MenuLabel": "Configurer le marché",
+      "Save": "Enregistrer",
+      "Cancel": "Annuler",
+      "Close": "Fermer",
+      "SavedSuccess": "Configuration du marché enregistrée avec succès.",
+      "SaveError": "Erreur lors de l'enregistrement de la configuration du marché.",
+      "Tabs": {
+        "Sources": "Sources & Types",
+        "Prices": "Modificateurs de prix",
+        "Exclusions": "Exclusions",
+        "Locations": "Lieux & Rareté",
+        "Diagnostic": "Diagnostic"
+      },
+      "Sources": {
+        "EnabledSources": "Sources actives",
+        "EnabledSourcesHint": "Sélectionnez les sources d'objets scannées par le marché.",
+        "AllowedTypes": "Types d'objets autorisés",
+        "AllowedTypesHint": "Sélectionnez les types d'objets pouvant apparaître dans le marché.",
+        "DedupStrategy": "Stratégie de déduplication",
+        "DedupStrategyHint": "Comment gérer les objets présents dans plusieurs sources.",
+        "DedupPreferCompendium": "Préférer le compendium (recommandé)",
+        "DedupPreferNewest": "Préférer le plus récent",
+        "DedupKeepAll": "Conserver tous les doublons"
+      },
+      "Prices": {
+        "Global": "Modificateur de prix global",
+        "GlobalHint": "Applique un modificateur de pourcentage à tous les prix du marché. Les valeurs positives augmentent les prix ; les valeurs négatives les réduisent.",
+        "GlobalLabel": "Modificateur global",
+        "TypeModifiers": "Modificateurs de prix par type",
+        "TypeModifiersHint": "Définissez un modificateur de pourcentage supplémentaire par type d'objet. Ces modificateurs s'ajoutent au modificateur global.",
+        "TypeColumn": "Type d'objet",
+        "ModifierColumn": "Modificateur"
+      },
+      "Exclusions": {
+        "ManuallyExcluded": "Objets exclus manuellement",
+        "ManuallyExcludedHint": "Les objets listés ici n'apparaîtront jamais dans le catalogue du marché, quelle que soit leur source ou leur type.",
+        "AddItem": "Ajouter un objet exclu",
+        "AddItemTitle": "Ajouter un objet à la liste d'exclusion",
+        "AddItemHint": "Saisissez l'UUID de l'objet à exclure du marché.",
+        "UuidLabel": "UUID de l'objet",
+        "RemoveItem": "Retirer de la liste d'exclusion",
+        "AlreadyExcluded": "Cet objet est déjà exclu du marché.",
+        "Empty": "Aucun objet exclu manuellement."
+      },
+      "Locations": {
+        "ConfiguredLocations": "Lieux de marché configurés",
+        "ConfiguredLocationsHint": "Définissez des lieux avec des modificateurs de rareté personnalisés pour le marché.",
+        "AddLocation": "Ajouter un lieu",
+        "AddLocationTitle": "Ajouter un lieu de marché",
+        "NameLabel": "Nom du lieu",
+        "NamePlaceholder": "ex. Mos Eisley",
+        "RemoveLocation": "Supprimer le lieu",
+        "AlreadyExists": "Un lieu nommé \"{name}\" existe déjà.",
+        "Empty": "Aucun lieu configuré."
+      },
+      "Diagnostic": {
+        "CatalogScan": "Analyse du catalogue",
+        "CatalogScanHint": "Scanne le catalogue du marché avec la configuration actuelle et affiche le nombre d'articles visibles.",
+        "ScanCatalog": "Analyser le catalogue",
+        "ScanResult": "Articles visibles dans le catalogue actuel :",
+        "ScanError": "L'analyse du catalogue a échoué — vérifiez la console du navigateur.",
+        "ExportTitle": "Exporter la configuration",
+        "ExportHint": "Exporte la configuration complète du marché au format JSON (copié dans le presse-papiers).",
+        "Export": "Exporter la configuration",
+        "ExportCopied": "Configuration du marché copiée dans le presse-papiers.",
+        "ResetTitle": "Réinitialiser les paramètres",
+        "ResetHint": "Cela effacera tous les paramètres personnalisés du marché et restaurera les valeurs par défaut. Cette action est irréversible.",
+        "ResetDefaults": "Réinitialiser",
+        "ResetConfirm": "Réinitialiser tous les paramètres",
+        "ResetContent": "Êtes-vous sûr de vouloir réinitialiser tous les paramètres du marché ? Cela supprimera toutes les exclusions, les modificateurs de prix et les configurations de lieux.",
+        "ResetSuccess": "Paramètres du marché réinitialisés."
       }
     }
   }

--- a/module/applications/_module.mjs
+++ b/module/applications/_module.mjs
@@ -2,6 +2,7 @@
 export { default as ActionConfig } from './config/action.mjs'
 export { default as CharacterAuditLogApp } from './character-audit-log.mjs'
 export { default as MarketApplicationV2 } from './market/market-application.mjs'
+export { default as MarketSettingsPanel } from './settings/market-settings-panel.mjs'
 export { default as SkillConfig } from './config/skill.mjs'
 export { default as SpecializationTreeApp } from './specialization-tree-app.mjs'
 

--- a/module/applications/market/market-application.mjs
+++ b/module/applications/market/market-application.mjs
@@ -1,7 +1,7 @@
 import { createMarketEntry, resolveMarketCatalogVisibility } from '../../lib/market/market-entry.mjs'
 import { loadMarketCatalog } from '../../lib/market/catalog-loader.mjs'
 import { validatePurchase } from '../../lib/market/purchase.mjs'
-import { readMarketConfig } from '../../lib/market/market-settings.mjs'
+import { readMarketConfig, readMarketExcludedItems } from '../../lib/market/market-settings.mjs'
 import { evaluateObtainability } from '../../lib/market/rarity-engine.mjs'
 import { CONSEQUENCE_TYPES, evaluateMarketConsequences } from '../../lib/market/consequences.mjs'
 import { serializeConsequence } from '../../lib/market/consequence-persistence.mjs'
@@ -332,6 +332,7 @@ export default class MarketApplicationV2 extends api.HandlebarsApplicationMixin(
     const activeMarketType = this._viewState.activeMarketType ?? DEFAULT_MARKET_TYPE
     const marketContext = { ...DEFAULT_MARKET_CONTEXT, marketType: activeMarketType }
     const marketConfig = readMarketConfig('swerpg')
+    const excludedIds = readMarketExcludedItems('swerpg')
 
     // 1. Load world items
     const worldItems = Array.from(game.items).map((item) => itemToRawItem(item))
@@ -344,7 +345,7 @@ export default class MarketApplicationV2 extends api.HandlebarsApplicationMixin(
       logger.warn('[Market] Could not load compendium items', err)
     }
 
-    // 3. Delegate to domain loader (handles eligibility, config filtering, dedup)
+    // 3. Delegate to domain loader (handles eligibility, config filtering, dedup, exclusions)
     let allEntries
     try {
       allEntries = loadMarketCatalog({
@@ -352,6 +353,7 @@ export default class MarketApplicationV2 extends api.HandlebarsApplicationMixin(
         compendiumItems,
         config: marketConfig,
         marketContext,
+        excludedIds,
       })
     } catch (err) {
       logger.error('[Market] Catalog loading failed', err)

--- a/module/applications/market/market-chat.mjs
+++ b/module/applications/market/market-chat.mjs
@@ -80,7 +80,7 @@ export async function buildPurchaseChatData({ buyer, entry, outcome = null, cons
   return {
     content,
     speaker: ChatMessage.getSpeaker({ actor: buyer }),
-    type: CONST.CHAT_MESSAGE_TYPES?.IC ?? CONST.CHAT_MESSAGE_STYLES?.IC ?? 0,
+    type: 'ic',
     flavor: game.i18n.localize('MARKET.Chat.PurchaseTitle'),
   }
 }

--- a/module/applications/market/market-chat.mjs
+++ b/module/applications/market/market-chat.mjs
@@ -80,7 +80,8 @@ export async function buildPurchaseChatData({ buyer, entry, outcome = null, cons
   return {
     content,
     speaker: ChatMessage.getSpeaker({ actor: buyer }),
-    type: 'ic',
     flavor: game.i18n.localize('MARKET.Chat.PurchaseTitle'),
+    // Note: No `type` field - Foundry v14 uses `type` for document types, not message styles.
+    // Use `style: CONST.CHAT_MESSAGE_STYLES.IC` if specific styling is needed.
   }
 }

--- a/module/applications/settings/market-settings-panel.mjs
+++ b/module/applications/settings/market-settings-panel.mjs
@@ -1,0 +1,457 @@
+import {
+  readMarketConfig,
+  writeMarketConfig,
+  readMarketExcludedItems,
+  writeMarketExcludedItems,
+  readMarketTypeModifiers,
+  writeMarketTypeModifiers,
+  readMarketGlobalPriceModifier,
+  writeMarketGlobalPriceModifier,
+  readMarketLocationConfigs,
+  writeMarketLocationConfigs,
+} from '../../lib/market/market-settings.mjs'
+import { createLocationConfig, upsertLocationConfig, removeLocationConfig } from '../../lib/market/location-config.mjs'
+import { loadMarketCatalog } from '../../lib/market/catalog-loader.mjs'
+import { loadCompendiumItems } from '../market/compendium-source-adapter.mjs'
+import { PURCHASABLE_ITEM_TYPES, SOURCE_TYPES, MARKET_TYPES, DEFAULT_MARKET_CONFIG } from '../../config/market.mjs'
+import { logger } from '../../utils/logger.mjs'
+
+const { api } = foundry.applications
+
+/* -------------------------------------------- */
+
+/**
+ * Market Settings Panel — ApplicationV2 providing the GM with a tabbed interface
+ * for configuring all Market settings without touching the Foundry console or JSON.
+ *
+ * Tabs:
+ *   - sources      : enabled sources, allowed item types, dedup strategy
+ *   - prices       : per-type price modifiers + global price modifier
+ *   - exclusions   : manually excluded item UUIDs
+ *   - locations    : location configs with rarity modifiers
+ *   - diagnostic   : catalog scan + export config + reset to defaults
+ */
+export default class MarketSettingsPanel extends api.HandlebarsApplicationMixin(api.ApplicationV2) {
+  /** @inheritDoc */
+  static DEFAULT_OPTIONS = {
+    id: 'market-settings-panel',
+    classes: ['swerpg', 'application', 'market-settings-panel'],
+    window: {
+      title: 'MARKET.Settings.Title',
+      minimizable: true,
+      resizable: true,
+    },
+    position: {
+      width: 720,
+      height: 620,
+    },
+    actions: {
+      addExcludedItem: MarketSettingsPanel.#onAddExcludedItem,
+      removeExcludedItem: MarketSettingsPanel.#onRemoveExcludedItem,
+      addLocation: MarketSettingsPanel.#onAddLocation,
+      removeLocation: MarketSettingsPanel.#onRemoveLocation,
+      scanCatalog: MarketSettingsPanel.#onScanCatalog,
+      exportConfig: MarketSettingsPanel.#onExportConfig,
+      resetDefaults: MarketSettingsPanel.#onResetDefaults,
+      saveSettings: MarketSettingsPanel.#onSaveSettings,
+    },
+  }
+
+  /** @override */
+  static PARTS = {
+    header: { template: 'systems/swerpg/templates/settings/market-header.hbs' },
+    tabs: { template: 'systems/swerpg/templates/settings/market-tabs.hbs' },
+    sources: { template: 'systems/swerpg/templates/settings/market-sources.hbs' },
+    exclusions: { template: 'systems/swerpg/templates/settings/market-exclusions.hbs' },
+    prices: { template: 'systems/swerpg/templates/settings/market-prices.hbs' },
+    locations: { template: 'systems/swerpg/templates/settings/market-locations.hbs' },
+    diagnostic: { template: 'systems/swerpg/templates/settings/market-diagnostic.hbs' },
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Currently active tab.
+   * @type {string}
+   */
+  _activeTab = 'sources'
+
+  /**
+   * Last catalog scan result (count of visible items).
+   * null means no scan has been run yet.
+   * @type {number|null}
+   */
+  _lastScanCount = null
+
+  /* -------------------------------------------- */
+
+  /** @override */
+  async _prepareContext(options) {
+    const context = await super._prepareContext(options)
+    const systemId = game.system.id
+
+    context.activeTab = this._activeTab
+    context.tabs = [
+      { id: 'sources', label: 'MARKET.Settings.Tabs.Sources', icon: 'fa-solid fa-database' },
+      { id: 'prices', label: 'MARKET.Settings.Tabs.Prices', icon: 'fa-solid fa-coins' },
+      { id: 'exclusions', label: 'MARKET.Settings.Tabs.Exclusions', icon: 'fa-solid fa-ban' },
+      { id: 'locations', label: 'MARKET.Settings.Tabs.Locations', icon: 'fa-solid fa-map-location-dot' },
+      { id: 'diagnostic', label: 'MARKET.Settings.Tabs.Diagnostic', icon: 'fa-solid fa-stethoscope' },
+    ]
+
+    context.config = readMarketConfig(systemId)
+    context.excludedItems = readMarketExcludedItems(systemId)
+    context.typeModifiers = readMarketTypeModifiers(systemId)
+    context.globalPriceModifier = readMarketGlobalPriceModifier(systemId)
+    context.locationConfigs = readMarketLocationConfigs(systemId)
+    context.locationList = Object.values(context.locationConfigs)
+    context.lastScanCount = this._lastScanCount
+
+    context.purchasableTypes = Object.values(PURCHASABLE_ITEM_TYPES)
+    context.sourceTypes = Object.values(SOURCE_TYPES)
+    context.marketTypes = Object.values(MARKET_TYPES)
+
+    context.dedupOptions = [
+      { value: 'prefer-compendium', label: 'MARKET.Settings.Sources.DedupPreferCompendium' },
+      { value: 'prefer-newest', label: 'MARKET.Settings.Sources.DedupPreferNewest' },
+      { value: 'keep-all', label: 'MARKET.Settings.Sources.DedupKeepAll' },
+    ]
+
+    return context
+  }
+
+  /** @override */
+  async _preparePartContext(partId, context, options) {
+    context.partId = partId
+    context.isActive = partId === this._activeTab || partId === 'header' || partId === 'tabs'
+    return context
+  }
+
+  /* -------------------------------------------- */
+  /*  Event Listeners                             */
+  /* -------------------------------------------- */
+
+  /** @override */
+  _onRender(context, options) {
+    super._onRender?.(context, options)
+    const html = this.element
+    if (!html) return
+
+    // Tab click handler
+    html.querySelectorAll('.market-settings-panel__tab-link').forEach((el) => {
+      el.addEventListener('click', (event) => {
+        event.preventDefault()
+        const tab = event.currentTarget.dataset?.tab
+        if (tab) {
+          this._activeTab = tab
+          this.render()
+        }
+      })
+    })
+  }
+
+  /* -------------------------------------------- */
+  /*  Actions                                     */
+  /* -------------------------------------------- */
+
+  /**
+   * Collect and save all settings from the current form state.
+   * @this {MarketSettingsPanel}
+   * @param {PointerEvent} _event
+   * @param {HTMLElement}  _target
+   * @returns {Promise<void>}
+   */
+  static async #onSaveSettings(_event, _target) {
+    const systemId = game.system.id
+    const html = this.element
+    if (!html) return
+
+    try {
+      // --- Sources & Types ---
+      const enabledSources = Array.from(html.querySelectorAll('[name="enabledSource"]:checked')).map((el) => el.value)
+      const allowedItemTypes = Array.from(html.querySelectorAll('[name="allowedItemType"]:checked')).map((el) => el.value)
+      const dedupStrategyEl = html.querySelector('[name="dedupStrategy"]')
+      const dedupStrategy = dedupStrategyEl?.value ?? 'prefer-compendium'
+
+      await writeMarketConfig(systemId, { enabledSources, allowedItemTypes, dedupStrategy })
+
+      // --- Global price modifier ---
+      const globalPriceEl = html.querySelector('[name="globalPriceModifier"]')
+      const globalPriceModifier = globalPriceEl ? Number(globalPriceEl.value) || 0 : 0
+      await writeMarketGlobalPriceModifier(systemId, globalPriceModifier)
+
+      // --- Per-type price modifiers ---
+      const typeModifiers = {}
+      html.querySelectorAll('[data-type-modifier]').forEach((el) => {
+        const itemType = el.dataset.typeModifier
+        const value = Number(el.value)
+        if (itemType && Number.isFinite(value)) {
+          typeModifiers[itemType] = { priceModifier: value / 100 }
+        }
+      })
+      await writeMarketTypeModifiers(systemId, typeModifiers)
+
+      ui.notifications.info(game.i18n.localize('MARKET.Settings.SavedSuccess'))
+      logger.info('[MarketSettingsPanel] Settings saved successfully')
+
+      // Trigger Market refresh if open
+      const market = Object.values(ui.windows ?? {}).find((w) => w.constructor.name === 'MarketApplicationV2')
+      if (market) {
+        logger.debug('[MarketSettingsPanel] Refreshing open Market after settings change')
+        await market.render()
+      }
+
+      await this.render()
+    } catch (err) {
+      logger.error('[MarketSettingsPanel] Failed to save settings', err)
+      ui.notifications.error(game.i18n.localize('MARKET.Settings.SaveError'))
+    }
+  }
+
+  /**
+   * Open an item-picker dialog and add the selected item's UUID to the exclusions list.
+   * Falls back to a simple prompt input when no item picker is available.
+   *
+   * @this {MarketSettingsPanel}
+   * @param {PointerEvent} _event
+   * @param {HTMLElement}  _target
+   * @returns {Promise<void>}
+   */
+  static async #onAddExcludedItem(_event, _target) {
+    const systemId = game.system.id
+
+    // Simple prompt fallback — the GM types the UUID manually
+    const uuid = await new Promise((resolve) => {
+      const dialog = new foundry.applications.api.DialogV2({
+        window: { title: game.i18n.localize('MARKET.Settings.Exclusions.AddItemTitle') },
+        content: `<p>${game.i18n.localize('MARKET.Settings.Exclusions.AddItemHint')}</p>
+          <div class="form-group">
+            <label>${game.i18n.localize('MARKET.Settings.Exclusions.UuidLabel')}</label>
+            <input type="text" name="uuid" placeholder="Item.xxxx" />
+          </div>`,
+        buttons: [
+          {
+            action: 'confirm',
+            label: game.i18n.localize('MARKET.Settings.Exclusions.AddItem'),
+            icon: 'fa-solid fa-plus',
+            callback: (event, button, htmlEl) => htmlEl.querySelector('[name="uuid"]')?.value?.trim() ?? '',
+          },
+          { action: 'cancel', label: game.i18n.localize('MARKET.Settings.Cancel'), icon: 'fa-solid fa-xmark' },
+        ],
+        default: 'confirm',
+      })
+      dialog.render(true)
+      dialog.addEventListener('close', () => resolve(null))
+      dialog.addEventListener('button', (data) => {
+        if (data.action === 'confirm') resolve(data.result)
+        else resolve(null)
+      })
+    })
+
+    if (!uuid) return
+
+    const existing = readMarketExcludedItems(systemId)
+    if (existing.includes(uuid)) {
+      ui.notifications.info(game.i18n.localize('MARKET.Settings.Exclusions.AlreadyExcluded'))
+      return
+    }
+
+    await writeMarketExcludedItems(systemId, [...existing, uuid])
+    logger.info('[MarketSettingsPanel] Item excluded from Market', { uuid })
+    await this.render()
+  }
+
+  /**
+   * Remove an item UUID from the exclusions list.
+   *
+   * @this {MarketSettingsPanel}
+   * @param {PointerEvent} _event
+   * @param {HTMLElement}  target   Element bearing data-uuid
+   * @returns {Promise<void>}
+   */
+  static async #onRemoveExcludedItem(_event, target) {
+    const systemId = game.system.id
+    const uuid = target.dataset?.uuid
+    if (!uuid) return
+
+    const existing = readMarketExcludedItems(systemId)
+    const updated = existing.filter((id) => id !== uuid)
+    await writeMarketExcludedItems(systemId, updated)
+    logger.info('[MarketSettingsPanel] Item removed from exclusion list', { uuid })
+    await this.render()
+  }
+
+  /**
+   * Open a dialog to create a new location configuration.
+   *
+   * @this {MarketSettingsPanel}
+   * @param {PointerEvent} _event
+   * @param {HTMLElement}  _target
+   * @returns {Promise<void>}
+   */
+  static async #onAddLocation(_event, _target) {
+    const systemId = game.system.id
+
+    const name = await foundry.applications.api.DialogV2.prompt({
+      window: { title: game.i18n.localize('MARKET.Settings.Locations.AddLocationTitle') },
+      content: `<div class="form-group">
+        <label>${game.i18n.localize('MARKET.Settings.Locations.NameLabel')}</label>
+        <input type="text" name="locationName" placeholder="${game.i18n.localize('MARKET.Settings.Locations.NamePlaceholder')}" />
+      </div>`,
+      label: game.i18n.localize('MARKET.Settings.Locations.AddLocation'),
+      callback: (event, button, htmlEl) => htmlEl.querySelector('[name="locationName"]')?.value?.trim() ?? '',
+    })
+
+    if (!name) return
+
+    const existing = readMarketLocationConfigs(systemId)
+    if (existing[name]) {
+      ui.notifications.warn(game.i18n.format('MARKET.Settings.Locations.AlreadyExists', { name }))
+      return
+    }
+
+    const newConfig = createLocationConfig(name)
+    const updated = upsertLocationConfig(existing, newConfig)
+    await writeMarketLocationConfigs(systemId, updated)
+    logger.info('[MarketSettingsPanel] Location added', { name })
+    await this.render()
+  }
+
+  /**
+   * Remove a location configuration by name.
+   *
+   * @this {MarketSettingsPanel}
+   * @param {PointerEvent} _event
+   * @param {HTMLElement}  target  Element bearing data-location-name
+   * @returns {Promise<void>}
+   */
+  static async #onRemoveLocation(_event, target) {
+    const systemId = game.system.id
+    const name = target.dataset?.locationName
+    if (!name) return
+
+    const existing = readMarketLocationConfigs(systemId)
+    const updated = removeLocationConfig(existing, name)
+    await writeMarketLocationConfigs(systemId, updated)
+    logger.info('[MarketSettingsPanel] Location removed', { name })
+    await this.render()
+  }
+
+  /**
+   * Run a quick catalog scan and display the visible items count.
+   *
+   * @this {MarketSettingsPanel}
+   * @param {PointerEvent} _event
+   * @param {HTMLElement}  _target
+   * @returns {Promise<void>}
+   */
+  static async #onScanCatalog(_event, _target) {
+    try {
+      const systemId = game.system.id
+      const marketConfig = readMarketConfig(systemId)
+      const excludedIds = readMarketExcludedItems(systemId)
+
+      const worldItems = Array.from(game.items).map((item) => ({
+        uuid: item.uuid ?? '',
+        name: item.name ?? '',
+        type: item.type ?? '',
+        basePrice: item.system?._source?.price ?? item.system?.price ?? 0,
+        rarity: item.system?.rarity ?? 0,
+        availability: item.system?.availability ?? undefined,
+        nonPurchasable: item.system?.nonPurchasable === true,
+        broken: item.system?.broken === true,
+      }))
+
+      let compendiumItems = []
+      try {
+        compendiumItems = await loadCompendiumItems()
+      } catch (err) {
+        logger.warn('[MarketSettingsPanel] Could not load compendium items for scan', err)
+      }
+
+      const entries = loadMarketCatalog({
+        worldItems,
+        compendiumItems,
+        config: marketConfig,
+        marketContext: { availability: 'available', marketType: 'standard', manualModifier: 0 },
+        excludedIds,
+      })
+
+      this._lastScanCount = entries.length
+      logger.info('[MarketSettingsPanel] Catalog scan completed', { count: entries.length })
+      ui.notifications.info(game.i18n.format('MARKET.Settings.Diagnostic.ScanResult', { count: entries.length }))
+      await this.render()
+    } catch (err) {
+      logger.error('[MarketSettingsPanel] Catalog scan failed', err)
+      ui.notifications.error(game.i18n.localize('MARKET.Settings.Diagnostic.ScanError'))
+    }
+  }
+
+  /**
+   * Export the current Market configuration as a JSON string copied to clipboard.
+   *
+   * @this {MarketSettingsPanel}
+   * @param {PointerEvent} _event
+   * @param {HTMLElement}  _target
+   * @returns {Promise<void>}
+   */
+  static async #onExportConfig(_event, _target) {
+    const systemId = game.system.id
+    const exportData = {
+      config: readMarketConfig(systemId),
+      excludedItems: readMarketExcludedItems(systemId),
+      typeModifiers: readMarketTypeModifiers(systemId),
+      globalPriceModifier: readMarketGlobalPriceModifier(systemId),
+      locationConfigs: readMarketLocationConfigs(systemId),
+      exportedAt: new Date().toISOString(),
+    }
+
+    const json = JSON.stringify(exportData, null, 2)
+
+    try {
+      await navigator.clipboard.writeText(json)
+      ui.notifications.info(game.i18n.localize('MARKET.Settings.Diagnostic.ExportCopied'))
+    } catch {
+      // Fallback: show in a dialog
+      await foundry.applications.api.DialogV2.prompt({
+        window: { title: game.i18n.localize('MARKET.Settings.Diagnostic.Export') },
+        content: `<textarea rows="16" style="width:100%;font-family:monospace;font-size:0.75em;" readonly>${json}</textarea>`,
+        label: game.i18n.localize('MARKET.Settings.Close'),
+      })
+    }
+
+    logger.info('[MarketSettingsPanel] Configuration exported')
+  }
+
+  /**
+   * Reset all Market settings to their system defaults.
+   *
+   * @this {MarketSettingsPanel}
+   * @param {PointerEvent} _event
+   * @param {HTMLElement}  _target
+   * @returns {Promise<void>}
+   */
+  static async #onResetDefaults(_event, _target) {
+    const confirmed = await foundry.applications.api.DialogV2.confirm({
+      window: { title: game.i18n.localize('MARKET.Settings.Diagnostic.ResetTitle') },
+      content: `<p>${game.i18n.localize('MARKET.Settings.Diagnostic.ResetContent')}</p>`,
+      yes: { label: game.i18n.localize('MARKET.Settings.Diagnostic.ResetConfirm'), icon: 'fa-solid fa-rotate-left' },
+      no: { label: game.i18n.localize('MARKET.Settings.Cancel'), icon: 'fa-solid fa-xmark' },
+    })
+
+    if (!confirmed) return
+
+    const systemId = game.system.id
+
+    await writeMarketConfig(systemId, DEFAULT_MARKET_CONFIG)
+    await writeMarketExcludedItems(systemId, [])
+    await writeMarketTypeModifiers(systemId, {})
+    await writeMarketGlobalPriceModifier(systemId, 0)
+    await writeMarketLocationConfigs(systemId, {})
+
+    this._lastScanCount = null
+    logger.info('[MarketSettingsPanel] All Market settings reset to defaults')
+    ui.notifications.info(game.i18n.localize('MARKET.Settings.Diagnostic.ResetSuccess'))
+    await this.render()
+  }
+}

--- a/module/applications/settings/settings.js
+++ b/module/applications/settings/settings.js
@@ -2,6 +2,7 @@ import * as chat from '../../chat.mjs'
 import { OggDudeDataImporter } from '../../settings/OggDudeDataImporter.mjs'
 import { logger } from '../../utils/logger.mjs'
 import { registerMarketSettings } from '../../lib/market/market-settings.mjs'
+import MarketSettingsPanel from './market-settings-panel.mjs'
 
 export const registerSystemSettings = function () {
   /**
@@ -39,6 +40,17 @@ export const registerSystemSettings = function () {
       label: game.i18n.localize('SETTINGS.OggDudeDataImporter.label'),
       icon: 'fa-solid fa-book-journal-whills',
       type: OggDudeDataImporter,
+      scope: 'world',
+      config: true,
+      restricted: true,
+    })
+
+    game.settings.registerMenu('swerpg', 'marketSettingsPanel', {
+      name: game.i18n.localize('MARKET.Settings.MenuName'),
+      hint: game.i18n.localize('MARKET.Settings.MenuHint'),
+      label: game.i18n.localize('MARKET.Settings.MenuLabel'),
+      icon: 'fa-solid fa-store',
+      type: MarketSettingsPanel,
       scope: 'world',
       config: true,
       restricted: true,
@@ -92,7 +104,7 @@ export const registerSystemSettings = function () {
     default: 0,
   })
 
-  // Market configuration settings
+  // Market configuration settings (Phase 1–9)
   registerMarketSettings(SYSTEM.id)
 
   // Audit Log max entries setting

--- a/module/lib/market/catalog-loader.mjs
+++ b/module/lib/market/catalog-loader.mjs
@@ -9,24 +9,28 @@ import { createMarketEntry } from './market-entry.mjs'
  *
  * Pipeline:
  *  1. Tag each raw item with its source type (_sourceType).
- *  2. Create a MarketEntry per item via createMarketEntry (throws for non-purchasable types → skip).
- *  3. Filter to eligible entries only.
- *  4. Apply active config (enabledSources, allowedItemTypes).
- *  5. Deduplicate by strategy.
+ *  2. Filter out manually excluded items (by UUID in excludedIds).
+ *  3. Create a MarketEntry per item via createMarketEntry (throws for non-purchasable types → skip).
+ *  4. Filter to eligible entries only.
+ *  5. Apply active config (enabledSources, allowedItemTypes).
+ *  6. Deduplicate by strategy.
  *
  * @param {Object} options
  * @param {Array<import('./market-entry.mjs').RawItem>} options.worldItems         Raw items from game.items or fallback
  * @param {Array<import('./market-entry.mjs').RawItem>} options.compendiumItems    Raw items from game.packs, with _sourceId
  * @param {import('../../config/market.mjs').MarketConfig} options.config          Market runtime config
  * @param {Partial<import('../../config/market.mjs').MarketContext>} options.marketContext  Price context
+ * @param {string[]} [options.excludedIds]  Array of item UUIDs manually excluded by the GM
  * @returns {import('./market-entry.mjs').MarketEntry[]}  Eligible, deduplicated, priced entries
  */
-export function loadMarketCatalog({ worldItems, compendiumItems, config, marketContext }) {
+export function loadMarketCatalog({ worldItems, compendiumItems, config, marketContext, excludedIds = [] }) {
+  const excludedSet = new Set(excludedIds)
+
   // 1. Merge sources with proper source type tagging
   const allRawItems = [
     ...worldItems.map((item) => ({ ...item, _sourceType: 'world' })),
     ...compendiumItems.map((item) => ({ ...item, _sourceType: 'compendium' })),
-  ]
+  ].filter((item) => !excludedSet.has(item.uuid))
 
   // 2. Create market entries — skip items whose type is not purchasable
   const entries = allRawItems

--- a/module/lib/market/location-config.mjs
+++ b/module/lib/market/location-config.mjs
@@ -1,0 +1,240 @@
+/**
+ * @typedef {Object} LocationRarityModifiers
+ * @property {number} [weapon]  Rarity offset applied to weapons at this location
+ * @property {number} [armor]   Rarity offset applied to armor at this location
+ * @property {number} [gear]    Rarity offset applied to gear at this location
+ */
+
+/**
+ * @typedef {Object} LocationConfig
+ * @property {string} name                       Display name of the location
+ * @property {string} [planetId]                 Optional planet identifier
+ * @property {string} [regionId]                 Optional region identifier
+ * @property {string} preferredMarketType        Preferred market type key (one of MARKET_TYPES keys)
+ * @property {LocationRarityModifiers} rarityModifiers  Per-type rarity offsets
+ */
+
+/**
+ * @typedef {Record<string, LocationConfig>} LocationConfigMap
+ *   Map of location name (key) to its configuration.
+ */
+
+/* -------------------------------------------- */
+
+/**
+ * Default rarity modifiers with no modifications.
+ * All offsets default to 0 (no effect).
+ * @type {Readonly<LocationRarityModifiers>}
+ */
+export const DEFAULT_RARITY_MODIFIERS = Object.freeze({
+  weapon: 0,
+  armor: 0,
+  gear: 0,
+})
+
+/**
+ * Default location configuration applied when creating a new location.
+ * @type {Readonly<Omit<LocationConfig, 'name'>>}
+ */
+export const DEFAULT_LOCATION_CONFIG = Object.freeze({
+  planetId: '',
+  regionId: '',
+  preferredMarketType: 'standard',
+  rarityModifiers: DEFAULT_RARITY_MODIFIERS,
+})
+
+/* -------------------------------------------- */
+
+/**
+ * Validate a single LocationConfig object.
+ * Returns an array of error strings — empty array means valid.
+ *
+ * Pure domain function — no Foundry dependencies.
+ *
+ * @param {unknown} config  The config to validate
+ * @returns {string[]} Validation error messages
+ */
+export function validateLocationConfig(config) {
+  const errors = []
+
+  if (!config || typeof config !== 'object') {
+    errors.push('LocationConfig must be a plain object')
+    return errors
+  }
+
+  if (typeof config.name !== 'string' || config.name.trim().length === 0) {
+    errors.push('LocationConfig.name must be a non-empty string')
+  }
+
+  if (typeof config.preferredMarketType !== 'string' || config.preferredMarketType.trim().length === 0) {
+    errors.push('LocationConfig.preferredMarketType must be a non-empty string')
+  }
+
+  if (config.rarityModifiers !== undefined) {
+    if (typeof config.rarityModifiers !== 'object' || config.rarityModifiers === null) {
+      errors.push('LocationConfig.rarityModifiers must be an object')
+    } else {
+      for (const [itemType, offset] of Object.entries(config.rarityModifiers)) {
+        if (typeof offset !== 'number' || !Number.isFinite(offset)) {
+          errors.push(`LocationConfig.rarityModifiers.${itemType} must be a finite number`)
+        }
+      }
+    }
+  }
+
+  if (config.planetId !== undefined && typeof config.planetId !== 'string') {
+    errors.push('LocationConfig.planetId must be a string')
+  }
+
+  if (config.regionId !== undefined && typeof config.regionId !== 'string') {
+    errors.push('LocationConfig.regionId must be a string')
+  }
+
+  return errors
+}
+
+/* -------------------------------------------- */
+
+/**
+ * Validate a LocationConfigMap — an object keyed by location name.
+ * Returns an array of error strings — empty array means valid.
+ *
+ * @param {unknown} configMap  The map to validate
+ * @returns {string[]} Validation error messages
+ */
+export function validateLocationConfigMap(configMap) {
+  const errors = []
+
+  if (!configMap || typeof configMap !== 'object' || Array.isArray(configMap)) {
+    errors.push('LocationConfigMap must be a plain object')
+    return errors
+  }
+
+  for (const [key, config] of Object.entries(configMap)) {
+    const configErrors = validateLocationConfig({ ...config, name: key })
+    for (const err of configErrors) {
+      errors.push(`[${key}] ${err}`)
+    }
+  }
+
+  return errors
+}
+
+/* -------------------------------------------- */
+
+/**
+ * Create a new LocationConfig with defaults merged with the provided overrides.
+ * Merges rarityModifiers deeply.
+ *
+ * Pure domain function — no Foundry dependencies.
+ *
+ * @param {string} name       Display name for the location
+ * @param {Partial<LocationConfig>} [overrides]  Optional config overrides
+ * @returns {LocationConfig}
+ * @throws {TypeError} If name is not a non-empty string
+ */
+export function createLocationConfig(name, overrides = {}) {
+  if (typeof name !== 'string' || name.trim().length === 0) {
+    throw new TypeError('createLocationConfig: name must be a non-empty string')
+  }
+
+  const rarityModifiers = {
+    ...DEFAULT_RARITY_MODIFIERS,
+    ...(overrides.rarityModifiers ?? {}),
+  }
+
+  return {
+    name,
+    planetId: overrides.planetId ?? DEFAULT_LOCATION_CONFIG.planetId,
+    regionId: overrides.regionId ?? DEFAULT_LOCATION_CONFIG.regionId,
+    preferredMarketType: overrides.preferredMarketType ?? DEFAULT_LOCATION_CONFIG.preferredMarketType,
+    rarityModifiers,
+  }
+}
+
+/* -------------------------------------------- */
+
+/**
+ * Look up a LocationConfig by name in the given map.
+ * Returns null when the location is not found.
+ *
+ * @param {LocationConfigMap} configMap  The location config map
+ * @param {string}            name       Location name to look up
+ * @returns {LocationConfig|null}
+ */
+export function findLocationConfig(configMap, name) {
+  if (!configMap || typeof name !== 'string') return null
+  return configMap[name] ?? null
+}
+
+/* -------------------------------------------- */
+
+/**
+ * Add or replace a LocationConfig entry in the given map.
+ * Returns a new map — does not mutate the input.
+ *
+ * @param {LocationConfigMap} configMap  The existing map
+ * @param {LocationConfig}    config     The config to add or update (uses config.name as key)
+ * @returns {LocationConfigMap}
+ * @throws {TypeError} If config.name is not a non-empty string
+ */
+export function upsertLocationConfig(configMap, config) {
+  if (!config || typeof config.name !== 'string' || config.name.trim().length === 0) {
+    throw new TypeError('upsertLocationConfig: config.name must be a non-empty string')
+  }
+  return { ...configMap, [config.name]: config }
+}
+
+/* -------------------------------------------- */
+
+/**
+ * Remove a LocationConfig entry from the map by name.
+ * Returns a new map — does not mutate the input.
+ * If the name does not exist in the map, returns the map unchanged.
+ *
+ * @param {LocationConfigMap} configMap  The existing map
+ * @param {string}            name       Location name to remove
+ * @returns {LocationConfigMap}
+ */
+export function removeLocationConfig(configMap, name) {
+  if (!configMap || !name) return configMap ?? {}
+  const { [name]: _removed, ...remaining } = configMap
+  return remaining
+}
+
+/* -------------------------------------------- */
+
+/**
+ * Parse a JSON string into a LocationConfigMap.
+ * Returns an empty object on any parse or validation error.
+ *
+ * @param {string} raw  Raw JSON string
+ * @returns {LocationConfigMap}
+ */
+export function parseLocationConfigMap(raw) {
+  if (typeof raw !== 'string' || raw.trim().length === 0) return {}
+  try {
+    const parsed = JSON.parse(raw)
+    if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) return {}
+    return parsed
+  } catch {
+    return {}
+  }
+}
+
+/* -------------------------------------------- */
+
+/**
+ * Get the rarity offset for a given item type at a specific location.
+ * Returns 0 when the location is not found or has no modifier for the given type.
+ *
+ * @param {LocationConfigMap} configMap   The location config map
+ * @param {string}            locationName  Location name to look up
+ * @param {string}            itemType      Item type key (e.g. 'weapon', 'armor', 'gear')
+ * @returns {number}  Rarity offset (integer or fractional, may be negative)
+ */
+export function getRarityModifierForLocation(configMap, locationName, itemType) {
+  const config = findLocationConfig(configMap, locationName)
+  if (!config) return 0
+  return config.rarityModifiers?.[itemType] ?? 0
+}

--- a/module/lib/market/market-settings.mjs
+++ b/module/lib/market/market-settings.mjs
@@ -1,4 +1,5 @@
 import { DEFAULT_MARKET_CONFIG, MARKET_FLAG_NAMESPACE, MARKET_EXCLUDED_FLAG } from '../../config/market.mjs'
+import { parseLocationConfigMap } from './location-config.mjs'
 import { logger } from '../../utils/logger.mjs'
 
 /**
@@ -21,6 +22,34 @@ export const SETTING_MARKET_ALLOWED_ITEM_TYPES = 'marketAllowedItemTypes'
  * @type {string}
  */
 export const SETTING_MARKET_DEDUP_STRATEGY = 'marketDedupStrategy'
+
+/**
+ * Foundry settings key for Market manually excluded item UUIDs.
+ * Stored as a JSON-serialised array of item UUID strings.
+ * @type {string}
+ */
+export const SETTING_MARKET_EXCLUDED_ITEMS = 'marketExcludedItems'
+
+/**
+ * Foundry settings key for Market per-type price modifiers.
+ * Stored as a JSON-serialised object: { weapon: { priceModifier: 0.1 }, ... }
+ * @type {string}
+ */
+export const SETTING_MARKET_TYPE_MODIFIERS = 'marketTypeModifiers'
+
+/**
+ * Foundry settings key for Market global price modifier (%).
+ * Stored as a number (-100 to +100).
+ * @type {string}
+ */
+export const SETTING_MARKET_GLOBAL_PRICE_MOD = 'marketGlobalPriceModifier'
+
+/**
+ * Foundry settings key for Market location configurations.
+ * Stored as a JSON-serialised LocationConfigMap.
+ * @type {string}
+ */
+export const SETTING_MARKET_LOCATION_CONFIGS = 'marketLocationConfigs'
 
 /* -------------------------------------------- */
 
@@ -56,6 +85,42 @@ export function registerMarketSettings(systemId) {
     config: false,
     type: String,
     default: DEFAULT_MARKET_CONFIG.dedupStrategy,
+  })
+
+  game.settings.register(systemId, SETTING_MARKET_EXCLUDED_ITEMS, {
+    name: 'SWERPG.SETTINGS.MARKET_EXCLUDED_ITEMS_NAME',
+    hint: 'SWERPG.SETTINGS.MARKET_EXCLUDED_ITEMS_HINT',
+    scope: 'world',
+    config: false,
+    type: String,
+    default: JSON.stringify([]),
+  })
+
+  game.settings.register(systemId, SETTING_MARKET_TYPE_MODIFIERS, {
+    name: 'SWERPG.SETTINGS.MARKET_TYPE_MODIFIERS_NAME',
+    hint: 'SWERPG.SETTINGS.MARKET_TYPE_MODIFIERS_HINT',
+    scope: 'world',
+    config: false,
+    type: String,
+    default: JSON.stringify({}),
+  })
+
+  game.settings.register(systemId, SETTING_MARKET_GLOBAL_PRICE_MOD, {
+    name: 'SWERPG.SETTINGS.MARKET_GLOBAL_PRICE_MOD_NAME',
+    hint: 'SWERPG.SETTINGS.MARKET_GLOBAL_PRICE_MOD_HINT',
+    scope: 'world',
+    config: false,
+    type: Number,
+    default: 0,
+  })
+
+  game.settings.register(systemId, SETTING_MARKET_LOCATION_CONFIGS, {
+    name: 'SWERPG.SETTINGS.MARKET_LOCATION_CONFIGS_NAME',
+    hint: 'SWERPG.SETTINGS.MARKET_LOCATION_CONFIGS_HINT',
+    scope: 'world',
+    config: false,
+    type: String,
+    default: JSON.stringify({}),
   })
 }
 
@@ -139,4 +204,147 @@ export function isItemMarketExcluded(item) {
  */
 export async function setItemMarketExcluded(item, excluded) {
   return item.setFlag(MARKET_FLAG_NAMESPACE, MARKET_EXCLUDED_FLAG, excluded === true)
+}
+
+/* -------------------------------------------- */
+
+/**
+ * Read the list of manually excluded item UUIDs from Foundry settings.
+ * Falls back to an empty array on any parse or access error.
+ *
+ * @param {string} systemId  The system ID (e.g. 'swerpg')
+ * @returns {string[]}  Array of item UUIDs excluded from the Market
+ */
+export function readMarketExcludedItems(systemId) {
+  try {
+    const raw = game.settings.get(systemId, SETTING_MARKET_EXCLUDED_ITEMS)
+    if (typeof raw === 'string' && raw.length > 0) {
+      const parsed = JSON.parse(raw)
+      if (Array.isArray(parsed)) return parsed
+    }
+  } catch (err) {
+    logger.warn(`[Market] Could not read setting "${SETTING_MARKET_EXCLUDED_ITEMS}", using default`, err)
+  }
+  return []
+}
+
+/**
+ * Write the list of manually excluded item UUIDs to Foundry settings.
+ *
+ * @param {string}   systemId  The system ID (e.g. 'swerpg')
+ * @param {string[]} items     Array of item UUIDs to exclude
+ * @returns {Promise<void>}
+ */
+export async function writeMarketExcludedItems(systemId, items) {
+  return game.settings.set(systemId, SETTING_MARKET_EXCLUDED_ITEMS, JSON.stringify(items))
+}
+
+/* -------------------------------------------- */
+
+/**
+ * Read per-type price modifiers from Foundry settings.
+ * Returns an object mapping item type keys to { priceModifier: number }.
+ * Falls back to an empty object on any parse or access error.
+ *
+ * @param {string} systemId  The system ID (e.g. 'swerpg')
+ * @returns {Record<string, { priceModifier: number }>}
+ */
+export function readMarketTypeModifiers(systemId) {
+  try {
+    const raw = game.settings.get(systemId, SETTING_MARKET_TYPE_MODIFIERS)
+    if (typeof raw === 'string' && raw.length > 0) {
+      const parsed = JSON.parse(raw)
+      if (typeof parsed === 'object' && parsed !== null && !Array.isArray(parsed)) return parsed
+    }
+  } catch (err) {
+    logger.warn(`[Market] Could not read setting "${SETTING_MARKET_TYPE_MODIFIERS}", using default`, err)
+  }
+  return {}
+}
+
+/**
+ * Write per-type price modifiers to Foundry settings.
+ *
+ * @param {string} systemId  The system ID (e.g. 'swerpg')
+ * @param {Record<string, { priceModifier: number }>} modifiers
+ * @returns {Promise<void>}
+ */
+export async function writeMarketTypeModifiers(systemId, modifiers) {
+  return game.settings.set(systemId, SETTING_MARKET_TYPE_MODIFIERS, JSON.stringify(modifiers))
+}
+
+/* -------------------------------------------- */
+
+/**
+ * Read the global price modifier (%) from Foundry settings.
+ * Returns 0 on any access error.
+ *
+ * @param {string} systemId  The system ID (e.g. 'swerpg')
+ * @returns {number}  Percentage modifier (-100 to +100)
+ */
+export function readMarketGlobalPriceModifier(systemId) {
+  try {
+    const raw = game.settings.get(systemId, SETTING_MARKET_GLOBAL_PRICE_MOD)
+    if (typeof raw === 'number' && Number.isFinite(raw)) return raw
+  } catch (err) {
+    logger.warn(`[Market] Could not read setting "${SETTING_MARKET_GLOBAL_PRICE_MOD}", using default`, err)
+  }
+  return 0
+}
+
+/**
+ * Write the global price modifier (%) to Foundry settings.
+ *
+ * @param {string} systemId  The system ID (e.g. 'swerpg')
+ * @param {number} modifier  Percentage modifier (-100 to +100)
+ * @returns {Promise<void>}
+ */
+export async function writeMarketGlobalPriceModifier(systemId, modifier) {
+  return game.settings.set(systemId, SETTING_MARKET_GLOBAL_PRICE_MOD, modifier)
+}
+
+/* -------------------------------------------- */
+
+/**
+ * Read the location configurations from Foundry settings.
+ * Returns an empty object on any parse or access error.
+ *
+ * @param {string} systemId  The system ID (e.g. 'swerpg')
+ * @returns {import('./location-config.mjs').LocationConfigMap}
+ */
+export function readMarketLocationConfigs(systemId) {
+  try {
+    const raw = game.settings.get(systemId, SETTING_MARKET_LOCATION_CONFIGS)
+    return parseLocationConfigMap(raw)
+  } catch (err) {
+    logger.warn(`[Market] Could not read setting "${SETTING_MARKET_LOCATION_CONFIGS}", using default`, err)
+  }
+  return {}
+}
+
+/**
+ * Write the location configurations to Foundry settings.
+ *
+ * @param {string} systemId  The system ID (e.g. 'swerpg')
+ * @param {import('./location-config.mjs').LocationConfigMap} configs
+ * @returns {Promise<void>}
+ */
+export async function writeMarketLocationConfigs(systemId, configs) {
+  return game.settings.set(systemId, SETTING_MARKET_LOCATION_CONFIGS, JSON.stringify(configs))
+}
+
+/* -------------------------------------------- */
+
+/**
+ * Write the base Market configuration (sources, item types, dedup strategy) to Foundry settings.
+ * Groups the three settings into a single update operation.
+ *
+ * @param {string} systemId  The system ID (e.g. 'swerpg')
+ * @param {import('../../config/market.mjs').MarketConfig} config
+ * @returns {Promise<void>}
+ */
+export async function writeMarketConfig(systemId, config) {
+  await game.settings.set(systemId, SETTING_MARKET_ENABLED_SOURCES, JSON.stringify(config.enabledSources))
+  await game.settings.set(systemId, SETTING_MARKET_ALLOWED_ITEM_TYPES, JSON.stringify(config.allowedItemTypes))
+  await game.settings.set(systemId, SETTING_MARKET_DEDUP_STRATEGY, config.dedupStrategy)
 }

--- a/module/lib/market/price-engine.mjs
+++ b/module/lib/market/price-engine.mjs
@@ -5,6 +5,7 @@ import { computeMarketPrice } from './pricing.mjs'
  * @typedef {Object} ItemData
  * @property {number}  basePrice    Original item price from the data model (>= 0)
  * @property {number}  rarity       Item rarity score (0–10)
+ * @property {string}  [itemType]   Item type key (e.g. 'weapon', 'armor', 'gear') — used for type modifiers
  * @property {string}  [availability]  Availability key — overrides context if provided
  */
 
@@ -25,6 +26,12 @@ import { computeMarketPrice } from './pricing.mjs'
  * @property {PriceModifier[]}  modifiers   Ordered list of modifier steps for traceability
  */
 
+/**
+ * @typedef {Object} PriceEngineOptions
+ * @property {Record<string, { priceModifier: number }>} [typeModifiers]    Per-type price modifiers from GM config
+ * @property {number}                                    [globalModifier]   Global GM price modifier (%)
+ */
+
 /* -------------------------------------------- */
 
 /**
@@ -39,15 +46,25 @@ import { computeMarketPrice } from './pricing.mjs'
  *   2. `marketContext.availability` (context-level)
  *   3. `DEFAULT_MARKET_CONTEXT.availability` (fallback)
  *
+ * Type modifier resolution:
+ *   When `options.typeModifiers` is provided and contains the item's type key,
+ *   that fractional modifier is added to the computation and appears in the
+ *   `modifiers` array with label `'typeModifier'`.
+ *
+ * Global modifier resolution:
+ *   When `options.globalModifier` is non-zero, it is treated as an additional
+ *   GM percentage modifier and stacked on top of `marketContext.manualModifier`.
+ *
  * No Foundry dependencies — accepts plain objects only.
  *
  * @param {ItemData}      itemData       Normalised item data (plain object)
  * @param {Partial<MarketContext>} [marketContext]  Optional market context; merged with defaults
+ * @param {PriceEngineOptions} [options]  Optional extra modifiers from GM advanced config
  * @returns {PriceResult}
  * @throws {TypeError} If basePrice is not a finite non-negative number
  * @throws {TypeError} If rarity is not a finite number
  */
-export function calculateItemPrice(itemData, marketContext = {}) {
+export function calculateItemPrice(itemData, marketContext = {}, options = {}) {
   const ctx = { ...DEFAULT_MARKET_CONTEXT, ...marketContext }
 
   // Item-level availability takes precedence over context
@@ -57,13 +74,20 @@ export function calculateItemPrice(itemData, marketContext = {}) {
   const marketTypeDef = MARKET_TYPES[ctx.marketType]
   const marketTypeModifier = marketTypeDef?.priceModifier ?? 0
 
+  // Per-type price modifier from advanced GM config
+  const typeModifierDef = options.typeModifiers?.[itemData.itemType]
+  const typeModifier = typeof typeModifierDef?.priceModifier === 'number' ? typeModifierDef.priceModifier : 0
+
+  // Global modifier stacks on top of manualModifier
+  const globalModifier = typeof options.globalModifier === 'number' && Number.isFinite(options.globalModifier) ? options.globalModifier : 0
+
   const pricingContext = {
     basePrice: itemData.basePrice,
     rarity: itemData.rarity,
     availability,
-    gmModifier: ctx.manualModifier ?? 0,
+    gmModifier: (ctx.manualModifier ?? 0) + globalModifier,
     marketType: ctx.marketType,
-    marketTypeModifier,
+    marketTypeModifier: marketTypeModifier + typeModifier,
   }
 
   const { finalPrice, basePrice, breakdown } = computeMarketPrice(pricingContext)

--- a/module/models/action.mjs
+++ b/module/models/action.mjs
@@ -1185,7 +1185,7 @@ export default class SwerpgAction extends foundry.abstract.DataModel {
 
     // Create chat message
     const messageData = {
-      type: CONST.CHAT_MESSAGE_TYPES[rolls.length > 0 ? 'ROLL' : 'OTHER'],
+      type: rolls.length > 0 ? 'roll' : 'other',
       content: content,
       speaker: ChatMessage.getSpeaker({ actor: this.actor }),
       rolls: rolls,

--- a/module/utils/audit-log.mjs
+++ b/module/utils/audit-log.mjs
@@ -237,7 +237,7 @@ async function handleWriteError(actor, err) {
         content,
         speaker: ChatMessage.getSpeaker({ actor }),
         whisper: ChatMessage.getWhisperRecipients('GM'),
-        type: CONST.CHAT_MESSAGE_TYPES.WHISPER,
+        type: 'whisper',
       })
     } catch (chatErr) {
       logger.warn('[AuditLog] Failed to send GM whisper for write error:', chatErr)

--- a/templates/settings/market-diagnostic.hbs
+++ b/templates/settings/market-diagnostic.hbs
@@ -1,0 +1,36 @@
+{{#if (eq activeTab "diagnostic")}}
+<section class="market-settings-panel__section market-settings-panel__section--diagnostic" data-application-part="diagnostic">
+  <h3>{{localize "MARKET.Settings.Diagnostic.CatalogScan"}}</h3>
+  <p class="notes">{{localize "MARKET.Settings.Diagnostic.CatalogScanHint"}}</p>
+
+  <div class="market-settings-panel__diagnostic-row">
+    <button type="button" data-action="scanCatalog" class="market-settings-panel__scan-btn">
+      <i class="fa-solid fa-magnifying-glass"></i>
+      {{localize "MARKET.Settings.Diagnostic.ScanCatalog"}}
+    </button>
+    {{#if (notNull lastScanCount)}}
+      <span class="market-settings-panel__scan-result">
+        {{localize "MARKET.Settings.Diagnostic.ScanResult"}} <strong>{{lastScanCount}}</strong>
+      </span>
+    {{/if}}
+  </div>
+
+  <h3>{{localize "MARKET.Settings.Diagnostic.ExportTitle"}}</h3>
+  <p class="notes">{{localize "MARKET.Settings.Diagnostic.ExportHint"}}</p>
+  <div class="market-settings-panel__diagnostic-row">
+    <button type="button" data-action="exportConfig" class="market-settings-panel__export-btn">
+      <i class="fa-solid fa-file-export"></i>
+      {{localize "MARKET.Settings.Diagnostic.Export"}}
+    </button>
+  </div>
+
+  <h3>{{localize "MARKET.Settings.Diagnostic.ResetTitle"}}</h3>
+  <p class="notes hint warning">{{localize "MARKET.Settings.Diagnostic.ResetHint"}}</p>
+  <div class="market-settings-panel__diagnostic-row">
+    <button type="button" data-action="resetDefaults" class="market-settings-panel__reset-btn danger">
+      <i class="fa-solid fa-rotate-left"></i>
+      {{localize "MARKET.Settings.Diagnostic.ResetDefaults"}}
+    </button>
+  </div>
+</section>
+{{/if}}

--- a/templates/settings/market-exclusions.hbs
+++ b/templates/settings/market-exclusions.hbs
@@ -1,0 +1,33 @@
+{{#if (eq activeTab "exclusions")}}
+<section class="market-settings-panel__section market-settings-panel__section--exclusions" data-application-part="exclusions">
+  <h3>{{localize "MARKET.Settings.Exclusions.ManuallyExcluded"}}</h3>
+  <p class="notes">{{localize "MARKET.Settings.Exclusions.ManuallyExcludedHint"}}</p>
+
+  <div class="market-settings-panel__exclusions-toolbar">
+    <button type="button" data-action="addExcludedItem" class="market-settings-panel__add-btn">
+      <i class="fa-solid fa-plus"></i>
+      {{localize "MARKET.Settings.Exclusions.AddItem"}}
+    </button>
+  </div>
+
+  {{#if excludedItems.length}}
+    <ul class="market-settings-panel__exclusions-list">
+      {{#each excludedItems}}
+        <li class="market-settings-panel__exclusion-entry">
+          <span class="market-settings-panel__exclusion-uuid">{{this}}</span>
+          <button type="button"
+                  class="market-settings-panel__remove-btn"
+                  data-action="removeExcludedItem"
+                  data-uuid="{{this}}"
+                  aria-label="{{localize 'MARKET.Settings.Exclusions.RemoveItem'}}"
+                  data-tooltip="{{localize 'MARKET.Settings.Exclusions.RemoveItem'}}">
+            <i class="fa-solid fa-xmark"></i>
+          </button>
+        </li>
+      {{/each}}
+    </ul>
+  {{else}}
+    <p class="market-settings-panel__empty">{{localize "MARKET.Settings.Exclusions.Empty"}}</p>
+  {{/if}}
+</section>
+{{/if}}

--- a/templates/settings/market-header.hbs
+++ b/templates/settings/market-header.hbs
@@ -1,0 +1,4 @@
+<header class="market-settings-panel__header">
+  <h2>{{localize "MARKET.Settings.Title"}}</h2>
+  <p class="market-settings-panel__subtitle">{{localize "MARKET.Settings.Subtitle"}}</p>
+</header>

--- a/templates/settings/market-locations.hbs
+++ b/templates/settings/market-locations.hbs
@@ -1,0 +1,66 @@
+{{#if (eq activeTab "locations")}}
+<section class="market-settings-panel__section market-settings-panel__section--locations" data-application-part="locations">
+  <h3>{{localize "MARKET.Settings.Locations.ConfiguredLocations"}}</h3>
+  <p class="notes">{{localize "MARKET.Settings.Locations.ConfiguredLocationsHint"}}</p>
+
+  <div class="market-settings-panel__locations-toolbar">
+    <button type="button" data-action="addLocation" class="market-settings-panel__add-btn">
+      <i class="fa-solid fa-plus"></i>
+      {{localize "MARKET.Settings.Locations.AddLocation"}}
+    </button>
+  </div>
+
+  {{#if locationList.length}}
+    <ul class="market-settings-panel__locations-list">
+      {{#each locationList}}
+        <li class="market-settings-panel__location-entry">
+          <div class="market-settings-panel__location-header">
+            <strong class="market-settings-panel__location-name">
+              <i class="fa-solid fa-map-location-dot"></i>
+              {{this.name}}
+            </strong>
+            <span class="market-settings-panel__location-type">
+              {{this.preferredMarketType}}
+            </span>
+            <button type="button"
+                    class="market-settings-panel__remove-btn"
+                    data-action="removeLocation"
+                    data-location-name="{{this.name}}"
+                    aria-label="{{localize 'MARKET.Settings.Locations.RemoveLocation'}}"
+                    data-tooltip="{{localize 'MARKET.Settings.Locations.RemoveLocation'}}">
+              <i class="fa-solid fa-trash"></i>
+            </button>
+          </div>
+          {{#if (or this.planetId this.regionId)}}
+            <div class="market-settings-panel__location-meta">
+              {{#if this.planetId}}
+                <span class="market-settings-panel__location-planet">
+                  <i class="fa-solid fa-earth-asia"></i> {{this.planetId}}
+                </span>
+              {{/if}}
+              {{#if this.regionId}}
+                <span class="market-settings-panel__location-region">
+                  <i class="fa-solid fa-compass"></i> {{this.regionId}}
+                </span>
+              {{/if}}
+            </div>
+          {{/if}}
+          {{#if this.rarityModifiers}}
+            <div class="market-settings-panel__location-rarity">
+              {{#each this.rarityModifiers}}
+                {{#unless (eq this 0)}}
+                  <span class="market-settings-panel__rarity-badge {{#if (gt this 0)}}positive{{else}}negative{{/if}}">
+                    {{@key}}: {{#if (gt this 0)}}+{{/if}}{{this}}
+                  </span>
+                {{/unless}}
+              {{/each}}
+            </div>
+          {{/if}}
+        </li>
+      {{/each}}
+    </ul>
+  {{else}}
+    <p class="market-settings-panel__empty">{{localize "MARKET.Settings.Locations.Empty"}}</p>
+  {{/if}}
+</section>
+{{/if}}

--- a/templates/settings/market-prices.hbs
+++ b/templates/settings/market-prices.hbs
@@ -1,0 +1,49 @@
+{{#if (eq activeTab "prices")}}
+<section class="market-settings-panel__section market-settings-panel__section--prices" data-application-part="prices">
+  <h3>{{localize "MARKET.Settings.Prices.Global"}}</h3>
+  <p class="notes">{{localize "MARKET.Settings.Prices.GlobalHint"}}</p>
+  <div class="form-group">
+    <label>{{localize "MARKET.Settings.Prices.GlobalLabel"}}</label>
+    <input type="number" name="globalPriceModifier"
+           value="{{globalPriceModifier}}"
+           min="-100" max="100" step="1"
+           placeholder="0" />
+    <span class="units">%</span>
+  </div>
+
+  <h3>{{localize "MARKET.Settings.Prices.TypeModifiers"}}</h3>
+  <p class="notes">{{localize "MARKET.Settings.Prices.TypeModifiersHint"}}</p>
+  <table class="market-settings-panel__type-modifiers">
+    <thead>
+      <tr>
+        <th>{{localize "MARKET.Settings.Prices.TypeColumn"}}</th>
+        <th>{{localize "MARKET.Settings.Prices.ModifierColumn"}} (%)</th>
+      </tr>
+    </thead>
+    <tbody>
+      {{#each purchasableTypes}}
+        <tr>
+          <td>
+            <i class="{{this.icon}}"></i>
+            {{localize this.label}}
+          </td>
+          <td>
+            <input type="number"
+                   data-type-modifier="{{this.id}}"
+                   value="{{typeModifierPercent ../typeModifiers this.id}}"
+                   min="-100" max="100" step="1"
+                   placeholder="0" />
+          </td>
+        </tr>
+      {{/each}}
+    </tbody>
+  </table>
+
+  <div class="market-settings-panel__actions">
+    <button type="button" data-action="saveSettings" class="market-settings-panel__save-btn">
+      <i class="fa-solid fa-floppy-disk"></i>
+      {{localize "MARKET.Settings.Save"}}
+    </button>
+  </div>
+</section>
+{{/if}}

--- a/templates/settings/market-sources.hbs
+++ b/templates/settings/market-sources.hbs
@@ -1,0 +1,51 @@
+{{#if (eq activeTab "sources")}}
+<section class="market-settings-panel__section market-settings-panel__section--sources" data-application-part="sources">
+  <h3>{{localize "MARKET.Settings.Sources.EnabledSources"}}</h3>
+  <p class="notes">{{localize "MARKET.Settings.Sources.EnabledSourcesHint"}}</p>
+  <div class="form-group market-settings-panel__checkboxes">
+    {{#each sourceTypes}}
+      <label class="checkbox">
+        <input type="checkbox"
+               name="enabledSource"
+               value="{{this.id}}"
+               {{#if (includes ../config.enabledSources this.id)}}checked{{/if}} />
+        {{localize this.label}}
+      </label>
+    {{/each}}
+  </div>
+
+  <h3>{{localize "MARKET.Settings.Sources.AllowedTypes"}}</h3>
+  <p class="notes">{{localize "MARKET.Settings.Sources.AllowedTypesHint"}}</p>
+  <div class="form-group market-settings-panel__checkboxes">
+    {{#each purchasableTypes}}
+      <label class="checkbox">
+        <input type="checkbox"
+               name="allowedItemType"
+               value="{{this.id}}"
+               {{#if (includes ../config.allowedItemTypes this.id)}}checked{{/if}} />
+        <i class="{{this.icon}}"></i>
+        {{localize this.label}}
+      </label>
+    {{/each}}
+  </div>
+
+  <h3>{{localize "MARKET.Settings.Sources.DedupStrategy"}}</h3>
+  <p class="notes">{{localize "MARKET.Settings.Sources.DedupStrategyHint"}}</p>
+  <div class="form-group">
+    <select name="dedupStrategy">
+      {{#each dedupOptions}}
+        <option value="{{this.value}}" {{#if (eq this.value ../config.dedupStrategy)}}selected{{/if}}>
+          {{localize this.label}}
+        </option>
+      {{/each}}
+    </select>
+  </div>
+
+  <div class="market-settings-panel__actions">
+    <button type="button" data-action="saveSettings" class="market-settings-panel__save-btn">
+      <i class="fa-solid fa-floppy-disk"></i>
+      {{localize "MARKET.Settings.Save"}}
+    </button>
+  </div>
+</section>
+{{/if}}

--- a/templates/settings/market-tabs.hbs
+++ b/templates/settings/market-tabs.hbs
@@ -1,0 +1,10 @@
+<nav class="market-settings-panel__tabs">
+  {{#each tabs}}
+    <a class="market-settings-panel__tab-link{{#if (eq this.id ../activeTab)}} active{{/if}}"
+       data-tab="{{this.id}}"
+       aria-label="{{localize this.label}}">
+      <i class="{{this.icon}}"></i>
+      <span>{{localize this.label}}</span>
+    </a>
+  {{/each}}
+</nav>

--- a/tests/applications/settings/market-settings-panel.test.mjs
+++ b/tests/applications/settings/market-settings-panel.test.mjs
@@ -1,0 +1,285 @@
+import { describe, test, expect, beforeEach, vi } from 'vitest'
+import {
+  readMarketExcludedItems,
+  writeMarketExcludedItems,
+  readMarketTypeModifiers,
+  writeMarketTypeModifiers,
+  readMarketGlobalPriceModifier,
+  writeMarketGlobalPriceModifier,
+  readMarketLocationConfigs,
+  writeMarketLocationConfigs,
+  writeMarketConfig,
+  SETTING_MARKET_EXCLUDED_ITEMS,
+  SETTING_MARKET_TYPE_MODIFIERS,
+  SETTING_MARKET_GLOBAL_PRICE_MOD,
+  SETTING_MARKET_LOCATION_CONFIGS,
+} from '../../../module/lib/market/market-settings.mjs'
+
+const SYSTEM_ID = 'swerpg'
+
+/**
+ * Build a minimal game.settings stub with controllable store.
+ */
+function makeSettingsStub(store = {}) {
+  return {
+    register: vi.fn(),
+    get: vi.fn((systemId, key) => store[key] ?? null),
+    set: vi.fn(async (systemId, key, value) => {
+      store[key] = value
+    }),
+  }
+}
+
+/* -------------------------------------------- */
+
+describe('readMarketExcludedItems', () => {
+  beforeEach(() => {
+    global.game = { settings: makeSettingsStub() }
+  })
+
+  test('returns empty array when setting is not set', () => {
+    expect(readMarketExcludedItems(SYSTEM_ID)).toEqual([])
+  })
+
+  test('returns parsed array when stored as JSON', () => {
+    const uuids = ['Item.abc123', 'Compendium.swerpg.weapons.Item.xyz']
+    global.game = { settings: makeSettingsStub({ [SETTING_MARKET_EXCLUDED_ITEMS]: JSON.stringify(uuids) }) }
+    expect(readMarketExcludedItems(SYSTEM_ID)).toEqual(uuids)
+  })
+
+  test('returns empty array on malformed JSON', () => {
+    global.game = { settings: makeSettingsStub({ [SETTING_MARKET_EXCLUDED_ITEMS]: '{broken' }) }
+    expect(readMarketExcludedItems(SYSTEM_ID)).toEqual([])
+  })
+
+  test('returns empty array when stored value is not an array', () => {
+    global.game = { settings: makeSettingsStub({ [SETTING_MARKET_EXCLUDED_ITEMS]: '{"a":1}' }) }
+    expect(readMarketExcludedItems(SYSTEM_ID)).toEqual([])
+  })
+
+  test('returns empty array gracefully when settings.get throws', () => {
+    global.game = {
+      settings: {
+        get: vi.fn(() => {
+          throw new Error('error')
+        }),
+      },
+    }
+    expect(readMarketExcludedItems(SYSTEM_ID)).toEqual([])
+  })
+})
+
+/* -------------------------------------------- */
+
+describe('writeMarketExcludedItems', () => {
+  test('calls settings.set with JSON-serialised array', async () => {
+    const store = {}
+    global.game = { settings: makeSettingsStub(store) }
+    const uuids = ['Item.abc123']
+    await writeMarketExcludedItems(SYSTEM_ID, uuids)
+    expect(store[SETTING_MARKET_EXCLUDED_ITEMS]).toBe(JSON.stringify(uuids))
+  })
+
+  test('persists empty array correctly', async () => {
+    const store = {}
+    global.game = { settings: makeSettingsStub(store) }
+    await writeMarketExcludedItems(SYSTEM_ID, [])
+    expect(store[SETTING_MARKET_EXCLUDED_ITEMS]).toBe('[]')
+  })
+})
+
+/* -------------------------------------------- */
+
+describe('readMarketTypeModifiers', () => {
+  beforeEach(() => {
+    global.game = { settings: makeSettingsStub() }
+  })
+
+  test('returns empty object when setting is not set', () => {
+    expect(readMarketTypeModifiers(SYSTEM_ID)).toEqual({})
+  })
+
+  test('returns parsed object when stored as JSON', () => {
+    const modifiers = { weapon: { priceModifier: 0.1 }, armor: { priceModifier: -0.05 } }
+    global.game = { settings: makeSettingsStub({ [SETTING_MARKET_TYPE_MODIFIERS]: JSON.stringify(modifiers) }) }
+    expect(readMarketTypeModifiers(SYSTEM_ID)).toEqual(modifiers)
+  })
+
+  test('returns empty object on malformed JSON', () => {
+    global.game = { settings: makeSettingsStub({ [SETTING_MARKET_TYPE_MODIFIERS]: '{broken' }) }
+    expect(readMarketTypeModifiers(SYSTEM_ID)).toEqual({})
+  })
+
+  test('returns empty object when stored value is an array', () => {
+    global.game = { settings: makeSettingsStub({ [SETTING_MARKET_TYPE_MODIFIERS]: '[]' }) }
+    expect(readMarketTypeModifiers(SYSTEM_ID)).toEqual({})
+  })
+
+  test('returns empty object gracefully when settings.get throws', () => {
+    global.game = {
+      settings: {
+        get: vi.fn(() => {
+          throw new Error('error')
+        }),
+      },
+    }
+    expect(readMarketTypeModifiers(SYSTEM_ID)).toEqual({})
+  })
+})
+
+/* -------------------------------------------- */
+
+describe('writeMarketTypeModifiers', () => {
+  test('calls settings.set with JSON-serialised object', async () => {
+    const store = {}
+    global.game = { settings: makeSettingsStub(store) }
+    const modifiers = { weapon: { priceModifier: 0.1 } }
+    await writeMarketTypeModifiers(SYSTEM_ID, modifiers)
+    expect(store[SETTING_MARKET_TYPE_MODIFIERS]).toBe(JSON.stringify(modifiers))
+  })
+})
+
+/* -------------------------------------------- */
+
+describe('readMarketGlobalPriceModifier', () => {
+  beforeEach(() => {
+    global.game = { settings: makeSettingsStub() }
+  })
+
+  test('returns 0 when setting is not set', () => {
+    expect(readMarketGlobalPriceModifier(SYSTEM_ID)).toBe(0)
+  })
+
+  test('returns the stored number', () => {
+    global.game = { settings: makeSettingsStub({ [SETTING_MARKET_GLOBAL_PRICE_MOD]: 15 }) }
+    expect(readMarketGlobalPriceModifier(SYSTEM_ID)).toBe(15)
+  })
+
+  test('returns 0 when stored value is NaN', () => {
+    global.game = { settings: makeSettingsStub({ [SETTING_MARKET_GLOBAL_PRICE_MOD]: NaN }) }
+    expect(readMarketGlobalPriceModifier(SYSTEM_ID)).toBe(0)
+  })
+
+  test('returns 0 gracefully when settings.get throws', () => {
+    global.game = {
+      settings: {
+        get: vi.fn(() => {
+          throw new Error('error')
+        }),
+      },
+    }
+    expect(readMarketGlobalPriceModifier(SYSTEM_ID)).toBe(0)
+  })
+
+  test('supports negative values', () => {
+    global.game = { settings: makeSettingsStub({ [SETTING_MARKET_GLOBAL_PRICE_MOD]: -10 }) }
+    expect(readMarketGlobalPriceModifier(SYSTEM_ID)).toBe(-10)
+  })
+})
+
+/* -------------------------------------------- */
+
+describe('writeMarketGlobalPriceModifier', () => {
+  test('calls settings.set with the number', async () => {
+    const store = {}
+    global.game = { settings: makeSettingsStub(store) }
+    await writeMarketGlobalPriceModifier(SYSTEM_ID, 25)
+    expect(store[SETTING_MARKET_GLOBAL_PRICE_MOD]).toBe(25)
+  })
+})
+
+/* -------------------------------------------- */
+
+describe('readMarketLocationConfigs', () => {
+  beforeEach(() => {
+    global.game = { settings: makeSettingsStub() }
+  })
+
+  test('returns empty object when setting is not set', () => {
+    expect(readMarketLocationConfigs(SYSTEM_ID)).toEqual({})
+  })
+
+  test('returns parsed map when stored as JSON', () => {
+    const configs = {
+      'Mos Eisley': { name: 'Mos Eisley', preferredMarketType: 'standard', rarityModifiers: { weapon: 1, armor: 0, gear: 0 } },
+    }
+    global.game = { settings: makeSettingsStub({ [SETTING_MARKET_LOCATION_CONFIGS]: JSON.stringify(configs) }) }
+    const result = readMarketLocationConfigs(SYSTEM_ID)
+    expect(result['Mos Eisley']).toBeDefined()
+    expect(result['Mos Eisley'].preferredMarketType).toBe('standard')
+  })
+
+  test('returns empty object on malformed JSON', () => {
+    global.game = { settings: makeSettingsStub({ [SETTING_MARKET_LOCATION_CONFIGS]: '{broken' }) }
+    expect(readMarketLocationConfigs(SYSTEM_ID)).toEqual({})
+  })
+
+  test('returns empty object gracefully when settings.get throws', () => {
+    global.game = {
+      settings: {
+        get: vi.fn(() => {
+          throw new Error('error')
+        }),
+      },
+    }
+    expect(readMarketLocationConfigs(SYSTEM_ID)).toEqual({})
+  })
+})
+
+/* -------------------------------------------- */
+
+describe('writeMarketLocationConfigs', () => {
+  test('calls settings.set with JSON-serialised map', async () => {
+    const store = {}
+    global.game = { settings: makeSettingsStub(store) }
+    const configs = { 'Mos Eisley': { name: 'Mos Eisley', preferredMarketType: 'standard' } }
+    await writeMarketLocationConfigs(SYSTEM_ID, configs)
+    expect(store[SETTING_MARKET_LOCATION_CONFIGS]).toBe(JSON.stringify(configs))
+  })
+})
+
+/* -------------------------------------------- */
+
+describe('writeMarketConfig', () => {
+  test('writes all three base market settings', async () => {
+    const store = {}
+    global.game = { settings: makeSettingsStub(store) }
+    await writeMarketConfig(SYSTEM_ID, {
+      enabledSources: ['compendium'],
+      allowedItemTypes: ['weapon', 'armor'],
+      dedupStrategy: 'prefer-newest',
+    })
+    expect(store.marketEnabledSources).toBe(JSON.stringify(['compendium']))
+    expect(store.marketAllowedItemTypes).toBe(JSON.stringify(['weapon', 'armor']))
+    expect(store.marketDedupStrategy).toBe('prefer-newest')
+  })
+})
+
+/* -------------------------------------------- */
+
+describe('SETTING_* constant keys', () => {
+  test('SETTING_MARKET_EXCLUDED_ITEMS is a non-empty string', () => {
+    expect(typeof SETTING_MARKET_EXCLUDED_ITEMS).toBe('string')
+    expect(SETTING_MARKET_EXCLUDED_ITEMS.length).toBeGreaterThan(0)
+  })
+
+  test('SETTING_MARKET_TYPE_MODIFIERS is a non-empty string', () => {
+    expect(typeof SETTING_MARKET_TYPE_MODIFIERS).toBe('string')
+    expect(SETTING_MARKET_TYPE_MODIFIERS.length).toBeGreaterThan(0)
+  })
+
+  test('SETTING_MARKET_GLOBAL_PRICE_MOD is a non-empty string', () => {
+    expect(typeof SETTING_MARKET_GLOBAL_PRICE_MOD).toBe('string')
+    expect(SETTING_MARKET_GLOBAL_PRICE_MOD.length).toBeGreaterThan(0)
+  })
+
+  test('SETTING_MARKET_LOCATION_CONFIGS is a non-empty string', () => {
+    expect(typeof SETTING_MARKET_LOCATION_CONFIGS).toBe('string')
+    expect(SETTING_MARKET_LOCATION_CONFIGS.length).toBeGreaterThan(0)
+  })
+
+  test('all four new Phase 9 setting keys are distinct', () => {
+    const keys = new Set([SETTING_MARKET_EXCLUDED_ITEMS, SETTING_MARKET_TYPE_MODIFIERS, SETTING_MARKET_GLOBAL_PRICE_MOD, SETTING_MARKET_LOCATION_CONFIGS])
+    expect(keys.size).toBe(4)
+  })
+})

--- a/tests/applications/settings/settings.test.mjs
+++ b/tests/applications/settings/settings.test.mjs
@@ -38,8 +38,8 @@ describe('System Settings Registration', () => {
     test('should register all system settings', () => {
       registerSystemSettings()
 
-      // Verify all settings were registered (8 core + 3 market = 11 total)
-      expect(mockGameSettings.register).toHaveBeenCalledTimes(11) // 11 settings total
+      // Verify all settings were registered (8 core + 3 original market + 4 phase-9 market = 15 total)
+      expect(mockGameSettings.register).toHaveBeenCalledTimes(15) // 15 settings total
       expect(mockKeybindings.register).toHaveBeenCalledTimes(1) // 1 keybinding
     })
 
@@ -155,9 +155,9 @@ describe('System Settings Registration', () => {
 
         const calls = mockGameSettings.register.mock.calls
 
-        // World-scoped settings (7 core + 3 market = 10)
+        // World-scoped settings (7 core + 3 original market + 4 phase-9 market = 14)
         const worldSettings = calls.filter((call) => call[2].scope === 'world')
-        expect(worldSettings).toHaveLength(10)
+        expect(worldSettings).toHaveLength(14)
 
         // Client-scoped settings
         const clientSettings = calls.filter((call) => call[2].scope === 'client')
@@ -170,9 +170,9 @@ describe('System Settings Registration', () => {
 
         const calls = mockGameSettings.register.mock.calls
 
-        // Hidden settings (config: false) — 5 core + 3 market = 8
+        // Hidden settings (config: false) — 5 core + 3 original market + 4 phase-9 market = 12
         const hiddenSettings = calls.filter((call) => call[2].config === false)
-        expect(hiddenSettings).toHaveLength(8)
+        expect(hiddenSettings).toHaveLength(12)
 
         // Visible settings (config: true)
         const visibleSettings = calls.filter((call) => call[2].config === true)
@@ -190,11 +190,20 @@ describe('System Settings Registration', () => {
 
         const calls = mockGameSettings.register.mock.calls
 
-        // String settings — 2 core + 3 market = 5
+        // String settings — 2 core + 3 original market + 3 phase-9 market (string) = 8
         const stringSettings = calls.filter((call) => call[2].type === String)
-        expect(stringSettings).toHaveLength(5)
+        expect(stringSettings).toHaveLength(8)
         expect(stringSettings.map((call) => call[1])).toEqual(
-          expect.arrayContaining(['systemMigrationVersion', 'worldKey', 'marketEnabledSources', 'marketAllowedItemTypes', 'marketDedupStrategy']),
+          expect.arrayContaining([
+            'systemMigrationVersion',
+            'worldKey',
+            'marketEnabledSources',
+            'marketAllowedItemTypes',
+            'marketDedupStrategy',
+            'marketExcludedItems',
+            'marketTypeModifiers',
+            'marketLocationConfigs',
+          ]),
         )
 
         // Boolean settings
@@ -202,10 +211,12 @@ describe('System Settings Registration', () => {
         expect(booleanSettings).toHaveLength(3)
         expect(booleanSettings.map((call) => call[1])).toEqual(expect.arrayContaining(['devMode', 'actionAnimations', 'welcome']))
 
-        // Number settings
+        // Number settings (autoConfirm, heroism, auditLogMaxEntries, marketGlobalPriceModifier)
         const numberSettings = calls.filter((call) => call[2].type === Number)
-        expect(numberSettings).toHaveLength(3)
-        expect(numberSettings.map((call) => call[1])).toEqual(expect.arrayContaining(['autoConfirm', 'heroism', 'auditLogMaxEntries']))
+        expect(numberSettings).toHaveLength(4)
+        expect(numberSettings.map((call) => call[1])).toEqual(
+          expect.arrayContaining(['autoConfirm', 'heroism', 'auditLogMaxEntries', 'marketGlobalPriceModifier']),
+        )
       })
 
       test('should have correct default values', () => {
@@ -289,8 +300,8 @@ describe('System Settings Registration', () => {
         registerSystemSettings()
         registerSystemSettings()
 
-        // Should have been called twice for each setting (11 settings x 2 calls)
-        expect(mockGameSettings.register).toHaveBeenCalledTimes(22) // 11 settings x 2 calls
+        // Should have been called twice for each setting (15 settings x 2 calls)
+        expect(mockGameSettings.register).toHaveBeenCalledTimes(30) // 15 settings x 2 calls
         expect(mockKeybindings.register).toHaveBeenCalledTimes(2) // 1 keybinding x 2 calls
       })
     })
@@ -312,6 +323,10 @@ describe('System Settings Registration', () => {
           'marketEnabledSources',
           'marketAllowedItemTypes',
           'marketDedupStrategy',
+          'marketExcludedItems',
+          'marketTypeModifiers',
+          'marketGlobalPriceModifier',
+          'marketLocationConfigs',
         ]
 
         for (const key of expectedKeys) {

--- a/tests/lib/market/catalog-loader.test.mjs
+++ b/tests/lib/market/catalog-loader.test.mjs
@@ -264,4 +264,85 @@ describe('loadMarketCatalog', () => {
 
     expect(result).toHaveLength(4)
   })
+
+  test('excludes items whose UUID is in excludedIds', () => {
+    const worldItems = [
+      makeWorldItem({ uuid: 'world.1', name: 'Blaster', type: 'weapon', basePrice: 500 }),
+      makeWorldItem({ uuid: 'world.2', name: 'Light Armor', type: 'armor', basePrice: 300 }),
+    ]
+
+    const result = loadMarketCatalog({
+      worldItems,
+      compendiumItems: [],
+      config: DEFAULT_MARKET_CONFIG,
+      marketContext: DEFAULT_MARKET_CONTEXT,
+      excludedIds: ['world.1'],
+    })
+
+    expect(result).toHaveLength(1)
+    expect(result[0].name).toBe('Light Armor')
+  })
+
+  test('excludes compendium items by UUID', () => {
+    const compendiumItems = [
+      makeCompendiumItem({ uuid: 'pack.1', name: 'Rifle', type: 'weapon', basePrice: 1000, _sourceId: 'swerpg.weapons' }),
+      makeCompendiumItem({ uuid: 'pack.2', name: 'Medpac', type: 'gear', basePrice: 25, _sourceId: 'swerpg.gear' }),
+    ]
+
+    const result = loadMarketCatalog({
+      worldItems: [],
+      compendiumItems,
+      config: DEFAULT_MARKET_CONFIG,
+      marketContext: DEFAULT_MARKET_CONTEXT,
+      excludedIds: ['pack.1'],
+    })
+
+    expect(result).toHaveLength(1)
+    expect(result[0].name).toBe('Medpac')
+  })
+
+  test('excludes no items when excludedIds is empty', () => {
+    const worldItems = [makeWorldItem({ uuid: 'world.1', name: 'Blaster', type: 'weapon', basePrice: 500 })]
+
+    const result = loadMarketCatalog({
+      worldItems,
+      compendiumItems: [],
+      config: DEFAULT_MARKET_CONFIG,
+      marketContext: DEFAULT_MARKET_CONTEXT,
+      excludedIds: [],
+    })
+
+    expect(result).toHaveLength(1)
+  })
+
+  test('excludes all items when all UUIDs are in excludedIds', () => {
+    const worldItems = [
+      makeWorldItem({ uuid: 'world.1', name: 'Blaster', type: 'weapon', basePrice: 500 }),
+      makeWorldItem({ uuid: 'world.2', name: 'Light Armor', type: 'armor', basePrice: 300 }),
+    ]
+
+    const result = loadMarketCatalog({
+      worldItems,
+      compendiumItems: [],
+      config: DEFAULT_MARKET_CONFIG,
+      marketContext: DEFAULT_MARKET_CONTEXT,
+      excludedIds: ['world.1', 'world.2'],
+    })
+
+    expect(result).toHaveLength(0)
+  })
+
+  test('ignores UUIDs in excludedIds that do not match any item', () => {
+    const worldItems = [makeWorldItem({ uuid: 'world.1', name: 'Blaster', type: 'weapon', basePrice: 500 })]
+
+    const result = loadMarketCatalog({
+      worldItems,
+      compendiumItems: [],
+      config: DEFAULT_MARKET_CONFIG,
+      marketContext: DEFAULT_MARKET_CONTEXT,
+      excludedIds: ['nonexistent.uuid'],
+    })
+
+    expect(result).toHaveLength(1)
+  })
 })

--- a/tests/lib/market/location-config.test.mjs
+++ b/tests/lib/market/location-config.test.mjs
@@ -1,0 +1,320 @@
+import { describe, expect, it } from 'vitest'
+import {
+  DEFAULT_RARITY_MODIFIERS,
+  DEFAULT_LOCATION_CONFIG,
+  validateLocationConfig,
+  validateLocationConfigMap,
+  createLocationConfig,
+  findLocationConfig,
+  upsertLocationConfig,
+  removeLocationConfig,
+  parseLocationConfigMap,
+  getRarityModifierForLocation,
+} from '../../../module/lib/market/location-config.mjs'
+
+/* -------------------------------------------- */
+/*  Helpers                                     */
+/* -------------------------------------------- */
+
+function makeLocation(overrides = {}) {
+  return {
+    name: overrides.name ?? 'Mos Eisley',
+    planetId: overrides.planetId ?? 'Tatooine',
+    regionId: overrides.regionId ?? '',
+    preferredMarketType: overrides.preferredMarketType ?? 'standard',
+    rarityModifiers: overrides.rarityModifiers ?? { weapon: 1, armor: 0, gear: 0 },
+  }
+}
+
+/* -------------------------------------------- */
+
+describe('DEFAULT_RARITY_MODIFIERS', () => {
+  it('has weapon, armor, gear all set to 0', () => {
+    expect(DEFAULT_RARITY_MODIFIERS.weapon).toBe(0)
+    expect(DEFAULT_RARITY_MODIFIERS.armor).toBe(0)
+    expect(DEFAULT_RARITY_MODIFIERS.gear).toBe(0)
+  })
+
+  it('is frozen', () => {
+    expect(Object.isFrozen(DEFAULT_RARITY_MODIFIERS)).toBe(true)
+  })
+})
+
+describe('DEFAULT_LOCATION_CONFIG', () => {
+  it('has preferredMarketType set to "standard"', () => {
+    expect(DEFAULT_LOCATION_CONFIG.preferredMarketType).toBe('standard')
+  })
+
+  it('has empty planetId and regionId', () => {
+    expect(DEFAULT_LOCATION_CONFIG.planetId).toBe('')
+    expect(DEFAULT_LOCATION_CONFIG.regionId).toBe('')
+  })
+
+  it('is frozen', () => {
+    expect(Object.isFrozen(DEFAULT_LOCATION_CONFIG)).toBe(true)
+  })
+})
+
+/* -------------------------------------------- */
+
+describe('validateLocationConfig', () => {
+  it('returns empty array for a valid config', () => {
+    const errors = validateLocationConfig(makeLocation())
+    expect(errors).toHaveLength(0)
+  })
+
+  it('returns error when config is not an object', () => {
+    expect(validateLocationConfig(null)).not.toHaveLength(0)
+    expect(validateLocationConfig('string')).not.toHaveLength(0)
+    expect(validateLocationConfig(42)).not.toHaveLength(0)
+  })
+
+  it('returns error when name is empty', () => {
+    const errors = validateLocationConfig({ ...makeLocation(), name: '' })
+    expect(errors.some((e) => e.includes('name'))).toBe(true)
+  })
+
+  it('returns error when name is not a string', () => {
+    const errors = validateLocationConfig({ ...makeLocation(), name: 42 })
+    expect(errors.some((e) => e.includes('name'))).toBe(true)
+  })
+
+  it('returns error when preferredMarketType is empty', () => {
+    const errors = validateLocationConfig({ ...makeLocation(), preferredMarketType: '' })
+    expect(errors.some((e) => e.includes('preferredMarketType'))).toBe(true)
+  })
+
+  it('returns error when rarityModifiers is not an object', () => {
+    const errors = validateLocationConfig({ ...makeLocation(), rarityModifiers: 'bad' })
+    expect(errors.some((e) => e.includes('rarityModifiers'))).toBe(true)
+  })
+
+  it('returns error when rarityModifiers contains non-finite value', () => {
+    const errors = validateLocationConfig({ ...makeLocation(), rarityModifiers: { weapon: NaN } })
+    expect(errors.some((e) => e.includes('rarityModifiers'))).toBe(true)
+  })
+
+  it('returns error when planetId is not a string', () => {
+    const errors = validateLocationConfig({ ...makeLocation(), planetId: 42 })
+    expect(errors.some((e) => e.includes('planetId'))).toBe(true)
+  })
+
+  it('accepts missing optional fields (planetId, regionId, rarityModifiers)', () => {
+    const errors = validateLocationConfig({ name: 'Coruscant', preferredMarketType: 'standard' })
+    expect(errors).toHaveLength(0)
+  })
+})
+
+/* -------------------------------------------- */
+
+describe('validateLocationConfigMap', () => {
+  it('returns empty array for a valid map', () => {
+    const map = { 'Mos Eisley': makeLocation() }
+    const errors = validateLocationConfigMap(map)
+    expect(errors).toHaveLength(0)
+  })
+
+  it('returns error when map is not an object', () => {
+    expect(validateLocationConfigMap(null)).not.toHaveLength(0)
+    expect(validateLocationConfigMap([])).not.toHaveLength(0)
+    expect(validateLocationConfigMap('bad')).not.toHaveLength(0)
+  })
+
+  it('returns errors for each invalid location with key prefix', () => {
+    const map = {
+      'Mos Eisley': { preferredMarketType: '' },
+    }
+    const errors = validateLocationConfigMap(map)
+    expect(errors.some((e) => e.startsWith('[Mos Eisley]'))).toBe(true)
+  })
+
+  it('returns empty array for an empty map', () => {
+    expect(validateLocationConfigMap({})).toHaveLength(0)
+  })
+})
+
+/* -------------------------------------------- */
+
+describe('createLocationConfig', () => {
+  it('creates a valid location with given name and defaults', () => {
+    const loc = createLocationConfig('Mos Eisley')
+    expect(loc.name).toBe('Mos Eisley')
+    expect(loc.preferredMarketType).toBe('standard')
+    expect(loc.planetId).toBe('')
+    expect(loc.regionId).toBe('')
+    expect(loc.rarityModifiers).toEqual(DEFAULT_RARITY_MODIFIERS)
+  })
+
+  it('merges overrides over defaults', () => {
+    const loc = createLocationConfig('Tatooine', { preferredMarketType: 'local', planetId: 'Tatooine' })
+    expect(loc.preferredMarketType).toBe('local')
+    expect(loc.planetId).toBe('Tatooine')
+  })
+
+  it('deep-merges rarityModifiers', () => {
+    const loc = createLocationConfig('Outer Rim', { rarityModifiers: { weapon: 2 } })
+    expect(loc.rarityModifiers.weapon).toBe(2)
+    expect(loc.rarityModifiers.armor).toBe(0)
+    expect(loc.rarityModifiers.gear).toBe(0)
+  })
+
+  it('throws TypeError when name is empty', () => {
+    expect(() => createLocationConfig('')).toThrow(TypeError)
+  })
+
+  it('throws TypeError when name is not a string', () => {
+    expect(() => createLocationConfig(null)).toThrow(TypeError)
+    expect(() => createLocationConfig(42)).toThrow(TypeError)
+  })
+})
+
+/* -------------------------------------------- */
+
+describe('findLocationConfig', () => {
+  const map = {
+    'Mos Eisley': makeLocation({ name: 'Mos Eisley' }),
+    Coruscant: makeLocation({ name: 'Coruscant', preferredMarketType: 'specialized' }),
+  }
+
+  it('returns the config for an existing location', () => {
+    const found = findLocationConfig(map, 'Mos Eisley')
+    expect(found).not.toBeNull()
+    expect(found.name).toBe('Mos Eisley')
+  })
+
+  it('returns null for a non-existent location', () => {
+    expect(findLocationConfig(map, 'Dantooine')).toBeNull()
+  })
+
+  it('returns null when map is null or undefined', () => {
+    expect(findLocationConfig(null, 'Mos Eisley')).toBeNull()
+    expect(findLocationConfig(undefined, 'Mos Eisley')).toBeNull()
+  })
+
+  it('returns null when name is not a string', () => {
+    expect(findLocationConfig(map, null)).toBeNull()
+  })
+})
+
+/* -------------------------------------------- */
+
+describe('upsertLocationConfig', () => {
+  it('adds a new location to the map', () => {
+    const map = {}
+    const config = makeLocation({ name: 'Mos Eisley' })
+    const result = upsertLocationConfig(map, config)
+    expect(result['Mos Eisley']).toBeDefined()
+    expect(result['Mos Eisley'].name).toBe('Mos Eisley')
+  })
+
+  it('replaces an existing location', () => {
+    const map = { 'Mos Eisley': makeLocation({ name: 'Mos Eisley', preferredMarketType: 'standard' }) }
+    const updated = makeLocation({ name: 'Mos Eisley', preferredMarketType: 'specialized' })
+    const result = upsertLocationConfig(map, updated)
+    expect(result['Mos Eisley'].preferredMarketType).toBe('specialized')
+  })
+
+  it('does not mutate the input map', () => {
+    const map = {}
+    upsertLocationConfig(map, makeLocation())
+    expect(Object.keys(map)).toHaveLength(0)
+  })
+
+  it('throws TypeError when config.name is empty', () => {
+    expect(() => upsertLocationConfig({}, { name: '' })).toThrow(TypeError)
+  })
+
+  it('throws TypeError when config.name is missing', () => {
+    expect(() => upsertLocationConfig({}, {})).toThrow(TypeError)
+  })
+})
+
+/* -------------------------------------------- */
+
+describe('removeLocationConfig', () => {
+  const map = {
+    'Mos Eisley': makeLocation({ name: 'Mos Eisley' }),
+    Coruscant: makeLocation({ name: 'Coruscant' }),
+  }
+
+  it('removes the location by name', () => {
+    const result = removeLocationConfig(map, 'Mos Eisley')
+    expect(result['Mos Eisley']).toBeUndefined()
+    expect(result.Coruscant).toBeDefined()
+  })
+
+  it('returns the map unchanged when name does not exist', () => {
+    const result = removeLocationConfig(map, 'Dantooine')
+    expect(Object.keys(result)).toHaveLength(2)
+  })
+
+  it('does not mutate the input map', () => {
+    removeLocationConfig(map, 'Mos Eisley')
+    expect(map['Mos Eisley']).toBeDefined()
+  })
+
+  it('returns empty object when map is null', () => {
+    expect(removeLocationConfig(null, 'anything')).toEqual({})
+  })
+})
+
+/* -------------------------------------------- */
+
+describe('parseLocationConfigMap', () => {
+  it('returns a parsed object for valid JSON', () => {
+    const map = { 'Mos Eisley': makeLocation() }
+    const result = parseLocationConfigMap(JSON.stringify(map))
+    expect(result['Mos Eisley']).toBeDefined()
+  })
+
+  it('returns empty object for invalid JSON', () => {
+    expect(parseLocationConfigMap('{broken')).toEqual({})
+  })
+
+  it('returns empty object for empty string', () => {
+    expect(parseLocationConfigMap('')).toEqual({})
+  })
+
+  it('returns empty object for a JSON array', () => {
+    expect(parseLocationConfigMap('[]')).toEqual({})
+  })
+
+  it('returns empty object for a JSON null', () => {
+    expect(parseLocationConfigMap('null')).toEqual({})
+  })
+
+  it('returns empty object when raw is not a string', () => {
+    expect(parseLocationConfigMap(null)).toEqual({})
+    expect(parseLocationConfigMap(undefined)).toEqual({})
+    expect(parseLocationConfigMap(42)).toEqual({})
+  })
+})
+
+/* -------------------------------------------- */
+
+describe('getRarityModifierForLocation', () => {
+  const map = {
+    'Mos Eisley': makeLocation({ name: 'Mos Eisley', rarityModifiers: { weapon: 2, armor: -1, gear: 0 } }),
+  }
+
+  it('returns the rarity modifier for an existing location and type', () => {
+    expect(getRarityModifierForLocation(map, 'Mos Eisley', 'weapon')).toBe(2)
+    expect(getRarityModifierForLocation(map, 'Mos Eisley', 'armor')).toBe(-1)
+  })
+
+  it('returns 0 for a type with no modifier', () => {
+    expect(getRarityModifierForLocation(map, 'Mos Eisley', 'gear')).toBe(0)
+  })
+
+  it('returns 0 when location does not exist', () => {
+    expect(getRarityModifierForLocation(map, 'Dantooine', 'weapon')).toBe(0)
+  })
+
+  it('returns 0 for a type not present in rarityModifiers', () => {
+    expect(getRarityModifierForLocation(map, 'Mos Eisley', 'unknown-type')).toBe(0)
+  })
+
+  it('returns 0 when map is null', () => {
+    expect(getRarityModifierForLocation(null, 'Mos Eisley', 'weapon')).toBe(0)
+  })
+})

--- a/tests/lib/market/price-engine.test.mjs
+++ b/tests/lib/market/price-engine.test.mjs
@@ -254,4 +254,97 @@ describe('calculateItemPrice', () => {
       expect(result.finalPrice).toBe(140)
     })
   })
+
+  /* -------------------------------------------- */
+  /*  Per-type price modifiers (Phase 9)           */
+  /* -------------------------------------------- */
+
+  describe('per-type price modifiers (options.typeModifiers)', () => {
+    it('applies a per-type modifier for a matching item type', () => {
+      // base=100, rarity=0, weapon typeModifier=0.1 → 100 * (1 + 0.1) = 110
+      const result = calculateItemPrice({ basePrice: 100, rarity: 0, itemType: 'weapon' }, {}, { typeModifiers: { weapon: { priceModifier: 0.1 } } })
+      expect(result.finalPrice).toBe(110)
+    })
+
+    it('does not apply type modifier when itemType does not match', () => {
+      const result = calculateItemPrice({ basePrice: 100, rarity: 0, itemType: 'armor' }, {}, { typeModifiers: { weapon: { priceModifier: 0.5 } } })
+      expect(result.finalPrice).toBe(100)
+    })
+
+    it('applies negative type modifier correctly', () => {
+      // base=100, armor typeModifier=-0.05 → 100 * (1 - 0.05) = 95
+      const result = calculateItemPrice({ basePrice: 100, rarity: 0, itemType: 'armor' }, {}, { typeModifiers: { armor: { priceModifier: -0.05 } } })
+      expect(result.finalPrice).toBe(95)
+    })
+
+    it('type modifier stacks with market type modifier', () => {
+      // base=100, specialized(+0.25) + weapon typeModifier(+0.1) = 1.35 → 135
+      const result = calculateItemPrice(
+        { basePrice: 100, rarity: 0, itemType: 'weapon' },
+        { marketType: 'specialized' },
+        { typeModifiers: { weapon: { priceModifier: 0.1 } } },
+      )
+      expect(result.finalPrice).toBe(135)
+    })
+
+    it('ignores type modifier when itemType is undefined', () => {
+      const result = calculateItemPrice({ basePrice: 100, rarity: 0 }, {}, { typeModifiers: { weapon: { priceModifier: 0.5 } } })
+      expect(result.finalPrice).toBe(100)
+    })
+
+    it('returns same result when typeModifiers is empty object', () => {
+      const result = calculateItemPrice({ basePrice: 100, rarity: 0, itemType: 'weapon' }, {}, { typeModifiers: {} })
+      expect(result.finalPrice).toBe(100)
+    })
+  })
+
+  /* -------------------------------------------- */
+  /*  Global price modifier (Phase 9)              */
+  /* -------------------------------------------- */
+
+  describe('global price modifier (options.globalModifier)', () => {
+    it('applies a positive global modifier', () => {
+      // base=100, globalModifier=20 → 100 * (1 + 0.2) = 120
+      const result = calculateItemPrice({ basePrice: 100, rarity: 0 }, {}, { globalModifier: 20 })
+      expect(result.finalPrice).toBe(120)
+    })
+
+    it('applies a negative global modifier', () => {
+      // base=100, globalModifier=-10 → 100 * (1 - 0.1) = 90
+      const result = calculateItemPrice({ basePrice: 100, rarity: 0 }, {}, { globalModifier: -10 })
+      expect(result.finalPrice).toBe(90)
+    })
+
+    it('global modifier stacks with manualModifier from context', () => {
+      // base=100, manualModifier=10, globalModifier=10 → 100 * (1 + 0.2) = 120
+      const result = calculateItemPrice({ basePrice: 100, rarity: 0 }, { manualModifier: 10 }, { globalModifier: 10 })
+      expect(result.finalPrice).toBe(120)
+    })
+
+    it('global modifier of 0 produces no change', () => {
+      const result = calculateItemPrice({ basePrice: 100, rarity: 0 }, {}, { globalModifier: 0 })
+      expect(result.finalPrice).toBe(100)
+    })
+
+    it('ignores non-finite globalModifier', () => {
+      const result = calculateItemPrice({ basePrice: 100, rarity: 0 }, {}, { globalModifier: NaN })
+      expect(result.finalPrice).toBe(100)
+    })
+
+    it('ignores undefined globalModifier', () => {
+      const result = calculateItemPrice({ basePrice: 100, rarity: 0 }, {}, { globalModifier: undefined })
+      expect(result.finalPrice).toBe(100)
+    })
+
+    it('stacks global modifier, type modifier, and market type modifier', () => {
+      // base=100, specialized(+0.25), weapon typeModifier(+0.1), globalModifier(+5=0.05)
+      // → 100 * (1 + 0.25 + 0.1 + 0.05) = 140
+      const result = calculateItemPrice(
+        { basePrice: 100, rarity: 0, itemType: 'weapon' },
+        { marketType: 'specialized' },
+        { typeModifiers: { weapon: { priceModifier: 0.1 } }, globalModifier: 5 },
+      )
+      expect(result.finalPrice).toBe(140)
+    })
+  })
 })

--- a/tests/utils/audit-log.test.mjs
+++ b/tests/utils/audit-log.test.mjs
@@ -55,11 +55,7 @@ beforeEach(() => {
     },
   }
 
-  globalThis.CONST = {
-    CHAT_MESSAGE_TYPES: {
-      WHISPER: 4,
-    },
-  }
+  globalThis.CONST = {}
 
   globalThis.ChatMessage = {
     create: vi.fn().mockResolvedValue(undefined),


### PR DESCRIPTION
## Summary

- Add Phase 9 market settings UI, price engine extensions and tests
- Implement per-type and global price modifiers; add market settings panel and templates
- Add tests for market settings, location configs, price engine and catalog loader

## Context

This branch implements Phase 9 changes to the market feature: a new market settings panel, per-type price modifiers and a global price modifier in the price engine, related templates, util changes (audit-log), and a set of unit tests covering the new code. It updates localization entries (en/fr) and adds documentation plan for audit logging.


## Tests

- Unit tests added and modified across tests/lib/market and tests/applications/settings (Vitest). Not run (not requested).

## Notes

- No lint/test/build were executed by this PR preparation.
- Branch is tracked on remote origin/482-hitl-market-intégration-du-coût-narratif-dette-faveur-risque.
