### PR TITLE
feat(market): add search and sort functionality to sell-mode inventory

### DIFF
--- a/documentation/plan/market/527-market-ui-ajouter-recherche-et-tri-en-mode-vente-symetrie-des-parcours.md
+++ b/documentation/plan/market/527-market-ui-ajouter-recherche-et-tri-en-mode-vente-symetrie-des-parcours.md
@@ -1,0 +1,67 @@
+# Issue #527 — Market UI : ajouter recherche et tri en mode vente (symétrie des parcours)
+
+**Issue** : https://github.com/herveDarritchon/foundryvtt-swerpg/issues/527  
+**Domaine métier** : `market`
+
+## Goal
+
+Donner au mode vente les mêmes capacités de repérage rapide que le mode achat, en ajoutant une toolbar de recherche / tri / reset adaptée à l’inventaire vendeur, sans régression sur le catalogue achat ni sur le flow de vente existant.
+
+## Contexte utile
+
+- `templates/market/market.hbs` n’affiche la `.market-toolbar` qu’en mode achat ; le mode vente montre aujourd’hui uniquement la buyer bar, la description et la table d’inventaire.
+- `module/applications/market/market-application.mjs` sait déjà piloter la recherche et le tri du catalogue achat via `_viewState`, alors que `#prepareInventory()` se limite à un tri alphabétique fixe.
+- `styles/market.less` contient déjà les styles de `.market-toolbar`, ce qui permet de viser un partage de markup et de comportements plutôt qu’une nouvelle UI parallèle.
+- `tests/applications/market/market-application.test.mjs` couvre déjà les comportements buy et sell ; c’est le point d’ancrage naturel pour verrouiller l’absence de régression demandée par l’issue.
+
+## Plan d’implémentation
+
+### Étape 1 — Isoler un état de toolbar compatible buy / sell
+
+**Fichiers** : `module/applications/market/market-application.mjs`
+
+**What** :
+
+- Étendre le state UI pour supporter la recherche et le tri du mode vente sans recycler aveuglément les filtres buy-only (`type`, `source`, `restriction`, `affordableOnly`).
+- Définir le contrat de vue du mode vente : recherche texte, clé de tri et direction, avec des options limitées à `name`, `basePrice` et `resaleEstimate`.
+- Ajuster l’action de reset pour réinitialiser les contrôles utiles du mode courant sans faire sortir l’utilisateur du mode vente ni casser l’état utile du mode achat.
+
+**Résultat attendu** : le mode vente dispose d’un state UI propre et prédictible, sans couplage involontaire avec les filtres du catalogue achat.
+
+### Étape 2 — Brancher le pipeline recherche / tri sur l’inventaire vendeur
+
+**Fichiers** : `module/applications/market/market-application.mjs`
+
+**What** :
+
+- Refactoriser `#prepareInventory()` pour appliquer un pipeline explicite : collecte des items vendables → normalisation des champs utiles → filtre texte sur le nom → tri par nom / prix de base / estimation de revente.
+- Exposer au template les métadonnées nécessaires à la toolbar vente et un état vide filtré dédié quand la recherche ne retourne aucun item.
+- Conserver strictement la logique métier existante de vente, négociation et calcul de revente ; seul l’ordre et la visibilité des lignes changent.
+
+**Résultat attendu** : la vue vente se comporte comme une liste pilotée par state, avec une recherche et un tri déterministes sur l’inventaire vendeur.
+
+### Étape 3 — Rendre la toolbar en mode vente et verrouiller la parité
+
+**Fichiers** : `templates/market/market.hbs`, `lang/en.json`, `lang/fr.json`, `tests/applications/market/market-application.test.mjs` _(et `styles/market.less` seulement si un hook visuel mineur manque)_
+
+**What** :
+
+- Réutiliser ou décliner `.market-toolbar` dans la branche `sell` du template avec champ de recherche, tri, direction et reset, sans réintroduire les filtres achat qui n’ont pas de sens en inventaire.
+- Ajouter les libellés i18n spécifiques aux tris vente si les libellés achat existants sont trop ambigus (`prix de base` vs `prix de revente`).
+- Étendre les tests autour du mode vente : recherche par nom, tri par nom / prix, reset, état vide filtré, et non-régression du mode achat / du toggle buy-sell.
+
+**Résultat attendu** : la vue vente atteint la symétrie fonctionnelle demandée avec le mode achat, tout en gardant un scope strictement UI/application.
+
+## Périmètre / hors périmètre
+
+### Inclus
+
+- Toolbar recherche / tri / reset du mode vente
+- State UI et préparation de contexte associés à l’inventaire Market
+- i18n et tests ciblés Market
+
+### Exclus
+
+- Nouveaux filtres métier en mode vente
+- Changement de logique de vente, de négociation ou de calcul de revente
+- Refonte visuelle globale du Market au-delà du partage de la toolbar existante

--- a/lang/en.json
+++ b/lang/en.json
@@ -1804,7 +1804,18 @@
       "ResaleEstimate": "Resale (25%)",
       "SellAriaLabel": "Sell",
       "SellButton": "Sell",
-      "Empty": "Your inventory contains no sellable items."
+      "Empty": "Your inventory contains no sellable items.",
+      "Toolbar": {
+        "Search": {
+          "Label": "Search inventory",
+          "Placeholder": "Search…"
+        },
+        "Sort": {
+          "BasePrice": "Base Price",
+          "ResaleEstimate": "Resale Price"
+        },
+        "EmptySearch": "No items in your inventory match the search."
+      }
     },
     "Settings": {
       "Title": "Market Configuration",

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -1700,7 +1700,18 @@
       "ResaleEstimate": "Revente (25%)",
       "SellAriaLabel": "Vendre",
       "SellButton": "Vendre",
-      "Empty": "Votre inventaire ne contient aucun article vendable."
+      "Empty": "Votre inventaire ne contient aucun article vendable.",
+      "Toolbar": {
+        "Search": {
+          "Label": "Rechercher dans l'inventaire",
+          "Placeholder": "Rechercher…"
+        },
+        "Sort": {
+          "BasePrice": "Prix de base",
+          "ResaleEstimate": "Prix de revente"
+        },
+        "EmptySearch": "Aucun article de votre inventaire ne correspond à la recherche."
+      }
     },
     "Settings": {
       "Title": "Configuration du marché",

--- a/module/applications/market/market-application.mjs
+++ b/module/applications/market/market-application.mjs
@@ -32,8 +32,11 @@ const { api } = foundry.applications
  * @property {boolean} affordableOnly    When true, only items the buyer can afford are shown
  * @property {string} sortBy             Sort field key: 'name' | 'price' | 'rarity'
  * @property {'asc'|'desc'} sortDirection  Sort direction
- * @property {string} activeMarketType   Active market type key (key of MARKET_TYPES)
- * @property {'buy'|'sell'} mode         Current market mode: buy catalogue or sell inventory
+ * @property {string} activeMarketType        Active market type key (key of MARKET_TYPES)
+ * @property {'buy'|'sell'} mode              Current market mode: buy catalogue or sell inventory
+ * @property {string} inventorySearch         Text search query for sell-mode inventory
+ * @property {string} inventorySortBy         Sort field key for inventory: 'name' | 'basePrice' | 'resaleEstimate'
+ * @property {'asc'|'desc'} inventorySortDirection  Sort direction for inventory
  */
 
 /**
@@ -44,6 +47,17 @@ const MARKET_SORT_FIELDS = Object.freeze({
   name: 'name',
   price: 'price',
   rarity: 'rarity',
+})
+
+/**
+ * Canonical sort field keys for the sell-mode inventory.
+ * Limited to fields meaningful for a seller's own inventory.
+ * @enum {string}
+ */
+const INVENTORY_SORT_FIELDS = Object.freeze({
+  name: 'name',
+  basePrice: 'basePrice',
+  resaleEstimate: 'resaleEstimate',
 })
 
 /**
@@ -60,6 +74,9 @@ const DEFAULT_VIEW_STATE = Object.freeze({
   sortDirection: 'asc',
   activeMarketType: DEFAULT_MARKET_TYPE,
   mode: 'buy',
+  inventorySearch: '',
+  inventorySortBy: INVENTORY_SORT_FIELDS.name,
+  inventorySortDirection: 'asc',
 })
 
 /* -------------------------------------------- */
@@ -172,6 +189,7 @@ export default class MarketApplicationV2 extends api.HandlebarsApplicationMixin(
     actions: {
       openItem: MarketApplicationV2.#onOpenItem,
       resetCatalog: MarketApplicationV2.#onResetCatalog,
+      resetInventory: MarketApplicationV2.#onResetInventory,
       buyItem: MarketApplicationV2.#onBuyItem,
       negotiateItem: MarketApplicationV2.#onNegotiateItem,
       changeMarket: MarketApplicationV2.#onChangeMarket,
@@ -249,7 +267,8 @@ export default class MarketApplicationV2 extends api.HandlebarsApplicationMixin(
       context.sourceFilterOptions = this.#buildSourceFilterOptions()
       context.restrictionFilterOptions = this.#buildRestrictionFilterOptions()
       context.marketTypeOptions = this.#buildMarketTypeOptions()
-      context.inventory = buyer ? this.#prepareInventory(buyer) : { items: [] }
+      context.inventorySortOptions = this.#buildInventorySortOptions()
+      context.inventory = buyer ? this.#prepareInventory(buyer) : { items: [], isEmpty: true, isFilteredEmpty: false }
     }
 
     return context
@@ -348,6 +367,19 @@ export default class MarketApplicationV2 extends api.HandlebarsApplicationMixin(
       description: def.description,
       uiVariant: def.uiVariant,
     }))
+  }
+
+  /**
+   * Build the list of available sort options for the sell-mode inventory toolbar.
+   * Limited to fields relevant to the seller's inventory: name, base price, resale estimate.
+   * @returns {Array<{value: string, label: string}>}
+   */
+  #buildInventorySortOptions() {
+    return [
+      { value: INVENTORY_SORT_FIELDS.name, label: 'MARKET.Toolbar.Sort.Name' },
+      { value: INVENTORY_SORT_FIELDS.basePrice, label: 'MARKET.Inventory.Toolbar.Sort.BasePrice' },
+      { value: INVENTORY_SORT_FIELDS.resaleEstimate, label: 'MARKET.Inventory.Toolbar.Sort.ResaleEstimate' },
+    ]
   }
 
   /* -------------------------------------------- */
@@ -518,6 +550,25 @@ export default class MarketApplicationV2 extends api.HandlebarsApplicationMixin(
    */
   static async #onResetCatalog(_event, _target) {
     this._viewState = { ...DEFAULT_VIEW_STATE }
+    await this.render()
+  }
+
+  /**
+   * Reset the sell-mode inventory search and sort to their defaults, then re-render.
+   * Does not change the mode or the buy-mode filters.
+   * @this {MarketApplicationV2}
+   * @param {PointerEvent} _event   The initiating click event
+   * @param {HTMLElement}  _target  The element bearing data-action="resetInventory"
+   * @returns {Promise<void>}
+   */
+  static async #onResetInventory(_event, _target) {
+    this._viewState = {
+      ...this._viewState,
+      inventorySearch: DEFAULT_VIEW_STATE.inventorySearch,
+      inventorySortBy: DEFAULT_VIEW_STATE.inventorySortBy,
+      inventorySortDirection: DEFAULT_VIEW_STATE.inventorySortDirection,
+    }
+    logger.debug('[Market] Inventory search/sort reset')
     await this.render()
   }
 
@@ -877,13 +928,15 @@ export default class MarketApplicationV2 extends api.HandlebarsApplicationMixin(
 
   /**
    * Build the inventory context for the sell mode.
-   * Filters actor items to only include sellable types and annotates them with resale estimates.
+   * Pipeline: collect sellable items → normalise fields → filter by text search → sort.
+   * Search and sort are driven by the inventory-specific fields in `_viewState`.
    *
    * @param {Actor} actor  The seller actor.
-   * @returns {{ items: Array<object> }}
+   * @returns {{ items: Array<object>, isEmpty: boolean, isFilteredEmpty: boolean }}
    */
   #prepareInventory(actor) {
-    const sellableItems = []
+    // 1. Collect all sellable items and normalise fields
+    const allItems = []
 
     for (const item of actor.items ?? []) {
       if (!(item.type in PURCHASABLE_ITEM_TYPES)) continue
@@ -891,7 +944,7 @@ export default class MarketApplicationV2 extends api.HandlebarsApplicationMixin(
       const valuation = computeResalePrice({ basePrice, negotiationOutcome: 'failure' })
       const typeConfig = PURCHASABLE_ITEM_TYPES[item.type]
 
-      sellableItems.push({
+      allItems.push({
         id: item.id,
         name: item.name,
         img: item.img ?? '',
@@ -903,9 +956,42 @@ export default class MarketApplicationV2 extends api.HandlebarsApplicationMixin(
       })
     }
 
-    sellableItems.sort((a, b) => a.name.localeCompare(b.name))
+    const totalCount = allItems.length
 
-    return { items: sellableItems }
+    // 2. Apply text search on item name (case-insensitive)
+    const { inventorySearch, inventorySortBy, inventorySortDirection } = this._viewState
+    let filtered = allItems
+    if (inventorySearch) {
+      const needle = inventorySearch.trim().toLowerCase()
+      if (needle) {
+        filtered = allItems.filter((entry) => entry.name.toLowerCase().includes(needle))
+      }
+    }
+
+    // 3. Sort by selected field and direction
+    const multiplier = inventorySortDirection === 'desc' ? -1 : 1
+    const sorted = [...filtered].sort((a, b) => {
+      let cmp = 0
+      if (inventorySortBy === INVENTORY_SORT_FIELDS.name) {
+        cmp = a.name.localeCompare(b.name)
+      } else if (inventorySortBy === INVENTORY_SORT_FIELDS.basePrice) {
+        cmp = a.basePrice - b.basePrice
+      } else if (inventorySortBy === INVENTORY_SORT_FIELDS.resaleEstimate) {
+        cmp = a.resaleEstimate - b.resaleEstimate
+      } else {
+        cmp = a.name.localeCompare(b.name)
+      }
+      return cmp * multiplier
+    })
+
+    const filteredCount = sorted.length
+    const hasActiveFilter = !!inventorySearch?.trim()
+
+    return {
+      items: sorted,
+      isEmpty: totalCount === 0,
+      isFilteredEmpty: totalCount > 0 && filteredCount === 0 && hasActiveFilter,
+    }
   }
 
   /* -------------------------------------------- */
@@ -1151,6 +1237,33 @@ export default class MarketApplicationV2 extends api.HandlebarsApplicationMixin(
     if (sortDirSelect) {
       sortDirSelect.addEventListener('change', (event) => {
         this._viewState = { ...this._viewState, sortDirection: event.currentTarget.value === 'desc' ? 'desc' : 'asc' }
+        this.render()
+      })
+    }
+
+    // Sell-mode toolbar: inventory search input
+    const inventorySearchInput = html.querySelector('.market-inventory-toolbar__search')
+    if (inventorySearchInput) {
+      inventorySearchInput.addEventListener('input', (event) => {
+        this._viewState = { ...this._viewState, inventorySearch: event.currentTarget.value ?? '' }
+        this.render()
+      })
+    }
+
+    // Sell-mode toolbar: inventory sort field
+    const inventorySortBySelect = html.querySelector('.market-inventory-toolbar__sort--field')
+    if (inventorySortBySelect) {
+      inventorySortBySelect.addEventListener('change', (event) => {
+        this._viewState = { ...this._viewState, inventorySortBy: event.currentTarget.value ?? INVENTORY_SORT_FIELDS.name }
+        this.render()
+      })
+    }
+
+    // Sell-mode toolbar: inventory sort direction
+    const inventorySortDirSelect = html.querySelector('.market-inventory-toolbar__sort--direction')
+    if (inventorySortDirSelect) {
+      inventorySortDirSelect.addEventListener('change', (event) => {
+        this._viewState = { ...this._viewState, inventorySortDirection: event.currentTarget.value === 'desc' ? 'desc' : 'asc' }
         this.render()
       })
     }

--- a/templates/market/market.hbs
+++ b/templates/market/market.hbs
@@ -43,7 +43,63 @@
         <p class="market-selector__description">{{localize "MARKET.Inventory.Description"}}</p>
       </div>
 
-      {{#if inventory.items.length}}
+      {{!-- Sell-mode toolbar: search, sort, reset --}}
+      <div class="market-toolbar market-inventory-toolbar">
+        <div class="market-toolbar__search-group">
+          <label for="market-inventory-search" class="sr-only">{{localize "MARKET.Inventory.Toolbar.Search.Label"}}</label>
+          <input
+            id="market-inventory-search"
+            class="market-toolbar__search market-inventory-toolbar__search"
+            type="search"
+            placeholder="{{localize 'MARKET.Inventory.Toolbar.Search.Placeholder'}}"
+            value="{{viewState.inventorySearch}}"
+            aria-label="{{localize 'MARKET.Inventory.Toolbar.Search.Label'}}"
+          />
+        </div>
+
+        <div class="market-toolbar__sort">
+          <label for="market-inventory-sort-field" class="sr-only">{{localize "MARKET.Toolbar.Sort.Label"}}</label>
+          <select id="market-inventory-sort-field" class="market-toolbar__sort--field market-inventory-toolbar__sort--field" aria-label="{{localize 'MARKET.Toolbar.Sort.Label'}}">
+            {{#each inventorySortOptions as |opt|}}
+              <option value="{{opt.value}}" {{#if (eq opt.value ../viewState.inventorySortBy)}}selected{{/if}}>
+                {{localize opt.label}}
+              </option>
+            {{/each}}
+          </select>
+
+          <label for="market-inventory-sort-dir" class="sr-only">{{localize "MARKET.Toolbar.Sort.DirectionLabel"}}</label>
+          <select id="market-inventory-sort-dir" class="market-toolbar__sort--direction market-inventory-toolbar__sort--direction" aria-label="{{localize 'MARKET.Toolbar.Sort.DirectionLabel'}}">
+            <option value="asc" {{#if (eq viewState.inventorySortDirection "asc")}}selected{{/if}}>
+              {{localize "MARKET.Toolbar.Sort.Asc"}}
+            </option>
+            <option value="desc" {{#if (eq viewState.inventorySortDirection "desc")}}selected{{/if}}>
+              {{localize "MARKET.Toolbar.Sort.Desc"}}
+            </option>
+          </select>
+        </div>
+
+        <button
+          type="button"
+          class="market-toolbar__reset"
+          data-action="resetInventory"
+          data-tooltip="{{localize 'MARKET.Toolbar.Reset.Tooltip'}}"
+          aria-label="{{localize 'MARKET.Toolbar.Reset.Tooltip'}}"
+        >
+          <i class="fa-solid fa-rotate-left" aria-hidden="true"></i>
+          <span class="market-toolbar__reset-label">{{localize "MARKET.Toolbar.Reset.Label"}}</span>
+        </button>
+      </div>
+
+      {{#if inventory.isEmpty}}
+        <div class="market-empty">
+          <p>{{localize "MARKET.Inventory.Empty"}}</p>
+        </div>
+      {{else if inventory.isFilteredEmpty}}
+        <p class="market-empty market-empty--filtered">
+          <i class="fa-solid fa-magnifying-glass" aria-hidden="true"></i>
+          {{localize "MARKET.Inventory.Toolbar.EmptySearch"}}
+        </p>
+      {{else if inventory.items.length}}
         <table class="market-inventory__table">
           <thead>
             <tr>
@@ -85,10 +141,6 @@
             {{/each}}
           </tbody>
         </table>
-      {{else}}
-        <div class="market-empty">
-          <p>{{localize "MARKET.Inventory.Empty"}}</p>
-        </div>
       {{/if}}
 
     {{else}}

--- a/tests/applications/market/market-application.test.mjs
+++ b/tests/applications/market/market-application.test.mjs
@@ -1975,6 +1975,377 @@ describe('MarketApplicationV2', () => {
   })
 
   /* -------------------------------------------- */
+  /*  Sell-mode toolbar: search, sort, reset      */
+  /* -------------------------------------------- */
+
+  describe('sell-mode inventory toolbar — search', () => {
+    it('_viewState starts with empty inventorySearch', () => {
+      const app = new MarketApplicationV2()
+      expect(app._viewState.inventorySearch).toBe('')
+    })
+
+    it('filters inventory items by name when inventorySearch is set (case-insensitive)', async () => {
+      globalThis.game.items = makeItemsCollection([])
+
+      const items = [
+        { id: 'w1', name: 'Blaster Pistol', img: '', type: 'weapon', system: { price: 100 } },
+        { id: 'w2', name: 'Vibro Knife', img: '', type: 'weapon', system: { price: 80 } },
+      ]
+      const actor = {
+        id: 'actor-1',
+        name: 'Test',
+        system: { credits: 500 },
+        items: makeItemsCollection(items),
+      }
+
+      const app = new MarketApplicationV2()
+      app.setBuyerActor(actor)
+      app._viewState = { ...app._viewState, inventorySearch: 'blaster' }
+      const context = await app._preparePartContext('catalog', {})
+
+      expect(context.inventory.items).toHaveLength(1)
+      expect(context.inventory.items[0].name).toBe('Blaster Pistol')
+    })
+
+    it('inventory search is case-insensitive', async () => {
+      globalThis.game.items = makeItemsCollection([])
+
+      const item = { id: 'w1', name: 'Blaster Pistol', img: '', type: 'weapon', system: { price: 100 } }
+      const actor = {
+        id: 'actor-1',
+        name: 'Test',
+        system: { credits: 500 },
+        items: makeItemsCollection([item]),
+      }
+
+      const app = new MarketApplicationV2()
+      app.setBuyerActor(actor)
+      app._viewState = { ...app._viewState, inventorySearch: 'BLASTER' }
+      const context = await app._preparePartContext('catalog', {})
+
+      expect(context.inventory.items).toHaveLength(1)
+    })
+
+    it('empty inventorySearch returns all sellable items', async () => {
+      globalThis.game.items = makeItemsCollection([])
+
+      const items = [
+        { id: 'w1', name: 'Blaster', img: '', type: 'weapon', system: { price: 100 } },
+        { id: 'a1', name: 'Armor', img: '', type: 'armor', system: { price: 200 } },
+      ]
+      const actor = {
+        id: 'actor-1',
+        name: 'Test',
+        system: { credits: 500 },
+        items: makeItemsCollection(items),
+      }
+
+      const app = new MarketApplicationV2()
+      app.setBuyerActor(actor)
+      app._viewState = { ...app._viewState, inventorySearch: '' }
+      const context = await app._preparePartContext('catalog', {})
+
+      expect(context.inventory.items).toHaveLength(2)
+    })
+
+    it('returns isFilteredEmpty=true when search matches nothing but inventory has items', async () => {
+      globalThis.game.items = makeItemsCollection([])
+
+      const item = { id: 'w1', name: 'Blaster', img: '', type: 'weapon', system: { price: 100 } }
+      const actor = {
+        id: 'actor-1',
+        name: 'Test',
+        system: { credits: 500 },
+        items: makeItemsCollection([item]),
+      }
+
+      const app = new MarketApplicationV2()
+      app.setBuyerActor(actor)
+      app._viewState = { ...app._viewState, inventorySearch: 'lightsaber' }
+      const context = await app._preparePartContext('catalog', {})
+
+      expect(context.inventory.isEmpty).toBe(false)
+      expect(context.inventory.isFilteredEmpty).toBe(true)
+      expect(context.inventory.items).toHaveLength(0)
+    })
+  })
+
+  describe('sell-mode inventory toolbar — sort', () => {
+    it('_viewState starts with inventorySortBy=name and inventorySortDirection=asc', () => {
+      const app = new MarketApplicationV2()
+      expect(app._viewState.inventorySortBy).toBe('name')
+      expect(app._viewState.inventorySortDirection).toBe('asc')
+    })
+
+    it('sorts inventory by name ascending (A→Z)', async () => {
+      globalThis.game.items = makeItemsCollection([])
+
+      const items = [
+        { id: 'z1', name: 'Z-6 Blaster', img: '', type: 'weapon', system: { price: 100 } },
+        { id: 'a1', name: 'A-300 Rifle', img: '', type: 'weapon', system: { price: 150 } },
+      ]
+      const actor = {
+        id: 'actor-1',
+        name: 'Test',
+        system: { credits: 500 },
+        items: makeItemsCollection(items),
+      }
+
+      const app = new MarketApplicationV2()
+      app.setBuyerActor(actor)
+      app._viewState = { ...app._viewState, inventorySortBy: 'name', inventorySortDirection: 'asc' }
+      const context = await app._preparePartContext('catalog', {})
+
+      const names = context.inventory.items.map((i) => i.name)
+      expect(names).toEqual([...names].sort((a, b) => a.localeCompare(b)))
+    })
+
+    it('sorts inventory by name descending (Z→A)', async () => {
+      globalThis.game.items = makeItemsCollection([])
+
+      const items = [
+        { id: 'a1', name: 'A-300 Rifle', img: '', type: 'weapon', system: { price: 100 } },
+        { id: 'z1', name: 'Z-6 Blaster', img: '', type: 'weapon', system: { price: 150 } },
+      ]
+      const actor = {
+        id: 'actor-1',
+        name: 'Test',
+        system: { credits: 500 },
+        items: makeItemsCollection(items),
+      }
+
+      const app = new MarketApplicationV2()
+      app.setBuyerActor(actor)
+      app._viewState = { ...app._viewState, inventorySortBy: 'name', inventorySortDirection: 'desc' }
+      const context = await app._preparePartContext('catalog', {})
+
+      const names = context.inventory.items.map((i) => i.name)
+      expect(names[0]).toBe('Z-6 Blaster')
+      expect(names[1]).toBe('A-300 Rifle')
+    })
+
+    it('sorts inventory by basePrice ascending (cheapest first)', async () => {
+      globalThis.game.items = makeItemsCollection([])
+
+      const items = [
+        { id: 'e1', name: 'Expensive', img: '', type: 'weapon', system: { price: 500 } },
+        { id: 'c1', name: 'Cheap', img: '', type: 'weapon', system: { price: 50 } },
+      ]
+      const actor = {
+        id: 'actor-1',
+        name: 'Test',
+        system: { credits: 500 },
+        items: makeItemsCollection(items),
+      }
+
+      const app = new MarketApplicationV2()
+      app.setBuyerActor(actor)
+      app._viewState = { ...app._viewState, inventorySortBy: 'basePrice', inventorySortDirection: 'asc' }
+      const context = await app._preparePartContext('catalog', {})
+
+      const prices = context.inventory.items.map((i) => i.basePrice)
+      expect(prices[0]).toBeLessThanOrEqual(prices[1])
+    })
+
+    it('sorts inventory by basePrice descending (most expensive first)', async () => {
+      globalThis.game.items = makeItemsCollection([])
+
+      const items = [
+        { id: 'c1', name: 'Cheap', img: '', type: 'weapon', system: { price: 50 } },
+        { id: 'e1', name: 'Expensive', img: '', type: 'weapon', system: { price: 500 } },
+      ]
+      const actor = {
+        id: 'actor-1',
+        name: 'Test',
+        system: { credits: 500 },
+        items: makeItemsCollection(items),
+      }
+
+      const app = new MarketApplicationV2()
+      app.setBuyerActor(actor)
+      app._viewState = { ...app._viewState, inventorySortBy: 'basePrice', inventorySortDirection: 'desc' }
+      const context = await app._preparePartContext('catalog', {})
+
+      const prices = context.inventory.items.map((i) => i.basePrice)
+      expect(prices[0]).toBeGreaterThanOrEqual(prices[1])
+    })
+
+    it('sorts inventory by resaleEstimate ascending', async () => {
+      globalThis.game.items = makeItemsCollection([])
+
+      const items = [
+        { id: 'h1', name: 'High', img: '', type: 'weapon', system: { price: 400 } },
+        { id: 'l1', name: 'Low', img: '', type: 'weapon', system: { price: 100 } },
+      ]
+      const actor = {
+        id: 'actor-1',
+        name: 'Test',
+        system: { credits: 500 },
+        items: makeItemsCollection(items),
+      }
+
+      const app = new MarketApplicationV2()
+      app.setBuyerActor(actor)
+      app._viewState = { ...app._viewState, inventorySortBy: 'resaleEstimate', inventorySortDirection: 'asc' }
+      const context = await app._preparePartContext('catalog', {})
+
+      const estimates = context.inventory.items.map((i) => i.resaleEstimate)
+      expect(estimates[0]).toBeLessThanOrEqual(estimates[1])
+    })
+
+    it('exposes inventorySortOptions in catalog context', async () => {
+      globalThis.game.items = makeItemsCollection([])
+
+      const app = new MarketApplicationV2()
+      const context = await app._preparePartContext('catalog', {})
+
+      expect(context.inventorySortOptions).toBeDefined()
+      expect(Array.isArray(context.inventorySortOptions)).toBe(true)
+      expect(context.inventorySortOptions).toHaveLength(3)
+
+      const values = context.inventorySortOptions.map((o) => o.value)
+      expect(values).toContain('name')
+      expect(values).toContain('basePrice')
+      expect(values).toContain('resaleEstimate')
+    })
+  })
+
+  describe('sell-mode inventory toolbar — reset', () => {
+    it('declares the resetInventory action', () => {
+      expect(MarketApplicationV2.DEFAULT_OPTIONS.actions).toHaveProperty('resetInventory')
+    })
+
+    it('resetInventory resets inventorySearch, inventorySortBy, inventorySortDirection to defaults', async () => {
+      globalThis.game.items = makeItemsCollection([])
+
+      const app = new MarketApplicationV2()
+      app._viewState = {
+        ...app._viewState,
+        inventorySearch: 'blaster',
+        inventorySortBy: 'basePrice',
+        inventorySortDirection: 'desc',
+      }
+      app.render = vi.fn().mockResolvedValue(undefined)
+
+      const action = MarketApplicationV2.DEFAULT_OPTIONS.actions.resetInventory
+      await action.call(app, {}, {})
+
+      expect(app._viewState.inventorySearch).toBe('')
+      expect(app._viewState.inventorySortBy).toBe('name')
+      expect(app._viewState.inventorySortDirection).toBe('asc')
+      expect(app.render).toHaveBeenCalled()
+    })
+
+    it('resetInventory preserves the current mode (sell) and buy-mode state', async () => {
+      globalThis.game.items = makeItemsCollection([])
+
+      const app = new MarketApplicationV2()
+      app._viewState = {
+        ...app._viewState,
+        mode: 'sell',
+        search: 'blaster',
+        filterType: 'weapon',
+        activeMarketType: 'black-market',
+        inventorySearch: 'rifle',
+        inventorySortBy: 'basePrice',
+        inventorySortDirection: 'desc',
+      }
+      app.render = vi.fn().mockResolvedValue(undefined)
+
+      const action = MarketApplicationV2.DEFAULT_OPTIONS.actions.resetInventory
+      await action.call(app, {}, {})
+
+      // Inventory state reset
+      expect(app._viewState.inventorySearch).toBe('')
+      expect(app._viewState.inventorySortBy).toBe('name')
+      expect(app._viewState.inventorySortDirection).toBe('asc')
+
+      // Buy-mode state and current mode preserved
+      expect(app._viewState.mode).toBe('sell')
+      expect(app._viewState.search).toBe('blaster')
+      expect(app._viewState.filterType).toBe('weapon')
+      expect(app._viewState.activeMarketType).toBe('black-market')
+    })
+
+    it('resetInventory does not reset buy-mode search when in sell mode', async () => {
+      globalThis.game.items = makeItemsCollection([])
+
+      const app = new MarketApplicationV2()
+      app._viewState = {
+        ...app._viewState,
+        mode: 'sell',
+        search: 'vibro',
+        inventorySearch: 'blaster',
+      }
+      app.render = vi.fn().mockResolvedValue(undefined)
+
+      const action = MarketApplicationV2.DEFAULT_OPTIONS.actions.resetInventory
+      await action.call(app, {}, {})
+
+      expect(app._viewState.inventorySearch).toBe('')
+      expect(app._viewState.search).toBe('vibro')
+    })
+  })
+
+  describe('sell-mode inventory toolbar — combined search+sort', () => {
+    it('applies search and sort together (search first, then sort result)', async () => {
+      globalThis.game.items = makeItemsCollection([])
+
+      const items = [
+        { id: 'b2', name: 'Blaster Rifle', img: '', type: 'weapon', system: { price: 300 } },
+        { id: 'b1', name: 'Blaster Pistol', img: '', type: 'weapon', system: { price: 100 } },
+        { id: 'v1', name: 'Vibro Knife', img: '', type: 'weapon', system: { price: 80 } },
+      ]
+      const actor = {
+        id: 'actor-1',
+        name: 'Test',
+        system: { credits: 500 },
+        items: makeItemsCollection(items),
+      }
+
+      const app = new MarketApplicationV2()
+      app.setBuyerActor(actor)
+      // Search for "blaster" then sort by basePrice ascending
+      app._viewState = { ...app._viewState, inventorySearch: 'blaster', inventorySortBy: 'basePrice', inventorySortDirection: 'asc' }
+      const context = await app._preparePartContext('catalog', {})
+
+      // Only blaster items, sorted by base price ascending
+      expect(context.inventory.items).toHaveLength(2)
+      expect(context.inventory.items[0].name).toBe('Blaster Pistol') // 100 < 300
+      expect(context.inventory.items[1].name).toBe('Blaster Rifle')
+    })
+  })
+
+  describe('sell-mode inventory — non-regression on buy mode', () => {
+    it('buy-mode catalog is not affected by inventory search state', async () => {
+      const weapon = makeItem({ type: 'weapon', name: 'Blaster Pistol' })
+      globalThis.game.items = makeItemsCollection([weapon])
+
+      const app = new MarketApplicationV2()
+      app._viewState = { ...app._viewState, mode: 'buy', inventorySearch: 'lightsaber' }
+      const context = await app._preparePartContext('catalog', {})
+
+      // Buy-mode catalog should still show the weapon — inventorySearch does not affect it
+      expect(context.catalog.items).toHaveLength(1)
+      expect(context.catalog.items[0].name).toBe('Blaster Pistol')
+    })
+
+    it('toggling from sell to buy does not clear the buy-mode search', async () => {
+      globalThis.game.items = makeItemsCollection([])
+
+      const app = new MarketApplicationV2()
+      app._viewState = { ...app._viewState, mode: 'sell', search: 'blaster' }
+      app.render = vi.fn().mockResolvedValue(undefined)
+
+      const action = MarketApplicationV2.DEFAULT_OPTIONS.actions.toggleMode
+      await action.call(app, {}, { dataset: { mode: 'buy' } })
+
+      expect(app._viewState.mode).toBe('buy')
+      expect(app._viewState.search).toBe('blaster')
+    })
+  })
+
+  /* -------------------------------------------- */
   /*  sellItem action                             */
   /* -------------------------------------------- */
 


### PR DESCRIPTION
## Summary

- Add search and sort functionality to the market "sell" inventory UI.
- Update Handlebars template and i18n keys (en/fr).
- Add unit tests for market application and project plan documentation.

## Context

This change implements search and sorting behaviour for the market sell-mode inventory UI in the market application. It also adds a focused unit test and the related documentation plan under documentation/plan/market.

## Tests

- Not run (not requested).

## Notes

- Changed files include: module/applications/market/market-application.mjs, templates/market/market.hbs, lang/en.json, lang/fr.json, tests/applications/market/market-application.test.mjs, documentation/plan/market/527-market-ui-ajouter-recherche-et-tri-en-mode-vente-symetrie-des-parcours.md
