### PR TITLE
feat(market): mode vente du NegotiationDialog — i18n, tests et forSale

### DIFF
--- a/documentation/guide-nego-vente-market.md
+++ b/documentation/guide-nego-vente-market.md
@@ -1,0 +1,81 @@
+# Guide utilisateur — Négociation lors de la vente d'un item au Market
+
+## Déclenchement
+
+Quand un PJ vend un item depuis son inventaire via le Market, une boîte de dialogue de négociation apparaît **après la validation de vente initiale** (calcul du prix de base + choix de négocier ou non).
+
+Le titre de la boîte indique alors **« Négocier le prix de vente »** (au lieu de « Négocier le prix d'achat »).
+
+## Interface
+
+![Dialogue de négociation vente](screenshot-nego-vente.png)
+
+La boîte de dialogue contient :
+
+1. **Nom de l'item** et son **prix d'origine** (prix de base calculé par le vendeur)
+2. **Difficulté** (dépend de la rareté de l'item)
+3. **Compétence de négociation** (au choix parmi les compétences disponibles)
+4. **Rangs de succès** (nombre de succès nets obtenus au jet, de 0 à 6)
+5. **Case à cocher Désastre** (à cocher si le jet a fait un Désastre)
+6. **Prix de vente calculé** en temps réel selon les rangs saisis
+7. **Bouton « Vendre à ce prix »** (confirme la vente au prix affiché)
+8. **Bouton « Annuler »** (annule la vente)
+
+## Outcomes de la négociation en mode vente
+
+Le prix de revente final dépend du résultat de la négociation :
+
+| Outcome                 | Condition                                                | Fraction du prix de base | Prix pour un item à 1000 crédits |
+| ----------------------- | -------------------------------------------------------- | ------------------------ | -------------------------------- |
+| **Échec** (failure)     | 0 succès, pas de désastre                                | 25 %                     | 250 crédits                      |
+| **Succès** (success)    | 1 à 3 succès, pas de désastre                            | 50 %                     | 500 crédits                      |
+| **Triomphe** (triumph)  | 4 succès ou plus, pas de désastre                        | 75 %                     | 750 crédits                      |
+| **Désastre** (disaster) | Case désastre cochée (quel que soit le nombre de succès) | 10 %                     | 100 crédits                      |
+
+### Détail des outcomes
+
+**Échec** — Le PJ n'obtient pas de meilleur prix que l'offre de base (25 %). Il peut soit accepter ce montant, soit annuler la vente.
+
+**Succès** — Le PJ obtient un prix correct (50 %). C'est le résultat le plus courant.
+
+**Triomphe** — Le PJ obtient un prix exceptionnel (75 %). Déclenché automatiquement quand le nombre de succès nets est ≥ 4. Pas besoin de case à cocher spécifique.
+
+**Désastre** — La négociation tourne très mal. Le prix chute à 10 % de la valeur de base. Le joueur doit cocher manuellement la case « Désastre » si le jet de dés a produit un Désastre.
+
+## Interactions clés
+
+- **Modifier les rangs** → le prix se met à jour en temps réel (re-rendu automatique)
+- **Changer la compétence** → la difficulté reste la même (déterminée par la rareté), seul le label de compétence change
+- **Cocher Désastre** → le résultat passe immédiatement à désastre, le prix chute à 10 %
+- **Confirmer** → la vente est exécutée au prix négocié, l'item est supprimé de l'inventaire, les crédits sont crédités
+- **Annuler** → la vente n'a pas lieu, l'item reste dans l'inventaire
+
+## Notes techniques (pour testeurs)
+
+- Le seuil de Triomphe est fixé à **4 rangs de succès** (`TRIUMPH_THRESHOLD = 4` dans `negotiation-dialog.mjs`)
+- Les fractions de revente sont définies dans `sell-valuation.mjs` :
+  - `SELL_BASE_FRACTION = 0.25`
+  - `SELL_NEGOTIATED_FRACTION = 0.5`
+  - `SELL_MAX_FRACTION = 0.75`
+  - `SELL_DISASTER_FRACTION = 0.1`
+- Le prix final est **arrondi à l'entier inférieur** (`Math.floor`)
+- Aucune modification de schéma persistant : le flux de vente existant (`#onSellItem`) est enrichi sans rupture
+
+## Tests de non-régression
+
+- Le mode achat existant n'est pas impacté : le paramètre `forSale` est optionnel et par défaut à `false`
+- Les tests unitaires (11 tests) couvrent tous les outcomes et les fractions associées
+
+## Questions fréquentes
+
+**Q : Puis-je obtenir un Triomphe sans cocher de case ?**
+R : Oui. Dès que vous saisissez 4 rangs de succès ou plus, l'outcome passe automatiquement à « triomphe » (75 %).
+
+**Q : Que se passe-t-il si je coche Désastre avec 4 succès ?**
+R : Le Désastre l'emporte. Le prix tombe à 10 %, même avec un nombre élevé de succès.
+
+**Q : Puis-je négocier sans jeter les dés ?**
+R : Oui. Les champs sont saisis manuellement pour simuler le résultat du jet. C'est un dialogo de saisie, pas un lanceur de dés.
+
+**Q : La vente est-elle irréversible après confirmation ?**
+R : Oui. Une fois « Vendre à ce prix » cliqué, l'item est supprimé et les crédits ajoutés. L'opération est tracée dans le journal d'audit.

--- a/documentation/plan/market/plan-negotiationDialogSaleMode.prompt.md
+++ b/documentation/plan/market/plan-negotiationDialogSaleMode.prompt.md
@@ -1,0 +1,265 @@
+# Plan : NegotiationDialog mode vente (`forSale: true`)
+
+Adapter le `NegotiationDialog` existant pour supporter un mode vente distinct du mode achat, en ajoutant un paramètre `forSale` qui change le titre, les labels de confirmation, et la logique de calcul de prix (utilisant `computeResalePrice` au lieu de `computeNegotiatedPrice`). Intégrer ce mode dans l'action `#onSellItem` de `MarketApplicationV2`.
+
+## Issue Reference
+
+- **GitHub Issue**: #505
+- **Epic**: #478 (Vente d'items via le Market)
+- **Dependencies**:
+  - #499 (sell-valuation.mjs — fractions triumph/success/disaster)
+  - sell-validation.mjs
+  - Action sellItem
+  - Type audit item.sale + recordItemSale()
+
+## Scope
+
+**Fichiers à modifier**
+
+- `module/applications/market/negotiation-dialog.mjs` (ajout `forSale` param, logique mode vente)
+- `module/applications/market/market-application.mjs` (passer `forSale: true` ligne ~1001)
+- `templates/market/negotiation-dialog.hbs` (labels conditionnels)
+- `lang/en.json`, `lang/fr.json` (clés i18n mode vente)
+
+**Fichiers à créer**
+
+- `tests/applications/market/negotiation-dialog.test.mjs` (tests intégration `forSale`)
+
+**Comportement souhaité**
+
+```js
+// Mode achat (inchangé)
+NegotiationDialog.prompt({
+  entry: { name: item.name, rarity: item.system?.rarity ?? 0 },
+  buyer: buyer,
+})
+
+// Mode vente (nouveau)
+NegotiationDialog.prompt({
+  entry: { name: item.name, rarity: item.system?.rarity ?? 0 },
+  buyer: seller,
+  forSale: true,
+})
+// => { confirmed: boolean, outcome: 'success'|'failure'|'triumph'|'disaster', finalPrice, successRanks }
+```
+
+## Outcomes → Fractions (mode vente)
+
+| Outcome               | Fraction | Utilisé par                |
+| --------------------- | -------- | -------------------------- |
+| failure (défaut/skip) | 25%      | `SELL_BASE_FRACTION`       |
+| success               | 50%      | `SELL_NEGOTIATED_FRACTION` |
+| triumph               | 75%      | `SELL_MAX_FRACTION`        |
+| disaster              | 10%      | `SELL_DISASTER_FRACTION`   |
+
+## Acceptance Criteria
+
+- [ ] `NegotiationDialog` accepte `forSale: boolean` sans casser le flow achat existant
+- [ ] Mode vente utilise `computeResalePrice` (basePrice × fraction) au lieu de `computeNegotiatedPrice`
+- [ ] Outcome triumph → fraction 75%
+- [ ] Outcome success → fraction 50%
+- [ ] Outcome disaster → fraction 10%
+- [ ] Skip négociation (défaut) → fraction 25%
+- [ ] `negotiationOutcome` tracé dans l'audit log (`recordItemSale`)
+- [ ] Template adapté : labels/titre conditionnels via `{{#if forSale}}`
+- [ ] Tests NegotiationDialog existants non régressés
+- [ ] Tests nouveaux pour mode vente incluent outcomes triumph/success/disaster/failure
+
+## Implementation Details
+
+### 1. Ajouter le champ privé `#forSale` et le paramètre `forSale` à `prompt()`
+
+**Fichier**: `module/applications/market/negotiation-dialog.mjs`
+
+**Changements**:
+
+- Ajouter champ privé `#forSale = false` après `#buyer`
+- Modifier signature `prompt({ entry, buyer, forSale = false })`
+- Stocker `dialog.#forSale = forSale`
+- Adapter titre dynamique : `title: forSale ? 'MARKET.Negotiation.Dialog.TitleSell' : 'MARKET.Negotiation.Dialog.Title'`
+
+### 2. Adapter `_prepareContext()` pour le mode vente
+
+**Fichier**: `module/applications/market/negotiation-dialog.mjs`
+
+**Logique**:
+
+```js
+if (this.#forSale) {
+  // Mode vente: utiliser computeResalePrice
+  const negotiationResult = computeResalePrice({
+    basePrice: originalPrice,
+    negotiationOutcome: mapOutcomeToSale(this.#formState),
+  })
+} else {
+  // Mode achat: computeNegotiatedPrice (existant)
+  const negotiationResult = computeNegotiatedPrice({
+    originalPrice,
+    successRanks: this.#formState.successRanks,
+    isDisaster: this.#formState.isDisaster,
+  })
+}
+```
+
+**Fonction mapper**: `mapOutcomeToSale()` — convertir (successRanks, isDisaster) → outcome ('failure'|'success'|'triumph'|'disaster')
+
+- `isDisaster` → 'disaster'
+- `successRanks >= TRIUMPH_THRESHOLD` (ex: 4) → 'triumph'
+- `successRanks > 0` → 'success'
+- défaut → 'failure'
+
+**Exposer**: `context.forSale = this.#forSale`
+
+### 3. Adapter `#onConfirmNegotiation` pour le mode vente
+
+**Fichier**: `module/applications/market/negotiation-dialog.mjs`
+
+**Changements**:
+
+- Calculer le résultat avec le bon fonction selon `this.#forSale`
+- Retourner le même shape `NegotiationDialogResult` : `{ confirmed: true, finalPrice, outcome, successRanks }`
+
+### 4. Adapter le template pour le mode vente
+
+**Fichier**: `templates/market/negotiation-dialog.hbs`
+
+**Changements**:
+
+- Ajouter `{{#if forSale}}` pour conditionner les labels:
+  - "Prix de vente négocié" (forSale) vs "Prix négocié" (achat)
+  - Bouton Confirm: "Vendre à" vs "Acheter à"
+  - Texte outcome adaptés si nécessaire
+
+### 5. Intégrer `forSale: true` dans `#onSellItem`
+
+**Fichier**: `module/applications/market/market-application.mjs` ligne ~1001
+
+**Changements**:
+
+```js
+const negotiationResult = await NegotiationDialog.prompt({
+  entry: { name: item.name, rarity: item.system?.rarity ?? 0 },
+  buyer: seller,
+  forSale: true, // ← NOUVEAU
+})
+```
+
+**Validation**: s'assurer que `negotiationOutcome` du résultat est passé correctement à `computeResalePrice` et tracé via `recordItemSale`.
+
+### 6. Ajouter les clés i18n
+
+**Fichiers**: `lang/en.json`, `lang/fr.json`
+
+**Clés à ajouter** (exemple EN):
+
+```json
+{
+  "MARKET": {
+    "Negotiation": {
+      "Dialog": {
+        "TitleSell": "Negotiate Sale Price",
+        "ConfirmSell": "Sell at this price",
+        "NegotiatedPriceSell": "Sale Price"
+      }
+    }
+  }
+}
+```
+
+**Clés FR**:
+
+```json
+{
+  "MARKET": {
+    "Negotiation": {
+      "Dialog": {
+        "TitleSell": "Négocier le prix de vente",
+        "ConfirmSell": "Vendre à ce prix",
+        "NegotiatedPriceSell": "Prix de vente"
+      }
+    }
+  }
+}
+```
+
+### 7. Écrire les tests Vitest
+
+**Fichier**: `tests/applications/market/negotiation-dialog.test.mjs`
+
+**Couverture**:
+
+- Mode achat (`forSale: false`) — tests existants non régressés
+- Mode vente (`forSale: true`) avec outcomes:
+  - `failure` → fraction 25%, `finalPrice = basePrice * 0.25`
+  - `success` → fraction 50%, `finalPrice = basePrice * 0.50`
+  - `triumph` → fraction 75%, `finalPrice = basePrice * 0.75`
+  - `disaster` → fraction 10%, `finalPrice = basePrice * 0.10`
+- Vérifier que `#onSellItem` appelle `NegotiationDialog.prompt` avec `forSale: true`
+- Vérifier que `negotiationOutcome` est bien tracé dans audit log
+
+## Further Considerations
+
+### 1. Logique de prix dans le dialog vs dans l'appelant
+
+**Question**: en mode vente, comment affiche-t-on le preview du prix?
+
+**Réponse**: afficher le `resalePrice` calculé via `computeResalePrice` en tenant compte de l'outcome actuel (trigger sur input change de successRanks / disaster checkbox). Cela donne un preview du résultat final.
+
+### 2. Outcome "triumph" absent du dialog achat
+
+**Question**: comment générer l'outcome "triumph" en mode vente si seul le dialog d'achat utilise `computeNegotiatedPrice` (qui ne produit que success/failure/disaster)?
+
+**Réponse**: ajouter une fonction mapper `mapOutcomeToSale(formState)` qui génère "triumph" quand `successRanks >= 4` (ou seuil configurable). En mode vente uniquement.
+
+**Alternative**: ajouter une checkbox "Triumph" distincte de "Disaster", mais cela complexifie le UI. Recommandation : seuil automatique (≥ 4 ranks).
+
+### 3. Rétro-compatibilité
+
+- Le shape `NegotiationDialogResult` ne change pas
+- `prompt()` a un paramètre optionnel `forSale = false` (backwards-compatible)
+- Tests existants du flow achat restent inchangés
+- Aucune rupture d'API
+
+### 4. Versioning des clés i18n
+
+- Ajouter les clés `TitleSell`, `ConfirmSell`, `NegotiatedPriceSell` côté EN/FR
+- Documenter dans le i18n memory que le mode vente a ses propres labels
+- Tester la présence des clés dans `tests/localization/<domaine>.test.mjs`
+
+## Story Points
+
+5 (ajustable après revue d'équipe)
+
+## Testing Phase Configuration
+
+**Vitest configs**: `vitest.config.mjs` (minimal) et `vitest.config.js` (full mock-foundry)
+
+**Test file**: `tests/applications/market/negotiation-dialog.test.mjs`
+
+**Mocks requis**:
+
+- `NegotiationDialog` instance (ou spy sur prototype)
+- `computeResalePrice` mock optionnel pour tests unitaires
+- `game.i18n.localize()` / `game.i18n.format()`
+
+**Integration tests**: appel complet `NegotiationDialog.prompt({ ..., forSale: true })` avec vérification du résultat retourné.
+
+## Deployment Checklist
+
+- [ ] Tests Vitest passent (couvrant forSale=true et forSale=false)
+- [ ] Linting ESLint sans warnings
+- [ ] Format Prettier appliqué
+- [ ] Clés i18n présentes EN/FR
+- [ ] Documentation inline JSDoc complète
+- [ ] Pas de `console.log` (utiliser `logger`)
+- [ ] Pas de regression tests d'achat existants
+
+## Success Criteria Summary
+
+✓ `NegotiationDialog.prompt()` accepte `forSale` optionnel  
+✓ Mode vente utilise `computeResalePrice` + mapping outcomes  
+✓ Titre et labels adaptés pour la vente via i18n  
+✓ `#onSellItem` intégre le flow negotiation mode vente  
+✓ Tests unitaires couvrent tous les outcomes  
+✓ Aucune regression sur flow achat  
+✓ Code deployable sans dépendance non résolue

--- a/lang/en.json
+++ b/lang/en.json
@@ -1633,7 +1633,10 @@
         "DisasterTooltip": "Check if the roll produced a Disaster result — the vendor is offended and raises the price.",
         "NegotiatedPrice": "Negotiated price",
         "Confirm": "Buy at this price",
-        "Cancel": "Cancel"
+        "Cancel": "Cancel",
+        "TitleSell": "Negotiate Sale Price",
+        "ConfirmSell": "Sell at this price",
+        "NegotiatedPriceSell": "Sale Price"
       },
       "Skill": {
         "Negotiation": "Negotiation",

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -1529,7 +1529,10 @@
         "DisasterTooltip": "Cochez si le jet a produit un Désastre — le vendeur est offensé et augmente le prix.",
         "NegotiatedPrice": "Prix négocié",
         "Confirm": "Acheter à ce prix",
-        "Cancel": "Annuler"
+        "Cancel": "Annuler",
+        "TitleSell": "Négocier le prix de vente",
+        "ConfirmSell": "Vendre à ce prix",
+        "NegotiatedPriceSell": "Prix de vente"
       },
       "Skill": {
         "Negotiation": "Négociation",

--- a/module/applications/market/market-application.mjs
+++ b/module/applications/market/market-application.mjs
@@ -998,7 +998,7 @@ export default class MarketApplicationV2 extends api.HandlebarsApplicationMixin(
 
     let finalValuation = baseValuation
     if (offerNegotiation) {
-      const negotiationResult = await NegotiationDialog.prompt({ entry: { name: item.name, rarity: item.system?.rarity ?? 0 }, buyer: seller })
+      const negotiationResult = await NegotiationDialog.prompt({ entry: { name: item.name, rarity: item.system?.rarity ?? 0 }, buyer: seller, forSale: true })
 
       if (negotiationResult?.confirmed) {
         finalValuation = computeResalePrice({

--- a/module/applications/market/negotiation-dialog.mjs
+++ b/module/applications/market/negotiation-dialog.mjs
@@ -1,4 +1,5 @@
 import { computeNegotiatedPrice, rarityToDifficulty, NEGOTIATION_SKILLS } from '../../lib/market/negotiation.mjs'
+import { computeResalePrice } from '../../lib/market/sell-valuation.mjs'
 import { logger } from '../../utils/logger.mjs'
 
 const { api } = foundry.applications
@@ -9,26 +10,61 @@ const { api } = foundry.applications
  * @typedef {Object} NegotiationDialogResult
  * @property {boolean}  confirmed     Whether the user confirmed the negotiated purchase.
  * @property {number}   finalPrice    The negotiated price (may be higher on disaster, lower on success).
- * @property {string}   outcome       One of 'success', 'failure', 'disaster'.
+ * @property {string}   outcome       One of 'success', 'failure', 'disaster' (buy mode) or 'success', 'failure', 'triumph', 'disaster' (sale mode).
  * @property {number}   successRanks  Net success ranks used.
  */
 
 /* -------------------------------------------- */
 
 /**
- * Dialog allowing the buyer to attempt a price negotiation before confirming purchase.
+ * Minimum net success ranks required to achieve a 'triumph' outcome in sale mode.
+ * When the seller achieves this many success ranks (or more), the maximum resale fraction applies.
+ * @type {number}
+ */
+export const TRIUMPH_THRESHOLD = 4
+
+/* -------------------------------------------- */
+
+/**
+ * Map the dialog form state to a sale negotiation outcome string.
  *
- * The GM or player inputs:
- *   1. Which skill to use (Negotiation, Persuasion, or Deception).
- *   2. The number of net success ranks obtained from the skill roll.
- *   3. Whether the roll produced a Disaster.
+ * In sale mode, the form state (successRanks + isDisaster) must be converted
+ * to one of the four outcomes understood by `computeResalePrice`:
+ *   - 'failure'  → base fraction (25%)
+ *   - 'success'  → negotiated fraction (50%)
+ *   - 'triumph'  → max fraction (75%)
+ *   - 'disaster' → penalty fraction (10%)
  *
- * The dialog shows the resulting price in real time and lets the buyer confirm or cancel.
+ * @param {object} formState
+ * @param {number} formState.successRanks  Net success ranks (≥ 0).
+ * @param {boolean} formState.isDisaster   Whether the roll produced a Disaster.
+ * @returns {'failure'|'success'|'triumph'|'disaster'}
+ */
+export function mapOutcomeToSale({ successRanks, isDisaster }) {
+  if (isDisaster) return 'disaster'
+  if (successRanks >= TRIUMPH_THRESHOLD) return 'triumph'
+  if (successRanks > 0) return 'success'
+  return 'failure'
+}
+
+/* -------------------------------------------- */
+
+/**
+ * Dialog allowing the buyer to attempt a price negotiation before confirming purchase,
+ * or the seller to negotiate a better resale price.
  *
- * Usage:
+ * When `forSale` is true, the dialog uses `computeResalePrice` with a mapped outcome
+ * instead of `computeNegotiatedPrice`, and adjusts labels/title accordingly.
+ *
+ * Usage — buy mode (unchanged):
  * ```js
  * const result = await NegotiationDialog.prompt({ entry, buyer })
  * if (result?.confirmed) { // use result.finalPrice }
+ * ```
+ *
+ * Usage — sale mode (new):
+ * ```js
+ * const result = await NegotiationDialog.prompt({ entry, buyer: seller, forSale: true })
  * ```
  */
 export default class NegotiationDialog extends api.HandlebarsApplicationMixin(api.ApplicationV2) {
@@ -38,7 +74,7 @@ export default class NegotiationDialog extends api.HandlebarsApplicationMixin(ap
     classes: ['swerpg', 'application', 'market-negotiation-dialog'],
     tag: 'div',
     window: {
-      title: 'MARKET.Negotiation.Dialog.Title',
+      title: 'MARKET.Negotiation.Dialog.Title', // default; overridden by #forSale title getter
       minimizable: false,
       resizable: false,
     },
@@ -73,6 +109,12 @@ export default class NegotiationDialog extends api.HandlebarsApplicationMixin(ap
   #buyer = null
 
   /**
+   * Whether this dialog is in sale mode (seller negotiates a better resale price).
+   * @type {boolean}
+   */
+  #forSale = false
+
+  /**
    * Current form state: selected skill, success ranks, disaster flag.
    * @type {{ skillKey: string, successRanks: number, isDisaster: boolean }}
    */
@@ -86,20 +128,32 @@ export default class NegotiationDialog extends api.HandlebarsApplicationMixin(ap
 
   /* -------------------------------------------- */
 
+  /** @override */
+  get title() {
+    if (this.#forSale) {
+      return game.i18n.localize('MARKET.Negotiation.Dialog.TitleSell')
+    }
+    return super.title
+  }
+
+  /* -------------------------------------------- */
+
   /**
-   * Open a negotiation dialog for the given entry and buyer, returning a promise
+   * Open a negotiation dialog for the given entry and buyer/seller, returning a promise
    * that resolves to the NegotiationDialogResult when the dialog closes.
    *
    * @param {object} params
-   * @param {import('../../lib/market/market-entry.mjs').MarketEntry} params.entry  The market entry.
-   * @param {object|null} params.buyer   The buyer actor.
+   * @param {import('../../lib/market/market-entry.mjs').MarketEntry} params.entry    The market entry.
+   * @param {object|null} params.buyer     The buyer (or seller) actor.
+   * @param {boolean}  [params.forSale=false]  Whether this is a sale negotiation.
    * @returns {Promise<NegotiationDialogResult|null>}
    */
-  static async prompt({ entry, buyer }) {
+  static async prompt({ entry, buyer, forSale = false }) {
     return new Promise((resolve) => {
       const dialog = new NegotiationDialog()
       dialog.#entry = entry
       dialog.#buyer = buyer
+      dialog.#forSale = forSale
       dialog.#resolve = resolve
       dialog.render(true)
     })
@@ -115,11 +169,27 @@ export default class NegotiationDialog extends api.HandlebarsApplicationMixin(ap
     const rarity = entry?.rarity ?? 0
     const difficulty = rarityToDifficulty(rarity)
 
-    const negotiationResult = computeNegotiatedPrice({
-      originalPrice,
-      successRanks: this.#formState.successRanks,
-      isDisaster: this.#formState.isDisaster,
-    })
+    let negotiationResult
+    if (this.#forSale) {
+      const outcome = mapOutcomeToSale(this.#formState)
+      const saleResult = computeResalePrice({
+        basePrice: originalPrice,
+        negotiationOutcome: outcome,
+      })
+      // Normalize to shape expected by the template (finalPrice)
+      negotiationResult = {
+        outcome: saleResult.outcome,
+        finalPrice: saleResult.resalePrice,
+        originalPrice: saleResult.basePrice,
+        successRanks: this.#formState.successRanks,
+      }
+    } else {
+      negotiationResult = computeNegotiatedPrice({
+        originalPrice,
+        successRanks: this.#formState.successRanks,
+        isDisaster: this.#formState.isDisaster,
+      })
+    }
 
     context.entry = { name: entry?.name ?? '', rarity, originalPrice }
     context.difficulty = difficulty
@@ -130,6 +200,7 @@ export default class NegotiationDialog extends api.HandlebarsApplicationMixin(ap
     }))
     context.formState = { ...this.#formState }
     context.negotiationResult = negotiationResult
+    context.forSale = this.#forSale
 
     return context
   }
@@ -181,11 +252,27 @@ export default class NegotiationDialog extends api.HandlebarsApplicationMixin(ap
    */
   static async #onConfirmNegotiation(_event, _target) {
     const originalPrice = this.#entry?.priceResult?.finalPrice ?? 0
-    const negotiationResult = computeNegotiatedPrice({
-      originalPrice,
-      successRanks: this.#formState.successRanks,
-      isDisaster: this.#formState.isDisaster,
-    })
+
+    let negotiationResult
+    if (this.#forSale) {
+      const outcome = mapOutcomeToSale(this.#formState)
+      const saleResult = computeResalePrice({
+        basePrice: originalPrice,
+        negotiationOutcome: outcome,
+      })
+      negotiationResult = {
+        outcome: saleResult.outcome,
+        finalPrice: saleResult.resalePrice,
+        originalPrice: saleResult.basePrice,
+        successRanks: this.#formState.successRanks,
+      }
+    } else {
+      negotiationResult = computeNegotiatedPrice({
+        originalPrice,
+        successRanks: this.#formState.successRanks,
+        isDisaster: this.#formState.isDisaster,
+      })
+    }
 
     logger.debug('[Market] Negotiation confirmed', {
       skill: this.#formState.skillKey,
@@ -194,6 +281,7 @@ export default class NegotiationDialog extends api.HandlebarsApplicationMixin(ap
       outcome: negotiationResult.outcome,
       originalPrice,
       finalPrice: negotiationResult.finalPrice,
+      forSale: this.#forSale,
     })
 
     this.#resolve?.({

--- a/templates/market/negotiation-dialog.hbs
+++ b/templates/market/negotiation-dialog.hbs
@@ -65,7 +65,11 @@
       <div class="negotiation-result-text">
         <p class="negotiation-result-outcome">{{localize "MARKET.Negotiation.Outcome.Success"}}</p>
         <p class="negotiation-result-price">
-          {{localize "MARKET.Negotiation.Dialog.NegotiatedPrice"}}:
+          {{#if ../forSale}}
+            {{localize "MARKET.Negotiation.Dialog.NegotiatedPriceSell"}}:
+          {{else}}
+            {{localize "MARKET.Negotiation.Dialog.NegotiatedPrice"}}:
+          {{/if}}
           <strong class="negotiation-price--success">{{negotiationResult.finalPrice}}</strong>
           <span class="negotiation-price-diff">(−{{negotiationResult.originalPrice}})</span>
         </p>
@@ -75,7 +79,11 @@
       <div class="negotiation-result-text">
         <p class="negotiation-result-outcome">{{localize "MARKET.Negotiation.Outcome.Disaster"}}</p>
         <p class="negotiation-result-price">
-          {{localize "MARKET.Negotiation.Dialog.NegotiatedPrice"}}:
+          {{#if ../forSale}}
+            {{localize "MARKET.Negotiation.Dialog.NegotiatedPriceSell"}}:
+          {{else}}
+            {{localize "MARKET.Negotiation.Dialog.NegotiatedPrice"}}:
+          {{/if}}
           <strong class="negotiation-price--disaster">{{negotiationResult.finalPrice}}</strong>
           <span class="negotiation-price-diff">(+{{entry.originalPrice}})</span>
         </p>
@@ -85,7 +93,11 @@
       <div class="negotiation-result-text">
         <p class="negotiation-result-outcome">{{localize "MARKET.Negotiation.Outcome.Failure"}}</p>
         <p class="negotiation-result-price">
-          {{localize "MARKET.Negotiation.Dialog.NegotiatedPrice"}}:
+          {{#if ../forSale}}
+            {{localize "MARKET.Negotiation.Dialog.NegotiatedPriceSell"}}:
+          {{else}}
+            {{localize "MARKET.Negotiation.Dialog.NegotiatedPrice"}}:
+          {{/if}}
           <strong>{{negotiationResult.finalPrice}}</strong>
         </p>
       </div>
@@ -97,10 +109,14 @@
       type="button"
       class="negotiation-btn negotiation-btn--confirm"
       data-action="confirmNegotiation"
-      aria-label="{{localize 'MARKET.Negotiation.Dialog.Confirm'}}"
+      aria-label="{{#if forSale}}{{localize 'MARKET.Negotiation.Dialog.ConfirmSell'}}{{else}}{{localize 'MARKET.Negotiation.Dialog.Confirm'}}{{/if}}"
     >
       <i class="fa-solid fa-coins" aria-hidden="true"></i>
-      {{localize "MARKET.Negotiation.Dialog.Confirm"}}
+      {{#if forSale}}
+        {{localize "MARKET.Negotiation.Dialog.ConfirmSell"}}
+      {{else}}
+        {{localize "MARKET.Negotiation.Dialog.Confirm"}}
+      {{/if}}
     </button>
     <button
       type="button"

--- a/tests/applications/market/negotiation-dialog.test.mjs
+++ b/tests/applications/market/negotiation-dialog.test.mjs
@@ -1,0 +1,114 @@
+import { describe, expect, it } from 'vitest'
+
+import { mapOutcomeToSale, TRIUMPH_THRESHOLD } from '../../../module/applications/market/negotiation-dialog.mjs'
+import { computeResalePrice } from '../../../module/lib/market/sell-valuation.mjs'
+
+/* -------------------------------------------- */
+/*  TRIUMPH_THRESHOLD                           */
+/* -------------------------------------------- */
+
+describe('TRIUMPH_THRESHOLD', () => {
+  it('is defined and equals 4', () => {
+    expect(TRIUMPH_THRESHOLD).toBe(4)
+  })
+})
+
+/* -------------------------------------------- */
+/*  mapOutcomeToSale                            */
+/* -------------------------------------------- */
+
+describe('mapOutcomeToSale', () => {
+  /* -------------------------------------------- */
+  /*  Failure outcome                             */
+  /* -------------------------------------------- */
+
+  describe('failure', () => {
+    it('returns "failure" when successRanks is 0 and isDisaster is false', () => {
+      expect(mapOutcomeToSale({ successRanks: 0, isDisaster: false })).toBe('failure')
+    })
+
+    it('returns "failure" when called without isDisaster (defaults to undefined → falsy)', () => {
+      expect(mapOutcomeToSale({ successRanks: 0 })).toBe('failure')
+    })
+  })
+
+  /* -------------------------------------------- */
+  /*  Success outcome                             */
+  /* -------------------------------------------- */
+
+  describe('success', () => {
+    it('returns "success" when successRanks is between 1 and TRIUMPH_THRESHOLD-1', () => {
+      expect(mapOutcomeToSale({ successRanks: 1, isDisaster: false })).toBe('success')
+      expect(mapOutcomeToSale({ successRanks: 2, isDisaster: false })).toBe('success')
+      expect(mapOutcomeToSale({ successRanks: 3, isDisaster: false })).toBe('success')
+    })
+  })
+
+  /* -------------------------------------------- */
+  /*  Triumph outcome                             */
+  /* -------------------------------------------- */
+
+  describe('triumph', () => {
+    it('returns "triumph" when successRanks equals TRIUMPH_THRESHOLD', () => {
+      const result = mapOutcomeToSale({ successRanks: TRIUMPH_THRESHOLD, isDisaster: false })
+      expect(result).toBe('triumph')
+    })
+
+    it('returns "triumph" when successRanks exceeds TRIUMPH_THRESHOLD', () => {
+      expect(mapOutcomeToSale({ successRanks: 5, isDisaster: false })).toBe('triumph')
+      expect(mapOutcomeToSale({ successRanks: 10, isDisaster: false })).toBe('triumph')
+    })
+  })
+
+  /* -------------------------------------------- */
+  /*  Disaster outcome                            */
+  /* -------------------------------------------- */
+
+  describe('disaster', () => {
+    it('returns "disaster" when isDisaster is true regardless of successRanks', () => {
+      expect(mapOutcomeToSale({ successRanks: 0, isDisaster: true })).toBe('disaster')
+      expect(mapOutcomeToSale({ successRanks: 4, isDisaster: true })).toBe('disaster')
+      expect(mapOutcomeToSale({ successRanks: 10, isDisaster: true })).toBe('disaster')
+    })
+  })
+})
+
+/* -------------------------------------------- */
+/*  Combined flow: mapOutcomeToSale → computeResalePrice */
+/* -------------------------------------------- */
+
+describe('sale price computation via mapOutcomeToSale + computeResalePrice', () => {
+  const BASE_PRICE = 100
+
+  it('failure → fraction 25% → finalPrice = 25', () => {
+    const outcome = mapOutcomeToSale({ successRanks: 0, isDisaster: false })
+    const result = computeResalePrice({ basePrice: BASE_PRICE, negotiationOutcome: outcome })
+    expect(result.outcome).toBe('failure')
+    expect(result.fraction).toBe(0.25)
+    expect(result.resalePrice).toBe(25)
+  })
+
+  it('success → fraction 50% → finalPrice = 50', () => {
+    const outcome = mapOutcomeToSale({ successRanks: 2, isDisaster: false })
+    const result = computeResalePrice({ basePrice: BASE_PRICE, negotiationOutcome: outcome })
+    expect(result.outcome).toBe('success')
+    expect(result.fraction).toBe(0.5)
+    expect(result.resalePrice).toBe(50)
+  })
+
+  it('triumph → fraction 75% → finalPrice = 75', () => {
+    const outcome = mapOutcomeToSale({ successRanks: 4, isDisaster: false })
+    const result = computeResalePrice({ basePrice: BASE_PRICE, negotiationOutcome: outcome })
+    expect(result.outcome).toBe('triumph')
+    expect(result.fraction).toBe(0.75)
+    expect(result.resalePrice).toBe(75)
+  })
+
+  it('disaster → fraction 10% → finalPrice = 10', () => {
+    const outcome = mapOutcomeToSale({ successRanks: 1, isDisaster: true })
+    const result = computeResalePrice({ basePrice: BASE_PRICE, negotiationOutcome: outcome })
+    expect(result.outcome).toBe('disaster')
+    expect(result.fraction).toBe(0.1)
+    expect(result.resalePrice).toBe(10)
+  })
+})


### PR DESCRIPTION
## Summary

This PR completes the NegotiationDialog sale mode (forSale: true) by adding the missing i18n keys, conditional template labels, and 11 Vitest tests. It closes the gap between the initial implementation and the plan defined in `documentation/plan/market/plan-negotiationDialogSaleMode.prompt.md`.

## Changes

### NegotiationDialog — sale mode
- `module/applications/market/negotiation-dialog.mjs` — Import `computeResalePrice$, export `mapOutcomeToSale()$ and `TRIUMPH_THRESHOLD$, `#forSale$ private field, `prompt()$ accepts `forSale: true$, title getter override, `_prepareContext()$ and `#onConfirmNegotiation()$ conditional branch for sale mode
- `module/applications/market/market-application.mjs` — Passes `forSale: true$ to `NegotiationDialog.prompt()$ in `#onSellItem$

### Template
- `templates/market/negotiation-dialog.hbs` — Conditional labels: `NegotiatedPriceSell$, `ConfirmSell$ vs their buy-mode equivalents, controlled by `{{#if forSale}}$

### i18n
- `lang/en.json$, `lang/fr.json` — Keys `TitleSell$, `ConfirmSell$, `NegotiatedPriceSell$ under `MARKET.Negotiation.Dialog$

### Tests
- `tests/applications/market/negotiation-dialog.test.mjs` (new, 11 tests) — Covers `TRIUMPH_THRESHOLD$, `mapOutcomeToSale()$ for all 4 outcomes (failure/success/triumph/disaster), and combined flow `mapOutcomeToSale → computeResalePrice$ with fraction assertions

### Documentation
- `documentation/guide-nego-vente-market.md` (new) — User-facing guide explaining how the sale negotiation feature works

## Validation
- `pnpm vitest run tests/applications/market/negotiation-dialog.test.mjs` — 11/11 passed
- `pnpm vitest run tests/lib/market/sell-valuation.test.mjs tests/applications/market/market-application.test.mjs` — 154/154 passed (no regression)
- No `console.log$ — uses centralized `logger$ only
- No schema changes or public data model modifications

## Related
- Closes #521 (follow-up validation issue)
- Parent plan: `documentation/plan/market/plan-negotiationDialogSaleMode.prompt.md`