### PR TITLE
feat(market): enhance buyer credits display and improve action button clarity

### DIFF
--- a/documentation/plan/market/529-market-ui-valoriser-le-portefeuille-et-agrandir-les-actions-d-achat-negocier.md
+++ b/documentation/plan/market/529-market-ui-valoriser-le-portefeuille-et-agrandir-les-actions-d-achat-negocier.md
@@ -1,0 +1,69 @@
+# Issue #529 — Market UI : valoriser le portefeuille et agrandir les actions d’achat / négocier
+
+**Issue** : https://github.com/herveDarritchon/foundryvtt-swerpg/issues/529  
+**Domaine métier** : `market`
+
+## Goal
+
+Rendre l’en-tête crédits plus lisible et plus "valuable", puis augmenter la clarté et la taille des CTA d’achat / négociation, sans toucher à la logique métier du Market ni aux règles d’achat/vente.
+
+## Contexte utile
+
+- `templates/market/market.hbs` affiche aujourd’hui le portefeuille en texte brut (`Credits: {{buyer.credits}}`) dans les deux modes, sans icône ni formatage monétaire.
+- `module/applications/market/market-application.mjs` expose seulement `buyer.credits` au template ; aucun champ de présentation formaté n’est fourni pour distinguer valeur brute et rendu UI.
+- `styles/market.less` donne à `.market-buyer-bar` un rendu sobre, et garde `.market-item__buy` / `.market-item__negotiate` sur des boutons compacts à icône seule avec padding `0.3rem`.
+- `lang/en.json` et `lang/fr.json` contiennent déjà les libellés métier `MARKET.Purchase.BuyButton` et `MARKET.Purchase.NegotiateButton`, réutilisables pour rendre les actions compréhensibles sans tooltip.
+- L’audit `documentation/audit/market/audit-ui-ux-market.md` cible explicitement UX6 (portefeuille peu valorisé) et UX7 (CTA trop petits / icon-only), avec critère a11y de cible tactile ≥ 44px.
+
+## Plan d’implémentation
+
+### Étape 1 — Préparer un contrat d’affichage enrichi pour le portefeuille
+
+**Fichiers** : `module/applications/market/market-application.mjs`, `tests/applications/market/market-application.test.mjs`
+
+**What** :
+
+- Étendre le contexte buyer exposé au template pour distinguer la valeur numérique métier (`credits`) et une variante prête à afficher (`formattedCredits` ou équivalent).
+- Centraliser ce contrat dans `_preparePartContext` pour garantir un rendu homogène entre mode achat et mode vente, sans dupliquer de logique de formatage dans le Handlebars.
+- Verrouiller en test le nouveau contrat de contexte afin d’éviter une régression sur la récupération des crédits depuis `creditBudget.availableCredits` / `system.credits`.
+
+**Résultat attendu** : le template reçoit une donnée portefeuille déjà formatée et exploitable visuellement, sans altérer les calculs métier existants.
+
+### Étape 2 — Revaloriser visuellement la buyer bar dans les deux modes
+
+**Fichiers** : `templates/market/market.hbs`, `styles/market.less` _(et `lang/en.json`, `lang/fr.json` seulement si un libellé dédié manque pour l’accessibilité)_
+
+**What** :
+
+- Enrichir la buyer bar avec une icône crédits, un séparateur visuel clair entre nom du buyer et montant, et une emphase visuelle portée sur le montant formaté.
+- Harmoniser le markup buy/sell autour d’un même rendu portefeuille pour éviter que l’un des deux modes garde l’ancienne version texte brut.
+- Préserver l’état vide (`market-buyer-bar--empty`) et l’accessibilité clavier / lecteur d’écran du bandeau.
+
+**Résultat attendu** : le portefeuille devient un repère visuel immédiat du Market, cohérent dans les deux parcours buy/sell.
+
+### Étape 3 — Agrandir et expliciter les CTA achat / négocier
+
+**Fichiers** : `templates/market/market.hbs`, `styles/market.less` _(et `tests/applications/market/market-application.test.mjs` si un contrat de rendu/template est verrouillé côté tests)_
+
+**What** :
+
+- Faire évoluer la colonne d’actions achat pour supporter des boutons réellement actionnables (cibles ≥ 44px), sans casser le layout du tableau ni l’état disabled existant.
+- Ajouter un libellé court visible ou une combinaison icône + texte pour distinguer immédiatement `Acheter` et `Négocier`, sans dépendre exclusivement du tooltip.
+- Ajuster `.market-col--buy`, `.market-item__buy` et `.market-item__negotiate` pour conserver une hiérarchie claire entre CTA, états hover/focus-visible/disabled compris.
+- Prévoir la validation finale par `pnpm run build` et revue visuelle ciblée du mode achat, sans ouvrir de refonte globale du tableau Market.
+
+**Résultat attendu** : les actions d’achat et de négociation sont compréhensibles au premier regard, plus confortables au clic/tactile, et restent compatibles avec les affordances existantes.
+
+## Périmètre / hors périmètre
+
+### Inclus
+
+- Formatage et mise en avant visuelle du portefeuille buyer
+- Ajustements localisés de markup et styles sur la buyer bar et les CTA achat / négocier
+- Contrat de contexte UI et tests ciblés associés
+
+### Exclus
+
+- Toute modification de logique métier de crédits, d’achat, de vente ou de négociation
+- Refonte globale du tableau Market au-delà de la colonne d’actions
+- Refonte générale du design system ou des autres écrans du système

--- a/module/applications/market/market-application.mjs
+++ b/module/applications/market/market-application.mjs
@@ -257,6 +257,7 @@ export default class MarketApplicationV2 extends api.HandlebarsApplicationMixin(
           id: buyer.id,
           name: buyer.name,
           credits: buyerCredits,
+          formattedCredits: buyerCredits !== null ? buyerCredits.toLocaleString() : '—',
         }
       : null
 

--- a/styles/market.less
+++ b/styles/market.less
@@ -337,7 +337,29 @@
 }
 
 .market-buyer-bar__credits {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
   color: var(--color-secondary);
+}
+
+.market-buyer-bar__credits-icon {
+  color: var(--color-accent-yellow);
+  font-size: var(--font-size-14);
+}
+
+.market-buyer-bar__credits-label {
+  font-family: var(--font-sans);
+  font-size: var(--font-size-12);
+  color: var(--color-secondary);
+}
+
+.market-buyer-bar__credits-amount {
+  font-family: var(--font-h2);
+  font-size: var(--font-size-15);
+  font-weight: 700;
+  color: var(--color-accent-yellow);
+  letter-spacing: 0.02em;
 }
 
 .market-buyer-bar--empty {
@@ -350,13 +372,12 @@
 /*  Market Buy Column & Button               */
 /* ----------------------------------------- */
 
-.market-col--buy {
-  width: 50px;
-  text-align: center;
-}
-
 .market-item__buy {
-  padding: 0.3rem 0.5rem;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+  min-height: 44px;
+  padding: 0.4rem 0.75rem;
   background: var(--color-success-15);
   border: 1px solid var(--color-success-30);
   border-radius: 4px;
@@ -367,6 +388,7 @@
     color 0.12s ease;
   font-family: var(--font-sans);
   font-size: var(--font-size-13);
+  white-space: nowrap;
 
   &:hover {
     background: var(--color-success-30);
@@ -558,14 +580,28 @@
 /* ----------------------------------------- */
 
 .market-col--buy {
+  width: 160px;
+  text-align: center;
   display: flex;
   align-items: center;
   justify-content: center;
   gap: 0.3rem;
+  padding: 0.25rem 0.4rem;
+}
+
+.market-item__btn-label {
+  font-family: var(--font-sans);
+  font-size: var(--font-size-12);
+  font-weight: 600;
+  letter-spacing: 0.02em;
 }
 
 .market-item__negotiate {
-  padding: 0.3rem 0.5rem;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+  min-height: 44px;
+  padding: 0.4rem 0.75rem;
   background: var(--color-accent-blue-15);
   border: 1px solid var(--color-accent-blue-30);
   border-radius: 4px;
@@ -576,6 +612,7 @@
     color 0.12s ease;
   font-family: var(--font-sans);
   font-size: var(--font-size-13);
+  white-space: nowrap;
 
   &:hover {
     background: var(--color-accent-blue-30);

--- a/styles/swerpg.css
+++ b/styles/swerpg.css
@@ -5383,7 +5383,26 @@ input[type='range'] {
   letter-spacing: 0.04em;
 }
 .market-buyer-bar__credits {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
   color: var(--color-secondary);
+}
+.market-buyer-bar__credits-icon {
+  color: var(--color-accent-yellow);
+  font-size: var(--font-size-14);
+}
+.market-buyer-bar__credits-label {
+  font-family: var(--font-sans);
+  font-size: var(--font-size-12);
+  color: var(--color-secondary);
+}
+.market-buyer-bar__credits-amount {
+  font-family: var(--font-h2);
+  font-size: var(--font-size-15);
+  font-weight: 700;
+  color: var(--color-accent-yellow);
+  letter-spacing: 0.02em;
 }
 .market-buyer-bar--empty {
   justify-content: center;
@@ -5393,12 +5412,12 @@ input[type='range'] {
 /* ----------------------------------------- */
 /*  Market Buy Column & Button               */
 /* ----------------------------------------- */
-.market-col--buy {
-  width: 50px;
-  text-align: center;
-}
 .market-item__buy {
-  padding: 0.3rem 0.5rem;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+  min-height: 44px;
+  padding: 0.4rem 0.75rem;
   background: var(--color-success-15);
   border: 1px solid var(--color-success-30);
   border-radius: 4px;
@@ -5407,6 +5426,7 @@ input[type='range'] {
   transition: background 0.12s ease, color 0.12s ease;
   font-family: var(--font-sans);
   font-size: var(--font-size-13);
+  white-space: nowrap;
 }
 .market-item__buy:hover {
   background: var(--color-success-30);
@@ -5564,13 +5584,26 @@ input[type='range'] {
 /*  Market Negotiate Button                  */
 /* ----------------------------------------- */
 .market-col--buy {
+  width: 160px;
+  text-align: center;
   display: flex;
   align-items: center;
   justify-content: center;
   gap: 0.3rem;
+  padding: 0.25rem 0.4rem;
+}
+.market-item__btn-label {
+  font-family: var(--font-sans);
+  font-size: var(--font-size-12);
+  font-weight: 600;
+  letter-spacing: 0.02em;
 }
 .market-item__negotiate {
-  padding: 0.3rem 0.5rem;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+  min-height: 44px;
+  padding: 0.4rem 0.75rem;
   background: var(--color-accent-blue-15);
   border: 1px solid var(--color-accent-blue-30);
   border-radius: 4px;
@@ -5579,6 +5612,7 @@ input[type='range'] {
   transition: background 0.12s ease, color 0.12s ease;
   font-family: var(--font-sans);
   font-size: var(--font-size-13);
+  white-space: nowrap;
 }
 .market-item__negotiate:hover {
   background: var(--color-accent-blue-30);

--- a/templates/market/market.hbs
+++ b/templates/market/market.hbs
@@ -35,7 +35,9 @@
       <div class="market-buyer-bar">
         <span class="market-buyer-bar__name">{{buyer.name}}</span>
         <span class="market-buyer-bar__credits">
-          {{localize "MARKET.Buyer.Credits"}}: <strong>{{buyer.credits}}</strong>
+          <i class="fa-solid fa-coins market-buyer-bar__credits-icon" aria-hidden="true"></i>
+          <span class="market-buyer-bar__credits-label">{{localize "MARKET.Buyer.Credits"}}</span>
+          <strong class="market-buyer-bar__credits-amount">{{buyer.formattedCredits}}</strong>
         </span>
       </div>
 
@@ -182,7 +184,9 @@
     <div class="market-buyer-bar">
       <span class="market-buyer-bar__name">{{buyer.name}}</span>
       <span class="market-buyer-bar__credits">
-        {{localize "MARKET.Buyer.Credits"}}: <strong>{{buyer.credits}}</strong>
+        <i class="fa-solid fa-coins market-buyer-bar__credits-icon" aria-hidden="true"></i>
+        <span class="market-buyer-bar__credits-label">{{localize "MARKET.Buyer.Credits"}}</span>
+        <strong class="market-buyer-bar__credits-amount">{{buyer.formattedCredits}}</strong>
       </span>
     </div>
   {{else}}
@@ -416,6 +420,7 @@
                     aria-label="{{localize 'MARKET.Purchase.NegotiateButton'}}"
                   >
                     <i class="fa-solid fa-handshake" aria-hidden="true"></i>
+                    <span class="market-item__btn-label">{{localize "MARKET.Purchase.NegotiateButton"}}</span>
                   </button>
                 {{/if}}
                 <button
@@ -428,6 +433,7 @@
                   aria-label="{{localize 'MARKET.Purchase.BuyButton'}}"
                 >
                   <i class="fa-solid fa-coins" aria-hidden="true"></i>
+                  <span class="market-item__btn-label">{{localize "MARKET.Purchase.BuyButton"}}</span>
                 </button>
               </td>
             {{/if}}

--- a/tests/applications/market/market-application.test.mjs
+++ b/tests/applications/market/market-application.test.mjs
@@ -230,6 +230,51 @@ describe('MarketApplicationV2', () => {
       expect(context.buyer.name).toBe('Vara Kesh')
       expect(context.buyer.credits).toBe(750)
     })
+
+    it('exposes buyer formattedCredits as a non-empty string when credits are set', async () => {
+      globalThis.game.items = makeItemsCollection([])
+
+      const actor = { id: 'actor-1', name: 'Vara Kesh', system: { credits: 1250 } }
+      const app = new MarketApplicationV2()
+      app.setBuyerActor(actor)
+      const context = await app._preparePartContext('catalog', {})
+
+      expect(context.buyer).not.toBeNull()
+      expect(typeof context.buyer.formattedCredits).toBe('string')
+      expect(context.buyer.formattedCredits).not.toBe('')
+    })
+
+    it('exposes buyer formattedCredits as "—" when credits are null', async () => {
+      globalThis.game.items = makeItemsCollection([])
+
+      // Actor with no credits field — resolves to null
+      const actor = { id: 'actor-1', name: 'No Credits', system: {} }
+      const app = new MarketApplicationV2()
+      app.setBuyerActor(actor)
+      const context = await app._preparePartContext('catalog', {})
+
+      expect(context.buyer).not.toBeNull()
+      expect(context.buyer.formattedCredits).toBe('—')
+    })
+
+    it('exposes formattedCredits derived from creditBudget.availableCredits when present', async () => {
+      globalThis.game.items = makeItemsCollection([])
+
+      const actor = {
+        id: 'actor-2',
+        name: 'Rich Character',
+        system: { creditBudget: { availableCredits: 3000 }, credits: 0 },
+      }
+      const app = new MarketApplicationV2()
+      app.setBuyerActor(actor)
+      const context = await app._preparePartContext('catalog', {})
+
+      expect(context.buyer).not.toBeNull()
+      // formattedCredits must reflect creditBudget.availableCredits (3000), not system.credits (0)
+      expect(context.buyer.credits).toBe(3000)
+      expect(typeof context.buyer.formattedCredits).toBe('string')
+      expect(context.buyer.formattedCredits).not.toBe('—')
+    })
   })
 
   describe('canBuy annotation on catalog entries', () => {


### PR DESCRIPTION
## Summary

- Enhance buyer credits display in the Market UI and improve clarity of action buttons (buy / negotiate).
- Add a unit test for the market application.

## Context

This PR implements frontend and styling changes for the Market application and adds a short implementation plan document under documentation/plan/.

## Tests

- Not run (not requested).
- Added test file: tests/applications/market/market-application.test.mjs

## Notes

Files changed (develop...HEAD):
- documentation/plan/market/529-market-ui-valoriser-le-portefeuille-et-agrandir-les-actions-d-achat-negocier.md
- module/applications/market/market-application.mjs
- styles/market.less
- styles/swerpg.css
- templates/market/market.hbs
- tests/applications/market/market-application.test.mjs
