### PR TITLE
feat(market): sell items from inventory via market UI

### DIFF
--- a/documentation/plan/market/plan-marketItemSell.prompt.md
+++ b/documentation/plan/market/plan-marketItemSell.prompt.md
@@ -1,0 +1,730 @@
+# Plan : Vente d'items via le Market (Issue #478)
+
+## Vue d'ensemble
+
+**TL;DR** : Ajouter un mode "vente" au Market permettant à un acteur de vendre ses items (weapon/armor/gear). La logique de valorisation pure (`sell-valuation.mjs`) calcule le prix de revente (25%/50%/75% du basePrice selon négociation). L'UI ajoute un onglet/PART "Mes articles" listant l'inventaire vendable. Un test de Négociation optionnel améliore le prix. La transaction supprime l'item (`deleteEmbeddedDocuments`) et crédite l'acteur (`update`). L'audit log enregistre via un nouveau type `item.sale`.
+
+## Objectifs
+
+1. **Traçabilité complète** : Chaque vente d'item via le Market est enregistrée dans l'audit log du personnage avec type `item.sale`.
+2. **Logique de valorisation pure** : Calcul du prix de revente indépendant de Foundry, testable en isolation.
+3. **Négociation optionnelle** : Un test de Négociation/Persuasion/Tromperie peut améliorer la fraction de revente (25% → 50% → 75%).
+4. **Interface cohérente** : Mode buy/sell dans le même Market, UI inventaire vendable claire.
+5. **Mutations complètes** : Suppression d'item + crédit d'acteur atomiques, audit log synchronisé.
+
+## Périmètre détaillé
+
+### Inclus
+
+- Nouveau module `sell-valuation.mjs` — logique pure de calcul prix revente
+- Nouveau module `sell-validation.mjs` — validation logique vente
+- PART `inventory` dans MarketApplicationV2 stateful avec mode buy/sell
+- Action `sellItem` — orchestre validation → négociation optionnelle → mutations
+- Nouveau type audit `item.sale` + `recordItemSale()`
+- Famille de filtre `sales` dans Character Audit Log
+- Tests Vitest complets (valuation, validation, intégration)
+- Clés i18n EN/FR pour tous les nouveaux termes
+
+### Exclus
+
+- Migration rétroactive des ventes passées
+- Historique des prix de revente par item type
+- Vente par lot (un item à la fois)
+- Intégration avec autres systèmes de commerce tiers-partis
+- Restrictions de localisation ou légales (toutes les ventes autorisées au même titre que les achats)
+
+### Hypothèses
+
+- L'acteur qui vend possède l'item (UX: liste seulement les items de l'inventaire)
+- Les items vendables sont les mêmes que les types achetables (`PURCHASABLE_ITEM_TYPES`)
+- Le test de négociation utilise le même pool que à l'achat (Négociation/Persuasion/Tromperie)
+- Les crédits sont déduits/crédités via `actor.update({ 'system.credits': newValue })` direct
+- Le Market UI peut basculer entre buy/sell sans fermer/rouvrir
+
+### Contraintes
+
+- Pas de modification du flow d'achat existant
+- Vente non bloquée si audit log échoue (non-critical)
+- Taille max audit log existante (FIFO) doit être respectée
+- Item supprimé ← avant → crédits créditées dans le même `update()`
+- Aucune ressource Foundry ne doit être laissée orpheline
+
+## Architecture
+
+```mermaid
+graph LR
+    UI["Market UI<br/>mode=buy|sell"] -->|onSellItem| Validation["validateSale"]
+    Validation -->|ok| Dialog["Confirmation Dialog"]
+    Dialog -->|confirmed| Negotiate["Negociation Test?"]
+    Negotiate -->|skip or result| Valuation["computeResalePrice"]
+    Valuation -->|fraction| Transaction["Delete Item<br/>+ Update Credits"]
+    Transaction -->|success| Audit["recordItemSale"]
+    Audit -->|async| Chat["Chat Message"]
+    UI -->|display| Inventory["Inventory List<br/>with resale prices"]
+```
+
+### Points d'entrée
+
+1. **Market UI** (`module/applications/market/market-application.mjs`) — mode toggle, inventory PART, action `sellItem`
+2. **Sell Valuation** (`module/lib/market/sell-valuation.mjs`) — calcul prix revente pur
+3. **Sell Validation** (`module/lib/market/sell-validation.mjs`) — vérifications inventaire/type
+4. **Audit Log** (`module/utils/audit-log.mjs`) — enregistre `item.sale`, famille `sales`
+5. **Character Audit Log UI** (`module/applications/character-audit-log.mjs`) — affiche et filtre ventes
+
+### Données d'exemple
+
+```javascript
+// Input
+const actor = { /* ... */ }
+const item = { name: 'Blaster Pistol', type: 'weapon', system: { price: 100 } }
+
+// sell-validation
+const validation = validateSale({ actor, item })
+// ✓ { canSell: true }
+
+// Negociation (optional, user choice)
+const negotiationResult = { successRanks: 1, isDisaster: false, outcome: 'success' }
+
+// sell-valuation
+const valuation = computeResalePrice({
+  basePrice: 100,
+  negotiationOutcome: 'success' // or 'failure', 'triumph', 'disaster'
+})
+// ✓ { resalePrice: 50, fraction: 0.5 }
+
+// Audit Entry
+{
+  type: 'item.sale',
+  data: {
+    itemId: '...',
+    itemName: 'Blaster Pistol',
+    itemType: 'weapon',
+    basePrice: 100,
+    resalePrice: 50,
+    fraction: 0.5,
+    negotiationOutcome: 'success'
+  },
+  creditDelta: 50,
+  snapshot: { creditsBefore: 100, creditsAfter: 150, creditsDelta: 50 },
+  timestamp: 1234567890,
+  userId: 'user-123'
+}
+```
+
+## Tâches implémentation
+
+### 1. Créer `module/lib/market/sell-valuation.mjs`
+
+**Fichiers** : `module/lib/market/sell-valuation.mjs`, tests `tests/lib/market/sell-valuation.test.mjs`
+
+**Contenu** :
+
+```javascript
+// Constants
+export const SELL_BASE_FRACTION = 0.25 // 25% de basePrice
+export const SELL_NEGOTIATED_FRACTION = 0.5 // 50% avec succès
+export const SELL_MAX_FRACTION = 0.75 // 75% avec triomphe
+export const SELL_DISASTER_FRACTION = 0.1 // 10% en cas de désastre
+
+// Pure function
+export function computeResalePrice({ basePrice, negotiationOutcome = 'failure' }) {
+  // Validate inputs
+  if (!Number.isFinite(basePrice) || basePrice < 0) {
+    throw new TypeError(`basePrice must be a non-negative number, got ${basePrice}`)
+  }
+
+  // Determine fraction based on negotiation outcome
+  let fraction = SELL_BASE_FRACTION
+  if (negotiationOutcome === 'triumph') {
+    fraction = SELL_MAX_FRACTION
+  } else if (negotiationOutcome === 'success') {
+    fraction = SELL_NEGOTIATED_FRACTION
+  } else if (negotiationOutcome === 'disaster') {
+    fraction = SELL_DISASTER_FRACTION
+  }
+
+  // Calculate and floor
+  const resalePrice = Math.floor(basePrice * fraction)
+
+  return {
+    resalePrice,
+    fraction,
+    basePrice,
+    outcome: negotiationOutcome,
+  }
+}
+```
+
+**Tests** :
+
+- ✓ Calcul standard 25% du basePrice
+- ✓ Succès → 50%
+- ✓ Triomphe → 75%
+- ✓ Désastre → 10%
+- ✓ Valeur négative rejetée
+- ✓ basePrice = 0 → resalePrice = 0
+- ✓ Résultat toujours un entier (Math.floor)
+
+### 2. Créer `module/lib/market/sell-validation.mjs`
+
+**Fichiers** : `module/lib/market/sell-validation.mjs`, tests `tests/lib/market/sell-validation.test.mjs`
+
+**Contenu** :
+
+```javascript
+import { PURCHASABLE_ITEM_TYPES } from '../../config/market.mjs'
+
+/**
+ * @typedef {Object} SaleValidationResult
+ * @property {boolean} canSell       Whether all pre-conditions are satisfied
+ * @property {string}  reason        Machine-readable reason key
+ * @property {string}  [messageKey]  i18n key for user-facing message
+ */
+
+export function validateSale({ actor, item } = {}) {
+  // Validate actor
+  if (!actor || typeof actor !== 'object') {
+    return {
+      canSell: false,
+      reason: 'missing-actor',
+      messageKey: 'MARKET.Sale.Error.MissingActor',
+    }
+  }
+
+  // Validate item
+  if (!item || typeof item !== 'object') {
+    return {
+      canSell: false,
+      reason: 'missing-item',
+      messageKey: 'MARKET.Sale.Error.MissingItem',
+    }
+  }
+
+  // Check item type is sellable
+  if (!item.type || !(item.type in PURCHASABLE_ITEM_TYPES)) {
+    return {
+      canSell: false,
+      reason: 'unsellable-type',
+      messageKey: 'MARKET.Sale.Error.UnsellableType',
+    }
+  }
+
+  // Check item exists in actor's inventory
+  const hasItem = actor.items && Array.isArray(actor.items) ? actor.items.some((i) => i.id === item.id || i.uuid === item.uuid) : false
+
+  if (!hasItem) {
+    return {
+      canSell: false,
+      reason: 'not-in-inventory',
+      messageKey: 'MARKET.Sale.Error.NotInInventory',
+    }
+  }
+
+  // Check basePrice exists
+  const basePrice = item.system?.price ?? 0
+  if (typeof basePrice !== 'number' || basePrice < 0) {
+    return {
+      canSell: false,
+      reason: 'invalid-price',
+      messageKey: 'MARKET.Sale.Error.InvalidPrice',
+    }
+  }
+
+  return {
+    canSell: true,
+    reason: '',
+    basePrice,
+  }
+}
+```
+
+**Tests** :
+
+- ✓ Item vendable retourne `canSell: true`
+- ✓ Type non vendable rejeté
+- ✓ Item absent de l'inventaire rejeté
+- ✓ Prix négatif rejeté
+- ✓ Tous les messageKey sont définis
+
+### 3. Modifier `MarketApplicationV2` — ajouter PART `inventory` et state toggle
+
+**Fichiers** : `module/applications/market/market-application.mjs`
+
+**Contenu** :
+
+- Ajouter `mode: 'buy' | 'sell'` à `_viewState`
+- Ajouter PART dans `static PARTS`:
+  ```javascript
+  inventory: {
+    template: 'systems/swerpg/templates/market/market-inventory.hbs',
+    scrollable: ['.market-inventory']
+  }
+  ```
+- Ajouter action `toggleMode: MarketApplicationV2.#onToggleMode`
+- Ajouter action `sellItem: MarketApplicationV2.#onSellItem`
+- Dans `_preparePartContext`:
+  ```javascript
+  if (partId === 'inventory' && this._viewState.mode === 'sell') {
+    context.inventory = this.#prepareInventory(buyer)
+  }
+  ```
+
+### 4. Implémenter action `#onSellItem`
+
+**Fichiers** : `module/applications/market/market-application.mjs`
+
+**Contenu** :
+
+```javascript
+static async #onSellItem(_event, target) {
+  const seller = this._buyerActor
+  if (!seller) return
+
+  const itemId = target.dataset?.itemId
+  if (!itemId) return
+
+  const item = seller.items.get(itemId)
+  if (!item) {
+    ui.notifications.error('MARKET.Sale.Error.ItemNotFound')
+    return
+  }
+
+  // Validate sale
+  const validation = validateSale({ actor: seller, item })
+  if (!validation.canSell) {
+    ui.notifications.warn(game.i18n.localize(validation.messageKey))
+    return
+  }
+
+  // Compute resale price (base 25%)
+  const valuation = computeResalePrice({
+    basePrice: validation.basePrice,
+    negotiationOutcome: 'failure'
+  })
+
+  // Show confirmation dialog
+  const currentCredits = seller.system?.creditBudget?.availableCredits ?? seller.system?.credits ?? 0
+  const creditsAfter = currentCredits + valuation.resalePrice
+
+  const confirmed = await foundry.applications.api.DialogV2.confirm({
+    window: {
+      title: game.i18n.format('MARKET.Sale.Confirm.Title', { name: item.name })
+    },
+    content: `<p>${game.i18n.format('MARKET.Sale.Confirm.Content', {
+      name: item.name,
+      price: valuation.resalePrice,
+      credits: currentCredits,
+      remaining: creditsAfter
+    })}</p>`,
+    yes: {
+      label: game.i18n.format('MARKET.Sale.Confirm.Sell', { price: valuation.resalePrice }),
+      icon: 'fa-solid fa-coins'
+    },
+    no: {
+      label: game.i18n.localize('MARKET.Sale.Confirm.Cancel'),
+      icon: 'fa-solid fa-xmark'
+    }
+  })
+
+  if (!confirmed) return
+
+  // Optional: allow negotiation
+  const offerNegotiation = await foundry.applications.api.DialogV2.confirm({
+    window: {
+      title: 'MARKET.Sale.Negotiate.Title'
+    },
+    content: game.i18n.localize('MARKET.Sale.Negotiate.Offer'),
+    yes: {
+      label: 'MARKET.Sale.Negotiate.Accept',
+      icon: 'fa-solid fa-handshake'
+    },
+    no: {
+      label: 'MARKET.Sale.Negotiate.Skip',
+      icon: 'fa-solid fa-xmark'
+    }
+  })
+
+  let finalValuation = valuation
+  if (offerNegotiation) {
+    // Open NegotiationDialog (reuse existing for selling)
+    const negotiationResult = await NegotiationDialog.prompt({
+      entry: { name: item.name, rarity: item.system?.rarity ?? 0 },
+      buyer: seller,
+      forSale: true
+    })
+
+    if (negotiationResult?.confirmed) {
+      finalValuation = computeResalePrice({
+        basePrice: validation.basePrice,
+        negotiationOutcome: negotiationResult.outcome
+      })
+    }
+  }
+
+  // Execute sale: delete item + credit actor
+  try {
+    await seller.deleteEmbeddedDocuments('Item', [item.id])
+    const newCredits = currentCredits + finalValuation.resalePrice
+    await seller.update({ 'system.credits': newCredits })
+
+    // Record in audit log
+    try {
+      const { recordItemSale } = await import('../../utils/audit-log.mjs')
+      await recordItemSale(seller, {
+        itemName: item.name,
+        itemType: item.type,
+        basePrice: validation.basePrice,
+        resalePrice: finalValuation.resalePrice,
+        fraction: finalValuation.fraction,
+        negotiationOutcome: finalValuation.outcome,
+        creditsAfter: newCredits,
+        itemId: item.id
+      })
+    } catch (auditErr) {
+      logger.warn('[Market] Could not record item sale audit entry', auditErr)
+    }
+
+    ui.notifications.info(
+      game.i18n.format('MARKET.Sale.Success', {
+        name: item.name,
+        price: finalValuation.resalePrice,
+        remaining: newCredits
+      })
+    )
+
+    logger.info('[Market] Item sale completed', {
+      actorId: seller.id,
+      actorName: seller.name,
+      itemId: item.id,
+      itemName: item.name,
+      basePrice: validation.basePrice,
+      resalePrice: finalValuation.resalePrice,
+      creditsAfter: newCredits
+    })
+
+    await this.render()
+  } catch (err) {
+    logger.error('[Market] Sale failed', err)
+    ui.notifications.error('MARKET.Sale.Error.WriteFailed')
+  }
+}
+```
+
+### 5. Créer template `templates/market/market-inventory.hbs` et intégrer dans Market
+
+**Fichiers** : `templates/market/market-inventory.hbs`
+
+**Contenu** :
+
+```handlebars
+{{! Market Inventory — part: inventory }}
+<div class='market-inventory scrollable' data-application-part='inventory'>
+  <div class='market-selector'>
+    <p class='market-selector__description'>{{localize 'MARKET.Inventory.Description'}}</p>
+  </div>
+
+  {{#if inventory.items.length}}
+    <div class='inventory-list'>
+      {{#each inventory.items as |item|}}
+        <div class='inventory-item' data-item-id='{{item.id}}'>
+          <div class='inventory-item__header'>
+            <img src='{{item.img}}' class='inventory-item__icon' alt='{{item.name}}' />
+            <div class='inventory-item__info'>
+              <h3 class='inventory-item__name'>{{item.name}}</h3>
+              <p class='inventory-item__type'>{{localize item.typeLabel}}</p>
+            </div>
+          </div>
+          <div class='inventory-item__pricing'>
+            <div class='inventory-item__price-row'>
+              <span class='label'>{{localize 'MARKET.Inventory.BasePrice'}}:</span>
+              <span class='value'>{{item.basePrice}}</span>
+            </div>
+            <div class='inventory-item__price-row estimate'>
+              <span class='label'>{{localize 'MARKET.Inventory.ResaleEstimate'}}:</span>
+              <span class='value'>{{item.resaleEstimate}} ({{item.resaleFraction}}%)</span>
+            </div>
+          </div>
+          <button
+            class='inventory-item__sell-btn'
+            data-action='sellItem'
+            data-item-id='{{item.id}}'
+            aria-label='{{localize "MARKET.Inventory.SellAriaLabel"}} {{item.name}}'
+          >
+            {{localize 'MARKET.Inventory.SellButton'}}
+            {{item.resaleEstimate}}
+            {{localize 'MARKET.Currency'}}
+          </button>
+        </div>
+      {{/each}}
+    </div>
+  {{else}}
+    <div class='inventory-empty'>
+      <p>{{localize 'MARKET.Inventory.Empty'}}</p>
+    </div>
+  {{/if}}
+</div>
+```
+
+### 6. Ajouter type audit `item.sale` + `recordItemSale()`
+
+**Fichiers** : `module/utils/audit-log.mjs`, `module/applications/character-audit-log.mjs`
+
+**Contenu dans audit-log.mjs** :
+
+```javascript
+export async function recordItemSale(actor, { itemName, itemType, basePrice, resalePrice, fraction, negotiationOutcome = 'failure', creditsAfter, itemId }) {
+  const ts = Date.now()
+  const creditsBefore = actor.system?.creditBudget?.availableCredits ?? actor.system?.credits ?? null
+  const creditsDelta = creditsBefore !== null && creditsAfter !== null ? creditsAfter - creditsBefore : null
+  const snapshot = { creditsBefore, creditsAfter, creditsDelta }
+  const user = game.users?.get(game.user?.id) ?? null
+
+  const entry = {
+    ...makeEntry({
+      type: 'item.sale',
+      data: {
+        itemName,
+        itemType,
+        basePrice,
+        resalePrice,
+        fraction,
+        negotiationOutcome,
+        itemId,
+      },
+      xpDelta: 0,
+      ts,
+      userId: game.user?.id,
+      user,
+      snapshot,
+    }),
+    creditDelta: resalePrice,
+  }
+
+  await writeLogEntries(actor, [entry])
+}
+```
+
+**Contenu dans character-audit-log.mjs** :
+
+- Ajouter `sales: 'sales'` à `AUDIT_LOG_FAMILIES`
+- Ajouter mapping dans `AUDIT_LOG_FILTER_LABELS`
+- Ajouter case dans `getAuditLogFamily()`: `case 'item.sale': return AUDIT_LOG_FAMILIES.sales`
+- Ajouter case dans `buildAuditLogDescription()`:
+  ```javascript
+  case 'item.sale':
+    return game.i18n.format('SWERPG.AUDIT_LOG.DESCRIPTION.ITEM_SALE', {
+      itemName: data.itemName,
+      itemType: data.itemType,
+      resalePrice: data.resalePrice,
+      fraction: Math.round(data.fraction * 100)
+    })
+  ```
+- Ajouter case dans `_buildChatContext()`:
+  ```javascript
+  case 'item.sale':
+    return {
+      actorImg: actor.img ?? '',
+      actorName: actor.name,
+      eventLabel: game.i18n.localize('SWERPG.AUDIT_LOG.TYPE.ITEM_SALE'),
+      previousValue: null,
+      nextValue: `${data.itemName} (${data.itemType})`,
+      description: game.i18n.format('SWERPG.AUDIT_LOG.DESCRIPTION.ITEM_SALE', {
+        itemName: data.itemName,
+        resalePrice: data.resalePrice
+      }),
+      metaLeft: game.i18n.format('SWERPG.AUDIT_LOG.META.SoldFor', { price: data.resalePrice }),
+      metaRight: game.i18n.format('SWERPG.AUDIT_LOG.META.RemainingCredits', { credits: snapshot.creditsAfter }),
+      hasMeta: true,
+      variant: 'gain'
+    }
+  ```
+
+### 7. Clés i18n complètes EN/FR
+
+**Fichiers** : `lang/en.json`, `lang/fr.json`
+
+**Clés** :
+
+```json
+{
+  "MARKET.Sell.Confirm.Title": "Sell {name}",
+  "MARKET.Sell.Confirm.Content": "<p>Confirm sale of <strong>{name}</strong> for <strong>{price} credits</strong>.</p><p>Current credits: {credits} → {remaining} after sale</p>",
+  "MARKET.Sell.Confirm.Sell": "Sell for {price}",
+  "MARKET.Sell.Confirm.Cancel": "Cancel",
+  "MARKET.Sell.Negotiate.Title": "Improve Resale Price",
+  "MARKET.Sell.Negotiate.Offer": "Attempt to negotiate a better price? (Uses Negotiation, Persuasion, or Deception skill)",
+  "MARKET.Sell.Negotiate.Accept": "Attempt Negotiation",
+  "MARKET.Sell.Negotiate.Skip": "Keep Base Price (25%)",
+  "MARKET.Sale.Success": "Sold {name} for {price} credits. Credits remaining: {remaining}",
+  "MARKET.Sale.Error.MissingActor": "No seller actor found.",
+  "MARKET.Sale.Error.MissingItem": "Item not found.",
+  "MARKET.Sale.Error.UnsellableType": "This item type cannot be sold.",
+  "MARKET.Sale.Error.NotInInventory": "Item is not in your inventory.",
+  "MARKET.Sale.Error.InvalidPrice": "Item has no valid base price.",
+  "MARKET.Sale.Error.ItemNotFound": "Item was not found in your inventory.",
+  "MARKET.Sale.Error.WriteFailed": "Failed to complete sale. Check console.",
+  "MARKET.Inventory.Description": "Select items from your inventory to sell.",
+  "MARKET.Inventory.BasePrice": "Base Price",
+  "MARKET.Inventory.ResaleEstimate": "Resale Estimate (25%)",
+  "MARKET.Inventory.SellAriaLabel": "Sell",
+  "MARKET.Inventory.SellButton": "Sell",
+  "MARKET.Inventory.Empty": "Your inventory is empty or contains no sellable items.",
+  "MARKET.Currency": "credits",
+  "SWERPG.AUDIT_LOG.TYPE.ITEM_SALE": "Item sold",
+  "SWERPG.AUDIT_LOG.FILTER.SALES": "Sales",
+  "SWERPG.AUDIT_LOG.DESCRIPTION.ITEM_SALE": "Sold {itemName} ({itemType}) for {resalePrice} credits ({fraction}% of base price)",
+  "SWERPG.AUDIT_LOG.META.SoldFor": "Sold for {price} credits",
+  "SWERPG.AUDIT_LOG.META.RemainingCredits": "{credits} credits remaining"
+}
+```
+
+**Équivalents FR** :
+
+```json
+{
+  "MARKET.Sell.Confirm.Title": "Vendre {name}",
+  "MARKET.Sell.Confirm.Content": "<p>Confirmer la vente de <strong>{name}</strong> pour <strong>{price} crédits</strong>.</p><p>Crédits actuels : {credits} → {remaining} après vente</p>",
+  "MARKET.Sell.Confirm.Sell": "Vendre pour {price}",
+  "MARKET.Sell.Confirm.Cancel": "Annuler",
+  "MARKET.Sell.Negotiate.Title": "Améliorer le prix de revente",
+  "MARKET.Sell.Negotiate.Offer": "Tenter de négocier un meilleur prix ? (Utilise Négociation, Persuasion ou Tromperie)",
+  "MARKET.Sell.Negotiate.Accept": "Tenter une négociation",
+  "MARKET.Sell.Negotiate.Skip": "Garder le prix de base (25%)",
+  "MARKET.Sale.Success": "{name} vendu pour {price} crédits. Crédits restants : {remaining}",
+  "MARKET.Sale.Error.MissingActor": "Aucun vendeur trouvé.",
+  "MARKET.Sale.Error.MissingItem": "Article non trouvé.",
+  "MARKET.Sale.Error.UnsellableType": "Ce type d'article ne peut pas être vendu.",
+  "MARKET.Sale.Error.NotInInventory": "L'article n'est pas dans votre inventaire.",
+  "MARKET.Sale.Error.InvalidPrice": "L'article n'a pas de prix de base valide.",
+  "MARKET.Sale.Error.ItemNotFound": "L'article n'a pas été trouvé dans votre inventaire.",
+  "MARKET.Sale.Error.WriteFailed": "Impossible de compléter la vente. Consulter la console.",
+  "MARKET.Inventory.Description": "Sélectionnez des articles dans votre inventaire à vendre.",
+  "MARKET.Inventory.BasePrice": "Prix de base",
+  "MARKET.Inventory.ResaleEstimate": "Estimation de revente (25%)",
+  "MARKET.Inventory.SellAriaLabel": "Vendre",
+  "MARKET.Inventory.SellButton": "Vendre",
+  "MARKET.Inventory.Empty": "Votre inventaire est vide ou ne contient aucun article vendable.",
+  "MARKET.Currency": "crédits",
+  "SWERPG.AUDIT_LOG.TYPE.ITEM_SALE": "Article vendu",
+  "SWERPG.AUDIT_LOG.FILTER.SALES": "Ventes",
+  "SWERPG.AUDIT_LOG.DESCRIPTION.ITEM_SALE": "Vente de {itemName} ({itemType}) pour {resalePrice} crédits ({fraction}% du prix de base)",
+  "SWERPG.AUDIT_LOG.META.SoldFor": "Vendu pour {price} crédits",
+  "SWERPG.AUDIT_LOG.META.RemainingCredits": "{credits} crédits restants"
+}
+```
+
+### 8. Tests Vitest
+
+**Fichiers** : `tests/lib/market/sell-valuation.test.mjs`, `tests/lib/market/sell-validation.test.mjs`, tests d'intégration dans `tests/applications/market/market-application.test.mjs`
+
+**Coverage** :
+
+- ✓ sell-valuation: calcul 25/50/75%, désastre, bornes, Math.floor
+- ✓ sell-validation: items vendables, non-vendables, inventaire, prix invalides
+- ✓ action sellItem: validation failure flow, confirmation aborted, successful sale
+- ✓ audit log: type item.sale enregistré, famille sales affichée, CSV contient creditDelta
+
+## Découpage en issues GitHub
+
+| #   | Titre                                                           | Périmètre                                         | Dépendances | Story Points |
+| --- | --------------------------------------------------------------- | ------------------------------------------------- | ----------- | ------------ |
+| 1   | **feat: sell-valuation.mjs — logique pure calcul prix revente** | sell-valuation.mjs, tests pour fractions          | —           | 5            |
+| 2   | **feat: sell-validation.mjs — validation logique vente**        | sell-validation.mjs, tests pour inventaire        | Issue 1     | 3            |
+| 3   | **feat: UI Market PART inventory + mode toggle buy/sell**       | market-application.mjs PARTS, UI template         | Issues 1–2  | 8            |
+| 4   | **feat: Action sellItem — orchestration vente complète**        | market-application.mjs action, deleteEmbedded     | Issues 1–3  | 8            |
+| 5   | **feat: Type audit item.sale + recordItemSale()**               | audit-log.mjs, character-audit-log.mjs            | Issues 1–4  | 5            |
+| 6   | **feat: Template market-inventory.hbs et styling**              | templates/market, styles/market.less              | Issues 3–5  | 3            |
+| 7   | **feat: Intégration négociation optionnelle pour vente**        | NegotiationDialog adapt, sell-valuation.mjs adapt | Issues 1–5  | 5            |
+| 8   | **chore: Clés i18n complètes (EN + FR) pour item sale**         | lang/en.json, lang/fr.json                        | Issues 1–7  | 2            |
+| 9   | **test: Tests Vitest sellItem action, audit log integration**   | tests/ complets, e2e smoke regression             | Issues 1–8  | 8            |
+
+**Total estimation** : ~47 SP (3 sprints de développement)
+
+## Considérations supplémentaires
+
+### 1. Mode UI (buy/sell)
+
+**Question** : Ajouter un toggle buy/sell dans le header du Market (même fenêtre, même PART switch) plutôt qu'un onglet ApplicationV2 séparé ?
+
+**Recommandation** : Oui, toggle dans le header du Market avec deux boutons "Buy" / "Sell" qui basculent `_viewState.mode = 'buy' | 'sell'`. Cela :
+
+- Reste cohérent avec l'architecture existante (`_viewState`)
+- Évite perte de contexte (Market fermeture/réouverture)
+- Réutilise le même Market window plutôt que deux apps
+- Permet au joueur de passer rapidement buy → sell → buy sans friction
+
+### 2. Crédits : mutation directe
+
+**Question** : À l'achat, crédits déduits automatiquement via `_prepareCredits()`. À la vente, faut-il un `actor.update()` explicite ?
+
+**Recommandation** : Oui, `actor.update({ 'system.credits': currentCredits + salePrice })` direct après `deleteEmbeddedDocuments`. Raison :
+
+- La suppression d'un item ne "rend" pas les crédits automatiquement
+- L'update est atomique avec la suppression dans le même tick
+- Gérée immédiatement post-vente sans raccrochage
+
+### 3. Item équipé
+
+**Question** : Interdire vente si equipped, ou déséquiper automatiquement ?
+
+**Recommandation** : Interdire la vente avec message clair "Item is currently equipped. Unequip it first to sell." Raison :
+
+- Évite surprise utilisateur (perdre une arme équipée)
+- Cohérent avec achat existant (pas de cas limite)
+- Laisse contrôle explicite au joueur
+- Facilite debug si problème
+
+### 4. Négociation pour vente
+
+**Question** : Est-ce que NegotiationDialog réutilisable pour sell, ou créer SaleNegotiationDialog ?
+
+**Recommandation** : Adapter le `NegotiationDialog` existant via paramètre `forSale: boolean`. Cela :
+
+- Réutilise la logique de skill selection et success computation
+- Réduit duplication de code
+- Même UX pour buy/sell negotiation
+- Simpler à tester
+
+### 5. Audit trail
+
+**Question** : Tracer le `negotiationOutcome` dans audit log ?
+
+**Recommandation** : Oui, ajouter `negotiationOutcome` à `entry.data` pour vente. Cela :
+
+- Facilite audit finance (comprendre % final appliqué)
+- Trace les comportements de négociation
+- Aide diagnostic si besoin
+
+## Validation de succès
+
+- ✓ Chaque vente est enregistrée dans `actor.flags.swerpg.logs` avec type `item.sale`
+- ✓ Item supprimé de l'inventaire après vente réussie
+- ✓ Crédits de l'acteur augmentés du prix de revente
+- ✓ Un message chat est envoyé avec variante `gain` (vert)
+- ✓ Le filtre "Sales" affiche/masque les entrées vente correctement
+- ✓ Négociation optionnelle modifie la fraction (25% → 50% → 75%)
+- ✓ Export CSV inclut les ventes avec creditDelta positif
+- ✓ Tests Vitest couvrent tous les chemins happy path et erreur
+- ✓ Aucun blocage du Market si audit échoue
+- ✓ Clés i18n EN/FR complètes et testées
+
+## Prochaines étapes
+
+1. **Affiner ce plan** : Feedback utilisateur sur UI mode toggle, négociation optionnelle, fraction par défaut
+2. **Détailler Issue 1** : sell-valuation.mjs avec signature exacte et tous les tests
+3. **Créer issues GitHub** : Break down par issue, estimer, assigner
+4. **Implémenter par ordre** : Domaine pur (1–2) → UI (3–6) → Audit (5) → Négociation (7) → Tests (9)
+5. **Review + merge** : PR par issue avec tests, doc, i18n validés
+
+---
+
+## Statut (Template pour future mise à jour)
+
+### Phases à compléter
+
+- [ ] Phase 1 : Logique pure (Issues #1–2)
+- [ ] Phase 2 : UI et mutations (Issues #3–6)
+- [ ] Phase 3 : Audit et i18n (Issues #5, #8)
+- [ ] Phase 4 : Négociation et tests (Issues #7–9)
+
+---

--- a/lang/en.json
+++ b/lang/en.json
@@ -290,6 +290,7 @@
   "SWERPG.AUDIT_LOG.FILTER.DETAILS": "Core choices",
   "SWERPG.AUDIT_LOG.FILTER.ADVANCEMENT": "Advancement",
   "SWERPG.AUDIT_LOG.FILTER.PURCHASES": "Purchases",
+  "SWERPG.AUDIT_LOG.FILTER.SALES": "Sales",
   "SWERPG.AUDIT_LOG.TYPE.SKILL_TRAIN": "Skill purchase",
   "SWERPG.AUDIT_LOG.TYPE.SKILL_FORGET": "Skill refund",
   "SWERPG.AUDIT_LOG.TYPE.CHARACTERISTIC_INCREASE": "Characteristic increase",
@@ -309,6 +310,7 @@
   "SWERPG.AUDIT_LOG.TYPE.TALENT_NODE_FORGET_FAILED": "Talent node forget failed",
   "SWERPG.AUDIT_LOG.TYPE.ADVANCEMENT_LEVEL": "Level change",
   "SWERPG.AUDIT_LOG.TYPE.ITEM_PURCHASE": "Item purchased",
+  "SWERPG.AUDIT_LOG.TYPE.ITEM_SALE": "Item sold",
   "SWERPG.AUDIT_LOG.TYPE.UNKNOWN": "Unknown event",
   "SWERPG.AUDIT_LOG.NONE": "None",
   "SWERPG.AUDIT_LOG.UNKNOWN_VALUE": "Unknown value",
@@ -334,8 +336,10 @@
   "SWERPG.AUDIT_LOG.DESCRIPTION.TALENT_NODE_FORGET_FAILED": "Talent node forget failed: {reasonCode} (node {nodeId})",
   "SWERPG.AUDIT_LOG.DESCRIPTION.ADVANCEMENT_LEVEL": "Level {oldLevel} -> {newLevel}",
   "SWERPG.AUDIT_LOG.DESCRIPTION.ITEM_PURCHASE": "Purchased {itemName} ({itemType}) for {price} credits",
+  "SWERPG.AUDIT_LOG.DESCRIPTION.ITEM_SALE": "Sold {itemName} ({itemType}) for {resalePrice} credits ({fraction}% of base price)",
   "SWERPG.AUDIT_LOG.META.PRICE": "{price} credits",
   "SWERPG.AUDIT_LOG.META.CREDITS_REMAINING": "{credits} credits remaining",
+  "SWERPG.AUDIT_LOG.META.SOLD_FOR": "Sold for {price} credits",
   "SWERPG.AUDIT_LOG.DESCRIPTION.UNKNOWN": "Unrecognized event ({type})",
   "SWERPG.AUDIT_LOG.EXPORT": "Export",
   "SWERPG.AUDIT_LOG.EXPORT_TOOLTIP": "Export the complete history as a CSV file",
@@ -1715,6 +1719,44 @@
       "Negotiable": {
         "Tooltip": "Price negotiable"
       }
+    },
+    "Mode": {
+      "Buy": "Buy",
+      "Sell": "Sell"
+    },
+    "Sell": {
+      "Confirm": {
+        "Title": "Sell {name}",
+        "Content": "Confirm sale of {name} for {price} credits. Current credits: {credits} → {remaining} after sale.",
+        "Sell": "Sell for {price} credits",
+        "Cancel": "Cancel"
+      },
+      "Negotiate": {
+        "Title": "Improve Resale Price",
+        "Offer": "Attempt to negotiate a better resale price? (Uses Negotiation, Persuasion, or Deception skill)",
+        "Accept": "Attempt Negotiation",
+        "Skip": "Keep Base Price (25%)"
+      }
+    },
+    "Sale": {
+      "Success": "Sold {name} for {price} credits. Credits remaining: {remaining}.",
+      "Error": {
+        "MissingActor": "No seller actor found.",
+        "MissingItem": "Item not found.",
+        "UnsellableType": "This item type cannot be sold.",
+        "NotInInventory": "Item is not in your inventory.",
+        "InvalidPrice": "Item has no valid base price.",
+        "ItemNotFound": "Item was not found in your inventory.",
+        "WriteFailed": "Failed to complete the sale. Check the console for details."
+      }
+    },
+    "Inventory": {
+      "Description": "Select items from your inventory to sell.",
+      "BasePrice": "Base Price",
+      "ResaleEstimate": "Resale (25%)",
+      "SellAriaLabel": "Sell",
+      "SellButton": "Sell",
+      "Empty": "Your inventory contains no sellable items."
     },
     "Settings": {
       "Title": "Market Configuration",

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -265,6 +265,7 @@
   "SWERPG.AUDIT_LOG.FILTER.DETAILS": "Choix fondamentaux",
   "SWERPG.AUDIT_LOG.FILTER.ADVANCEMENT": "Avancement",
   "SWERPG.AUDIT_LOG.FILTER.PURCHASES": "Achats",
+  "SWERPG.AUDIT_LOG.FILTER.SALES": "Ventes",
   "SWERPG.AUDIT_LOG.TYPE.SKILL_TRAIN": "Achat de compétence",
   "SWERPG.AUDIT_LOG.TYPE.SKILL_FORGET": "Remboursement de compétence",
   "SWERPG.AUDIT_LOG.TYPE.CHARACTERISTIC_INCREASE": "Augmentation de caractéristique",
@@ -284,6 +285,7 @@
   "SWERPG.AUDIT_LOG.TYPE.TALENT_NODE_FORGET_FAILED": "Échec d'oubli de nœud de talent",
   "SWERPG.AUDIT_LOG.TYPE.ADVANCEMENT_LEVEL": "Changement de niveau",
   "SWERPG.AUDIT_LOG.TYPE.ITEM_PURCHASE": "Article acheté",
+  "SWERPG.AUDIT_LOG.TYPE.ITEM_SALE": "Article vendu",
   "SWERPG.AUDIT_LOG.TYPE.UNKNOWN": "Événement inconnu",
   "SWERPG.AUDIT_LOG.NONE": "Aucun",
   "SWERPG.AUDIT_LOG.UNKNOWN_VALUE": "Valeur inconnue",
@@ -309,8 +311,10 @@
   "SWERPG.AUDIT_LOG.DESCRIPTION.TALENT_NODE_FORGET_FAILED": "Échec d'oubli de nœud de talent : {reasonCode} (nœud {nodeId})",
   "SWERPG.AUDIT_LOG.DESCRIPTION.ADVANCEMENT_LEVEL": "Niveau {oldLevel} -> {newLevel}",
   "SWERPG.AUDIT_LOG.DESCRIPTION.ITEM_PURCHASE": "Achat de {itemName} ({itemType}) pour {price} crédits",
+  "SWERPG.AUDIT_LOG.DESCRIPTION.ITEM_SALE": "Vente de {itemName} ({itemType}) pour {resalePrice} crédits ({fraction}% du prix de base)",
   "SWERPG.AUDIT_LOG.META.PRICE": "{price} crédits",
   "SWERPG.AUDIT_LOG.META.CREDITS_REMAINING": "{credits} crédits restants",
+  "SWERPG.AUDIT_LOG.META.SOLD_FOR": "Vendu pour {price} crédits",
   "SWERPG.AUDIT_LOG.DESCRIPTION.UNKNOWN": "Événement non interprété ({type})",
   "SWERPG.AUDIT_LOG.EXPORT": "Exporter",
   "SWERPG.AUDIT_LOG.EXPORT_TOOLTIP": "Exporter l'historique complet au format CSV",
@@ -1611,6 +1615,44 @@
       "Negotiable": {
         "Tooltip": "Prix négociable"
       }
+    },
+    "Mode": {
+      "Buy": "Acheter",
+      "Sell": "Vendre"
+    },
+    "Sell": {
+      "Confirm": {
+        "Title": "Vendre {name}",
+        "Content": "Confirmer la vente de {name} pour {price} crédits. Crédits actuels : {credits} → {remaining} après vente.",
+        "Sell": "Vendre pour {price} crédits",
+        "Cancel": "Annuler"
+      },
+      "Negotiate": {
+        "Title": "Améliorer le prix de revente",
+        "Offer": "Tenter de négocier un meilleur prix ? (Utilise Négociation, Persuasion ou Tromperie)",
+        "Accept": "Tenter une négociation",
+        "Skip": "Garder le prix de base (25%)"
+      }
+    },
+    "Sale": {
+      "Success": "{name} vendu pour {price} crédits. Crédits restants : {remaining}.",
+      "Error": {
+        "MissingActor": "Aucun vendeur trouvé.",
+        "MissingItem": "Article non trouvé.",
+        "UnsellableType": "Ce type d'article ne peut pas être vendu.",
+        "NotInInventory": "L'article n'est pas dans votre inventaire.",
+        "InvalidPrice": "L'article n'a pas de prix de base valide.",
+        "ItemNotFound": "L'article n'a pas été trouvé dans votre inventaire.",
+        "WriteFailed": "Impossible de compléter la vente. Consultez la console pour plus de détails."
+      }
+    },
+    "Inventory": {
+      "Description": "Sélectionnez des articles de votre inventaire à vendre.",
+      "BasePrice": "Prix de base",
+      "ResaleEstimate": "Revente (25%)",
+      "SellAriaLabel": "Vendre",
+      "SellButton": "Vendre",
+      "Empty": "Votre inventaire ne contient aucun article vendable."
     },
     "Settings": {
       "Title": "Configuration du marché",

--- a/module/applications/character-audit-log.mjs
+++ b/module/applications/character-audit-log.mjs
@@ -15,6 +15,7 @@ const AUDIT_LOG_FAMILIES = Object.freeze({
   details: 'details',
   advancement: 'advancement',
   purchases: 'purchases',
+  sales: 'sales',
   other: 'other',
 })
 
@@ -27,6 +28,7 @@ const AUDIT_LOG_FILTER_ORDER = Object.freeze([
   AUDIT_LOG_FAMILIES.details,
   AUDIT_LOG_FAMILIES.advancement,
   AUDIT_LOG_FAMILIES.purchases,
+  AUDIT_LOG_FAMILIES.sales,
 ])
 
 const AUDIT_LOG_FILTER_LABELS = Object.freeze({
@@ -38,6 +40,7 @@ const AUDIT_LOG_FILTER_LABELS = Object.freeze({
   [AUDIT_LOG_FAMILIES.details]: 'SWERPG.AUDIT_LOG.FILTER.DETAILS',
   [AUDIT_LOG_FAMILIES.advancement]: 'SWERPG.AUDIT_LOG.FILTER.ADVANCEMENT',
   [AUDIT_LOG_FAMILIES.purchases]: 'SWERPG.AUDIT_LOG.FILTER.PURCHASES',
+  [AUDIT_LOG_FAMILIES.sales]: 'SWERPG.AUDIT_LOG.FILTER.SALES',
 })
 
 const AUDIT_LOG_TYPE_LABELS = Object.freeze({
@@ -60,6 +63,7 @@ const AUDIT_LOG_TYPE_LABELS = Object.freeze({
   'talent-node-forget-failed': 'SWERPG.AUDIT_LOG.TYPE.TALENT_NODE_FORGET_FAILED',
   'advancement.level': 'SWERPG.AUDIT_LOG.TYPE.ADVANCEMENT_LEVEL',
   'item.purchase': 'SWERPG.AUDIT_LOG.TYPE.ITEM_PURCHASE',
+  'item.sale': 'SWERPG.AUDIT_LOG.TYPE.ITEM_SALE',
 })
 
 /**
@@ -107,6 +111,8 @@ export function getAuditLogFamily(type) {
       return AUDIT_LOG_FAMILIES.advancement
     case 'item.purchase':
       return AUDIT_LOG_FAMILIES.purchases
+    case 'item.sale':
+      return AUDIT_LOG_FAMILIES.sales
     default:
       return AUDIT_LOG_FAMILIES.other
   }
@@ -293,6 +299,13 @@ export function buildAuditLogDescription(entry) {
         price: data.price ?? 0,
         quantity: data.quantity ?? 1,
       })
+    case 'item.sale':
+      return game.i18n.format('SWERPG.AUDIT_LOG.DESCRIPTION.ITEM_SALE', {
+        itemName: getAuditLogName(data.itemName, 'SWERPG.AUDIT_LOG.UNKNOWN_ITEM'),
+        itemType: data.itemType ?? '',
+        resalePrice: data.resalePrice ?? 0,
+        fraction: Math.round((data.fraction ?? 0) * 100),
+      })
     default:
       return game.i18n.format('SWERPG.AUDIT_LOG.DESCRIPTION.UNKNOWN', {
         type: getAuditLogName(entry?.type, 'SWERPG.AUDIT_LOG.UNKNOWN_VALUE'),
@@ -314,10 +327,10 @@ export function buildAuditLogEntries(actor, filter = AUDIT_LOG_FAMILIES.all) {
     .map((entry) => {
       const family = getAuditLogFamily(entry.type)
       const xpDelta = Number(entry.xpDelta) || 0
-      const isPurchaseEntry = entry.type === 'item.purchase'
+      const isCreditEntry = entry.type === 'item.purchase' || entry.type === 'item.sale'
       const creditDelta = Number(entry.creditDelta) || 0
-      const deltaValue = isPurchaseEntry ? creditDelta : xpDelta
-      const formattedDelta = isPurchaseEntry ? formatAuditLogCreditDelta(creditDelta) : formatAuditLogDelta(xpDelta)
+      const deltaValue = isCreditEntry ? creditDelta : xpDelta
+      const formattedDelta = isCreditEntry ? formatAuditLogCreditDelta(creditDelta) : formatAuditLogDelta(xpDelta)
 
       return {
         ...entry,

--- a/module/applications/market/market-application.mjs
+++ b/module/applications/market/market-application.mjs
@@ -11,6 +11,8 @@ import { loadCompendiumItems } from './compendium-source-adapter.mjs'
 import NegotiationDialog from './negotiation-dialog.mjs'
 import ConsequencesDialog from './consequences-dialog.mjs'
 import { logger } from '../../utils/logger.mjs'
+import { validateSale } from '../../lib/market/sell-validation.mjs'
+import { computeResalePrice } from '../../lib/market/sell-valuation.mjs'
 
 const { api } = foundry.applications
 
@@ -26,6 +28,7 @@ const { api } = foundry.applications
  * @property {string} sortBy             Sort field key: 'name' | 'price' | 'rarity'
  * @property {'asc'|'desc'} sortDirection  Sort direction
  * @property {string} activeMarketType   Active market type key (key of MARKET_TYPES)
+ * @property {'buy'|'sell'} mode         Current market mode: buy catalogue or sell inventory
  */
 
 /**
@@ -51,6 +54,7 @@ const DEFAULT_VIEW_STATE = Object.freeze({
   sortBy: MARKET_SORT_FIELDS.name,
   sortDirection: 'asc',
   activeMarketType: DEFAULT_MARKET_TYPE,
+  mode: 'buy',
 })
 
 /* -------------------------------------------- */
@@ -166,6 +170,8 @@ export default class MarketApplicationV2 extends api.HandlebarsApplicationMixin(
       buyItem: MarketApplicationV2.#onBuyItem,
       negotiateItem: MarketApplicationV2.#onNegotiateItem,
       changeMarket: MarketApplicationV2.#onChangeMarket,
+      toggleMode: MarketApplicationV2.#onToggleMode,
+      sellItem: MarketApplicationV2.#onSellItem,
     },
   }
 
@@ -174,6 +180,10 @@ export default class MarketApplicationV2 extends api.HandlebarsApplicationMixin(
     catalog: {
       template: 'systems/swerpg/templates/market/market.hbs',
       scrollable: ['.market-catalog'],
+    },
+    inventory: {
+      template: 'systems/swerpg/templates/market/market-inventory.hbs',
+      scrollable: ['.market-inventory'],
     },
   }
 
@@ -217,25 +227,33 @@ export default class MarketApplicationV2 extends api.HandlebarsApplicationMixin(
 
   /** @override */
   async _preparePartContext(partId, context) {
-    if (partId === 'catalog') {
-      const buyer = this._buyerActor
-      const buyerCredits = buyer?.system?.creditBudget?.availableCredits ?? buyer?.system?.credits ?? null
+    const buyer = this._buyerActor
+    const buyerCredits = buyer?.system?.creditBudget?.availableCredits ?? buyer?.system?.credits ?? null
+    const mode = this._viewState.mode ?? 'buy'
 
+    context.viewState = { ...this._viewState }
+    context.mode = mode
+    context.buyer = buyer
+      ? {
+          id: buyer.id,
+          name: buyer.name,
+          credits: buyerCredits,
+        }
+      : null
+
+    if (partId === 'catalog') {
       context.catalog = await this.#prepareCatalog(buyer, buyerCredits)
-      context.viewState = { ...this._viewState }
       context.sortOptions = this.#buildSortOptions()
       context.typeFilterOptions = this.#buildTypeFilterOptions()
       context.sourceFilterOptions = this.#buildSourceFilterOptions()
       context.restrictionFilterOptions = this.#buildRestrictionFilterOptions()
       context.marketTypeOptions = this.#buildMarketTypeOptions()
-      context.buyer = buyer
-        ? {
-            id: buyer.id,
-            name: buyer.name,
-            credits: buyerCredits,
-          }
-        : null
     }
+
+    if (partId === 'inventory') {
+      context.inventory = buyer ? this.#prepareInventory(buyer) : { items: [] }
+    }
+
     return context
   }
 
@@ -756,6 +774,207 @@ export default class MarketApplicationV2 extends api.HandlebarsApplicationMixin(
   }
 
   /* -------------------------------------------- */
+  /*  Inventory helpers                           */
+  /* -------------------------------------------- */
+
+  /**
+   * Build the inventory context for the sell mode.
+   * Filters actor items to only include sellable types and annotates them with resale estimates.
+   *
+   * @param {Actor} actor  The seller actor.
+   * @returns {{ items: Array<object> }}
+   */
+  #prepareInventory(actor) {
+    const sellableItems = []
+
+    for (const item of actor.items) {
+      if (!(item.type in PURCHASABLE_ITEM_TYPES)) continue
+      const basePrice = item.system?._source?.price ?? item.system?.price ?? 0
+      const valuation = computeResalePrice({ basePrice, negotiationOutcome: 'failure' })
+      const typeConfig = PURCHASABLE_ITEM_TYPES[item.type]
+
+      sellableItems.push({
+        id: item.id,
+        name: item.name,
+        img: item.img ?? '',
+        type: item.type,
+        typeLabel: typeConfig?.label ?? item.type,
+        basePrice,
+        resaleEstimate: valuation.resalePrice,
+        resaleFraction: Math.round(valuation.fraction * 100),
+      })
+    }
+
+    sellableItems.sort((a, b) => a.name.localeCompare(b.name))
+
+    return { items: sellableItems }
+  }
+
+  /* -------------------------------------------- */
+  /*  Actions (sell mode)                         */
+  /* -------------------------------------------- */
+
+  /**
+   * Toggle the market between buy and sell mode and re-render.
+   *
+   * @this {MarketApplicationV2}
+   * @param {PointerEvent} _event   The initiating click event
+   * @param {HTMLElement}  target   The element bearing data-action="toggleMode"
+   * @returns {Promise<void>}
+   */
+  static async #onToggleMode(_event, target) {
+    const nextMode = target.dataset?.mode ?? (this._viewState.mode === 'buy' ? 'sell' : 'buy')
+    if (nextMode !== 'buy' && nextMode !== 'sell') {
+      logger.warn('[Market] toggleMode received unknown mode', { mode: nextMode })
+      return
+    }
+    this._viewState = { ...this._viewState, mode: nextMode }
+    logger.debug('[Market] Mode toggled', { mode: nextMode })
+    await this.render()
+  }
+
+  /**
+   * Execute the sale flow for an item in the seller's inventory.
+   * Pipeline: validate → confirm dialog → optional negotiation → delete item + credit actor → audit log.
+   *
+   * @this {MarketApplicationV2}
+   * @param {PointerEvent} _event   The initiating click event
+   * @param {HTMLElement}  target   The element bearing data-action="sellItem" and data-item-id
+   * @returns {Promise<void>}
+   */
+  static async #onSellItem(_event, target) {
+    const seller = this._buyerActor
+    if (!seller) {
+      ui.notifications.warn(game.i18n.localize('MARKET.Purchase.Error.MissingActor'))
+      return
+    }
+
+    const itemId = target.dataset?.itemId
+    if (!itemId) {
+      logger.warn('[Market] sellItem action triggered without a data-item-id attribute')
+      return
+    }
+
+    const item = seller.items.get(itemId)
+    if (!item) {
+      ui.notifications.error(game.i18n.localize('MARKET.Sale.Error.ItemNotFound'))
+      return
+    }
+
+    // Validate sale eligibility
+    const validation = validateSale({ actor: seller, item })
+    if (!validation.canSell) {
+      ui.notifications.warn(game.i18n.localize(validation.messageKey))
+      return
+    }
+
+    // Compute base resale estimate (25% — may be improved by negotiation)
+    const baseValuation = computeResalePrice({ basePrice: validation.basePrice, negotiationOutcome: 'failure' })
+
+    // Confirmation dialog
+    const i18n = game.i18n
+    const currentCredits = seller.system?.creditBudget?.availableCredits ?? seller.system?.credits ?? 0
+    const creditsAfterBase = currentCredits + baseValuation.resalePrice
+
+    const confirmed = await foundry.applications.api.DialogV2.confirm({
+      window: {
+        title: i18n.format('MARKET.Sell.Confirm.Title', { name: item.name }),
+      },
+      content: `<p>${i18n.format('MARKET.Sell.Confirm.Content', {
+        name: item.name,
+        price: baseValuation.resalePrice,
+        credits: currentCredits,
+        remaining: creditsAfterBase,
+      })}</p>`,
+      yes: {
+        label: i18n.format('MARKET.Sell.Confirm.Sell', { price: baseValuation.resalePrice }),
+        icon: 'fa-solid fa-coins',
+      },
+      no: {
+        label: i18n.localize('MARKET.Sell.Confirm.Cancel'),
+        icon: 'fa-solid fa-xmark',
+      },
+    })
+
+    if (!confirmed) return
+
+    // Optional negotiation
+    const offerNegotiation = await foundry.applications.api.DialogV2.confirm({
+      window: {
+        title: i18n.localize('MARKET.Sell.Negotiate.Title'),
+      },
+      content: `<p>${i18n.localize('MARKET.Sell.Negotiate.Offer')}</p>`,
+      yes: {
+        label: i18n.localize('MARKET.Sell.Negotiate.Accept'),
+        icon: 'fa-solid fa-handshake',
+      },
+      no: {
+        label: i18n.localize('MARKET.Sell.Negotiate.Skip'),
+        icon: 'fa-solid fa-xmark',
+      },
+    })
+
+    let finalValuation = baseValuation
+    if (offerNegotiation) {
+      const negotiationResult = await NegotiationDialog.prompt({ entry: { name: item.name, rarity: item.system?.rarity ?? 0 }, buyer: seller })
+
+      if (negotiationResult?.confirmed) {
+        finalValuation = computeResalePrice({
+          basePrice: validation.basePrice,
+          negotiationOutcome: negotiationResult.outcome,
+        })
+      }
+    }
+
+    // Execute sale: delete item then credit actor
+    try {
+      await seller.deleteEmbeddedDocuments('Item', [item.id])
+      const newCredits = currentCredits + finalValuation.resalePrice
+      await seller.update({ 'system.credits': newCredits })
+
+      // Record in audit log (non-blocking)
+      try {
+        const { recordItemSale } = await import('../../utils/audit-log.mjs')
+        await recordItemSale(seller, {
+          itemName: item.name,
+          itemType: item.type,
+          basePrice: validation.basePrice,
+          resalePrice: finalValuation.resalePrice,
+          fraction: finalValuation.fraction,
+          negotiationOutcome: finalValuation.outcome,
+          creditsAfter: newCredits,
+          itemId: item.id,
+        })
+      } catch (auditErr) {
+        logger.warn('[Market] Could not record item sale audit entry', auditErr)
+      }
+
+      ui.notifications.info(
+        i18n.format('MARKET.Sale.Success', {
+          name: item.name,
+          price: finalValuation.resalePrice,
+          remaining: newCredits,
+        }),
+      )
+
+      logger.info('[Market] Item sale completed', {
+        actorId: seller.id,
+        actorName: seller.name,
+        itemId: item.id,
+        itemName: item.name,
+        basePrice: validation.basePrice,
+        resalePrice: finalValuation.resalePrice,
+        creditsAfter: newCredits,
+      })
+
+      await this.render()
+    } catch (err) {
+      logger.error('[Market] Sale failed', err)
+      ui.notifications.error(game.i18n.localize('MARKET.Sale.Error.WriteFailed'))
+    }
+  }
+
+  /* -------------------------------------------- */
   /*  Event Listeners                             */
   /* -------------------------------------------- */
 
@@ -764,6 +983,13 @@ export default class MarketApplicationV2 extends api.HandlebarsApplicationMixin(
     super._onRender?.(context, options)
     const html = this.element
     if (!html) return
+
+    // Show the active mode part, hide the other
+    const mode = this._viewState.mode ?? 'buy'
+    const catalogPart = html.querySelector('[data-application-part="catalog"]')
+    const inventoryPart = html.querySelector('[data-application-part="inventory"]')
+    if (catalogPart) catalogPart.hidden = mode !== 'buy'
+    if (inventoryPart) inventoryPart.hidden = mode !== 'sell'
 
     // Market type selector — updates activeMarketType and re-renders catalogue
     const marketTypeSelect = html.querySelector('.market-selector__select')

--- a/module/applications/market/market-application.mjs
+++ b/module/applications/market/market-application.mjs
@@ -179,11 +179,7 @@ export default class MarketApplicationV2 extends api.HandlebarsApplicationMixin(
   static PARTS = {
     catalog: {
       template: 'systems/swerpg/templates/market/market.hbs',
-      scrollable: ['.market-catalog'],
-    },
-    inventory: {
-      template: 'systems/swerpg/templates/market/market-inventory.hbs',
-      scrollable: ['.market-inventory'],
+      scrollable: ['.market-catalog', '.market-inventory'],
     },
   }
 
@@ -248,9 +244,6 @@ export default class MarketApplicationV2 extends api.HandlebarsApplicationMixin(
       context.sourceFilterOptions = this.#buildSourceFilterOptions()
       context.restrictionFilterOptions = this.#buildRestrictionFilterOptions()
       context.marketTypeOptions = this.#buildMarketTypeOptions()
-    }
-
-    if (partId === 'inventory') {
       context.inventory = buyer ? this.#prepareInventory(buyer) : { items: [] }
     }
 
@@ -787,7 +780,7 @@ export default class MarketApplicationV2 extends api.HandlebarsApplicationMixin(
   #prepareInventory(actor) {
     const sellableItems = []
 
-    for (const item of actor.items) {
+    for (const item of actor.items ?? []) {
       if (!(item.type in PURCHASABLE_ITEM_TYPES)) continue
       const basePrice = item.system?._source?.price ?? item.system?.price ?? 0
       const valuation = computeResalePrice({ basePrice, negotiationOutcome: 'failure' })
@@ -983,13 +976,6 @@ export default class MarketApplicationV2 extends api.HandlebarsApplicationMixin(
     super._onRender?.(context, options)
     const html = this.element
     if (!html) return
-
-    // Show the active mode part, hide the other
-    const mode = this._viewState.mode ?? 'buy'
-    const catalogPart = html.querySelector('[data-application-part="catalog"]')
-    const inventoryPart = html.querySelector('[data-application-part="inventory"]')
-    if (catalogPart) catalogPart.hidden = mode !== 'buy'
-    if (inventoryPart) inventoryPart.hidden = mode !== 'sell'
 
     // Market type selector — updates activeMarketType and re-renders catalogue
     const marketTypeSelect = html.querySelector('.market-selector__select')

--- a/module/lib/market/sell-validation.mjs
+++ b/module/lib/market/sell-validation.mjs
@@ -1,0 +1,94 @@
+/**
+ * Pure domain module for validating a Market item sale.
+ *
+ * No Foundry dependencies — accepts plain objects and returns plain values.
+ * All mutations are the responsibility of the Foundry adapter layer.
+ */
+
+import { PURCHASABLE_ITEM_TYPES } from '../../config/market.mjs'
+
+/* -------------------------------------------- */
+/*  Types                                       */
+/* -------------------------------------------- */
+
+/**
+ * @typedef {Object} SaleValidationResult
+ * @property {boolean} canSell      Whether all pre-conditions are satisfied.
+ * @property {string}  reason       Machine-readable reason key (empty string when canSell is true).
+ * @property {string}  [messageKey] i18n key for the user-facing message (present when canSell is false).
+ * @property {number}  [basePrice]  Resolved base price (present when canSell is true).
+ */
+
+/* -------------------------------------------- */
+/*  Pure function                               */
+/* -------------------------------------------- */
+
+/**
+ * Validate whether an actor can sell an item via the Market.
+ *
+ * Rules (in order of evaluation):
+ * 1. Actor must be a non-null object.
+ * 2. Item must be a non-null object.
+ * 3. Item type must be listed in `PURCHASABLE_ITEM_TYPES`.
+ * 4. Item must be present in the actor's inventory (matched by `id` or `uuid`).
+ * 5. Item's `system.price` must be a non-negative number (or 0).
+ *
+ * The actor's `items` may be any iterable collection with a `.some()` method, or a plain array.
+ * This matches both Foundry's `EmbeddedCollection` and plain test stubs.
+ *
+ * @param {object} params
+ * @param {{ items?: { some: Function } }} params.actor  Actor-like plain object.
+ * @param {{ id?: string, uuid?: string, type?: string, system?: { price?: number } }} params.item  Item-like plain object.
+ * @returns {SaleValidationResult}
+ */
+export function validateSale({ actor, item } = {}) {
+  if (!actor || typeof actor !== 'object') {
+    return {
+      canSell: false,
+      reason: 'missing-actor',
+      messageKey: 'MARKET.Sale.Error.MissingActor',
+    }
+  }
+
+  if (!item || typeof item !== 'object') {
+    return {
+      canSell: false,
+      reason: 'missing-item',
+      messageKey: 'MARKET.Sale.Error.MissingItem',
+    }
+  }
+
+  if (!item.type || !(item.type in PURCHASABLE_ITEM_TYPES)) {
+    return {
+      canSell: false,
+      reason: 'unsellable-type',
+      messageKey: 'MARKET.Sale.Error.UnsellableType',
+    }
+  }
+
+  const items = actor.items
+  const hasItem = items && typeof items.some === 'function' ? items.some((i) => i.id === item.id || (item.uuid && i.uuid === item.uuid)) : false
+
+  if (!hasItem) {
+    return {
+      canSell: false,
+      reason: 'not-in-inventory',
+      messageKey: 'MARKET.Sale.Error.NotInInventory',
+    }
+  }
+
+  const basePrice = item.system?.price ?? 0
+  if (typeof basePrice !== 'number' || !Number.isFinite(basePrice) || basePrice < 0) {
+    return {
+      canSell: false,
+      reason: 'invalid-price',
+      messageKey: 'MARKET.Sale.Error.InvalidPrice',
+    }
+  }
+
+  return {
+    canSell: true,
+    reason: '',
+    basePrice,
+  }
+}

--- a/module/lib/market/sell-valuation.mjs
+++ b/module/lib/market/sell-valuation.mjs
@@ -1,0 +1,97 @@
+/**
+ * Pure domain module for computing the resale price of an item sold via the Market.
+ *
+ * No Foundry dependencies — accepts plain values and returns plain values.
+ * All mutations (credit update, item deletion) are the responsibility
+ * of the Foundry adapter layer.
+ */
+
+/* -------------------------------------------- */
+/*  Constants                                   */
+/* -------------------------------------------- */
+
+/**
+ * Base resale fraction (no negotiation or failed negotiation): 25% of base price.
+ * @type {number}
+ */
+export const SELL_BASE_FRACTION = 0.25
+
+/**
+ * Resale fraction after a successful negotiation: 50% of base price.
+ * @type {number}
+ */
+export const SELL_NEGOTIATED_FRACTION = 0.5
+
+/**
+ * Maximum resale fraction after a triumph (exceptional success): 75% of base price.
+ * @type {number}
+ */
+export const SELL_MAX_FRACTION = 0.75
+
+/**
+ * Penalty resale fraction after a disaster: 10% of base price.
+ * @type {number}
+ */
+export const SELL_DISASTER_FRACTION = 0.1
+
+/* -------------------------------------------- */
+/*  Types                                       */
+/* -------------------------------------------- */
+
+/**
+ * @typedef {'failure'|'success'|'triumph'|'disaster'} NegotiationOutcome
+ */
+
+/**
+ * @typedef {Object} ResalePriceResult
+ * @property {number}             resalePrice       Floored resale price in credits.
+ * @property {number}             fraction          Fraction of base price applied (0–1).
+ * @property {number}             basePrice         The original base price passed in.
+ * @property {NegotiationOutcome} outcome           The negotiation outcome applied.
+ */
+
+/* -------------------------------------------- */
+/*  Pure function                               */
+/* -------------------------------------------- */
+
+/**
+ * Compute the resale price for an item based on its base price and the negotiation outcome.
+ *
+ * Fraction table:
+ * - `'failure'`  → 25% (base, no negotiation or failed attempt)
+ * - `'success'`  → 50%
+ * - `'triumph'`  → 75%
+ * - `'disaster'` → 10%
+ *
+ * The result is always floored to the nearest integer.
+ *
+ * @param {object}             params
+ * @param {number}             params.basePrice          Non-negative base price of the item.
+ * @param {NegotiationOutcome} [params.negotiationOutcome='failure']  Outcome of the negotiation roll.
+ * @returns {ResalePriceResult}
+ * @throws {TypeError} When basePrice is not a non-negative finite number.
+ */
+export function computeResalePrice({ basePrice, negotiationOutcome = 'failure' } = {}) {
+  if (!Number.isFinite(basePrice) || basePrice < 0) {
+    throw new TypeError(`basePrice must be a non-negative finite number, got ${basePrice}`)
+  }
+
+  let fraction = SELL_BASE_FRACTION
+
+  if (negotiationOutcome === 'triumph') {
+    fraction = SELL_MAX_FRACTION
+  } else if (negotiationOutcome === 'success') {
+    fraction = SELL_NEGOTIATED_FRACTION
+  } else if (negotiationOutcome === 'disaster') {
+    fraction = SELL_DISASTER_FRACTION
+  }
+
+  const resalePrice = Math.floor(basePrice * fraction)
+
+  return {
+    resalePrice,
+    fraction,
+    basePrice,
+    outcome: negotiationOutcome,
+  }
+}

--- a/module/utils/audit-log.mjs
+++ b/module/utils/audit-log.mjs
@@ -316,6 +316,7 @@ export {
   recordTalentNodePurchase,
   recordTalentNodeOperation,
   recordItemPurchase,
+  recordItemSale,
 }
 
 /* -------------------------------------------- */
@@ -529,6 +530,52 @@ async function recordItemPurchase(actor, { itemName, itemType, price, quantity =
   await writeLogEntries(actor, [entry])
 }
 
+/**
+ * Record an item sale audit entry when an item is sold via Market.
+ * Non-blocking: failures are caught internally without throwing.
+ *
+ * @param {object} actor The actor document instance.
+ * @param {object} saleData
+ * @param {string} saleData.itemName
+ * @param {string} saleData.itemType
+ * @param {number} saleData.basePrice
+ * @param {number} saleData.resalePrice
+ * @param {number} saleData.fraction
+ * @param {string} [saleData.negotiationOutcome='failure']
+ * @param {number} saleData.creditsAfter
+ * @param {string} [saleData.itemId]
+ */
+async function recordItemSale(actor, { itemName, itemType, basePrice, resalePrice, fraction, negotiationOutcome = 'failure', creditsAfter, itemId }) {
+  const ts = Date.now()
+  const creditsBefore = actor.system?.creditBudget?.availableCredits ?? actor.system?.credits ?? null
+  const creditsDelta = creditsBefore !== null && creditsAfter !== null ? creditsAfter - creditsBefore : null
+  const snapshot = { creditsBefore, creditsAfter, creditsDelta }
+  const user = game.users?.get(game.user?.id) ?? null
+
+  const entry = {
+    ...makeEntry({
+      type: 'item.sale',
+      data: {
+        itemName,
+        itemType,
+        basePrice,
+        resalePrice,
+        fraction,
+        negotiationOutcome,
+        itemId,
+      },
+      xpDelta: 0,
+      ts,
+      userId: game.user?.id,
+      user,
+      snapshot,
+    }),
+    creditDelta: resalePrice,
+  }
+
+  await writeLogEntries(actor, [entry])
+}
+
 /* -------------------------------------------- */
 /*  Émission de messages chat depuis l'audit    */
 /* -------------------------------------------- */
@@ -682,6 +729,18 @@ function _buildChatContext(actor, entry) {
       context.nextValue = `${data.itemName ?? ''} (${data.itemType ?? ''})`
       context.variant = 'add'
       context.metaLeft = game.i18n.format('SWERPG.AUDIT_LOG.META.PRICE', { price: data.price ?? 0 })
+      if (snapshot.creditsAfter !== undefined && snapshot.creditsAfter !== null) {
+        context.metaRight = game.i18n.format('SWERPG.AUDIT_LOG.META.CREDITS_REMAINING', { credits: snapshot.creditsAfter })
+      }
+      context.hasMeta = true
+      break
+    }
+
+    case 'item.sale': {
+      context.eventLabel = game.i18n.localize('SWERPG.AUDIT_LOG.TYPE.ITEM_SALE')
+      context.nextValue = `${data.itemName ?? ''} (${data.itemType ?? ''})`
+      context.variant = 'gain'
+      context.metaLeft = game.i18n.format('SWERPG.AUDIT_LOG.META.SOLD_FOR', { price: data.resalePrice ?? 0 })
       if (snapshot.creditsAfter !== undefined && snapshot.creditsAfter !== null) {
         context.metaRight = game.i18n.format('SWERPG.AUDIT_LOG.META.CREDITS_REMAINING', { credits: snapshot.creditsAfter })
       }

--- a/templates/market/market-inventory.hbs
+++ b/templates/market/market-inventory.hbs
@@ -1,0 +1,95 @@
+{{!-- Market Inventory — part: inventory --}}
+<div class="market-inventory scrollable" data-application-part="inventory">
+
+  {{!-- Mode toggle --}}
+  <div class="market-mode-toggle">
+    <button
+      type="button"
+      class="market-mode-toggle__btn {{#if (eq mode 'buy')}}is-active{{/if}}"
+      data-action="toggleMode"
+      data-mode="buy"
+      aria-pressed="{{#if (eq mode 'buy')}}true{{else}}false{{/if}}"
+    >
+      <i class="fa-solid fa-cart-shopping" aria-hidden="true"></i>
+      {{localize "MARKET.Mode.Buy"}}
+    </button>
+    <button
+      type="button"
+      class="market-mode-toggle__btn {{#if (eq mode 'sell')}}is-active{{/if}}"
+      data-action="toggleMode"
+      data-mode="sell"
+      aria-pressed="{{#if (eq mode 'sell')}}true{{else}}false{{/if}}"
+    >
+      <i class="fa-solid fa-hand-holding-dollar" aria-hidden="true"></i>
+      {{localize "MARKET.Mode.Sell"}}
+    </button>
+  </div>
+
+  {{#if buyer}}
+
+    <div class="market-buyer-bar">
+      <span class="market-buyer-bar__name">{{buyer.name}}</span>
+      <span class="market-buyer-bar__credits">
+        {{localize "MARKET.Buyer.Credits"}}: <strong>{{buyer.credits}}</strong>
+      </span>
+    </div>
+
+    <div class="market-selector">
+      <p class="market-selector__description">{{localize "MARKET.Inventory.Description"}}</p>
+    </div>
+
+    {{#if inventory.items.length}}
+      <table class="market-inventory__table">
+        <thead>
+          <tr>
+            <th class="market-col--icon" aria-label="{{localize 'MARKET.Catalog.Column.Name'}}"></th>
+            <th class="market-col--name">{{localize "MARKET.Catalog.Column.Name"}}</th>
+            <th class="market-col--type">{{localize "MARKET.Catalog.Column.Type"}}</th>
+            <th class="market-col--price">{{localize "MARKET.Inventory.BasePrice"}}</th>
+            <th class="market-col--price">{{localize "MARKET.Inventory.ResaleEstimate"}}</th>
+            <th class="market-col--sell" aria-label="{{localize 'MARKET.Inventory.SellButton'}}"></th>
+          </tr>
+        </thead>
+        <tbody>
+          {{#each inventory.items as |item|}}
+            <tr class="market-item" data-item-id="{{item.id}}">
+              <td class="market-col--icon">
+                {{#if item.img}}
+                  <img class="market-item__icon" src="{{item.img}}" alt="{{item.name}}" />
+                {{/if}}
+              </td>
+              <td class="market-col--name">{{item.name}}</td>
+              <td class="market-col--type">{{localize item.typeLabel}}</td>
+              <td class="market-col--price">{{item.basePrice}}</td>
+              <td class="market-col--price">
+                <span class="market-resale-estimate">{{item.resaleEstimate}} ({{item.resaleFraction}}%)</span>
+              </td>
+              <td class="market-col--sell">
+                <button
+                  type="button"
+                  class="market-item__sell"
+                  data-action="sellItem"
+                  data-item-id="{{item.id}}"
+                  data-tooltip="{{localize 'MARKET.Inventory.SellAriaLabel'}} {{item.name}}"
+                  aria-label="{{localize 'MARKET.Inventory.SellAriaLabel'}} {{item.name}}"
+                >
+                  <i class="fa-solid fa-hand-holding-dollar" aria-hidden="true"></i>
+                </button>
+              </td>
+            </tr>
+          {{/each}}
+        </tbody>
+      </table>
+    {{else}}
+      <div class="market-empty">
+        <p>{{localize "MARKET.Inventory.Empty"}}</p>
+      </div>
+    {{/if}}
+
+  {{else}}
+    <div class="market-buyer-bar market-buyer-bar--empty">
+      <span>{{localize "MARKET.Buyer.SelectCharacter"}}</span>
+    </div>
+  {{/if}}
+
+</div>

--- a/templates/market/market.hbs
+++ b/templates/market/market.hbs
@@ -1,5 +1,5 @@
-{{!-- Market Catalogue — part: catalog --}}
-<div class="market-catalog scrollable {{catalog.activeMarketDef.uiVariant}}" data-application-part="catalog">
+{{!-- Market — part: catalog (buy/sell) --}}
+<div class="market-catalog scrollable {{#unless (eq mode 'sell')}}{{catalog.activeMarketDef.uiVariant}}{{/unless}}" data-application-part="catalog">
 
   {{!-- Mode toggle (buy / sell) --}}
   <div class="market-mode-toggle">
@@ -24,6 +24,84 @@
       {{localize "MARKET.Mode.Sell"}}
     </button>
   </div>
+
+{{#if (eq mode 'sell')}}
+
+  {{!-- Sell / Inventory mode --}}
+  <div class="market-inventory">
+
+    {{#if buyer}}
+
+      <div class="market-buyer-bar">
+        <span class="market-buyer-bar__name">{{buyer.name}}</span>
+        <span class="market-buyer-bar__credits">
+          {{localize "MARKET.Buyer.Credits"}}: <strong>{{buyer.credits}}</strong>
+        </span>
+      </div>
+
+      <div class="market-selector">
+        <p class="market-selector__description">{{localize "MARKET.Inventory.Description"}}</p>
+      </div>
+
+      {{#if inventory.items.length}}
+        <table class="market-inventory__table">
+          <thead>
+            <tr>
+              <th class="market-col--icon" aria-label="{{localize 'MARKET.Catalog.Column.Name'}}"></th>
+              <th class="market-col--name">{{localize "MARKET.Catalog.Column.Name"}}</th>
+              <th class="market-col--type">{{localize "MARKET.Catalog.Column.Type"}}</th>
+              <th class="market-col--price">{{localize "MARKET.Inventory.BasePrice"}}</th>
+              <th class="market-col--price">{{localize "MARKET.Inventory.ResaleEstimate"}}</th>
+              <th class="market-col--sell" aria-label="{{localize 'MARKET.Inventory.SellButton'}}"></th>
+            </tr>
+          </thead>
+          <tbody>
+            {{#each inventory.items as |item|}}
+              <tr class="market-item" data-item-id="{{item.id}}">
+                <td class="market-col--icon">
+                  {{#if item.img}}
+                    <img class="market-item__icon" src="{{item.img}}" alt="{{item.name}}" />
+                  {{/if}}
+                </td>
+                <td class="market-col--name">{{item.name}}</td>
+                <td class="market-col--type">{{localize item.typeLabel}}</td>
+                <td class="market-col--price">{{item.basePrice}}</td>
+                <td class="market-col--price">
+                  <span class="market-resale-estimate">{{item.resaleEstimate}} ({{item.resaleFraction}}%)</span>
+                </td>
+                <td class="market-col--sell">
+                  <button
+                    type="button"
+                    class="market-item__sell"
+                    data-action="sellItem"
+                    data-item-id="{{item.id}}"
+                    data-tooltip="{{localize 'MARKET.Inventory.SellAriaLabel'}} {{item.name}}"
+                    aria-label="{{localize 'MARKET.Inventory.SellAriaLabel'}} {{item.name}}"
+                  >
+                    <i class="fa-solid fa-hand-holding-dollar" aria-hidden="true"></i>
+                  </button>
+                </td>
+              </tr>
+            {{/each}}
+          </tbody>
+        </table>
+      {{else}}
+        <div class="market-empty">
+          <p>{{localize "MARKET.Inventory.Empty"}}</p>
+        </div>
+      {{/if}}
+
+    {{else}}
+      <div class="market-buyer-bar market-buyer-bar--empty">
+        <span>{{localize "MARKET.Buyer.SelectCharacter"}}</span>
+      </div>
+    {{/if}}
+
+  </div>
+
+{{else}}
+
+  {{!-- Buy / Catalogue mode --}}
 
   {{!-- Market type selector --}}
   <div class="market-selector">
@@ -272,4 +350,6 @@
       </tbody>
     </table>
   {{/if}}
+
+{{/if}}
 </div>

--- a/templates/market/market.hbs
+++ b/templates/market/market.hbs
@@ -1,6 +1,30 @@
 {{!-- Market Catalogue — part: catalog --}}
 <div class="market-catalog scrollable {{catalog.activeMarketDef.uiVariant}}" data-application-part="catalog">
 
+  {{!-- Mode toggle (buy / sell) --}}
+  <div class="market-mode-toggle">
+    <button
+      type="button"
+      class="market-mode-toggle__btn {{#if (eq mode 'buy')}}is-active{{/if}}"
+      data-action="toggleMode"
+      data-mode="buy"
+      aria-pressed="{{#if (eq mode 'buy')}}true{{else}}false{{/if}}"
+    >
+      <i class="fa-solid fa-cart-shopping" aria-hidden="true"></i>
+      {{localize "MARKET.Mode.Buy"}}
+    </button>
+    <button
+      type="button"
+      class="market-mode-toggle__btn {{#if (eq mode 'sell')}}is-active{{/if}}"
+      data-action="toggleMode"
+      data-mode="sell"
+      aria-pressed="{{#if (eq mode 'sell')}}true{{else}}false{{/if}}"
+    >
+      <i class="fa-solid fa-hand-holding-dollar" aria-hidden="true"></i>
+      {{localize "MARKET.Mode.Sell"}}
+    </button>
+  </div>
+
   {{!-- Market type selector --}}
   <div class="market-selector">
     <label for="market-type-select" class="sr-only">{{localize "MARKET.MarketType.SelectorLabel"}}</label>

--- a/tests/lib/market/sell-validation.test.mjs
+++ b/tests/lib/market/sell-validation.test.mjs
@@ -1,0 +1,275 @@
+import { describe, expect, it } from 'vitest'
+
+import { validateSale } from '../../../module/lib/market/sell-validation.mjs'
+
+/* -------------------------------------------- */
+/*  Factories                                   */
+/* -------------------------------------------- */
+
+/**
+ * Build a minimal item-like plain object that can be sold.
+ * @param {object} [overrides]
+ */
+function makeItem({ id = 'item-1', uuid = 'Item.item-1', type = 'weapon', price = 100 } = {}) {
+  return {
+    id,
+    uuid,
+    type,
+    system: { price },
+  }
+}
+
+/**
+ * Build a minimal actor-like plain object with a given inventory.
+ * Uses a plain array for items (compatible with validateSale's `.some()` check).
+ * @param {object} [overrides]
+ */
+function makeActor({ id = 'actor-1', items = [] } = {}) {
+  return {
+    id,
+    items,
+  }
+}
+
+/**
+ * Build an actor that contains the given item in its inventory.
+ * @param {object} item
+ */
+function makeActorWithItem(item) {
+  return makeActor({ items: [item] })
+}
+
+/* -------------------------------------------- */
+/*  Tests                                       */
+/* -------------------------------------------- */
+
+describe('validateSale', () => {
+  /* -------------------------------------------- */
+  /*  Happy path                                  */
+  /* -------------------------------------------- */
+
+  describe('success', () => {
+    it('returns canSell=true when all conditions are met (weapon)', () => {
+      const item = makeItem({ type: 'weapon', price: 100 })
+      const actor = makeActorWithItem(item)
+      const result = validateSale({ actor, item })
+      expect(result.canSell).toBe(true)
+      expect(result.reason).toBe('')
+    })
+
+    it('returns canSell=true for armor type', () => {
+      const item = makeItem({ type: 'armor', price: 50 })
+      const actor = makeActorWithItem(item)
+      const result = validateSale({ actor, item })
+      expect(result.canSell).toBe(true)
+    })
+
+    it('returns canSell=true for gear type', () => {
+      const item = makeItem({ type: 'gear', price: 20 })
+      const actor = makeActorWithItem(item)
+      const result = validateSale({ actor, item })
+      expect(result.canSell).toBe(true)
+    })
+
+    it('includes the resolved basePrice in the result', () => {
+      const item = makeItem({ price: 250 })
+      const actor = makeActorWithItem(item)
+      const result = validateSale({ actor, item })
+      expect(result.basePrice).toBe(250)
+    })
+
+    it('returns canSell=true when price is 0', () => {
+      const item = makeItem({ price: 0 })
+      const actor = makeActorWithItem(item)
+      const result = validateSale({ actor, item })
+      expect(result.canSell).toBe(true)
+      expect(result.basePrice).toBe(0)
+    })
+
+    it('matches by uuid when item has no id match but uuid matches', () => {
+      const item = makeItem({ id: 'item-abc', uuid: 'Item.uuid-abc', type: 'weapon', price: 10 })
+      const actorItem = { id: 'item-other', uuid: 'Item.uuid-abc' }
+      const actor = makeActor({ items: [actorItem] })
+      const result = validateSale({ actor, item })
+      expect(result.canSell).toBe(true)
+    })
+  })
+
+  /* -------------------------------------------- */
+  /*  Missing actor                               */
+  /* -------------------------------------------- */
+
+  describe('missing actor', () => {
+    it('returns canSell=false with reason "missing-actor" when actor is null', () => {
+      const result = validateSale({ actor: null, item: makeItem() })
+      expect(result.canSell).toBe(false)
+      expect(result.reason).toBe('missing-actor')
+      expect(result.messageKey).toBe('MARKET.Sale.Error.MissingActor')
+    })
+
+    it('returns canSell=false when actor is undefined', () => {
+      const result = validateSale({ actor: undefined, item: makeItem() })
+      expect(result.canSell).toBe(false)
+      expect(result.reason).toBe('missing-actor')
+    })
+
+    it('returns canSell=false when called with no arguments', () => {
+      const result = validateSale()
+      expect(result.canSell).toBe(false)
+      expect(result.reason).toBe('missing-actor')
+    })
+  })
+
+  /* -------------------------------------------- */
+  /*  Missing item                                */
+  /* -------------------------------------------- */
+
+  describe('missing item', () => {
+    it('returns canSell=false with reason "missing-item" when item is null', () => {
+      const actor = makeActor()
+      const result = validateSale({ actor, item: null })
+      expect(result.canSell).toBe(false)
+      expect(result.reason).toBe('missing-item')
+      expect(result.messageKey).toBe('MARKET.Sale.Error.MissingItem')
+    })
+
+    it('returns canSell=false when item is undefined', () => {
+      const actor = makeActor()
+      const result = validateSale({ actor, item: undefined })
+      expect(result.canSell).toBe(false)
+      expect(result.reason).toBe('missing-item')
+    })
+  })
+
+  /* -------------------------------------------- */
+  /*  Unsellable type                             */
+  /* -------------------------------------------- */
+
+  describe('unsellable type', () => {
+    it('returns canSell=false for talent type', () => {
+      const item = makeItem({ type: 'talent' })
+      const actor = makeActorWithItem(item)
+      const result = validateSale({ actor, item })
+      expect(result.canSell).toBe(false)
+      expect(result.reason).toBe('unsellable-type')
+      expect(result.messageKey).toBe('MARKET.Sale.Error.UnsellableType')
+    })
+
+    it('returns canSell=false for career type', () => {
+      const item = makeItem({ type: 'career' })
+      const actor = makeActorWithItem(item)
+      const result = validateSale({ actor, item })
+      expect(result.canSell).toBe(false)
+      expect(result.reason).toBe('unsellable-type')
+    })
+
+    it('returns canSell=false when type is an empty string', () => {
+      const item = { ...makeItem(), type: '' }
+      const actor = makeActorWithItem(item)
+      const result = validateSale({ actor, item })
+      expect(result.canSell).toBe(false)
+      expect(result.reason).toBe('unsellable-type')
+    })
+
+    it('returns canSell=false when type is absent', () => {
+      const item = { id: 'item-1', system: { price: 10 } }
+      const actor = makeActorWithItem(item)
+      const result = validateSale({ actor, item })
+      expect(result.canSell).toBe(false)
+      expect(result.reason).toBe('unsellable-type')
+    })
+  })
+
+  /* -------------------------------------------- */
+  /*  Not in inventory                            */
+  /* -------------------------------------------- */
+
+  describe('not in inventory', () => {
+    it('returns canSell=false when item is not in actor inventory', () => {
+      const item = makeItem({ id: 'item-missing', uuid: 'Item.item-missing', type: 'weapon' })
+      const actor = makeActor({ items: [makeItem({ id: 'item-other', uuid: 'Item.item-other', type: 'weapon' })] })
+      const result = validateSale({ actor, item })
+      expect(result.canSell).toBe(false)
+      expect(result.reason).toBe('not-in-inventory')
+      expect(result.messageKey).toBe('MARKET.Sale.Error.NotInInventory')
+    })
+
+    it('returns canSell=false when actor has no items', () => {
+      const item = makeItem()
+      const actor = makeActor({ items: [] })
+      const result = validateSale({ actor, item })
+      expect(result.canSell).toBe(false)
+      expect(result.reason).toBe('not-in-inventory')
+    })
+
+    it('returns canSell=false when actor.items is undefined', () => {
+      const item = makeItem()
+      const actor = { id: 'actor-1' }
+      const result = validateSale({ actor, item })
+      expect(result.canSell).toBe(false)
+      expect(result.reason).toBe('not-in-inventory')
+    })
+  })
+
+  /* -------------------------------------------- */
+  /*  Invalid price                               */
+  /* -------------------------------------------- */
+
+  describe('invalid price', () => {
+    it('returns canSell=false when price is negative', () => {
+      const item = makeItem({ price: -10 })
+      const actor = makeActorWithItem(item)
+      const result = validateSale({ actor, item })
+      expect(result.canSell).toBe(false)
+      expect(result.reason).toBe('invalid-price')
+      expect(result.messageKey).toBe('MARKET.Sale.Error.InvalidPrice')
+    })
+
+    it('returns canSell=false when price is NaN', () => {
+      const item = makeItem({ price: NaN })
+      const actor = makeActorWithItem(item)
+      const result = validateSale({ actor, item })
+      expect(result.canSell).toBe(false)
+      expect(result.reason).toBe('invalid-price')
+    })
+
+    it('returns canSell=false when price is Infinity', () => {
+      const item = makeItem({ price: Infinity })
+      const actor = makeActorWithItem(item)
+      const result = validateSale({ actor, item })
+      expect(result.canSell).toBe(false)
+      expect(result.reason).toBe('invalid-price')
+    })
+
+    it('defaults to price 0 when system.price is absent (and allows the sale)', () => {
+      const item = { id: 'item-1', uuid: 'Item.item-1', type: 'weapon', system: {} }
+      const actor = makeActorWithItem(item)
+      const result = validateSale({ actor, item })
+      expect(result.canSell).toBe(true)
+      expect(result.basePrice).toBe(0)
+    })
+  })
+
+  /* -------------------------------------------- */
+  /*  messageKey completeness                     */
+  /* -------------------------------------------- */
+
+  describe('messageKey completeness', () => {
+    const failureCases = [
+      { desc: 'missing-actor', params: { actor: null, item: makeItem() } },
+      { desc: 'missing-item', params: { actor: makeActor(), item: null } },
+      { desc: 'unsellable-type', params: { actor: makeActorWithItem(makeItem({ type: 'talent' })), item: makeItem({ type: 'talent' }) } },
+      { desc: 'not-in-inventory', params: { actor: makeActor(), item: makeItem() } },
+      { desc: 'invalid-price', params: { actor: makeActorWithItem(makeItem({ price: -1 })), item: makeItem({ price: -1 }) } },
+    ]
+
+    for (const { desc, params } of failureCases) {
+      it(`defines a messageKey for reason "${desc}"`, () => {
+        const result = validateSale(params)
+        expect(result.canSell).toBe(false)
+        expect(typeof result.messageKey).toBe('string')
+        expect(result.messageKey.length).toBeGreaterThan(0)
+      })
+    }
+  })
+})

--- a/tests/lib/market/sell-valuation.test.mjs
+++ b/tests/lib/market/sell-valuation.test.mjs
@@ -1,0 +1,168 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  computeResalePrice,
+  SELL_BASE_FRACTION,
+  SELL_NEGOTIATED_FRACTION,
+  SELL_MAX_FRACTION,
+  SELL_DISASTER_FRACTION,
+} from '../../../module/lib/market/sell-valuation.mjs'
+
+/* -------------------------------------------- */
+/*  Tests                                       */
+/* -------------------------------------------- */
+
+describe('computeResalePrice', () => {
+  /* -------------------------------------------- */
+  /*  Default (failure / no negotiation)          */
+  /* -------------------------------------------- */
+
+  describe('default outcome (failure)', () => {
+    it('returns 25% of basePrice when no negotiation outcome is given', () => {
+      const result = computeResalePrice({ basePrice: 100 })
+      expect(result.resalePrice).toBe(25)
+      expect(result.fraction).toBe(SELL_BASE_FRACTION)
+    })
+
+    it('returns 25% when negotiationOutcome is explicitly "failure"', () => {
+      const result = computeResalePrice({ basePrice: 200, negotiationOutcome: 'failure' })
+      expect(result.resalePrice).toBe(50)
+      expect(result.fraction).toBe(SELL_BASE_FRACTION)
+    })
+
+    it('returns the base price, fraction, and outcome in the result', () => {
+      const result = computeResalePrice({ basePrice: 80, negotiationOutcome: 'failure' })
+      expect(result.basePrice).toBe(80)
+      expect(result.outcome).toBe('failure')
+    })
+  })
+
+  /* -------------------------------------------- */
+  /*  Success (50%)                               */
+  /* -------------------------------------------- */
+
+  describe('outcome: success', () => {
+    it('returns 50% of basePrice on success', () => {
+      const result = computeResalePrice({ basePrice: 100, negotiationOutcome: 'success' })
+      expect(result.resalePrice).toBe(50)
+      expect(result.fraction).toBe(SELL_NEGOTIATED_FRACTION)
+    })
+
+    it('returns correct outcome label', () => {
+      const result = computeResalePrice({ basePrice: 100, negotiationOutcome: 'success' })
+      expect(result.outcome).toBe('success')
+    })
+  })
+
+  /* -------------------------------------------- */
+  /*  Triumph (75%)                               */
+  /* -------------------------------------------- */
+
+  describe('outcome: triumph', () => {
+    it('returns 75% of basePrice on triumph', () => {
+      const result = computeResalePrice({ basePrice: 100, negotiationOutcome: 'triumph' })
+      expect(result.resalePrice).toBe(75)
+      expect(result.fraction).toBe(SELL_MAX_FRACTION)
+    })
+
+    it('returns correct outcome label', () => {
+      const result = computeResalePrice({ basePrice: 200, negotiationOutcome: 'triumph' })
+      expect(result.outcome).toBe('triumph')
+    })
+  })
+
+  /* -------------------------------------------- */
+  /*  Disaster (10%)                              */
+  /* -------------------------------------------- */
+
+  describe('outcome: disaster', () => {
+    it('returns 10% of basePrice on disaster', () => {
+      const result = computeResalePrice({ basePrice: 100, negotiationOutcome: 'disaster' })
+      expect(result.resalePrice).toBe(10)
+      expect(result.fraction).toBe(SELL_DISASTER_FRACTION)
+    })
+
+    it('returns correct outcome label', () => {
+      const result = computeResalePrice({ basePrice: 100, negotiationOutcome: 'disaster' })
+      expect(result.outcome).toBe('disaster')
+    })
+  })
+
+  /* -------------------------------------------- */
+  /*  Edge cases                                  */
+  /* -------------------------------------------- */
+
+  describe('edge cases', () => {
+    it('returns resalePrice = 0 when basePrice is 0', () => {
+      const result = computeResalePrice({ basePrice: 0, negotiationOutcome: 'triumph' })
+      expect(result.resalePrice).toBe(0)
+    })
+
+    it('always returns an integer (floors the result)', () => {
+      // 100 * 0.25 = 25 (exact), 33 * 0.25 = 8.25 → 8
+      const result = computeResalePrice({ basePrice: 33, negotiationOutcome: 'failure' })
+      expect(Number.isInteger(result.resalePrice)).toBe(true)
+      expect(result.resalePrice).toBe(8)
+    })
+
+    it('floors the result on success (50%)', () => {
+      // 33 * 0.5 = 16.5 → 16
+      const result = computeResalePrice({ basePrice: 33, negotiationOutcome: 'success' })
+      expect(result.resalePrice).toBe(16)
+      expect(Number.isInteger(result.resalePrice)).toBe(true)
+    })
+
+    it('floors the result on triumph (75%)', () => {
+      // 33 * 0.75 = 24.75 → 24
+      const result = computeResalePrice({ basePrice: 33, negotiationOutcome: 'triumph' })
+      expect(result.resalePrice).toBe(24)
+    })
+
+    it('floors the result on disaster (10%)', () => {
+      // 33 * 0.10 = 3.3 → 3
+      const result = computeResalePrice({ basePrice: 33, negotiationOutcome: 'disaster' })
+      expect(result.resalePrice).toBe(3)
+    })
+  })
+
+  /* -------------------------------------------- */
+  /*  Input validation                            */
+  /* -------------------------------------------- */
+
+  describe('input validation', () => {
+    it('throws TypeError when basePrice is negative', () => {
+      expect(() => computeResalePrice({ basePrice: -1 })).toThrow(TypeError)
+    })
+
+    it('throws TypeError when basePrice is NaN', () => {
+      expect(() => computeResalePrice({ basePrice: NaN })).toThrow(TypeError)
+    })
+
+    it('throws TypeError when basePrice is Infinity', () => {
+      expect(() => computeResalePrice({ basePrice: Infinity })).toThrow(TypeError)
+    })
+
+    it('throws TypeError when basePrice is undefined', () => {
+      expect(() => computeResalePrice({})).toThrow(TypeError)
+    })
+
+    it('defaults to "failure" outcome for unknown outcome strings', () => {
+      const result = computeResalePrice({ basePrice: 100, negotiationOutcome: 'unknown-outcome' })
+      expect(result.fraction).toBe(SELL_BASE_FRACTION)
+      expect(result.resalePrice).toBe(25)
+    })
+  })
+
+  /* -------------------------------------------- */
+  /*  Immutability                                */
+  /* -------------------------------------------- */
+
+  describe('immutability', () => {
+    it('does not mutate the input object', () => {
+      const params = { basePrice: 100, negotiationOutcome: 'success' }
+      const before = JSON.stringify(params)
+      computeResalePrice(params)
+      expect(JSON.stringify(params)).toBe(before)
+    })
+  })
+})


### PR DESCRIPTION
## Summary

- Add market inventory display and sell functionality for items (UI + backend).
- Implement sell validation and valuation logic and accompanying unit tests.
- Add i18n entries and Handlebars templates for the market UI; include documentation plan.

## Context

This PR implements the item-selling flow in the market application: UI templates and application logic, server-side validation and valuation modules, audit-log integration, unit tests for validation/valuation, and language entries.

## Tests

- Not run (not requested).

## Notes

- No breaking API changes expected. Manual QA / E2E was not executed in this PR.
