### PR TITLE
feat(market): implement automatic catalog filtering by market type and restriction level

### DIFF
--- a/documentation/plan/market/plan-marketAutomaticRestrictionFiltering.prompt.md
+++ b/documentation/plan/market/plan-marketAutomaticRestrictionFiltering.prompt.md
@@ -1,0 +1,505 @@
+# Plan d'Implémentation — Market Feature Issue #479
+
+## Filtrage automatique catalogue par type de marché et niveau de restriction
+
+## Vue d'ensemble
+
+**TL;DR** : Implémenter un filtrage automatique du catalogue Market selon le type de marché actif et le niveau de restriction des items. Les marchés standard/local masquent les items restricted/military/illegal. Le marché specialized affiche les items restreints et militaires. Le marché black-market affiche tout avec indicateurs visuels de risque. Une nouvelle fonction `isItemVisibleForMarket()` combine la visibilité d'availability (existante) avec une nouvelle règle de visibilité par restrictionLevel.
+
+## Objectifs
+
+1. **Filtrage automatique par restrictionLevel** : Masquer automatiquement les items restreints selon le type de marché, sans action utilisateur.
+2. **Respect de la hiérarchie marchés** : standard/local → aucun restreint; specialized → restreint+militaire ok; black-market → tout visible.
+3. **UI progressive/complète** : Badge visuels (⚠️ RESTREINT, 🎖️ MILITAIRE, ☠️ ILLÉGAL) pour items non-autorisés mais visibles en specialized/black-market.
+4. **Dropdown toolbar intelligent** : Les options du filtre restriction s'adaptent au marché actif (caché en standard/local, progressif en specialized, complet en black-market).
+5. **Zéro régression** : Comportement `specialized` et filtres existants demeurent intacts. Tests couvrent tous chemins.
+
+## Périmètre détaillé
+
+### Inclus
+
+- Nouvelle fonction `isItemVisibleForMarket(entry, marketTypeKey)` dans `module/lib/market/market-visibility.mjs`
+- Extension `MARKET_TYPES` dans `module/config/market.mjs` avec nouveau champ `allowedRestrictionLevels` sur chaque market type
+- Intégration dans `#prepareCatalog` du Market — remplacement de `resolveMarketCatalogVisibility` par `isItemVisibleForMarket`
+- Annotation chaque entry avec `isRestricted: boolean` (true si `restrictionLevel !== 'none'`)
+- Dropdown toolbar dynamique (`#buildRestrictionFilterOptions`) selon marché actif
+- Marquage visuel items restreints dans template market.hbs avec badge ⚠️/🎖️/☠️
+- Clés i18n pour labels des niveaux de restriction et tooltips
+- Tests Vitest couvrant 4 market types × 4 restriction levels + interaction availability
+- Zéro modification of `resolveMarketCatalogVisibility` existant — création d'une wrapper dans market-visibility.mjs
+
+### Exclus
+
+- Migration rétroactive de données d'items
+- Contrôle d'accès fine-grained par rôle
+- Conséquences penalties pour achat restreint (déjà couvert par ADR-0016 consequences.mjs)
+- Graphiques/analytics sur items restreints
+
+### Hypothèses
+
+- Items ont `restrictionLevel` (field ajouté par ADR-0009)
+- `MARKET_TYPES[key].allowedAvailability` est en lecture-seule (déjà frozen)
+- Template market.hbs supporte les classes CSS conditionnelles et les badges
+- Dropdown toolbar fait partie de vueState/filters standard
+
+### Contraintes
+
+- Deux axes filtrage indépendants mais co-actifs : availability (rareté) + restrictionLevel (légalité)
+- Item doit passer **les deux** critères pour être visible (ET logique)
+- Dropdown restriction adaptatif ne doit pas casser les filtres sauvegardés en vueState
+- Performance : filtrage pas plus de 2-3ms pour 100 items
+
+## Architecture
+
+```mermaid
+graph LR
+    Market["MarketApplicationV2<br/>#prepareCatalog"]
+    Visibility["isItemVisibleForMarket<br/>(market-visibility.mjs)"]
+    OldVisibility["resolveMarketCatalogVisibility<br/>(market-entry.mjs)"]
+    Annotate["Annotate:<br/>isRestricted=true"]
+    Render["Render catalog<br/>(market.hbs)"]
+
+    Market -->|loadMarketCatalog| AllEntries["allEntries"]
+    AllEntries -->|for each entry| Visibility
+    Visibility -->|calls| OldVisibility["resolveMarketCatalogVisibility<br/>(availability)"]
+    Visibility -->|+ restrictionLevel rule| CheckRestriction["check<br/>allowedRestrictionLevels"]
+    OldVisibility --> AvailPass{availability<br/>allowed?}
+    CheckRestriction --> RestrictPass{restriction<br/>allowed?}
+    AvailPass -->|yes| RestrictPass
+    AvailPass -->|no| HeadHide["hidden"]
+    RestrictPass -->|yes| VisibleEntry["visible entry"]
+    RestrictPass -->|no| HeadHide
+    VisibleEntry --> Annotate
+    Annotate --> Render
+    HeadHide --> FilteredOut["removed from catalog"]
+```
+
+### Détail fonction `isItemVisibleForMarket`
+
+```javascript
+/**
+ * Resolve whether a MarketEntry is visible in the given market type.
+ * Combines two axes: availability (rarity/supply) and restrictionLevel (legality).
+ *
+ * Rules:
+ * - Entry must pass availability check (existing resolveMarketCatalogVisibility logic)
+ * - Entry must pass restrictionLevel check against market's allowedRestrictionLevels
+ * - Both checks must succeed (AND logic)
+ * - If market unknown, returns permissive fallback (visible: true)
+ */
+export function isItemVisibleForMarket(entry, marketTypeKey = DEFAULT_MARKET_TYPE)
+  → { visible: boolean, reason: string|null }
+```
+
+## Structure des données
+
+### Extension `MARKET_TYPES`
+
+Ajouter champ `allowedRestrictionLevels` à chaque market type :
+
+```javascript
+MARKET_TYPES: {
+  standard: {
+    // ...existing fields...
+    allowedRestrictionLevels: ['none'], // only legal items
+  },
+  local: {
+    // ...existing fields...
+    allowedRestrictionLevels: ['none'], // only legal items
+  },
+  specialized: {
+    // ...existing fields...
+    allowedRestrictionLevels: ['none', 'restricted', 'military'], // legal + restricted + military
+  },
+  'black-market': {
+    // ...existing fields...
+    allowedRestrictionLevels: ['*'], // all restriction levels allowed
+  }
+}
+```
+
+### Annotation entry
+
+Chaque entry passant la visibilité doit être annotée :
+
+```javascript
+{
+  ...entry,
+  isRestricted: entry.restrictionLevel !== 'none', // true if restricted/military/illegal
+  restrictionLabel: SYSTEM.RESTRICTION_LEVELS[entry.restrictionLevel]?.label,
+  canBuy: ..., // existing
+  isBlackMarket: ..., // existing
+}
+```
+
+### Dropdown toolbar options
+
+Options varient selon `activeMarketType` :
+
+```javascript
+// standard/local
+[
+  { value: '', label: 'MARKET.Toolbar.Filter.AllRestrictions' },
+  // No other options (all restricted items hidden automatically)
+]
+
+// specialized
+[
+  { value: '', label: 'MARKET.Toolbar.Filter.AllRestrictions' },
+  { value: 'none', label: 'MARKET.Restriction.LegalOnly' },
+  { value: 'restricted', label: 'MARKET.Restriction.Restricted' },
+  { value: 'military', label: 'MARKET.Restriction.Military' },
+]
+
+// black-market
+[
+  { value: '', label: 'MARKET.Toolbar.Filter.AllRestrictions' },
+  { value: 'none', label: 'MARKET.Restriction.LegalOnly' },
+  { value: 'restricted', label: 'MARKET.Restriction.Restricted' },
+  { value: 'military', label: 'MARKET.Restriction.Military' },
+  { value: 'illegal', label: 'MARKET.Restriction.Illegal' },
+]
+```
+
+## Tâches implémentation
+
+### 1. Créer `module/lib/market/market-visibility.mjs`
+
+**Contenu** :
+
+- Import existant `resolveMarketCatalogVisibility` depuis `market-entry.mjs`
+- Export nouvelle fonction `isItemVisibleForMarket(entry, marketTypeKey)`
+  - Appel `resolveMarketCatalogVisibility(entry, marketTypeKey)` pour vérifier availability
+  - Si availability blocked → retourner `{ visible: false, reason: 'availability-not-allowed' }`
+  - Récupérer `allowedRestrictionLevels` du market type
+  - Si `allowedRestrictionLevels` inclut `'*'` (wildcard) → visible
+  - Sinon, vérifier si `entry.restrictionLevel` dans `allowedRestrictionLevels`
+  - Si non → retourner `{ visible: false, reason: 'restriction-not-allowed' }`
+  - Sinon → retourner `{ visible: true, reason: null }`
+
+**Tests** :
+
+- ✓ Standard market hides restricted items
+- ✓ Local market hides all restricted items
+- ✓ Specialized market hides illegal items
+- ✓ Black market shows all items
+- ✓ Fallback: unknown market → visible (permissive)
+- ✓ Availability blocked → item hidden regardless of restriction
+- ✓ Wildcard `'*'` allows all restrictions
+- ✓ Determinism: same inputs → same outputs
+
+### 2. Étendre `MARKET_TYPES` dans `module/config/market.mjs`
+
+**Contenu** :
+
+- Ajouter `allowedRestrictionLevels: Object.freeze([...])` à chaque market type
+- standard: `['none']`
+- local: `['none']`
+- specialized: `['none', 'restricted', 'military']`
+- black-market: `['*']` (wildcard = all)
+
+**Freeze** : `Object.freeze(array)` pour immutabilité
+
+**Tests contractuels** :
+
+- ✓ Chaque MARKET_TYPE contient allowedRestrictionLevels (array)
+- ✓ Standard allows only 'none'
+- ✓ Specialized excludes 'illegal'
+- ✓ Black-market wildcards to '\*'
+
+### 3. Intégrer dans `module/applications/market/market-application.mjs`
+
+**Contenu** dans `#prepareCatalog()` :
+
+- Importer `isItemVisibleForMarket` depuis `market-visibility.mjs`
+- Remplacer `resolveMarketCatalogVisibility(entry, activeMarketType)` par `isItemVisibleForMarket(entry, activeMarketType)` (ligne ~374)
+- Annoter chaque visible entry :
+  ```javascript
+  return {
+    ...entry,
+    canBuy: ..., // existing
+    isRestricted: entry.restrictionLevel !== 'none',
+    restrictionLabel: SYSTEM.RESTRICTION_LEVELS[entry.restrictionLevel]?.label ?? 'Unknown',
+    ...(existing annotations)
+  }
+  ```
+
+**Pas de modification** du filtre existant `filterByFilters` — reste inchangé
+
+**Tests d'intégration** :
+
+- ✓ Standard market excludes restricted items from totalCount
+- ✓ Specialized market includes restricted but shows badge
+- ✓ Black market includes all items
+- ✓ Filtering pipeline (search → availability → restriction → filters) works
+- ✓ No regression on existing affordableOnly/search/sort
+
+### 4. Adapter dropdown toolbar `#buildRestrictionFilterOptions()`
+
+**Contenu** :
+
+- Récupérer `activeMarketType` depuis `this._viewState`
+- Récupérer `allowedRestrictionLevels` du market type correspondant
+- Construire options dynamiquement :
+  - Si `activeMarketType` standard/local → retourner seulement option "Tous"
+  - Si specialized → retourner options pour 'none', 'restricted', 'military'
+  - Si black-market → retourner options pour 'none', 'restricted', 'military', 'illegal'
+- Toujours inclure option "Tous" (value: '')
+
+**Signature mise à jour** :
+
+```javascript
+#buildRestrictionFilterOptions() {
+  const marketDef = MARKET_TYPES[this._viewState.activeMarketType] ?? MARKET_TYPES[DEFAULT_MARKET_TYPE]
+  const allowedRestrictionLevels = marketDef.allowedRestrictionLevels ?? []
+
+  const allOption = { value: '', label: 'MARKET.Toolbar.Filter.AllRestrictions' }
+
+  // If only 'none' allowed, return just "All" option
+  if (allowedRestrictionLevels.length === 1 && allowedRestrictionLevels[0] === 'none') {
+    return [allOption]
+  }
+
+  // Build options for visible restriction levels
+  const restrictionOptions = allowedRestrictionLevels
+    .filter(rl => rl !== 'none' && rl !== '*') // Exclude 'none' and wildcard from options
+    .map(rl => ({
+      value: rl,
+      label: SYSTEM.RESTRICTION_LEVELS[rl]?.label ?? `MARKET.Restriction.${rl}`
+    }))
+
+  // Prepend legal-only option if any restricted items visible
+  if (restrictionOptions.length > 0) {
+    restrictionOptions.unshift({ value: 'none', label: 'MARKET.Restriction.LegalOnly' })
+  }
+
+  return [allOption, ...restrictionOptions]
+}
+```
+
+**Tests** :
+
+- ✓ Standard market: returns only "All" option
+- ✓ Specialized market: returns "All", "Legal Only", "Restricted", "Military"
+- ✓ Black-market: returns "All", "Legal Only", "Restricted", "Military", "Illegal"
+- ✓ Options use correct i18n keys
+- ✓ Changing market type updates options without clearing vueState.filterRestriction
+
+### 5. Marquer visuellement items restreints dans `templates/market/market.hbs`
+
+**Contenu** dans la boucle `{{#each catalog.items}}` :
+
+- Ajouter classe conditionnelle `market-entry--restricted` si `entry.isRestricted`
+- Ajouter badge dans `.market-entry__content` ou `.market-entry__header` :
+
+```handlebars
+{{#if entry.isRestricted}}
+  <span
+    class='market-entry__restriction-badge'
+    data-restriction='{{entry.restrictionLevel}}'
+    data-tooltip='{{localize entry.restrictionLabel}}'
+    role='img'
+    aria-label='{{localize entry.restrictionLabel}}'
+  >
+    {{#match entry.restrictionLevel 'restricted'}}⚠️{{/match}}
+    {{#match entry.restrictionLevel 'military'}}🎖️{{/match}}
+    {{#match entry.restrictionLevel 'illegal'}}☠️{{/match}}
+    <span class='market-entry__restriction-text'>{{localize entry.restrictionLabel}}</span>
+  </span>
+{{/if}}
+```
+
+**CSS en styles/market.less** :
+
+```less
+.market-entry--restricted {
+  opacity: 0.85;
+  border-left: 3px solid var(--color-warning, #ff9500);
+
+  &.market-entry--military {
+    border-left-color: var(--color-military-gold, #daa520);
+  }
+
+  &.market-entry--illegal {
+    border-left-color: var(--color-danger, #dc3545);
+  }
+}
+
+.market-entry__restriction-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  font-size: 0.85em;
+  padding: 0.25rem 0.5rem;
+  border-radius: 0.25rem;
+  background: var(--color-warning-bg, rgba(255, 149, 0, 0.1));
+  color: var(--color-warning-text, #ff9500);
+
+  &[data-restriction='military'] {
+    background: rgba(218, 165, 32, 0.1);
+    color: #daa520;
+  }
+
+  &[data-restriction='illegal'] {
+    background: rgba(220, 53, 69, 0.1);
+    color: #dc3545;
+  }
+}
+
+.market-entry__restriction-text {
+  font-weight: 500;
+}
+```
+
+**Tests** :
+
+- ✓ Restricted items in specialized/black-market have badge
+- ✓ Badge shows correct icon emoji per restriction level
+- ✓ Badge uses correct i18n label
+- ✓ Tooltip appears on hover
+- ✓ Legal (none) items have no badge
+
+### 6. Clés i18n dans `lang/en.json` et `lang/fr.json`
+
+**Nouvelles clés EN** :
+
+```json
+{
+  "MARKET.Restriction.LegalOnly": "Legal only",
+  "MARKET.Restriction.Restricted": "Restricted",
+  "MARKET.Restriction.Military": "Military",
+  "MARKET.Restriction.Illegal": "Illegal",
+  "MARKET.Toolbar.Filter.AllRestrictions": "All restrictions",
+  "MARKET.Toolbar.Filter.RestrictionLabel": "Restriction level filter"
+}
+```
+
+**Nouvelles clés FR** :
+
+```json
+{
+  "MARKET.Restriction.LegalOnly": "Légal uniquement",
+  "MARKET.Restriction.Restricted": "Restreint",
+  "MARKET.Restriction.Military": "Militaire",
+  "MARKET.Restriction.Illegal": "Illégal",
+  "MARKET.Toolbar.Filter.AllRestrictions": "Toutes restrictions",
+  "MARKET.Toolbar.Filter.RestrictionLabel": "Filtre par niveau de restriction"
+}
+```
+
+**Tests i18n** :
+
+- ✓ Keys exist in both en.json and fr.json
+- ✓ No hard-coded user-facing strings in code
+
+### 7. Tests Vitest
+
+**Fichier** : `tests/lib/market/market-visibility.test.mjs`
+
+**Couverture** :
+
+- Standard market: all available, legal=ok / restricted=hidden / military=hidden / illegal=hidden
+- Local market: common/available, legal=ok / restricted=hidden / military=hidden / illegal=hidden
+- Specialized market: all availability, legal=ok / restricted=ok / military=ok / illegal=hidden
+- Black-market: all availability & restrictions visible
+- Availability failure → item hidden regardless of restriction (AND logic)
+- Determinism: same entry + market → always same result
+- Wildcard '\*' handling in black-market
+- Unknown market type → permissive fallback
+- Edge cases: null/undefined values, frozen objects
+
+**Fichier** : `tests/applications/market/market-application.test.mjs` (add new describe blocks)
+
+**Couverture** :
+
+- Integration: prepare catalog with mixed items (available legal, rare restricted, etc.) in each market type
+- Validation: totalCount reflects correct visibility per market
+- Annotations: entry.isRestricted correctly set
+- Dropdown: #buildRestrictionFilterOptions returns correct options per market
+- No regression: existing filters/search/sort still work
+- Performance: prepareCatalog completes in <5ms for 100 items
+
+## Découpage par issues GitHub
+
+| #   | Titre                                                                | Périmètre                                                             | Dépendances | SP  |
+| --- | -------------------------------------------------------------------- | --------------------------------------------------------------------- | ----------- | --- |
+| 1   | **feat: Créer `isItemVisibleForMarket()` + `market-visibility.mjs`** | New function + MARKET_TYPES extension + config tests                  | —           | 5   |
+| 2   | **feat: Intégrer visibility filtering dans Market#prepareCatalog()** | Import market-visibility, replace resolveMarketCatalogVisibility call | #1          | 3   |
+| 3   | **feat: Dropdown restriction toolbar adaptatif**                     | Update #buildRestrictionFilterOptions() logic                         | #1          | 3   |
+| 4   | **feat: Marquage visuel items restreints (badge + CSS)**             | Template update + LESS styling                                        | #2          | 5   |
+| 5   | **chore: i18n clés restriction + filter labels (EN/FR)**             | lang/en.json + lang/fr.json updates                                   | —           | 2   |
+| 6   | **test: Vitest couverture `market-visibility.mjs`**                  | Tests unitaires fonction pure + contractuels MARKET_TYPES             | #1          | 5   |
+| 7   | **test: Integration tests Market prepareCatalog + dropdown**         | Market app tests + non-regessions                                     | #2, #3      | 5   |
+
+**Total estimation** : ~28 SP (2 sprints)
+
+## Considérations supplémentaires
+
+### 1. Interaction availability × restriction
+
+Deux axes **indépendants mais co-actifs** :
+
+- `availability` (rarity/supply) : contrôle si l'item est disponible à l'achat (common vs rare vs unavailable)
+- `restrictionLevel` (legality) : contrôle si l'item est légal à vendre dans ce marché
+
+**Règle** : Item doit passer **les deux** critères pour être visible. Si `availability` = 'unavailable' → masqué même en black-market. Si `restrictionLevel` = 'illegal' en standard → masqué même si available.
+
+**Implémentation** : `isItemVisibleForMarket` appelle d'abord `resolveMarketCatalogVisibility` (availability). Si blocked → retour immediate. Sinon, vérifier restriction. Les deux checks enchaînés (ET logique).
+
+### 2. Wildcard `'*'` dans black-market
+
+Black-market autorise tous les restriction levels → `allowedRestrictionLevels: ['*']`.
+
+**Implémentation** : Dans `isItemVisibleForMarket`, tester `if (allowedRestrictionLevels.includes('*')) return { visible: true }` avant vérifier entry.restrictionLevel.
+
+### 3. Dropdown comportement avec filtre sauvegardé
+
+Si user en black-market avec `filterRestriction='military'`, puis change en standard market :
+
+- Standard n'autorise que `restrictionLevel='none'`
+- Dropdown affiche seulement "Tous"
+- `filterRestriction='military'` reste en vueState mais aucun item ne match
+
+**Comportement** : C'est acceptable — le filtre reste sauvegardé mais inactif. Quand user revient en black-market, le filtre redevient actif. (Identique au switch entre compendium sources.)
+
+### 4. Performance
+
+Filtrage par restriction est O(1) check (simple array.includes ou strict equality). Pas d'impact perf notable.
+
+Concernant : 200+ items × 2 axes filtrage = ~0.5ms. Largement dans budget <5ms.
+
+### 5. Nommage cohérent
+
+Nouveau fichier `market-visibility.mjs` parallèle à `market-entry.mjs` (factory), `price-engine.mjs` (computation), `catalog-loader.mjs` (aggregation).
+
+Fonction `isItemVisibleForMarket` préfixée `is*` (booléan-returning) + suffixée `ForMarket` (contexte précis). Cohérent avec `evaluateEligibility()`, `resolveMarketCatalogVisibility()`.
+
+### 6. Zero-regression guarantee
+
+- `resolveMarketCatalogVisibility` demeure **inchangé** (private dans market-entry.mjs)
+- Callers migrés progressivement (market-application.mjs uniquement)
+- Tests neufs isolent market-visibility; tests existants couvrent market-application
+- Specialized market behavior (current, availability-based) stays intact
+
+## Validation de succès
+
+- ✓ Standard/local markets masquent tous items restricted/military/illegal automatiquement
+- ✓ Specialized market affiche restricted/military items avec badge ⚠️/🎖️
+- ✓ Black-market affiche tous items avec badge correspondant
+- ✓ Dropdown options adaptatif : limité en standard, progressif en specialized, complet en black-market
+- ✓ Badge visuels (icône + label i18n) corrects per restriction level
+- ✓ Filtre toolbar existant `filterRestriction` reste fonctionnel (intersection avec availability)
+- ✓ Tests Vitest couvrent 4 market types × 4 restriction levels + edge cases
+- ✓ i18n clés présentes EN+FR, aucune chaîne hard-codée
+- ✓ Performance <5ms catalog prep pour 200 items
+- ✓ Zéro régression behavior specialized market, search, sorting, affordableOnly
+- ✓ Disponibilité de `isItemVisibleForMarket` pour réutilisation future (compendium browser, loot tables, etc.)
+
+## Prochaines étapes
+
+1. **Raffiner ce plan** : Feedback utilisateur, architecture review
+2. **Détailler Issues 1–7** : Signatures exactes, checklist implementation
+3. **Créer issues GitHub** : Assigner, estimer story points
+4. **Implémenter par ordre** : 1 → 5 → 2 → 3 → 4 → 6 → 7 (tests en parallèle)
+5. **Review + merge** : PR par issue, validation tests + regressions
+6. **Documentation** : Update README marketplace, add ADR si architectural decision recordée

--- a/lang/en.json
+++ b/lang/en.json
@@ -1597,7 +1597,9 @@
       }
     },
     "Restriction": {
+      "LegalOnly": "Legal only",
       "Restricted": "Restricted",
+      "Military": "Military",
       "Illegal": "Illegal",
       "Licensed": "Licensed"
     },

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -1493,7 +1493,9 @@
       }
     },
     "Restriction": {
+      "LegalOnly": "Légal uniquement",
       "Restricted": "Restreint",
+      "Military": "Militaire",
       "Illegal": "Illégal",
       "Licensed": "Licencié"
     },

--- a/module/applications/market/market-application.mjs
+++ b/module/applications/market/market-application.mjs
@@ -1,4 +1,5 @@
-import { createMarketEntry, resolveMarketCatalogVisibility } from '../../lib/market/market-entry.mjs'
+import { createMarketEntry } from '../../lib/market/market-entry.mjs'
+import { isItemVisibleForMarket } from '../../lib/market/market-visibility.mjs'
 import { loadMarketCatalog } from '../../lib/market/catalog-loader.mjs'
 import { validatePurchase } from '../../lib/market/purchase.mjs'
 import { readMarketConfig, readMarketExcludedItems } from '../../lib/market/market-settings.mjs'
@@ -6,6 +7,7 @@ import { evaluateObtainability } from '../../lib/market/rarity-engine.mjs'
 import { CONSEQUENCE_TYPES, evaluateMarketConsequences } from '../../lib/market/consequences.mjs'
 import { serializeConsequence } from '../../lib/market/consequence-persistence.mjs'
 import { PURCHASABLE_ITEM_TYPES, SOURCE_TYPES, DEFAULT_MARKET_CONTEXT, MARKET_TYPES, DEFAULT_MARKET_TYPE } from '../../config/market.mjs'
+import { RESTRICTION_LEVELS } from '../../config/system.mjs'
 import { RESTRICTED_RESTRICTION_LEVELS, BLACK_MARKET_AVAILABILITY_KEYS } from '../../lib/market/consequences.mjs'
 import { loadCompendiumItems } from './compendium-source-adapter.mjs'
 import NegotiationDialog from './negotiation-dialog.mjs'
@@ -293,17 +295,42 @@ export default class MarketApplicationV2 extends api.HandlebarsApplicationMixin(
   }
 
   /**
-   * Build the list of restriction level filter options.
-   * First entry is the "all restrictions" placeholder.
+   * Build the list of restriction level filter options, adapted to the active market type.
+   *
+   * - standard/local: only the "All restrictions" option (all restricted items are hidden automatically)
+   * - specialized: "All", "Legal only", "Restricted", "Military"
+   * - black-market: "All", "Legal only", "Restricted", "Military", "Illegal"
+   *
    * @returns {Array<{value: string, label: string}>}
    */
   #buildRestrictionFilterOptions() {
+    const marketDef = MARKET_TYPES[this._viewState.activeMarketType] ?? MARKET_TYPES[DEFAULT_MARKET_TYPE]
+    const allowedRestrictionLevels = marketDef.allowedRestrictionLevels ?? []
+
     const allOption = { value: '', label: 'MARKET.Toolbar.Filter.AllRestrictions' }
-    const restrictionOptions = [
-      { value: 'restricted', label: 'MARKET.Restriction.Restricted' },
-      { value: 'illegal', label: 'MARKET.Restriction.Illegal' },
-      { value: 'licensed', label: 'MARKET.Restriction.Licensed' },
-    ]
+
+    // Standard/local: only 'none' is allowed — return just the "All" option since restricted items
+    // are hidden automatically; the dropdown would be meaningless with only one filter choice.
+    if (allowedRestrictionLevels.length === 1 && allowedRestrictionLevels[0] === 'none') {
+      return [allOption]
+    }
+
+    // Wildcard ('*') means all restriction levels are allowed — expand to all known levels
+    const levelsToShow = allowedRestrictionLevels.includes('*')
+      ? Object.keys(RESTRICTION_LEVELS).filter((rl) => rl !== 'none')
+      : allowedRestrictionLevels.filter((rl) => rl !== 'none' && rl !== '*')
+
+    // Build restriction-level-specific options
+    const restrictionOptions = levelsToShow.map((rl) => ({
+      value: rl,
+      label: RESTRICTION_LEVELS[rl]?.label ?? `MARKET.Restriction.${rl}`,
+    }))
+
+    // Prepend "Legal only" option when any restricted level is visible
+    if (restrictionOptions.length > 0) {
+      restrictionOptions.unshift({ value: 'none', label: 'MARKET.Restriction.LegalOnly' })
+    }
+
     return [allOption, ...restrictionOptions]
   }
 
@@ -370,9 +397,10 @@ export default class MarketApplicationV2 extends api.HandlebarsApplicationMixin(
       allEntries = []
     }
 
-    // 4. Apply market-type visibility rules (hide items whose availability is not allowed in this market)
+    // 4. Apply market-type visibility rules (hide items whose availability or restriction level is not
+    //    allowed in this market). isItemVisibleForMarket combines both availability and restriction axes.
     const visibleEntries = allEntries.filter((entry) => {
-      const { visible } = resolveMarketCatalogVisibility(entry, activeMarketType)
+      const { visible } = isItemVisibleForMarket(entry, activeMarketType)
       return visible
     })
 
@@ -394,6 +422,9 @@ export default class MarketApplicationV2 extends api.HandlebarsApplicationMixin(
       const isNegotiable = marketDef?.negotiationAllowed === true
       const isImperialSuspicion = RESTRICTED_RESTRICTION_LEVELS.includes(entry.restrictionLevel ?? '')
       const isBlackMarket = activeMarketType === 'black-market' || BLACK_MARKET_AVAILABILITY_KEYS.includes(entry.availability ?? '')
+      const restrictionLevel = entry.restrictionLevel ?? 'none'
+      const isRestricted = restrictionLevel !== 'none'
+      const restrictionLabel = RESTRICTION_LEVELS[restrictionLevel]?.label ?? null
       return {
         ...entry,
         canBuy: buyer !== null && validation.canPurchase,
@@ -402,6 +433,8 @@ export default class MarketApplicationV2 extends api.HandlebarsApplicationMixin(
         isNegotiable,
         isImperialSuspicion,
         isBlackMarket,
+        isRestricted,
+        restrictionLabel,
       }
     })
 

--- a/module/config/market.mjs
+++ b/module/config/market.mjs
@@ -245,14 +245,15 @@ export const DEFAULT_MARKET_CONFIG = Object.freeze({
 
 /**
  * @typedef {Object} MarketTypeDefinition
- * @property {string}   id                  Canonical market type key
- * @property {string}   label               Localization key
- * @property {string}   description         Short description localization key
- * @property {string[]} allowedItemTypes    Item type keys visible in this market (['*'] = all purchasable)
- * @property {string[]} allowedAvailability Availability keys allowed; items with other keys are hidden
- * @property {number}   priceModifier       Flat additive fractional modifier applied on top of item modifiers
- * @property {string}   uiVariant           CSS modifier class applied to the market UI for visual distinction
- * @property {boolean}  negotiationAllowed  Whether price negotiation is allowed in this market type
+ * @property {string}   id                        Canonical market type key
+ * @property {string}   label                     Localization key
+ * @property {string}   description               Short description localization key
+ * @property {string[]} allowedItemTypes          Item type keys visible in this market (['*'] = all purchasable)
+ * @property {string[]} allowedAvailability       Availability keys allowed; items with other keys are hidden
+ * @property {string[]} allowedRestrictionLevels  Restriction level keys allowed; ['*'] means all levels allowed
+ * @property {number}   priceModifier             Flat additive fractional modifier applied on top of item modifiers
+ * @property {string}   uiVariant                 CSS modifier class applied to the market UI for visual distinction
+ * @property {boolean}  negotiationAllowed        Whether price negotiation is allowed in this market type
  */
 
 /**
@@ -274,6 +275,7 @@ export const MARKET_TYPES = Object.freeze({
     description: 'MARKET.MarketType.Standard.Description',
     allowedItemTypes: Object.freeze(['*']),
     allowedAvailability: Object.freeze(['available', 'common', 'rare']),
+    allowedRestrictionLevels: Object.freeze(['none']),
     priceModifier: 0,
     uiVariant: 'market--standard',
     negotiationAllowed: true,
@@ -284,6 +286,7 @@ export const MARKET_TYPES = Object.freeze({
     description: 'MARKET.MarketType.Local.Description',
     allowedItemTypes: Object.freeze(['*']),
     allowedAvailability: Object.freeze(['available', 'common']),
+    allowedRestrictionLevels: Object.freeze(['none']),
     priceModifier: -0.1,
     uiVariant: 'market--local',
     negotiationAllowed: true,
@@ -294,6 +297,7 @@ export const MARKET_TYPES = Object.freeze({
     description: 'MARKET.MarketType.Specialized.Description',
     allowedItemTypes: Object.freeze(['*']),
     allowedAvailability: Object.freeze(['available', 'common', 'rare', 'veryRare']),
+    allowedRestrictionLevels: Object.freeze(['none', 'restricted', 'military']),
     priceModifier: 0.25,
     uiVariant: 'market--specialized',
     negotiationAllowed: true,
@@ -304,6 +308,7 @@ export const MARKET_TYPES = Object.freeze({
     description: 'MARKET.MarketType.BlackMarket.Description',
     allowedItemTypes: Object.freeze(['*']),
     allowedAvailability: Object.freeze(['available', 'common', 'rare', 'veryRare', 'restricted', 'blackMarket']),
+    allowedRestrictionLevels: Object.freeze(['*']),
     priceModifier: 0.5,
     uiVariant: 'market--black-market',
     negotiationAllowed: true,

--- a/module/lib/market/index.mjs
+++ b/module/lib/market/index.mjs
@@ -3,6 +3,7 @@ export { computeMarketPrice } from './pricing.mjs'
 export { calculateItemPrice } from './price-engine.mjs'
 export { resolveMarketSources, filterDuplicates, filterByActiveConfig, DEDUP_STRATEGIES } from './source-resolver.mjs'
 export { createMarketEntry, resolveMarketCatalogVisibility } from './market-entry.mjs'
+export { isItemVisibleForMarket } from './market-visibility.mjs'
 export { loadMarketCatalog } from './catalog-loader.mjs'
 export { validatePurchase } from './purchase.mjs'
 export {

--- a/module/lib/market/market-visibility.mjs
+++ b/module/lib/market/market-visibility.mjs
@@ -1,0 +1,62 @@
+import { MARKET_TYPES, DEFAULT_MARKET_TYPE } from '../../config/market.mjs'
+import { resolveMarketCatalogVisibility } from './market-entry.mjs'
+
+/**
+ * @typedef {Object} MarketItemVisibility
+ * @property {boolean}     visible  Whether this entry is visible in the active market
+ * @property {string|null} reason   Machine-readable reason for hiding, null if visible
+ */
+
+/**
+ * Resolve whether a MarketEntry is visible in the given market type.
+ *
+ * Combines two independent axes:
+ * - Availability (rarity/supply): delegates to `resolveMarketCatalogVisibility`
+ * - Restriction level (legality): checks `allowedRestrictionLevels` on the market type
+ *
+ * Both axes must pass for the entry to be visible (AND logic).
+ *
+ * Rules:
+ * - If the market type is unknown, the entry is visible (permissive fallback).
+ * - Availability is checked first; if blocked, returns immediately without checking restriction.
+ * - If `allowedRestrictionLevels` includes `'*'`, all restriction levels are allowed.
+ * - If `entry.restrictionLevel` is not in `allowedRestrictionLevels`, the entry is hidden.
+ *
+ * This function is a pure domain rule — no Foundry dependencies.
+ *
+ * @param {import('./market-entry.mjs').MarketEntry} entry        A market entry (plain object)
+ * @param {string} [marketTypeKey]                                 Active market type key (key of MARKET_TYPES)
+ * @returns {MarketItemVisibility}
+ */
+export function isItemVisibleForMarket(entry, marketTypeKey = DEFAULT_MARKET_TYPE) {
+  const marketDef = MARKET_TYPES[marketTypeKey]
+
+  // Unknown market type → permissive fallback: everything visible
+  if (!marketDef) {
+    return { visible: true, reason: null }
+  }
+
+  // Check availability axis first (existing logic in resolveMarketCatalogVisibility)
+  const availabilityResult = resolveMarketCatalogVisibility(entry, marketTypeKey)
+  if (!availabilityResult.visible) {
+    return { visible: false, reason: availabilityResult.reason ?? 'availability-not-allowed' }
+  }
+
+  // Check restriction level axis
+  const { allowedRestrictionLevels } = marketDef
+
+  // Wildcard: all restriction levels allowed
+  if (Array.isArray(allowedRestrictionLevels) && allowedRestrictionLevels.includes('*')) {
+    return { visible: true, reason: null }
+  }
+
+  // Determine the entry's restriction level; default to 'none' (fully legal) when absent
+  const entryRestrictionLevel = entry.restrictionLevel ?? 'none'
+  const isAllowed = Array.isArray(allowedRestrictionLevels) && allowedRestrictionLevels.includes(entryRestrictionLevel)
+
+  if (!isAllowed) {
+    return { visible: false, reason: 'restriction-not-allowed' }
+  }
+
+  return { visible: true, reason: null }
+}

--- a/styles/market.less
+++ b/styles/market.less
@@ -451,6 +451,39 @@
 }
 
 /* ----------------------------------------- */
+/*  Restriction Badge                        */
+/* ----------------------------------------- */
+
+.market-entry__restriction-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  font-size: 0.8em;
+  padding: 0.15rem 0.4rem;
+  border-radius: 0.25rem;
+  background: rgba(255, 149, 0, 0.1);
+  border: 1px solid rgba(255, 149, 0, 0.3);
+  color: #ff9500;
+  vertical-align: middle;
+
+  &[data-restriction='military'] {
+    background: rgba(218, 165, 32, 0.1);
+    border-color: rgba(218, 165, 32, 0.3);
+    color: #daa520;
+  }
+
+  &[data-restriction='illegal'] {
+    background: rgba(220, 53, 69, 0.1);
+    border-color: rgba(220, 53, 69, 0.3);
+    color: #dc3545;
+  }
+}
+
+.market-entry__restriction-text {
+  font-weight: 500;
+}
+
+/* ----------------------------------------- */
 /*  Negotiation Dialog                       */
 /* ----------------------------------------- */
 

--- a/styles/swerpg.css
+++ b/styles/swerpg.css
@@ -5408,6 +5408,34 @@ input[type='range'] {
   color: #90caf9;
 }
 /* ----------------------------------------- */
+/*  Restriction Badge                        */
+/* ----------------------------------------- */
+.market-entry__restriction-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  font-size: 0.8em;
+  padding: 0.15rem 0.4rem;
+  border-radius: 0.25rem;
+  background: rgba(255, 149, 0, 0.1);
+  border: 1px solid rgba(255, 149, 0, 0.3);
+  color: #ff9500;
+  vertical-align: middle;
+}
+.market-entry__restriction-badge[data-restriction='military'] {
+  background: rgba(218, 165, 32, 0.1);
+  border-color: rgba(218, 165, 32, 0.3);
+  color: #daa520;
+}
+.market-entry__restriction-badge[data-restriction='illegal'] {
+  background: rgba(220, 53, 69, 0.1);
+  border-color: rgba(220, 53, 69, 0.3);
+  color: #dc3545;
+}
+.market-entry__restriction-text {
+  font-weight: 500;
+}
+/* ----------------------------------------- */
 /*  Negotiation Dialog                       */
 /* ----------------------------------------- */
 .market-negotiation-dialog__body {

--- a/templates/market/market.hbs
+++ b/templates/market/market.hbs
@@ -261,6 +261,23 @@
             </td>
             <td class="market-col--name">
               {{entry.name}}
+              {{!-- Restriction badge (visible in specialized/black-market for restricted items) --}}
+              {{#if entry.isRestricted}}
+                <span class="market-entry__restriction-badge"
+                      data-restriction="{{entry.restrictionLevel}}"
+                      data-tooltip="{{localize entry.restrictionLabel}}"
+                      role="img"
+                      aria-label="{{localize entry.restrictionLabel}}">
+                  {{#if (eq entry.restrictionLevel 'restricted')}}
+                    <i class="fa-solid fa-triangle-exclamation" aria-hidden="true"></i>
+                  {{else if (eq entry.restrictionLevel 'military')}}
+                    <i class="fa-solid fa-shield-halved" aria-hidden="true"></i>
+                  {{else if (eq entry.restrictionLevel 'illegal')}}
+                    <i class="fa-solid fa-skull-crossbones" aria-hidden="true"></i>
+                  {{/if}}
+                  <span class="market-entry__restriction-text">{{localize entry.restrictionLabel}}</span>
+                </span>
+              {{/if}}
               {{!-- Narrative badges --}}
               <span class="market-badges" aria-label="{{localize 'MARKET.Badge.AriaLabel'}}">
                 {{#if entry.isImperialSuspicion}}

--- a/tests/applications/market/market-application.test.mjs
+++ b/tests/applications/market/market-application.test.mjs
@@ -1419,6 +1419,236 @@ describe('MarketApplicationV2', () => {
   })
 
   /* -------------------------------------------- */
+  /*  Restriction filtering in catalog            */
+  /* -------------------------------------------- */
+
+  describe('restriction level filtering in catalog', () => {
+    it('standard market hides items with restrictionLevel=restricted', async () => {
+      const legal = makeItem({ type: 'weapon', name: 'Legal Blaster', restrictionLevel: 'none', availability: 'available' })
+      const restricted = makeItem({ type: 'weapon', name: 'Restricted Blaster', restrictionLevel: 'restricted', availability: 'available' })
+      globalThis.game.items = makeItemsCollection([legal, restricted])
+
+      const app = new MarketApplicationV2()
+      app._viewState = { ...app._viewState, activeMarketType: 'standard' }
+      const context = await app._preparePartContext('catalog', {})
+
+      expect(context.catalog.totalCount).toBe(1)
+      expect(context.catalog.items[0].name).toBe('Legal Blaster')
+    })
+
+    it('standard market hides items with restrictionLevel=military', async () => {
+      const legal = makeItem({ type: 'weapon', name: 'Legal Blaster', restrictionLevel: 'none', availability: 'available' })
+      const military = makeItem({ type: 'weapon', name: 'Military Rifle', restrictionLevel: 'military', availability: 'available' })
+      globalThis.game.items = makeItemsCollection([legal, military])
+
+      const app = new MarketApplicationV2()
+      app._viewState = { ...app._viewState, activeMarketType: 'standard' }
+      const context = await app._preparePartContext('catalog', {})
+
+      expect(context.catalog.totalCount).toBe(1)
+      expect(context.catalog.items[0].name).toBe('Legal Blaster')
+    })
+
+    it('standard market hides items with restrictionLevel=illegal', async () => {
+      const legal = makeItem({ type: 'weapon', name: 'Legal Blaster', restrictionLevel: 'none', availability: 'available' })
+      const illegal = makeItem({ type: 'weapon', name: 'Illegal Weapon', restrictionLevel: 'illegal', availability: 'available' })
+      globalThis.game.items = makeItemsCollection([legal, illegal])
+
+      const app = new MarketApplicationV2()
+      app._viewState = { ...app._viewState, activeMarketType: 'standard' }
+      const context = await app._preparePartContext('catalog', {})
+
+      expect(context.catalog.totalCount).toBe(1)
+      expect(context.catalog.items[0].name).toBe('Legal Blaster')
+    })
+
+    it('specialized market shows restricted items (badge annotated)', async () => {
+      const restricted = makeItem({ type: 'weapon', name: 'Restricted Blaster', restrictionLevel: 'restricted', availability: 'available' })
+      globalThis.game.items = makeItemsCollection([restricted])
+
+      const app = new MarketApplicationV2()
+      app._viewState = { ...app._viewState, activeMarketType: 'specialized' }
+      const context = await app._preparePartContext('catalog', {})
+
+      expect(context.catalog.totalCount).toBe(1)
+      expect(context.catalog.items[0].isRestricted).toBe(true)
+    })
+
+    it('specialized market shows military items', async () => {
+      const military = makeItem({ type: 'weapon', name: 'Military Rifle', restrictionLevel: 'military', availability: 'available' })
+      globalThis.game.items = makeItemsCollection([military])
+
+      const app = new MarketApplicationV2()
+      app._viewState = { ...app._viewState, activeMarketType: 'specialized' }
+      const context = await app._preparePartContext('catalog', {})
+
+      expect(context.catalog.totalCount).toBe(1)
+      expect(context.catalog.items[0].isRestricted).toBe(true)
+    })
+
+    it('specialized market hides illegal items', async () => {
+      const illegal = makeItem({ type: 'weapon', name: 'Illegal Weapon', restrictionLevel: 'illegal', availability: 'available' })
+      globalThis.game.items = makeItemsCollection([illegal])
+
+      const app = new MarketApplicationV2()
+      app._viewState = { ...app._viewState, activeMarketType: 'specialized' }
+      const context = await app._preparePartContext('catalog', {})
+
+      expect(context.catalog.totalCount).toBe(0)
+    })
+
+    it('black-market shows all restriction levels', async () => {
+      const legal = makeItem({ type: 'weapon', name: 'Legal Blaster', restrictionLevel: 'none', availability: 'available' })
+      const restricted = makeItem({ type: 'weapon', name: 'Restricted Blaster', restrictionLevel: 'restricted', availability: 'available' })
+      const military = makeItem({ type: 'weapon', name: 'Military Rifle', restrictionLevel: 'military', availability: 'available' })
+      const illegal = makeItem({ type: 'weapon', name: 'Illegal Weapon', restrictionLevel: 'illegal', availability: 'available' })
+      globalThis.game.items = makeItemsCollection([legal, restricted, military, illegal])
+
+      const app = new MarketApplicationV2()
+      app._viewState = { ...app._viewState, activeMarketType: 'black-market' }
+      const context = await app._preparePartContext('catalog', {})
+
+      expect(context.catalog.totalCount).toBe(4)
+    })
+
+    it('annotates isRestricted=false on legal items', async () => {
+      const legal = makeItem({ type: 'weapon', name: 'Legal Blaster', restrictionLevel: 'none', availability: 'available' })
+      globalThis.game.items = makeItemsCollection([legal])
+
+      const app = new MarketApplicationV2()
+      const context = await app._preparePartContext('catalog', {})
+
+      expect(context.catalog.items[0].isRestricted).toBe(false)
+    })
+
+    it('annotates isRestricted=true on restricted items in black-market', async () => {
+      const restricted = makeItem({ type: 'weapon', name: 'Restricted Blaster', restrictionLevel: 'restricted', availability: 'available' })
+      globalThis.game.items = makeItemsCollection([restricted])
+
+      const app = new MarketApplicationV2()
+      app._viewState = { ...app._viewState, activeMarketType: 'black-market' }
+      const context = await app._preparePartContext('catalog', {})
+
+      expect(context.catalog.items[0].isRestricted).toBe(true)
+    })
+
+    it('annotates restrictionLabel on restricted items', async () => {
+      const restricted = makeItem({ type: 'weapon', name: 'Restricted Blaster', restrictionLevel: 'restricted', availability: 'available' })
+      globalThis.game.items = makeItemsCollection([restricted])
+
+      const app = new MarketApplicationV2()
+      app._viewState = { ...app._viewState, activeMarketType: 'black-market' }
+      const context = await app._preparePartContext('catalog', {})
+
+      // restrictionLabel should be a non-empty i18n key string
+      expect(context.catalog.items[0].restrictionLabel).toBeTruthy()
+      expect(typeof context.catalog.items[0].restrictionLabel).toBe('string')
+    })
+
+    it('local market hides restricted items (same as standard)', async () => {
+      const restricted = makeItem({ type: 'weapon', name: 'Restricted Blaster', restrictionLevel: 'restricted', availability: 'available' })
+      globalThis.game.items = makeItemsCollection([restricted])
+
+      const app = new MarketApplicationV2()
+      app._viewState = { ...app._viewState, activeMarketType: 'local' }
+      const context = await app._preparePartContext('catalog', {})
+
+      expect(context.catalog.totalCount).toBe(0)
+    })
+  })
+
+  /* -------------------------------------------- */
+  /*  Adaptive restriction filter dropdown        */
+  /* -------------------------------------------- */
+
+  describe('#buildRestrictionFilterOptions (via _preparePartContext)', () => {
+    it('standard market returns only the "All" option', async () => {
+      globalThis.game.items = makeItemsCollection([])
+
+      const app = new MarketApplicationV2()
+      app._viewState = { ...app._viewState, activeMarketType: 'standard' }
+      const context = await app._preparePartContext('catalog', {})
+
+      expect(context.restrictionFilterOptions).toHaveLength(1)
+      expect(context.restrictionFilterOptions[0].value).toBe('')
+    })
+
+    it('local market returns only the "All" option', async () => {
+      globalThis.game.items = makeItemsCollection([])
+
+      const app = new MarketApplicationV2()
+      app._viewState = { ...app._viewState, activeMarketType: 'local' }
+      const context = await app._preparePartContext('catalog', {})
+
+      expect(context.restrictionFilterOptions).toHaveLength(1)
+      expect(context.restrictionFilterOptions[0].value).toBe('')
+    })
+
+    it('specialized market returns "All", "Legal only", "Restricted", "Military" options', async () => {
+      globalThis.game.items = makeItemsCollection([])
+
+      const app = new MarketApplicationV2()
+      app._viewState = { ...app._viewState, activeMarketType: 'specialized' }
+      const context = await app._preparePartContext('catalog', {})
+
+      const values = context.restrictionFilterOptions.map((o) => o.value)
+      expect(values).toContain('')
+      expect(values).toContain('none')
+      expect(values).toContain('restricted')
+      expect(values).toContain('military')
+      expect(values).not.toContain('illegal')
+      expect(context.restrictionFilterOptions).toHaveLength(4)
+    })
+
+    it('black-market returns "All", "Legal only", "Restricted", "Military", "Illegal" options', async () => {
+      globalThis.game.items = makeItemsCollection([])
+
+      const app = new MarketApplicationV2()
+      app._viewState = { ...app._viewState, activeMarketType: 'black-market' }
+      const context = await app._preparePartContext('catalog', {})
+
+      const values = context.restrictionFilterOptions.map((o) => o.value)
+      expect(values).toContain('')
+      expect(values).toContain('none')
+      expect(values).toContain('restricted')
+      expect(values).toContain('military')
+      expect(values).toContain('illegal')
+      expect(context.restrictionFilterOptions).toHaveLength(5)
+    })
+
+    it('each option has value and label', async () => {
+      globalThis.game.items = makeItemsCollection([])
+
+      const app = new MarketApplicationV2()
+      app._viewState = { ...app._viewState, activeMarketType: 'black-market' }
+      const context = await app._preparePartContext('catalog', {})
+
+      for (const opt of context.restrictionFilterOptions) {
+        expect(opt).toHaveProperty('value')
+        expect(opt).toHaveProperty('label')
+        expect(typeof opt.label).toBe('string')
+      }
+    })
+
+    it('changing market type updates dropdown options without clearing filterRestriction from vueState', async () => {
+      globalThis.game.items = makeItemsCollection([])
+
+      const app = new MarketApplicationV2()
+      // Set a restriction filter while in black-market
+      app._viewState = { ...app._viewState, activeMarketType: 'black-market', filterRestriction: 'military' }
+      const bmContext = await app._preparePartContext('catalog', {})
+      expect(bmContext.restrictionFilterOptions).toHaveLength(5)
+
+      // Switch to standard — filter state is preserved in _viewState
+      app._viewState = { ...app._viewState, activeMarketType: 'standard' }
+      const stdContext = await app._preparePartContext('catalog', {})
+      expect(stdContext.restrictionFilterOptions).toHaveLength(1)
+      // filterRestriction remains set in _viewState (not cleared)
+      expect(app._viewState.filterRestriction).toBe('military')
+    })
+  })
+
+  /* -------------------------------------------- */
   /*  Consequence integration (Phase 7)           */
   /* -------------------------------------------- */
 

--- a/tests/lib/market/market-visibility.test.mjs
+++ b/tests/lib/market/market-visibility.test.mjs
@@ -1,0 +1,259 @@
+import { describe, expect, it } from 'vitest'
+import { isItemVisibleForMarket } from '../../../module/lib/market/market-visibility.mjs'
+
+/* -------------------------------------------- */
+/*  Helpers                                     */
+/* -------------------------------------------- */
+
+/**
+ * Build a minimal MarketEntry-shaped plain object.
+ * @param {object} [overrides]
+ * @returns {object}
+ */
+function makeEntry(overrides = {}) {
+  return {
+    uuid: 'Item.test',
+    name: 'Test Item',
+    availability: 'available',
+    restrictionLevel: 'none',
+    ...overrides,
+  }
+}
+
+/* -------------------------------------------- */
+/*  Tests                                       */
+/* -------------------------------------------- */
+
+describe('isItemVisibleForMarket', () => {
+  /* -------------------------------------------- */
+  /*  Standard market                             */
+  /* -------------------------------------------- */
+
+  describe('standard market', () => {
+    it('shows legal (none) items with available availability', () => {
+      const result = isItemVisibleForMarket(makeEntry({ availability: 'available', restrictionLevel: 'none' }), 'standard')
+      expect(result.visible).toBe(true)
+      expect(result.reason).toBeNull()
+    })
+
+    it('shows legal (none) items with common availability', () => {
+      const result = isItemVisibleForMarket(makeEntry({ availability: 'common', restrictionLevel: 'none' }), 'standard')
+      expect(result.visible).toBe(true)
+    })
+
+    it('shows legal (none) items with rare availability', () => {
+      const result = isItemVisibleForMarket(makeEntry({ availability: 'rare', restrictionLevel: 'none' }), 'standard')
+      expect(result.visible).toBe(true)
+    })
+
+    it('hides restricted items (availability ok)', () => {
+      const result = isItemVisibleForMarket(makeEntry({ availability: 'available', restrictionLevel: 'restricted' }), 'standard')
+      expect(result.visible).toBe(false)
+      expect(result.reason).toBe('restriction-not-allowed')
+    })
+
+    it('hides military items (availability ok)', () => {
+      const result = isItemVisibleForMarket(makeEntry({ availability: 'available', restrictionLevel: 'military' }), 'standard')
+      expect(result.visible).toBe(false)
+      expect(result.reason).toBe('restriction-not-allowed')
+    })
+
+    it('hides illegal items (availability ok)', () => {
+      const result = isItemVisibleForMarket(makeEntry({ availability: 'available', restrictionLevel: 'illegal' }), 'standard')
+      expect(result.visible).toBe(false)
+      expect(result.reason).toBe('restriction-not-allowed')
+    })
+
+    it('hides veryRare items (availability blocked)', () => {
+      const result = isItemVisibleForMarket(makeEntry({ availability: 'veryRare', restrictionLevel: 'none' }), 'standard')
+      expect(result.visible).toBe(false)
+      expect(result.reason).toBe('availability-not-allowed')
+    })
+  })
+
+  /* -------------------------------------------- */
+  /*  Local market                                */
+  /* -------------------------------------------- */
+
+  describe('local market', () => {
+    it('shows legal items with available availability', () => {
+      const result = isItemVisibleForMarket(makeEntry({ availability: 'available', restrictionLevel: 'none' }), 'local')
+      expect(result.visible).toBe(true)
+    })
+
+    it('shows legal items with common availability', () => {
+      const result = isItemVisibleForMarket(makeEntry({ availability: 'common', restrictionLevel: 'none' }), 'local')
+      expect(result.visible).toBe(true)
+    })
+
+    it('hides rare items (availability blocked)', () => {
+      const result = isItemVisibleForMarket(makeEntry({ availability: 'rare', restrictionLevel: 'none' }), 'local')
+      expect(result.visible).toBe(false)
+      expect(result.reason).toBe('availability-not-allowed')
+    })
+
+    it('hides restricted items (availability ok, restriction blocked)', () => {
+      const result = isItemVisibleForMarket(makeEntry({ availability: 'available', restrictionLevel: 'restricted' }), 'local')
+      expect(result.visible).toBe(false)
+      expect(result.reason).toBe('restriction-not-allowed')
+    })
+
+    it('hides military items', () => {
+      const result = isItemVisibleForMarket(makeEntry({ availability: 'available', restrictionLevel: 'military' }), 'local')
+      expect(result.visible).toBe(false)
+      expect(result.reason).toBe('restriction-not-allowed')
+    })
+
+    it('hides illegal items', () => {
+      const result = isItemVisibleForMarket(makeEntry({ availability: 'available', restrictionLevel: 'illegal' }), 'local')
+      expect(result.visible).toBe(false)
+      expect(result.reason).toBe('restriction-not-allowed')
+    })
+  })
+
+  /* -------------------------------------------- */
+  /*  Specialized market                          */
+  /* -------------------------------------------- */
+
+  describe('specialized market', () => {
+    it('shows legal items with available availability', () => {
+      const result = isItemVisibleForMarket(makeEntry({ availability: 'available', restrictionLevel: 'none' }), 'specialized')
+      expect(result.visible).toBe(true)
+    })
+
+    it('shows restricted items with available availability', () => {
+      const result = isItemVisibleForMarket(makeEntry({ availability: 'available', restrictionLevel: 'restricted' }), 'specialized')
+      expect(result.visible).toBe(true)
+    })
+
+    it('shows military items with available availability', () => {
+      const result = isItemVisibleForMarket(makeEntry({ availability: 'available', restrictionLevel: 'military' }), 'specialized')
+      expect(result.visible).toBe(true)
+    })
+
+    it('shows restricted items with veryRare availability', () => {
+      const result = isItemVisibleForMarket(makeEntry({ availability: 'veryRare', restrictionLevel: 'restricted' }), 'specialized')
+      expect(result.visible).toBe(true)
+    })
+
+    it('hides illegal items', () => {
+      const result = isItemVisibleForMarket(makeEntry({ availability: 'available', restrictionLevel: 'illegal' }), 'specialized')
+      expect(result.visible).toBe(false)
+      expect(result.reason).toBe('restriction-not-allowed')
+    })
+
+    it('hides items whose availability is not in allowedAvailability (restricted not in list)', () => {
+      // restricted (AVAILABILITY_STATUS key) is not in specialized allowedAvailability
+      const result = isItemVisibleForMarket(makeEntry({ availability: 'restricted', restrictionLevel: 'none' }), 'specialized')
+      expect(result.visible).toBe(false)
+      expect(result.reason).toBe('availability-not-allowed')
+    })
+  })
+
+  /* -------------------------------------------- */
+  /*  Black market                                */
+  /* -------------------------------------------- */
+
+  describe('black-market', () => {
+    it('shows legal items', () => {
+      const result = isItemVisibleForMarket(makeEntry({ availability: 'available', restrictionLevel: 'none' }), 'black-market')
+      expect(result.visible).toBe(true)
+    })
+
+    it('shows restricted items', () => {
+      const result = isItemVisibleForMarket(makeEntry({ availability: 'available', restrictionLevel: 'restricted' }), 'black-market')
+      expect(result.visible).toBe(true)
+    })
+
+    it('shows military items', () => {
+      const result = isItemVisibleForMarket(makeEntry({ availability: 'available', restrictionLevel: 'military' }), 'black-market')
+      expect(result.visible).toBe(true)
+    })
+
+    it('shows illegal items', () => {
+      const result = isItemVisibleForMarket(makeEntry({ availability: 'available', restrictionLevel: 'illegal' }), 'black-market')
+      expect(result.visible).toBe(true)
+    })
+
+    it('shows all restriction levels with restricted availability', () => {
+      const result = isItemVisibleForMarket(makeEntry({ availability: 'restricted', restrictionLevel: 'illegal' }), 'black-market')
+      expect(result.visible).toBe(true)
+    })
+
+    it('respects wildcard (*) for all restriction levels', () => {
+      // Wildcard means any restriction level passes — direct test of the mechanism
+      for (const rl of ['none', 'restricted', 'military', 'illegal']) {
+        const result = isItemVisibleForMarket(makeEntry({ availability: 'available', restrictionLevel: rl }), 'black-market')
+        expect(result.visible).toBe(true)
+      }
+    })
+  })
+
+  /* -------------------------------------------- */
+  /*  AND logic: availability × restriction       */
+  /* -------------------------------------------- */
+
+  describe('AND logic (both axes must pass)', () => {
+    it('hides restricted+availabilityBlocked item: availability blocks first', () => {
+      // Item availability not allowed in standard → hidden even though restrictionLevel='none'
+      const result = isItemVisibleForMarket(makeEntry({ availability: 'veryRare', restrictionLevel: 'none' }), 'standard')
+      expect(result.visible).toBe(false)
+      expect(result.reason).toBe('availability-not-allowed')
+    })
+
+    it('hides item whose availability passes but restriction fails', () => {
+      const result = isItemVisibleForMarket(makeEntry({ availability: 'available', restrictionLevel: 'illegal' }), 'standard')
+      expect(result.visible).toBe(false)
+      expect(result.reason).toBe('restriction-not-allowed')
+    })
+
+    it('hides item when both axes fail (availability checked first)', () => {
+      // veryRare availability blocked in standard → returns availability-not-allowed (short-circuit)
+      const result = isItemVisibleForMarket(makeEntry({ availability: 'veryRare', restrictionLevel: 'illegal' }), 'standard')
+      expect(result.visible).toBe(false)
+      expect(result.reason).toBe('availability-not-allowed')
+    })
+  })
+
+  /* -------------------------------------------- */
+  /*  Fallback / edge cases                       */
+  /* -------------------------------------------- */
+
+  describe('fallback and edge cases', () => {
+    it('unknown market type → permissive fallback (visible=true)', () => {
+      const result = isItemVisibleForMarket(makeEntry(), 'unknown-market-xyz')
+      expect(result.visible).toBe(true)
+      expect(result.reason).toBeNull()
+    })
+
+    it('defaults to standard market type when none provided', () => {
+      // 'illegal' restriction is hidden in standard market
+      const result = isItemVisibleForMarket(makeEntry({ restrictionLevel: 'illegal' }))
+      expect(result.visible).toBe(false)
+    })
+
+    it('treats missing restrictionLevel as "none" (legal fallback)', () => {
+      const entry = makeEntry()
+      delete entry.restrictionLevel
+      const result = isItemVisibleForMarket(entry, 'standard')
+      expect(result.visible).toBe(true)
+    })
+
+    it('treats null restrictionLevel as "none" (legal fallback)', () => {
+      const result = isItemVisibleForMarket(makeEntry({ restrictionLevel: null }), 'standard')
+      expect(result.visible).toBe(true)
+    })
+
+    it('is deterministic: same inputs always produce same output', () => {
+      const entry = makeEntry({ availability: 'available', restrictionLevel: 'restricted' })
+      const r1 = isItemVisibleForMarket(entry, 'standard')
+      const r2 = isItemVisibleForMarket(entry, 'standard')
+      expect(r1).toEqual(r2)
+    })
+
+    it('does not mutate the entry object', () => {
+      const entry = Object.freeze(makeEntry({ availability: 'available', restrictionLevel: 'none' }))
+      expect(() => isItemVisibleForMarket(entry, 'standard')).not.toThrow()
+    })
+  })
+})


### PR DESCRIPTION
## Summary

- Implement automatic catalog filtering by market type and restriction level.
- Add market visibility business logic and integrate with market application UI.
- Add templates, styles and unit tests covering the new visibility behaviour.

## Context

This branch implements automatic filtering of catalogue entries based on the selected market type and restriction level so the market UI only shows permissible items.

## Tests

- Not run (not requested).
- Added unit tests: tests/lib/market/market-visibility.test.mjs and module/applications/market/market-application.test.mjs

## Notes

- Files changed include language strings (lang/en.json, lang/fr.json), market config (module/config/market.mjs), market library logic (module/lib/market/*), market application (module/applications/market/market-application.mjs), templates/styles and two new test files.
