### PR TITLE
feat(market): add lightweight diegetic chrome with holographic frame and header

### DIFF
--- a/documentation/plan/market/533-market-ui-ajouter-un-chrome-diegetique-leger-cadre-holographique-lisere-en-tete-de-marche.md
+++ b/documentation/plan/market/533-market-ui-ajouter-un-chrome-diegetique-leger-cadre-holographique-lisere-en-tete-de-marche.md
@@ -1,0 +1,80 @@
+# Issue #533 — Market UI : ajouter un chrome diégétique léger (cadre holographique, liseré, en-tête de marché)
+
+**Issue** : https://github.com/herveDarritchon/foundryvtt-swerpg/issues/533  
+**Domaine métier** : `market`
+
+**Dépend sur** : [#523 — Market UI : Variabiliser toute la palette `market.less` sur le design system](https://github.com/herveDarritchon/foundryvtt-swerpg/issues/523), [#525 — Market UI : Appliquer l’identité typographique Star Wars (Orbitron / Rajdhani)](https://github.com/herveDarritchon/foundryvtt-swerpg/issues/525)
+
+**Tags** : `HITL` — validation humaine requise sur la direction artistique du chrome avant implémentation
+
+## Goal
+
+Donner au Market un framing léger de terminal galactique via un cadre holographique, un liseré et un en-tête distinctif, sans alourdir le DOM, sans changer la logique métier, et sans dégrader contraste ou focus.
+
+## Contexte utile
+
+- L’issue et l’audit `documentation/audit/market/audit-ui-ux-market.md` (DA5) demandent explicitement un chrome **léger**, à fort impact perçu et à faible coût CSS.
+- `templates/market/market.hbs` expose déjà les hooks visuels principaux (`.market-catalog`, `.market-mode-toggle`, `.market-selector`, `.market-buyer-bar`) : le plan doit capitaliser dessus avant d’ajouter du markup.
+- `styles/market.less` contient déjà la base visuelle du Market et les tokens nécessaires (`--color-glow`, fonds de frame, typographies Market) ; le chrome doit rester 100 % design tokens.
+- En mode achat, la racine reçoit déjà la classe `uiVariant` du marché actif ; le chrome et l’en-tête doivent rester compatibles avec ces variantes et avec les thèmes clair/sombre.
+
+## Plan d’implémentation
+
+### Étape 1 — Valider la direction artistique minimale (HITL)
+
+**Fichiers** : `styles/market.less`, `templates/market/market.hbs` _(zone d’impact cible)_
+
+**What** :
+
+- Faire valider un unique concept compact : forme des coins/biseaux, position du liseré, niveau d’intensité du glow, et composition de l’en-tête.
+- Trancher si l’en-tête s’appuie uniquement sur les éléments déjà visibles (sélecteur de marché, description, buyer bar) ou s’il faut un wrapper dédié très léger.
+
+**Résultat attendu** : une cible visuelle claire, validée avant toute écriture CSS structurelle.
+
+### Étape 2 — Poser une structure d’en-tête Market légère et réutilisable
+
+**Fichiers** : `templates/market/market.hbs`, `lang/en.json`, `lang/fr.json` _(uniquement si un libellé d’en-tête manque)_
+
+**What** :
+
+- Introduire si nécessaire un wrapper de type `market-header` autour des éléments déjà présents, sans refonte du flux buy/sell.
+- Mettre en avant l’identité du marché actif (nom, description, variante visuelle) dans une zone distincte du contenu tabulaire.
+- Préserver l’accessibilité existante : structure lisible, focus visible, aucun texte purement décoratif indispensable à la compréhension.
+
+**Résultat attendu** : l’en-tête du Market est visuellement distinct du contenu, sans logique métier supplémentaire.
+
+### Étape 3 — Ajouter le chrome diégétique en CSS via pseudo-éléments
+
+**Fichiers** : `styles/market.less`
+
+**What** :
+
+- Ajouter le cadre léger du terminal sur `.market-catalog` et/ou `.market-header` avec `::before` / `::after` : coins lumineux, bornes d’angle, liseré supérieur ou latéral.
+- Réutiliser `--color-glow` et les tokens du design system pour rester compatible avec `uiVariant`, les thèmes clair/sombre et l’ADR design tokens.
+- Garantir que le chrome reste décoratif : pas de masque sur les focus rings, pas d’obstacle à la lisibilité, pas d’animation ou d’illustration lourde.
+
+**Résultat attendu** : le Market évoque un terminal Star Wars au premier regard, avec un coût DOM/CSS maîtrisé.
+
+### Étape 4 — Validation ciblée
+
+**Fichiers** : aucun nouveau fichier requis
+
+**What** :
+
+- Vérifier que le cadre, le liseré et l’en-tête sont visibles sans perturber toolbar, tableau, toggle ou buyer bar.
+- Vérifier que contraste et focus restent lisibles dans les variantes de marché et les thèmes clair/sombre.
+- Prévoir la validation finale par `pnpm run build` et une revue visuelle manuelle du Market.
+
+## Périmètre / hors périmètre
+
+### Inclus
+
+- Chrome diégétique léger du conteneur Market
+- En-tête de marché distinctif
+- Ajustements minimes de template et d’i18n si nécessaires au rendu
+
+### Exclus
+
+- Refonte de la logique JS ou métier du Market
+- Recomposition lourde du DOM
+- Nouvelles animations, assets illustrés complexes ou effets non essentiels

--- a/styles/market.less
+++ b/styles/market.less
@@ -38,6 +38,12 @@
 /*  Market Catalogue                         */
 /* ----------------------------------------- */
 
+/*
+ * Diegetic chrome: corner luminous brackets on the catalog container.
+ * Purely decorative — pointer-events and user-select off.
+ * Uses ::before (top-left + bottom-right) and ::after (top-right + bottom-left)
+ * via a background-clip corner gradient technique to stay DOM-free.
+ */
 .market-catalog {
   flex: 1;
   overflow-y: auto;
@@ -45,6 +51,85 @@
   display: flex;
   flex-direction: column;
   gap: 1.5rem;
+  position: relative;
+
+  &::before,
+  &::after {
+    content: '';
+    position: absolute;
+    width: 14px;
+    height: 14px;
+    pointer-events: none;
+    user-select: none;
+    opacity: 0.65;
+    border-color: var(--color-glow-50);
+    border-style: solid;
+  }
+
+  /* Top-left corner bracket */
+  &::before {
+    top: 6px;
+    left: 6px;
+    border-width: 2px 0 0 2px;
+  }
+
+  /* Bottom-right corner bracket */
+  &::after {
+    bottom: 6px;
+    right: 6px;
+    border-width: 0 2px 2px 0;
+  }
+}
+
+/* ----------------------------------------- */
+/*  Market Header                            */
+/* ----------------------------------------- */
+
+/*
+ * Identity zone for buy mode: market selector + buyer bar.
+ * A top liseré (border-top) using --color-glow gives a terminal-frame feel.
+ * Two additional corner brackets via pseudo-elements complete the framing.
+ */
+.market-header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  padding: 0.75rem 0.75rem 0.5rem;
+  background: var(--color-frame-bg-50);
+  border: 1px solid var(--color-glow-22);
+  border-top: 2px solid var(--color-glow-50);
+  border-radius: 4px;
+  position: relative;
+
+  /* Top-right corner bracket */
+  &::before {
+    content: '';
+    position: absolute;
+    top: -2px;
+    right: -1px;
+    width: 14px;
+    height: 14px;
+    border-top: 2px solid var(--color-glow-50);
+    border-right: 2px solid var(--color-glow-50);
+    pointer-events: none;
+    user-select: none;
+    opacity: 0.65;
+  }
+
+  /* Bottom-left corner bracket */
+  &::after {
+    content: '';
+    position: absolute;
+    bottom: -1px;
+    left: -1px;
+    width: 14px;
+    height: 14px;
+    border-bottom: 2px solid var(--color-glow-22);
+    border-left: 2px solid var(--color-glow-22);
+    pointer-events: none;
+    user-select: none;
+    opacity: 0.65;
+  }
 }
 
 /* Empty state */

--- a/styles/swerpg.css
+++ b/styles/swerpg.css
@@ -5128,6 +5128,12 @@ input[type='range'] {
 /* ----------------------------------------- */
 /*  Market Catalogue                         */
 /* ----------------------------------------- */
+/*
+ * Diegetic chrome: corner luminous brackets on the catalog container.
+ * Purely decorative — pointer-events and user-select off.
+ * Uses ::before (top-left + bottom-right) and ::after (top-right + bottom-left)
+ * via a background-clip corner gradient technique to stay DOM-free.
+ */
 .market-catalog {
   flex: 1;
   overflow-y: auto;
@@ -5135,6 +5141,78 @@ input[type='range'] {
   display: flex;
   flex-direction: column;
   gap: 1.5rem;
+  position: relative;
+  /* Top-left corner bracket */
+  /* Bottom-right corner bracket */
+}
+.market-catalog::before,
+.market-catalog::after {
+  content: '';
+  position: absolute;
+  width: 14px;
+  height: 14px;
+  pointer-events: none;
+  user-select: none;
+  opacity: 0.65;
+  border-color: var(--color-glow-50);
+  border-style: solid;
+}
+.market-catalog::before {
+  top: 6px;
+  left: 6px;
+  border-width: 2px 0 0 2px;
+}
+.market-catalog::after {
+  bottom: 6px;
+  right: 6px;
+  border-width: 0 2px 2px 0;
+}
+/* ----------------------------------------- */
+/*  Market Header                            */
+/* ----------------------------------------- */
+/*
+ * Identity zone for buy mode: market selector + buyer bar.
+ * A top liseré (border-top) using --color-glow gives a terminal-frame feel.
+ * Two additional corner brackets via pseudo-elements complete the framing.
+ */
+.market-header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  padding: 0.75rem 0.75rem 0.5rem;
+  background: var(--color-frame-bg-50);
+  border: 1px solid var(--color-glow-22);
+  border-top: 2px solid var(--color-glow-50);
+  border-radius: 4px;
+  position: relative;
+  /* Top-right corner bracket */
+  /* Bottom-left corner bracket */
+}
+.market-header::before {
+  content: '';
+  position: absolute;
+  top: -2px;
+  right: -1px;
+  width: 14px;
+  height: 14px;
+  border-top: 2px solid var(--color-glow-50);
+  border-right: 2px solid var(--color-glow-50);
+  pointer-events: none;
+  user-select: none;
+  opacity: 0.65;
+}
+.market-header::after {
+  content: '';
+  position: absolute;
+  bottom: -1px;
+  left: -1px;
+  width: 14px;
+  height: 14px;
+  border-bottom: 2px solid var(--color-glow-22);
+  border-left: 2px solid var(--color-glow-22);
+  pointer-events: none;
+  user-select: none;
+  opacity: 0.65;
 }
 /* Empty state */
 .market-empty {

--- a/templates/market/market.hbs
+++ b/templates/market/market.hbs
@@ -157,43 +157,48 @@
 
   {{!-- Buy / Catalogue mode --}}
 
-  {{!-- Market type selector --}}
-  <div class="market-selector">
-    <label for="market-type-select" class="sr-only">{{localize "MARKET.MarketType.SelectorLabel"}}</label>
-    <select
-      id="market-type-select"
-      class="market-selector__select"
-      aria-label="{{localize 'MARKET.MarketType.SelectorLabel'}}"
-    >
-      {{#each marketTypeOptions as |opt|}}
-        <option
-          value="{{opt.value}}"
-          {{#if (eq opt.value ../viewState.activeMarketType)}}selected{{/if}}
-        >
-          {{localize opt.label}}
-        </option>
-      {{/each}}
-    </select>
-    {{#if catalog.activeMarketDef}}
-      <p class="market-selector__description">{{localize catalog.activeMarketDef.description}}</p>
-    {{/if}}
-  </div>
+  {{!-- Market header: identity zone (type selector + buyer bar) --}}
+  <header class="market-header">
 
-  {{!-- Buyer info bar (shows buyer credits when active, invitation message otherwise) --}}
-  {{#if buyer}}
-    <div class="market-buyer-bar">
-      <span class="market-buyer-bar__name">{{buyer.name}}</span>
-      <span class="market-buyer-bar__credits">
-        <i class="fa-solid fa-coins market-buyer-bar__credits-icon" aria-hidden="true"></i>
-        <span class="market-buyer-bar__credits-label">{{localize "MARKET.Buyer.Credits"}}</span>
-        <strong class="market-buyer-bar__credits-amount">{{buyer.formattedCredits}}</strong>
-      </span>
+    {{!-- Market type selector --}}
+    <div class="market-selector">
+      <label for="market-type-select" class="sr-only">{{localize "MARKET.MarketType.SelectorLabel"}}</label>
+      <select
+        id="market-type-select"
+        class="market-selector__select"
+        aria-label="{{localize 'MARKET.MarketType.SelectorLabel'}}"
+      >
+        {{#each marketTypeOptions as |opt|}}
+          <option
+            value="{{opt.value}}"
+            {{#if (eq opt.value ../viewState.activeMarketType)}}selected{{/if}}
+          >
+            {{localize opt.label}}
+          </option>
+        {{/each}}
+      </select>
+      {{#if catalog.activeMarketDef}}
+        <p class="market-selector__description">{{localize catalog.activeMarketDef.description}}</p>
+      {{/if}}
     </div>
-  {{else}}
-    <div class="market-buyer-bar market-buyer-bar--empty">
-      <span>{{localize "MARKET.Buyer.SelectCharacter"}}</span>
-    </div>
-  {{/if}}
+
+    {{!-- Buyer info bar (shows buyer credits when active, invitation message otherwise) --}}
+    {{#if buyer}}
+      <div class="market-buyer-bar">
+        <span class="market-buyer-bar__name">{{buyer.name}}</span>
+        <span class="market-buyer-bar__credits">
+          <i class="fa-solid fa-coins market-buyer-bar__credits-icon" aria-hidden="true"></i>
+          <span class="market-buyer-bar__credits-label">{{localize "MARKET.Buyer.Credits"}}</span>
+          <strong class="market-buyer-bar__credits-amount">{{buyer.formattedCredits}}</strong>
+        </span>
+      </div>
+    {{else}}
+      <div class="market-buyer-bar market-buyer-bar--empty">
+        <span>{{localize "MARKET.Buyer.SelectCharacter"}}</span>
+      </div>
+    {{/if}}
+
+  </header>
 
   {{!-- Toolbar: search, filters, sort, reset --}}
   <div class="market-toolbar">


### PR DESCRIPTION
## Summary

- Add a lightweight diegetic chrome (holographic frame) for the Market UI header.
- Update Market templates and styles to introduce the new framed header structure.
- Add the implementation plan document for issue #533.

## Context

This branch implements the Market UI visual enhancement requested in issue #533. Changes are limited to templates, styles, and documentation; no runtime API or business-logic changes are included.

## Tests

- Not run (not requested).

## Notes

- Commit included: `b72e47f9` `feat(market): add lightweight diegetic chrome with holographic frame and header`
- Diff vs `develop`: 4 files changed, 283 insertions, 35 deletions
- Worktree was clean at PR creation time.