### PR TITLE
feat: display price modification indicators with semantic colors

### DIFF
--- a/documentation/plan/market/532-market-ui-rendre-le-prix-modifie-visible-couleur-remise-premium-indicateur.md
+++ b/documentation/plan/market/532-market-ui-rendre-le-prix-modifie-visible-couleur-remise-premium-indicateur.md
@@ -1,0 +1,70 @@
+# Issue #532 — Market UI : rendre le prix modifié visible (couleur remise/premium + indicateur)
+
+**Issue** : https://github.com/herveDarritchon/foundryvtt-swerpg/issues/532  
+**Domaine métier** : `market`
+
+**Dépend sur** : [#523 — Market UI : Variabiliser toute la palette `market.less` sur le design system](https://github.com/herveDarritchon/foundryvtt-swerpg/issues/523)
+
+## Goal
+
+Rendre immédiatement lisible qu’un prix Market a été négocié ou modifié par le contexte métier, en affichant une couleur sémantique et un indicateur visuel ↑/↓ sans changer la logique de calcul de prix ni le tooltip existant base → final.
+
+## Contexte utile
+
+- Le template distingue déjà les prix modifiés via `.market-price--modified` dans `templates/market/market.hbs`, mais aucun style dédié n’est appliqué aujourd’hui.
+- `module/applications/market/market-application.mjs` enrichit déjà les entrées catalogue avec des view-models UI (`toolbarState`, `badges`, `rarityPips`) : c’est le bon point d’ancrage pour exposer un état prix simple à rendre.
+- `tests/applications/market/market-application.test.mjs` couvre déjà `priceResult` sur les entrées de catalogue ; il peut verrouiller le nouveau contrat UI sans dépendre d’une validation visuelle seule.
+- `styles/market.less` contient déjà les tokens sémantiques success / warning / danger consommables sans couleur en dur.
+
+## Plan d’implémentation
+
+### Étape 1 — Exposer un état visuel de variation de prix dans le view-model Market
+
+**Fichiers** : `module/applications/market/market-application.mjs`, `tests/applications/market/market-application.test.mjs`
+
+**What** :
+
+- Enrichir chaque entrée catalogue d’un petit état dérivé du `priceResult` (ex. `isModified`, `priceTrend`, `priceIndicator`, `priceStateClass`) basé sur la comparaison `basePrice` / `finalPrice`.
+- Distinguer explicitement les 3 cas utiles au template : prix inchangé, remise (`finalPrice < basePrice`), premium (`finalPrice > basePrice`).
+- Ajouter des tests ciblés sur ce contrat UI pour éviter toute logique conditionnelle implicite dans le template.
+
+**Résultat attendu** : le template reçoit une information prête à afficher, sans calcul métier embarqué dans le Handlebars.
+
+### Étape 2 — Brancher l’indicateur ↑/↓ et les états sémantiques dans le template prix
+
+**Fichiers** : `templates/market/market.hbs`, `lang/en.json`, `lang/fr.json` _(uniquement si un libellé aria dédié manque)_
+
+**What** :
+
+- Conserver le rendu actuel pour les prix non modifiés.
+- Pour les prix modifiés, ajouter à côté de la valeur un indicateur visuel compact (`↑` / `↓` ou équivalent décoratif) et les classes/attributs nécessaires au style et à l’accessibilité.
+- Préserver le tooltip existant `base → final`, qui reste la source de détail, sans refondre la structure de ligne ni les actions d’achat/négociation.
+
+**Résultat attendu** : un prix modifié est identifiable au premier coup d’œil, y compris avant survol du tooltip.
+
+### Étape 3 — Styliser remise vs premium dans `market.less`
+
+**Fichiers** : `styles/market.less`
+
+**What** :
+
+- Introduire le style de base de `.market-price` / `.market-price--modified` dans la colonne prix, puis décliner les variantes remise / premium avec tokens sémantiques (`--color-success*`, `--color-warning*` ou `--color-danger*`).
+- Donner à l’indicateur une présence visuelle nette mais compacte, cohérente avec la densité actuelle du tableau Market.
+- Veiller à ne pas altérer le rendu des prix normaux ni introduire de couleur en dur hors design system.
+
+**Résultat attendu** : remise et premium sont distingués visuellement sans ambiguïté, avec un prix normal inchangé.
+
+## Périmètre / hors périmètre
+
+### Inclus
+
+- View-model UI de variation de prix
+- Indicateur visuel ↑/↓ sur prix modifié
+- Styles sémantiques remise / premium
+- Tests ciblés sur le contrat de contexte Market
+
+### Exclus
+
+- Changement du calcul métier des prix, négociations ou modificateurs
+- Refonte globale de la table Market
+- Modification du détail tooltip base → final au-delà de sa conservation

--- a/lang/en.json
+++ b/lang/en.json
@@ -1541,6 +1541,10 @@
         "availability": "Availability",
         "rarity": "Rarity",
         "gmModifier": "GM adjustment"
+      },
+      "Trend": {
+        "discount": "Price reduced",
+        "premium": "Price increased"
       }
     },
     "Buyer": {

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -1437,6 +1437,10 @@
         "availability": "Disponibilité",
         "rarity": "Rareté",
         "gmModifier": "Ajustement MJ"
+      },
+      "Trend": {
+        "discount": "Prix réduit",
+        "premium": "Prix augmenté"
       }
     },
     "Buyer": {

--- a/module/applications/market/market-application.mjs
+++ b/module/applications/market/market-application.mjs
@@ -512,6 +512,22 @@ export default class MarketApplicationV2 extends api.HandlebarsApplicationMixin(
       const MAX_RARITY_PIPS = 10
       const rarityPips = Array.from({ length: Math.min(rarityValue, MAX_RARITY_PIPS) }, () => ({ filled: true }))
 
+      // Price variation view-model: expose pre-computed state so the template stays purely presentational.
+      // isModified: true when at least one modifier has changed the base price.
+      // priceTrend: 'discount' | 'premium' | 'none' — direction of the modification.
+      // priceStateClass: CSS modifier class to apply on the price cell.
+      // priceIndicator: visual arrow character ('↓' / '↑' / null) for the trend indicator.
+      const isModified = (entry.priceResult.modifiers?.length ?? 0) > 0
+      const finalPriceVal = entry.priceResult.finalPrice ?? 0
+      const basePriceVal = entry.priceResult.basePrice ?? 0
+      let priceTrend = 'none'
+      if (isModified) {
+        priceTrend = finalPriceVal < basePriceVal ? 'discount' : 'premium'
+      }
+      const priceStateClass = isModified ? `market-price--${priceTrend}` : ''
+      const priceIndicator = priceTrend === 'discount' ? '↓' : priceTrend === 'premium' ? '↑' : null
+      const priceTrendAriaKey = priceTrend !== 'none' ? `MARKET.Price.Trend.${priceTrend}` : null
+
       // Badge view-model: encode deduplication rules so the template stays purely presentational.
       // Rule 1 — black-market badge: suppress when restrictionLevel === 'illegal', because the
       //           restriction badge already displays the skull icon for that level.
@@ -537,6 +553,11 @@ export default class MarketApplicationV2 extends api.HandlebarsApplicationMixin(
         restrictionLabel,
         rarityPips,
         badges,
+        isModified,
+        priceTrend,
+        priceStateClass,
+        priceIndicator,
+        priceTrendAriaKey,
       }
     })
 

--- a/styles/market.less
+++ b/styles/market.less
@@ -362,6 +362,48 @@
   text-align: center;
 }
 
+/* ----------------------------------------- */
+/*  Market Price — modified state variants   */
+/* ----------------------------------------- */
+
+/* Base wrapper for any price cell content */
+.market-price {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  font-family: var(--font-sans);
+  font-weight: 500;
+}
+
+/* Discount: final price is lower than base — semantic success (green) */
+.market-price--discount {
+  color: var(--color-success-text);
+
+  .market-price__trend-indicator {
+    font-size: var(--font-size-11);
+    color: var(--color-success-text-light);
+    font-weight: 700;
+  }
+}
+
+/* Premium: final price is higher than base — semantic warning (amber) */
+.market-price--premium {
+  color: var(--color-warning-text);
+
+  .market-price__trend-indicator {
+    font-size: var(--font-size-11);
+    color: var(--color-warning-text);
+    font-weight: 700;
+  }
+}
+
+/* Trend indicator: compact arrow decorating the price value */
+.market-price__trend-indicator {
+  display: inline-block;
+  line-height: 1;
+  vertical-align: middle;
+}
+
 .market-col--restriction {
   width: 110px;
   text-align: center;

--- a/styles/swerpg.css
+++ b/styles/swerpg.css
@@ -5403,6 +5403,41 @@ input[type='range'] {
   width: 70px;
   text-align: center;
 }
+/* ----------------------------------------- */
+/*  Market Price — modified state variants   */
+/* ----------------------------------------- */
+/* Base wrapper for any price cell content */
+.market-price {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  font-family: var(--font-sans);
+  font-weight: 500;
+}
+/* Discount: final price is lower than base — semantic success (green) */
+.market-price--discount {
+  color: var(--color-success-text);
+}
+.market-price--discount .market-price__trend-indicator {
+  font-size: var(--font-size-11);
+  color: var(--color-success-text-light);
+  font-weight: 700;
+}
+/* Premium: final price is higher than base — semantic warning (amber) */
+.market-price--premium {
+  color: var(--color-warning-text);
+}
+.market-price--premium .market-price__trend-indicator {
+  font-size: var(--font-size-11);
+  color: var(--color-warning-text);
+  font-weight: 700;
+}
+/* Trend indicator: compact arrow decorating the price value */
+.market-price__trend-indicator {
+  display: inline-block;
+  line-height: 1;
+  vertical-align: middle;
+}
 .market-col--restriction {
   width: 110px;
   text-align: center;

--- a/templates/market/market.hbs
+++ b/templates/market/market.hbs
@@ -398,11 +398,16 @@
             </td>
             <td class="market-col--type">{{localize entry.itemType}}</td>
             <td class="market-col--price">
-              {{#if entry.priceResult.modifiers.length}}
-                <span class="market-price market-price--modified"
+              {{#if entry.isModified}}
+                <span class="market-price market-price--modified {{entry.priceStateClass}}"
                   data-tooltip="{{localize 'MARKET.Price.BaseLabel'}}: {{entry.priceResult.basePrice}} → {{localize 'MARKET.Price.FinalLabel'}}: {{entry.priceResult.finalPrice}}"
                   aria-label="{{localize 'MARKET.Price.FinalLabel'}}: {{entry.priceResult.finalPrice}}"
-                >{{entry.priceResult.finalPrice}}</span>
+                >
+                  {{entry.priceResult.finalPrice}}
+                  {{#if entry.priceIndicator}}
+                    <span class="market-price__trend-indicator" aria-label="{{localize entry.priceTrendAriaKey}}" aria-hidden="false">{{entry.priceIndicator}}</span>
+                  {{/if}}
+                </span>
               {{else}}
                 <span class="market-price">{{entry.priceResult.finalPrice}}</span>
               {{/if}}

--- a/tests/applications/market/market-application.test.mjs
+++ b/tests/applications/market/market-application.test.mjs
@@ -3138,4 +3138,118 @@ describe('MarketApplicationV2', () => {
       expect(context.toolbarState).toBeUndefined()
     })
   })
+
+  /* -------------------------------------------- */
+  /*  Price variation view-model (#532)            */
+  /* -------------------------------------------- */
+
+  describe('price variation view-model on catalog entries', () => {
+    it('isModified=false and priceTrend="none" when price has no modifiers (e.g. rarity=0, standard market)', async () => {
+      const item = makeItem({ type: 'weapon', name: 'Blaster', price: 100, rarity: 0, availability: 'available' })
+      globalThis.game.items = makeItemsCollection([item])
+
+      const app = new MarketApplicationV2()
+      app._viewState = { ...app._viewState, activeMarketType: 'standard' }
+      const context = await app._preparePartContext('catalog', {})
+
+      const entry = context.catalog.items[0]
+      expect(entry.isModified).toBe(false)
+      expect(entry.priceTrend).toBe('none')
+      expect(entry.priceStateClass).toBe('')
+      expect(entry.priceIndicator).toBeNull()
+      expect(entry.priceTrendAriaKey).toBeNull()
+    })
+
+    it('isModified=true and priceTrend="premium" when finalPrice > basePrice (e.g. black-market +50%)', async () => {
+      const item = makeItem({ type: 'weapon', name: 'Blaster', price: 100, rarity: 0, availability: 'available' })
+      globalThis.game.items = makeItemsCollection([item])
+
+      const app = new MarketApplicationV2()
+      app._viewState = { ...app._viewState, activeMarketType: 'black-market' }
+      const context = await app._preparePartContext('catalog', {})
+
+      const entry = context.catalog.items[0]
+      // Black-market applies a +50% premium: finalPrice=150 > basePrice=100
+      expect(entry.isModified).toBe(true)
+      expect(entry.priceTrend).toBe('premium')
+      expect(entry.priceStateClass).toBe('market-price--premium')
+      expect(entry.priceIndicator).toBe('↑')
+      expect(entry.priceTrendAriaKey).toBe('MARKET.Price.Trend.premium')
+    })
+
+    it('isModified=true and priceTrend="discount" when finalPrice < basePrice (e.g. local market -10%)', async () => {
+      const item = makeItem({ type: 'weapon', name: 'Blaster', price: 100, rarity: 0, availability: 'available' })
+      globalThis.game.items = makeItemsCollection([item])
+
+      const app = new MarketApplicationV2()
+      app._viewState = { ...app._viewState, activeMarketType: 'local' }
+      const context = await app._preparePartContext('catalog', {})
+
+      const entry = context.catalog.items[0]
+      // Local market applies a -10% discount: finalPrice=90 < basePrice=100
+      expect(entry.isModified).toBe(true)
+      expect(entry.priceTrend).toBe('discount')
+      expect(entry.priceStateClass).toBe('market-price--discount')
+      expect(entry.priceIndicator).toBe('↓')
+      expect(entry.priceTrendAriaKey).toBe('MARKET.Price.Trend.discount')
+    })
+
+    it('exposes isModified, priceTrend, priceStateClass, priceIndicator, priceTrendAriaKey on every catalog entry', async () => {
+      const items = [
+        makeItem({ type: 'weapon', name: 'Blaster A', price: 100, rarity: 0, availability: 'available' }),
+        makeItem({ type: 'armor', name: 'Armor B', price: 200, rarity: 1, availability: 'available' }),
+      ]
+      globalThis.game.items = makeItemsCollection(items)
+
+      const app = new MarketApplicationV2()
+      const context = await app._preparePartContext('catalog', {})
+
+      for (const entry of context.catalog.items) {
+        expect(entry).toHaveProperty('isModified')
+        expect(typeof entry.isModified).toBe('boolean')
+        expect(entry).toHaveProperty('priceTrend')
+        expect(['none', 'discount', 'premium']).toContain(entry.priceTrend)
+        expect(entry).toHaveProperty('priceStateClass')
+        expect(typeof entry.priceStateClass).toBe('string')
+        expect(entry).toHaveProperty('priceIndicator')
+        expect(entry).toHaveProperty('priceTrendAriaKey')
+      }
+    })
+
+    it('priceIndicator is null and priceTrendAriaKey is null when isModified=false', async () => {
+      const item = makeItem({ type: 'weapon', name: 'Blaster', price: 100, rarity: 0, availability: 'available' })
+      globalThis.game.items = makeItemsCollection([item])
+
+      const app = new MarketApplicationV2()
+      const context = await app._preparePartContext('catalog', {})
+
+      const entry = context.catalog.items[0]
+      expect(entry.priceIndicator).toBeNull()
+      expect(entry.priceTrendAriaKey).toBeNull()
+    })
+
+    it('priceStateClass is empty string when isModified=false', async () => {
+      const item = makeItem({ type: 'weapon', name: 'Blaster', price: 100, rarity: 0, availability: 'available' })
+      globalThis.game.items = makeItemsCollection([item])
+
+      const app = new MarketApplicationV2()
+      const context = await app._preparePartContext('catalog', {})
+
+      expect(context.catalog.items[0].priceStateClass).toBe('')
+    })
+
+    it('does not alter priceResult.basePrice or priceResult.finalPrice when adding trend fields', async () => {
+      const item = makeItem({ type: 'weapon', name: 'Blaster', price: 100, rarity: 0, availability: 'available' })
+      globalThis.game.items = makeItemsCollection([item])
+
+      const app = new MarketApplicationV2()
+      app._viewState = { ...app._viewState, activeMarketType: 'black-market' }
+      const context = await app._preparePartContext('catalog', {})
+
+      const entry = context.catalog.items[0]
+      // Price values must remain unchanged
+      expect(entry.priceResult.basePrice).toBe(100)
+      expect(entry.priceResult.finalPrice).toBe(150)
+    })
+  })
 })


### PR DESCRIPTION
## Summary

- Add Market catalog price state annotations so modified prices render as discount or premium states.
- Update the Market template and styles to show semantic colors and compact up/down indicators for modified prices.
- Add i18n labels, tests, and the implementation plan file for issue #532.

## Context

Closes #532

## Tests

- Not run (not requested).

## Notes

- Includes the implementation plan document under `documentation/plan/market/` alongside the UI change.
