### PR TITLE
feat(market): display rarity as visual pips and localize restriction labels

### DIFF
--- a/documentation/plan/market/528-market-ui-afficher-la-rarete-en-etoiles-pips-et-localiser-la-colonne-restriction.md
+++ b/documentation/plan/market/528-market-ui-afficher-la-rarete-en-etoiles-pips-et-localiser-la-colonne-restriction.md
@@ -1,0 +1,67 @@
+# Issue #528 — Market UI : afficher la rareté en étoiles/pips et localiser la colonne restriction
+
+**Issue** : https://github.com/herveDarritchon/foundryvtt-swerpg/issues/528  
+**Domaine métier** : `market`
+
+## Goal
+
+Rendre le catalogue Market plus lisible en remplaçant l’affichage brut de la rareté par un rendu visuel en étoiles/pips, et en affichant dans la colonne restriction le libellé localisé plutôt que la valeur technique, sans toucher à la logique métier d’achat / négociation.
+
+## Contexte utile
+
+- `templates/market/market.hbs` affiche aujourd’hui `{{entry.rarity}}` et `{{entry.restrictionLevel}}` dans les colonnes dédiées, alors que la colonne nom montre déjà un badge restriction localisé.
+- `module/applications/market/market-application.mjs` prépare déjà `restrictionLabel` et la valeur numérique `rarity`, ce qui permet d’ajouter un view-model de présentation sans déplacer la logique dans Handlebars.
+- `styles/market.less` ne contient aujourd’hui que des règles de largeur / alignement pour `.market-col--rarity` et `.market-col--restriction` ; un rendu en pips demandera donc seulement un ajustement CSS localisé.
+- `tests/applications/market/market-application.test.mjs` est le point d’ancrage naturel pour verrouiller le rendu localisé et l’absence de régression sur le catalogue.
+
+## Plan d’implémentation
+
+### Étape 1 — Préparer le contrat de rendu rareté / restriction
+
+**Fichiers** : `module/applications/market/market-application.mjs`
+
+**What** :
+
+- Ajouter au view-model du catalogue des champs purement UI pour la rareté (`rarityDisplay` / `rarityPips` / libellé accessible) à partir de l’entier existant, avec gestion explicite des cas `0` et absence de valeur.
+- Réutiliser `restrictionLabel` comme source canonique pour la colonne restriction afin de ne plus exposer les clés métier brutes (`restricted`, `military`, `illegal`, `none`).
+- Conserver strictement inchangées les logiques d’obtainability, d’achat, de négociation et de badges ; seul le contrat de présentation du tableau évolue.
+
+**Résultat attendu** : le template reçoit des données prêtes à afficher, sans calcul de présentation dispersé dans le HBS.
+
+### Étape 2 — Rendre les étoiles/pips et localiser la colonne restriction
+
+**Fichiers** : `templates/market/market.hbs` _(et `lang/en.json`, `lang/fr.json` seulement si une chaîne aria/tooltip manque)_
+
+**What** :
+
+- Remplacer l’entier brut de la colonne rareté par un rendu visuel compact en étoiles/pips, tout en conservant une information textuelle accessible via tooltip ou `aria-label`.
+- Remplacer `{{entry.restrictionLevel}}` par le libellé localisé déjà préparé, avec un fallback explicite pour les objets sans restriction.
+- Vérifier que le rendu reste cohérent avec le badge de restriction déjà présent dans la colonne nom, sans introduire de doublon contradictoire.
+
+**Résultat attendu** : la table Market devient lisible sans exposer de valeurs techniques à l’utilisateur.
+
+### Étape 3 — Ajuster le layout et verrouiller la non-régression
+
+**Fichiers** : `styles/market.less`, `tests/applications/market/market-application.test.mjs`
+
+**What** :
+
+- Ajouter uniquement les hooks CSS nécessaires pour aligner les étoiles/pips dans `.market-col--rarity` et préserver la compacité de la colonne restriction.
+- Étendre les tests ciblés pour couvrir : rendu visuel de la rareté, libellé de restriction localisé, cas `none`, et absence de régression sur le tri / filtrage existants du catalogue.
+- Prévoir la validation finale par `pnpm test` ciblé et revue visuelle Market au moment de l’implémentation, sans élargir le scope.
+
+**Résultat attendu** : le changement reste strictement UI/application, lisible et sécurisé par tests.
+
+## Périmètre / hors périmètre
+
+### Inclus
+
+- Affichage visuel de la rareté dans le catalogue Market
+- Localisation des valeurs de la colonne restriction
+- Ajustements localisés du view-model, template, styles et tests Market
+
+### Exclus
+
+- Changement des règles métier de rareté, disponibilité, achat ou négociation
+- Refonte du système de badges ou des autres colonnes Market
+- Refonte générale du Market au-delà du besoin de lisibilité demandé

--- a/module/applications/market/market-application.mjs
+++ b/module/applications/market/market-application.mjs
@@ -462,6 +462,13 @@ export default class MarketApplicationV2 extends api.HandlebarsApplicationMixin(
       const isRestricted = restrictionLevel !== 'none'
       const restrictionLabel = RESTRICTION_LEVELS[restrictionLevel]?.label ?? null
 
+      // Rarity display: build an array of pip flags for visual rendering.
+      // Each element is { filled: boolean } — filled pips represent the item's rarity value.
+      // A rarity of 0 produces an empty array (no pips displayed).
+      const rarityValue = entry.rarity ?? 0
+      const MAX_RARITY_PIPS = 10
+      const rarityPips = Array.from({ length: Math.min(rarityValue, MAX_RARITY_PIPS) }, () => ({ filled: true }))
+
       // Badge view-model: encode deduplication rules so the template stays purely presentational.
       // Rule 1 — black-market badge: suppress when restrictionLevel === 'illegal', because the
       //           restriction badge already displays the skull icon for that level.
@@ -485,6 +492,7 @@ export default class MarketApplicationV2 extends api.HandlebarsApplicationMixin(
         isBlackMarket,
         isRestricted,
         restrictionLabel,
+        rarityPips,
         badges,
       }
     })

--- a/styles/market.less
+++ b/styles/market.less
@@ -277,6 +277,30 @@
 }
 
 /* ----------------------------------------- */
+/*  Rarity Pips                              */
+/* ----------------------------------------- */
+
+.market-rarity-pips {
+  display: inline-flex;
+  align-items: center;
+  gap: 2px;
+  cursor: default;
+}
+
+.market-rarity-pip {
+  display: inline-block;
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+
+  &--filled {
+    background: var(--color-primary);
+    border: 1px solid var(--color-glow-25);
+    opacity: 0.85;
+  }
+}
+
+/* ----------------------------------------- */
 /*  Market Item Icon                         */
 /* ----------------------------------------- */
 

--- a/styles/swerpg.css
+++ b/styles/swerpg.css
@@ -5332,6 +5332,26 @@ input[type='range'] {
   color: var(--color-secondary);
 }
 /* ----------------------------------------- */
+/*  Rarity Pips                              */
+/* ----------------------------------------- */
+.market-rarity-pips {
+  display: inline-flex;
+  align-items: center;
+  gap: 2px;
+  cursor: default;
+}
+.market-rarity-pip {
+  display: inline-block;
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+}
+.market-rarity-pip--filled {
+  background: var(--color-primary);
+  border: 1px solid var(--color-glow-25);
+  opacity: 0.85;
+}
+/* ----------------------------------------- */
 /*  Market Item Icon                         */
 /* ----------------------------------------- */
 .market-item__icon {

--- a/templates/market/market.hbs
+++ b/templates/market/market.hbs
@@ -385,8 +385,24 @@
                 <span class="market-price">{{entry.priceResult.finalPrice}}</span>
               {{/if}}
             </td>
-            <td class="market-col--rarity">{{entry.rarity}}</td>
-            <td class="market-col--restriction">{{entry.restrictionLevel}}</td>
+            <td class="market-col--rarity"
+                data-tooltip="{{localize 'MARKET.Catalog.Column.Rarity'}}: {{entry.rarity}}"
+                aria-label="{{localize 'MARKET.Catalog.Column.Rarity'}}: {{entry.rarity}}">
+              {{#if entry.rarityPips.length}}
+                <span class="market-rarity-pips" aria-hidden="true">
+                  {{#each entry.rarityPips}}
+                    <span class="market-rarity-pip market-rarity-pip--filled"></span>
+                  {{/each}}
+                </span>
+              {{else}}
+                <span class="market-rarity-pips market-rarity-pips--empty" aria-hidden="true"></span>
+              {{/if}}
+            </td>
+            <td class="market-col--restriction">
+              {{#if entry.restrictionLabel}}
+                {{localize entry.restrictionLabel}}
+              {{/if}}
+            </td>
             {{#if ../buyer}}
               <td class="market-col--buy">
                 {{#if entry.isNegotiable}}

--- a/tests/applications/market/market-application.test.mjs
+++ b/tests/applications/market/market-application.test.mjs
@@ -1578,6 +1578,128 @@ describe('MarketApplicationV2', () => {
 
       expect(context.catalog.totalCount).toBe(0)
     })
+
+    it('annotates restrictionLabel for items with restrictionLevel=none (non-null i18n key)', async () => {
+      const legal = makeItem({ type: 'weapon', name: 'Legal Blaster', restrictionLevel: 'none', availability: 'available' })
+      globalThis.game.items = makeItemsCollection([legal])
+
+      const app = new MarketApplicationV2()
+      const context = await app._preparePartContext('catalog', {})
+
+      // restrictionLabel must not be null for none — the template falls back to empty display via {{#if}}
+      // but the key must be provided so the template can localize correctly when restrictionLevel is 'none'
+      expect(context.catalog.items[0].restrictionLabel).toBe('ITEM.RESTRICTION_LEVEL.NONE')
+    })
+  })
+
+  /* -------------------------------------------- */
+  /*  Rarity display — rarityPips view-model       */
+  /* -------------------------------------------- */
+
+  describe('rarityPips annotation on catalog entries', () => {
+    it('produces an array of filled pip objects matching the rarity value', async () => {
+      const item = makeItem({ type: 'weapon', name: 'Blaster', rarity: 3, availability: 'available' })
+      globalThis.game.items = makeItemsCollection([item])
+
+      const app = new MarketApplicationV2()
+      const context = await app._preparePartContext('catalog', {})
+
+      const entry = context.catalog.items[0]
+      expect(Array.isArray(entry.rarityPips)).toBe(true)
+      expect(entry.rarityPips).toHaveLength(3)
+      expect(entry.rarityPips.every((p) => p.filled === true)).toBe(true)
+    })
+
+    it('produces an empty array when rarity is 0', async () => {
+      const item = makeItem({ type: 'weapon', name: 'Common Blaster', rarity: 0, availability: 'available' })
+      globalThis.game.items = makeItemsCollection([item])
+
+      const app = new MarketApplicationV2()
+      const context = await app._preparePartContext('catalog', {})
+
+      const entry = context.catalog.items[0]
+      expect(entry.rarityPips).toHaveLength(0)
+    })
+
+    it('produces an empty array when rarity is missing/undefined (falls back to 0)', async () => {
+      const item = makeItem({ type: 'weapon', name: 'Unknown Rarity', availability: 'available' })
+      // Override rarity to undefined after factory
+      item.system.rarity = undefined
+      globalThis.game.items = makeItemsCollection([item])
+
+      const app = new MarketApplicationV2()
+      const context = await app._preparePartContext('catalog', {})
+
+      const entry = context.catalog.items[0]
+      expect(Array.isArray(entry.rarityPips)).toBe(true)
+      expect(entry.rarityPips).toHaveLength(0)
+    })
+
+    it('caps rarityPips at 10 even when rarity exceeds 10', async () => {
+      const item = makeItem({ type: 'weapon', name: 'Ultra Rare', rarity: 15, availability: 'available' })
+      globalThis.game.items = makeItemsCollection([item])
+
+      const app = new MarketApplicationV2()
+      const context = await app._preparePartContext('catalog', {})
+
+      const entry = context.catalog.items[0]
+      expect(entry.rarityPips).toHaveLength(10)
+    })
+
+    it('produces exactly 1 pip for rarity 1', async () => {
+      const item = makeItem({ type: 'weapon', name: 'Blaster', rarity: 1, availability: 'available' })
+      globalThis.game.items = makeItemsCollection([item])
+
+      const app = new MarketApplicationV2()
+      const context = await app._preparePartContext('catalog', {})
+
+      expect(context.catalog.items[0].rarityPips).toHaveLength(1)
+    })
+
+    it('produces exactly 10 pips for rarity 10', async () => {
+      const item = makeItem({ type: 'weapon', name: 'Legendary', rarity: 10, availability: 'available' })
+      globalThis.game.items = makeItemsCollection([item])
+
+      const app = new MarketApplicationV2()
+      // Use black-market to ensure visibility (rarity 10 items may be excluded in standard)
+      app._viewState = { ...app._viewState, activeMarketType: 'black-market' }
+      const context = await app._preparePartContext('catalog', {})
+
+      expect(context.catalog.items[0].rarityPips).toHaveLength(10)
+    })
+
+    it('exposes rarityPips on every catalog entry', async () => {
+      const items = [
+        makeItem({ type: 'weapon', name: 'Item A', rarity: 2, availability: 'available' }),
+        makeItem({ type: 'armor', name: 'Item B', rarity: 5, availability: 'available' }),
+        makeItem({ type: 'gear', name: 'Item C', rarity: 0, availability: 'available' }),
+      ]
+      globalThis.game.items = makeItemsCollection(items)
+
+      const app = new MarketApplicationV2()
+      const context = await app._preparePartContext('catalog', {})
+
+      for (const entry of context.catalog.items) {
+        expect(entry).toHaveProperty('rarityPips')
+        expect(Array.isArray(entry.rarityPips)).toBe(true)
+      }
+    })
+
+    it('does not alter sort-by-rarity behavior (rarityPips is presentation-only, entry.rarity unchanged)', async () => {
+      const common = makeItem({ type: 'weapon', name: 'Common', rarity: 1 })
+      const rare = makeItem({ type: 'weapon', name: 'Rare', rarity: 5 })
+      globalThis.game.items = makeItemsCollection([rare, common])
+
+      const app = new MarketApplicationV2()
+      app._viewState = { ...app._viewState, sortBy: 'rarity', sortDirection: 'asc' }
+      const context = await app._preparePartContext('catalog', {})
+
+      const rarities = context.catalog.items.map((e) => e.rarity)
+      expect(rarities[0]).toBeLessThanOrEqual(rarities[1])
+      // entry.rarity is preserved
+      expect(context.catalog.items[0].rarity).toBe(1)
+      expect(context.catalog.items[1].rarity).toBe(5)
+    })
   })
 
   /* -------------------------------------------- */


### PR DESCRIPTION
## Summary

- Display item rarity as visual pips (stars) in the Market UI.
- Localize restriction labels shown in the Market list.
- Add unit tests for the Market application and include a short implementation plan.

## Context

This branch updates the Market application UI to render rarity using visual pips (stars) instead of raw text and ensures restriction labels are localized (fr/en). The change includes the necessary template, styles and small application adjustments as well as a unit test file and a documentation plan under documentation/plan/market.

Closes: none

## Tests

- Not run (not requested).

## Notes

- Files changed: module/applications/market/market-application.mjs, templates/market/market.hbs, styles/market.less, styles/swerpg.css, tests/applications/market/market-application.test.mjs, documentation/plan/market/528-market-ui-afficher-la-rarete-en-etoiles-pips-et-localiser-la-colonne-restriction.md
