### PR TITLE
feat(market): add market mode toggle and inventory table styles

### DIFF
--- a/documentation/plan/market/524-market-ui-styler-la-table-de-vente-et-le-toggle-buy-sell-parite-avec-l-achat.md
+++ b/documentation/plan/market/524-market-ui-styler-la-table-de-vente-et-le-toggle-buy-sell-parite-avec-l-achat.md
@@ -1,0 +1,63 @@
+# Issue #524 — Market UI : styler la table de vente et le toggle buy/sell
+
+**Issue** : https://github.com/herveDarritchon/foundryvtt-swerpg/issues/524  
+**Domaine métier** : `market`
+
+## Goal
+
+Mettre le mode vente du Market au même niveau de finition que le mode achat, sans changer la logique métier ni le flow buy existant.
+
+## Contexte utile
+
+- Le rendu sell est déjà présent dans `templates/market/market.hbs` avec les hooks `.market-inventory__table`, `.market-col--sell`, `.market-item__sell`, `.market-resale-estimate` et `.market-mode-toggle`.
+- `styles/market.less` contient déjà les styles du catalogue achat (`.market-catalog__table`, `.market-item__buy`) mais aucune règle dédiée pour la table de vente ni pour le toggle buy/sell.
+- `templates/market/market-inventory.hbs` duplique les mêmes hooks visuels : garder les classes alignées si ce template est encore consommé.
+
+## Plan d’implémentation
+
+### Étape 1 — Harmoniser les styles de la table de vente
+
+**Fichiers** : `styles/market.less`, `templates/market/market.hbs` _(et `templates/market/market-inventory.hbs` seulement si harmonisation de hooks nécessaire)_
+
+**What** :
+
+- Ajouter une base de style pour `.market-inventory__table` au niveau de finition de `.market-catalog__table` : cadre, radius, header en capitales, padding cellules, hover de ligne.
+- Ajouter les règles manquantes pour `.market-col--sell`, `.market-item__sell` et `.market-resale-estimate`.
+- Réutiliser les design tokens existants du Market pour rester cohérent avec ADR-0022 et avec les boutons achat/négociation.
+
+**Résultat attendu** : la table vente ressemble visuellement au catalogue achat, avec une colonne action lisible et un estimateur de revente mis en valeur.
+
+### Étape 2 — Transformer le toggle buy/sell en segmented control
+
+**Fichiers** : `styles/market.less`, `templates/market/market.hbs` _(et `templates/market/market-inventory.hbs` si actif)_
+
+**What** :
+
+- Styliser `.market-mode-toggle` comme un conteneur segmenté : fond, bordure, espacement, radius.
+- Styliser `.market-mode-toggle__btn` pour distinguer clairement états actif, inactif, hover et focus-visible.
+- Utiliser `aria-pressed` / `.is-active` comme source d’état visuel, sans modifier la logique JS existante.
+
+**Résultat attendu** : le basculement buy/sell est immédiatement compréhensible et visuellement cohérent avec le reste du Market.
+
+### Étape 3 — Vérification ciblée sans élargir le scope
+
+**Fichiers** : aucun nouveau fichier requis
+
+**What** :
+
+- Vérifier que les nouveaux styles n’impactent pas les sélecteurs achat existants.
+- Vérifier la parité visuelle sur le mode achat et le mode vente.
+- Prévoir une validation finale par `pnpm run build` et une vérification visuelle du Market, sans refactor métier ni changement JS hors hooks éventuels.
+
+## Périmètre / hors périmètre
+
+### Inclus
+
+- CSS Market pour la table vente et le toggle buy/sell
+- Ajustements mineurs de template uniquement si nécessaires pour garder des hooks cohérents
+
+### Exclus
+
+- Toute modification de logique buy/sell
+- Refactor ApplicationV2 ou changement de state JS
+- Nouvelles fonctionnalités de vente ou de négociation

--- a/styles/market.less
+++ b/styles/market.less
@@ -341,6 +341,161 @@
 }
 
 /* ----------------------------------------- */
+/*  Market Mode Toggle (segmented control)   */
+/* ----------------------------------------- */
+
+.market-mode-toggle {
+  display: flex;
+  align-items: center;
+  gap: 0;
+  background: var(--color-frame-bg-70);
+  border: 1px solid var(--color-glow-22);
+  border-radius: 6px;
+  padding: 3px;
+  width: fit-content;
+  margin-bottom: 0.5rem;
+}
+
+.market-mode-toggle__btn {
+  display: flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.3rem 0.75rem;
+  background: transparent;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  color: var(--color-secondary);
+  font-size: var(--font-size-13);
+  cursor: pointer;
+  transition:
+    background 0.12s ease,
+    color 0.12s ease,
+    border-color 0.12s ease;
+
+  &:hover:not(.is-active) {
+    background: var(--color-glow-08);
+    color: var(--color-primary);
+  }
+
+  &:focus-visible {
+    outline: 2px solid var(--color-glow-50);
+    outline-offset: 2px;
+  }
+
+  &.is-active,
+  &[aria-pressed='true'] {
+    background: var(--color-glow-15);
+    border-color: var(--color-glow-25);
+    color: var(--color-primary);
+    font-weight: 600;
+  }
+}
+
+/* ----------------------------------------- */
+/*  Market Inventory Table                   */
+/* ----------------------------------------- */
+
+.market-inventory__table {
+  border: 1px solid var(--color-glow-22);
+  border-radius: 8px;
+  overflow: hidden;
+  background: var(--color-frame-bg-60);
+  width: 100%;
+  border-collapse: separate;
+  border-spacing: 0;
+  font-size: var(--font-size-13);
+
+  thead tr {
+    background: var(--color-frame-bg-50);
+  }
+
+  th {
+    padding: 0.35rem 0.75rem;
+    text-align: left;
+    color: var(--color-secondary);
+    font-size: var(--font-size-11);
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    border-bottom: 1px solid var(--color-glow-15);
+    white-space: nowrap;
+  }
+
+  tbody tr.market-item {
+    cursor: pointer;
+    transition: background 0.12s ease;
+
+    &:hover {
+      background: var(--color-glow-08);
+    }
+
+    &:not(:last-child) {
+      border-bottom: 1px solid var(--color-glow-07);
+    }
+  }
+
+  td {
+    padding: 0.4rem 0.75rem;
+    color: var(--color-text);
+    vertical-align: middle;
+  }
+}
+
+/* ----------------------------------------- */
+/*  Market Sell Column & Button              */
+/* ----------------------------------------- */
+
+.market-col--sell {
+  width: 50px;
+  text-align: center;
+}
+
+.market-item__sell {
+  padding: 0.3rem 0.5rem;
+  background: var(--color-warning-12);
+  border: 1px solid var(--color-warning-30);
+  border-radius: 4px;
+  color: var(--color-warning-text);
+  cursor: pointer;
+  transition:
+    background 0.12s ease,
+    color 0.12s ease;
+  font-size: var(--font-size-13);
+
+  &:hover {
+    background: var(--color-warning-25);
+  }
+
+  &:focus-visible {
+    outline: 2px solid var(--color-glow-50);
+    outline-offset: 2px;
+  }
+
+  &--disabled {
+    background: var(--color-glow-08);
+    border-color: var(--color-glow-15);
+    color: var(--color-secondary);
+    cursor: not-allowed;
+    opacity: 0.45;
+
+    &:hover {
+      background: var(--color-glow-08);
+      color: var(--color-secondary);
+    }
+  }
+}
+
+/* ----------------------------------------- */
+/*  Market Resale Estimate                   */
+/* ----------------------------------------- */
+
+.market-resale-estimate {
+  color: var(--color-warning-text);
+  font-weight: 500;
+  font-size: var(--font-size-12);
+}
+
+/* ----------------------------------------- */
 /*  Market Negotiate Button                  */
 /* ----------------------------------------- */
 

--- a/styles/swerpg.css
+++ b/styles/swerpg.css
@@ -5382,6 +5382,133 @@ input[type='range'] {
   color: var(--color-secondary);
 }
 /* ----------------------------------------- */
+/*  Market Mode Toggle (segmented control)   */
+/* ----------------------------------------- */
+.market-mode-toggle {
+  display: flex;
+  align-items: center;
+  gap: 0;
+  background: var(--color-frame-bg-70);
+  border: 1px solid var(--color-glow-22);
+  border-radius: 6px;
+  padding: 3px;
+  width: fit-content;
+  margin-bottom: 0.5rem;
+}
+.market-mode-toggle__btn {
+  display: flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.3rem 0.75rem;
+  background: transparent;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  color: var(--color-secondary);
+  font-size: var(--font-size-13);
+  cursor: pointer;
+  transition: background 0.12s ease, color 0.12s ease, border-color 0.12s ease;
+}
+.market-mode-toggle__btn:hover:not(.is-active) {
+  background: var(--color-glow-08);
+  color: var(--color-primary);
+}
+.market-mode-toggle__btn:focus-visible {
+  outline: 2px solid var(--color-glow-50);
+  outline-offset: 2px;
+}
+.market-mode-toggle__btn.is-active,
+.market-mode-toggle__btn[aria-pressed='true'] {
+  background: var(--color-glow-15);
+  border-color: var(--color-glow-25);
+  color: var(--color-primary);
+  font-weight: 600;
+}
+/* ----------------------------------------- */
+/*  Market Inventory Table                   */
+/* ----------------------------------------- */
+.market-inventory__table {
+  border: 1px solid var(--color-glow-22);
+  border-radius: 8px;
+  overflow: hidden;
+  background: var(--color-frame-bg-60);
+  width: 100%;
+  border-collapse: separate;
+  border-spacing: 0;
+  font-size: var(--font-size-13);
+}
+.market-inventory__table thead tr {
+  background: var(--color-frame-bg-50);
+}
+.market-inventory__table th {
+  padding: 0.35rem 0.75rem;
+  text-align: left;
+  color: var(--color-secondary);
+  font-size: var(--font-size-11);
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  border-bottom: 1px solid var(--color-glow-15);
+  white-space: nowrap;
+}
+.market-inventory__table tbody tr.market-item {
+  cursor: pointer;
+  transition: background 0.12s ease;
+}
+.market-inventory__table tbody tr.market-item:hover {
+  background: var(--color-glow-08);
+}
+.market-inventory__table tbody tr.market-item:not(:last-child) {
+  border-bottom: 1px solid var(--color-glow-07);
+}
+.market-inventory__table td {
+  padding: 0.4rem 0.75rem;
+  color: var(--color-text);
+  vertical-align: middle;
+}
+/* ----------------------------------------- */
+/*  Market Sell Column & Button              */
+/* ----------------------------------------- */
+.market-col--sell {
+  width: 50px;
+  text-align: center;
+}
+.market-item__sell {
+  padding: 0.3rem 0.5rem;
+  background: var(--color-warning-12);
+  border: 1px solid var(--color-warning-30);
+  border-radius: 4px;
+  color: var(--color-warning-text);
+  cursor: pointer;
+  transition: background 0.12s ease, color 0.12s ease;
+  font-size: var(--font-size-13);
+}
+.market-item__sell:hover {
+  background: var(--color-warning-25);
+}
+.market-item__sell:focus-visible {
+  outline: 2px solid var(--color-glow-50);
+  outline-offset: 2px;
+}
+.market-item__sell--disabled {
+  background: var(--color-glow-08);
+  border-color: var(--color-glow-15);
+  color: var(--color-secondary);
+  cursor: not-allowed;
+  opacity: 0.45;
+}
+.market-item__sell--disabled:hover {
+  background: var(--color-glow-08);
+  color: var(--color-secondary);
+}
+/* ----------------------------------------- */
+/*  Market Resale Estimate                   */
+/* ----------------------------------------- */
+.market-resale-estimate {
+  color: var(--color-warning-text);
+  font-weight: 500;
+  font-size: var(--font-size-12);
+}
+/* ----------------------------------------- */
 /*  Market Negotiate Button                  */
 /* ----------------------------------------- */
 .market-col--buy {


### PR DESCRIPTION
## Summary

- Add CSS styles for the market inventory table to support buy/sell presentation.
- Add styles for the market mode toggle (buy / sell) UI.
- Add implementation plan document describing the market UI styler and parity with purchase flow.

## Context

This branch contains UI styling changes and an implementation plan for market UI parity (buy/sell toggle). The diff is limited to styling and documentation files.

## Tests

- Not run (not requested).

## Notes

- Changes are CSS and documentation only (styles/market.less, styles/swerpg.css, documentation/plan/market/...).
- Verify the toggle appearance and table layout in the running app; no runtime behavior tests were executed in this PR.
