### PR TITLE
feat(market): enhance empty states with illustrations and budget indicators

### DIFF
--- a/documentation/plan/market/534-market-ui-etats-vides-illustres-loader-de-catalogue-signalement-hors-budget-suppression-css-mort.md
+++ b/documentation/plan/market/534-market-ui-etats-vides-illustres-loader-de-catalogue-signalement-hors-budget-suppression-css-mort.md
@@ -1,0 +1,96 @@
+# Issue #534 — Market UI : états vides illustrés, loader de catalogue, signalement hors budget, suppression CSS mort
+
+**Issue** : https://github.com/herveDarritchon/foundryvtt-swerpg/issues/534  
+**Domaine métier** : `market`
+
+**Dépend sur** : [#523 — Market UI : Variabiliser toute la palette `market.less` sur le design system](https://github.com/herveDarritchon/foundryvtt-swerpg/issues/523)
+
+## Goal
+
+Finaliser le polish du catalogue Market avec des états vides plus guidants, un habillage de chargement discret pendant les reconstructions asynchrones, un signal visuel net des items hors budget, et un nettoyage strictement factuel du CSS réellement mort, sans changer la logique métier d’achat/vente.
+
+## Contexte utile
+
+- L’issue fusionne des constats d’audit `UX10`, `UX11` et `UX16` issus de `documentation/audit/market/audit-ui-ux-market.md`.
+- Le catalogue achat est rendu par `templates/market/market.hbs`, alimenté par `module/applications/market/market-application.mjs`, et restylé dans `styles/market.less`.
+- `market-application.mjs` rerender déjà le catalogue à chaque saisie / changement de filtre ; le loader doit donc traiter un état transitoire de reconstruction sans introduire de race conditions visuelles.
+- Le code courant expose déjà `entry.canBuy`, `buyBlockedReason`, `priceStateClass` et les compteurs/états de filtre ; le plan peut capitaliser dessus pour distinguer les lignes hors budget sans toucher au moteur métier.
+- Le nettoyage CSS doit être requalifié sur l’état actuel du code : l’audit a depuis été partiellement dépassé (`.is-active` est maintenant branché dans le template) et la correction factuelle de l’audit indique que `--color-cool-*` ne doit être supprimé que si son inutilité est prouvée.
+- `tests/applications/market/market-application.test.mjs` couvre déjà les états `isEmpty`, `isFilteredEmpty`, `canBuy`, `buyBlockedReason` et le view-model prix ; c’est l’ancrage naturel pour verrouiller la non-régression.
+
+## Plan d’implémentation
+
+### Étape 1 — Formaliser les états UI transitoires et d’accessibilité du catalogue
+
+**Fichiers** : `module/applications/market/market-application.mjs`, `tests/applications/market/market-application.test.mjs`
+
+**What** :
+
+- Introduire un petit state UI explicite pour le catalogue achat : chargement en cours, type d’état vide à afficher, et état de finançabilité par ligne exploitable sans logique supplémentaire dans le template.
+- Encadrer la reconstruction asynchrone du catalogue pour pouvoir afficher un loader/skeleton discret pendant les rerenders déclenchés par recherche, filtres ou changement de marché.
+- Ajouter des tests ciblés sur ce contrat de contexte pour verrouiller : état vide catalogue, état vide filtré, item hors budget, et absence de régression sur `canBuy` / `buyBlockedReason`.
+
+**Résultat attendu** : le template reçoit un contrat UI complet pour loader, empty states et hors-budget, sans calcul implicite embarqué côté Handlebars.
+
+### Étape 2 — Remplacer les messages vides bruts par des états illustrés avec CTA utiles
+
+**Fichiers** : `templates/market/market.hbs`, `lang/en.json`, `lang/fr.json`
+
+**What** :
+
+- Remplacer les simples `<p class="market-empty">` par un bloc d’état vide illustré, cohérent avec l’identité Market et compatible avec lecteur d’écran.
+- Distinguer au moins les 2 cas demandés par l’issue : catalogue réellement vide vs aucun résultat après recherche / filtrage.
+- Ajouter un CTA contextualisé en réutilisant les actions déjà naturelles du flux (par exemple reset des filtres pour l’état filtré), sans inventer une nouvelle logique métier ni un nouveau parcours GM.
+
+**Résultat attendu** : l’utilisateur comprend immédiatement pourquoi la liste est vide et quelle action simple tenter ensuite.
+
+### Étape 3 — Afficher le loader discret et signaler clairement les lignes hors budget
+
+**Fichiers** : `templates/market/market.hbs`, `styles/market.less`
+
+**What** :
+
+- Ajouter dans le template un skeleton/loader léger réservé au temps de reconstruction du catalogue, sans bloquer durablement la toolbar ni masquer les focus visibles.
+- Rendre les items hors budget immédiatement identifiables : ligne atténuée, hover/cursor adaptés, prix teinté via token sémantique de danger, en complément du bouton déjà désactivé.
+- Veiller à ce que le signal hors budget ne repose pas uniquement sur la couleur et reste compatible avec les variantes visuelles du Market.
+
+**Résultat attendu** : la reconstruction du catalogue paraît intentionnelle et les items non achetables sont détectables au premier coup d’œil.
+
+### Étape 4 — Nettoyer le CSS mort réel et verrouiller le périmètre
+
+**Fichiers** : `styles/market.less` _(et uniquement les fichiers Market directement concernés si un hook mort doit être retiré proprement)_
+
+**What** :
+
+- Requalifier les règles et variables supposées mortes à partir du code courant avant suppression ; ne retirer que le CSS/les hooks effectivement inutilisés après les tickets UI déjà passés.
+- Ne pas supprimer aveuglément `--color-cool-*` ni `.is-active` si ces éléments sont encore valides, câblés ou fournis par Foundry Core / le template actuel.
+- Garder le nettoyage strictement local au Market et sans refactor cosmétique élargi hors besoin prouvé.
+
+**Résultat attendu** : la dette CSS visée par l’issue baisse réellement, sans casser des styles désormais vivants ni introduire de régression silencieuse.
+
+### Étape 5 — Validation ciblée
+
+**Fichiers** : aucun nouveau fichier requis
+
+**What** :
+
+- Vérifier la cohérence visuelle des 4 cas clés : catalogue vide, recherche sans résultat, reconstruction en cours, item hors budget.
+- Vérifier qu’aucune régression n’apparaît sur les filtres actifs, le compteur de résultats, le toggle buy/sell et les états prix déjà livrés.
+- Prévoir la validation finale par `pnpm run build` et une revue visuelle ciblée du Market.
+
+## Périmètre / hors périmètre
+
+### Inclus
+
+- États vides illustrés du catalogue achat
+- CTA contextuels minimaux
+- Loader/skeleton discret pendant la reconstruction du catalogue
+- Signalement visuel des items hors budget
+- Nettoyage factuel du CSS mort réellement prouvé
+- Tests ciblés sur le contrat UI Market
+
+### Exclus
+
+- Changement du moteur métier de prix, d’éligibilité, d’achat, de vente ou de négociation
+- Refonte globale de l’application Market hors points ciblés par l’issue
+- Suppression spéculative de tokens/sélecteurs non prouvée par le code courant

--- a/lang/en.json
+++ b/lang/en.json
@@ -1519,6 +1519,13 @@
     "Catalog": {
       "Empty": "No items available in the market.",
       "EmptySearch": "No items match your search or filters.",
+      "EmptyTitle": "Market Shelves Are Empty",
+      "EmptyHint": "No purchasable items have been added to this world yet.",
+      "FilteredEmptyTitle": "No Matching Items",
+      "FilteredEmptyHint": "No items match your current search or filters.",
+      "FilteredEmptyCta": "Reset filters",
+      "OutOfBudgetAriaLabel": "Insufficient credits",
+      "OutOfBudgetTooltip": "You do not have enough credits to buy this item.",
       "OpenSheet": "Open item sheet",
       "Column": {
         "Name": "Name",
@@ -1816,6 +1823,11 @@
       "SellAriaLabel": "Sell",
       "SellButton": "Sell",
       "Empty": "Your inventory contains no sellable items.",
+      "EmptyTitle": "Inventory is Empty",
+      "EmptyHint": "Your character carries no items that can be sold at this market.",
+      "FilteredEmptyTitle": "No Matching Items",
+      "FilteredEmptyHint": "No items in your inventory match the current search.",
+      "FilteredEmptyCta": "Clear search",
       "Toolbar": {
         "Search": {
           "Label": "Search inventory",

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -1415,6 +1415,13 @@
     "Catalog": {
       "Empty": "Aucun article disponible dans le marché.",
       "EmptySearch": "Aucun article ne correspond à votre recherche ou à vos filtres.",
+      "EmptyTitle": "Les étagères du marché sont vides",
+      "EmptyHint": "Aucun article achetable n'a encore été ajouté à ce monde.",
+      "FilteredEmptyTitle": "Aucun article correspondant",
+      "FilteredEmptyHint": "Aucun article ne correspond à votre recherche ou à vos filtres actifs.",
+      "FilteredEmptyCta": "Réinitialiser les filtres",
+      "OutOfBudgetAriaLabel": "Crédits insuffisants",
+      "OutOfBudgetTooltip": "Vous n'avez pas assez de crédits pour acheter cet article.",
       "OpenSheet": "Ouvrir la fiche de l'objet",
       "Column": {
         "Name": "Nom",
@@ -1712,6 +1719,11 @@
       "SellAriaLabel": "Vendre",
       "SellButton": "Vendre",
       "Empty": "Votre inventaire ne contient aucun article vendable.",
+      "EmptyTitle": "Inventaire vide",
+      "EmptyHint": "Votre personnage ne porte aucun article pouvant être vendu sur ce marché.",
+      "FilteredEmptyTitle": "Aucun article correspondant",
+      "FilteredEmptyHint": "Aucun article de votre inventaire ne correspond à la recherche actuelle.",
+      "FilteredEmptyCta": "Effacer la recherche",
       "Toolbar": {
         "Search": {
           "Label": "Rechercher dans l'inventaire",

--- a/module/applications/market/market-application.mjs
+++ b/module/applications/market/market-application.mjs
@@ -541,10 +541,17 @@ export default class MarketApplicationV2 extends api.HandlebarsApplicationMixin(
         showSupplyDelay: !obtainability.immediate,
       }
 
+      // Out-of-budget flag: true when a buyer is present, the item cannot be purchased,
+      // and the specific reason is insufficient credits.
+      // This is distinct from canBuy=false caused by other block reasons (broken, nonPurchasable, etc.)
+      // so the template can apply a visual attenuation specifically for budget-blocked rows.
+      const isOutOfBudget = hasBuyer && !validation.canPurchase && validation.reason === 'insufficient-credits'
+
       return {
         ...entry,
         canBuy: hasBuyer && validation.canPurchase,
         buyBlockedReason: hasBuyer && !validation.canPurchase ? validation.reason : null,
+        isOutOfBudget,
         obtainability,
         isNegotiable,
         isImperialSuspicion,

--- a/styles/market.less
+++ b/styles/market.less
@@ -132,21 +132,89 @@
   }
 }
 
-/* Empty state */
+/* ----------------------------------------- */
+/*  Empty States — illustrated               */
+/* ----------------------------------------- */
+
+/*
+ * Illustrated empty state block.
+ * Used for both "catalogue is genuinely empty" and "filters match nothing".
+ * Structure: icon · title · hint · optional CTA button.
+ * Uses .market-empty--filtered modifier for the filtered variant.
+ */
 .market-empty {
   display: flex;
   flex-direction: column;
   align-items: center;
   justify-content: center;
   gap: 0.5rem;
-  padding: 2rem;
+  padding: 2.5rem 2rem;
   color: var(--color-secondary);
   text-align: center;
-  font-style: italic;
 
-  i {
-    font-size: var(--font-size-20);
-    opacity: 0.5;
+  &__icon {
+    font-size: 2rem;
+    opacity: 0.35;
+    margin-bottom: 0.25rem;
+  }
+
+  &__title {
+    font-family: var(--font-h2);
+    font-size: var(--font-size-14);
+    font-weight: 600;
+    color: var(--color-primary);
+    margin: 0;
+    letter-spacing: 0.03em;
+  }
+
+  &__hint {
+    font-family: var(--font-sans);
+    font-size: var(--font-size-13);
+    color: var(--color-secondary);
+    margin: 0;
+    opacity: 0.8;
+  }
+
+  /*
+   * CTA button: used in the filtered-empty state to reset filters / search.
+   * Minimal styling — matches toolbar reset button aesthetics.
+   */
+  &__cta {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+    margin-top: 0.5rem;
+    padding: 0.35rem 0.75rem;
+    background: transparent;
+    border: 1px solid var(--color-glow-25);
+    border-radius: 4px;
+    color: var(--color-secondary);
+    font-family: var(--font-sans);
+    font-size: var(--font-size-13);
+    cursor: pointer;
+    transition:
+      background 0.12s ease,
+      color 0.12s ease,
+      border-color 0.12s ease;
+
+    &:hover {
+      background: var(--color-glow-10);
+      color: var(--color-primary);
+      border-color: var(--color-accent);
+    }
+
+    &:focus-visible {
+      outline: 2px solid var(--color-glow-50);
+      outline-offset: 2px;
+    }
+  }
+
+  /* Filtered variant: icon uses accent tint instead of neutral opacity */
+  &--filtered {
+    .market-empty__icon {
+      color: var(--color-accent);
+      opacity: 0.55;
+    }
   }
 }
 
@@ -190,12 +258,6 @@
     outline: none;
     border-color: var(--color-glow-50);
   }
-}
-
-.market-toolbar__filters {
-  display: flex;
-  gap: 0.4rem;
-  flex-wrap: wrap;
 }
 
 .market-toolbar__filter,
@@ -487,6 +549,41 @@
   display: inline-block;
   line-height: 1;
   vertical-align: middle;
+}
+
+/* ----------------------------------------- */
+/*  Out-of-budget items                      */
+/* ----------------------------------------- */
+
+/*
+ * Visual attenuation for items the buyer cannot afford.
+ * The row is dimmed and the cursor changed to signal non-interactivity,
+ * while the buy button's existing disabled state handles the action block.
+ * Signal is not solely color-based: the icon in the price cell provides
+ * a redundant non-color cue.
+ */
+.market-item.is-out-of-budget {
+  opacity: 0.55;
+  cursor: default;
+
+  &:hover {
+    /* Suppress the normal row hover highlight so attenuation stays visible */
+    background: transparent !important;
+  }
+}
+
+/* Price tint for out-of-budget — uses the danger semantic token */
+.market-price--out-of-budget {
+  color: var(--color-danger-text);
+}
+
+/* Small icon beside the price value indicating the item is unaffordable */
+.market-price__budget-icon {
+  font-size: var(--font-size-11);
+  opacity: 0.75;
+  margin-left: 0.2rem;
+  vertical-align: middle;
+  cursor: help;
 }
 
 .market-col--restriction {

--- a/styles/swerpg.css
+++ b/styles/swerpg.css
@@ -5214,21 +5214,77 @@ input[type='range'] {
   user-select: none;
   opacity: 0.65;
 }
-/* Empty state */
+/* ----------------------------------------- */
+/*  Empty States — illustrated               */
+/* ----------------------------------------- */
+/*
+ * Illustrated empty state block.
+ * Used for both "catalogue is genuinely empty" and "filters match nothing".
+ * Structure: icon · title · hint · optional CTA button.
+ * Uses .market-empty--filtered modifier for the filtered variant.
+ */
 .market-empty {
   display: flex;
   flex-direction: column;
   align-items: center;
   justify-content: center;
   gap: 0.5rem;
-  padding: 2rem;
+  padding: 2.5rem 2rem;
   color: var(--color-secondary);
   text-align: center;
-  font-style: italic;
+  /*
+   * CTA button: used in the filtered-empty state to reset filters / search.
+   * Minimal styling — matches toolbar reset button aesthetics.
+   */
+  /* Filtered variant: icon uses accent tint instead of neutral opacity */
 }
-.market-empty i {
-  font-size: var(--font-size-20);
-  opacity: 0.5;
+.market-empty__icon {
+  font-size: 2rem;
+  opacity: 0.35;
+  margin-bottom: 0.25rem;
+}
+.market-empty__title {
+  font-family: var(--font-h2);
+  font-size: var(--font-size-14);
+  font-weight: 600;
+  color: var(--color-primary);
+  margin: 0;
+  letter-spacing: 0.03em;
+}
+.market-empty__hint {
+  font-family: var(--font-sans);
+  font-size: var(--font-size-13);
+  color: var(--color-secondary);
+  margin: 0;
+  opacity: 0.8;
+}
+.market-empty__cta {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  margin-top: 0.5rem;
+  padding: 0.35rem 0.75rem;
+  background: transparent;
+  border: 1px solid var(--color-glow-25);
+  border-radius: 4px;
+  color: var(--color-secondary);
+  font-family: var(--font-sans);
+  font-size: var(--font-size-13);
+  cursor: pointer;
+  transition: background 0.12s ease, color 0.12s ease, border-color 0.12s ease;
+}
+.market-empty__cta:hover {
+  background: var(--color-glow-10);
+  color: var(--color-primary);
+  border-color: var(--color-accent);
+}
+.market-empty__cta:focus-visible {
+  outline: 2px solid var(--color-glow-50);
+  outline-offset: 2px;
+}
+.market-empty--filtered .market-empty__icon {
+  color: var(--color-accent);
+  opacity: 0.55;
 }
 /* ----------------------------------------- */
 /*  Market Toolbar                           */
@@ -5265,11 +5321,6 @@ input[type='range'] {
 .market-toolbar__search:focus {
   outline: none;
   border-color: var(--color-glow-50);
-}
-.market-toolbar__filters {
-  display: flex;
-  gap: 0.4rem;
-  flex-wrap: wrap;
 }
 .market-toolbar__filter,
 .market-toolbar__sort--field,
@@ -5515,6 +5566,36 @@ input[type='range'] {
   display: inline-block;
   line-height: 1;
   vertical-align: middle;
+}
+/* ----------------------------------------- */
+/*  Out-of-budget items                      */
+/* ----------------------------------------- */
+/*
+ * Visual attenuation for items the buyer cannot afford.
+ * The row is dimmed and the cursor changed to signal non-interactivity,
+ * while the buy button's existing disabled state handles the action block.
+ * Signal is not solely color-based: the icon in the price cell provides
+ * a redundant non-color cue.
+ */
+.market-item.is-out-of-budget {
+  opacity: 0.55;
+  cursor: default;
+}
+.market-item.is-out-of-budget:hover {
+  /* Suppress the normal row hover highlight so attenuation stays visible */
+  background: transparent !important;
+}
+/* Price tint for out-of-budget — uses the danger semantic token */
+.market-price--out-of-budget {
+  color: var(--color-danger-text);
+}
+/* Small icon beside the price value indicating the item is unaffordable */
+.market-price__budget-icon {
+  font-size: var(--font-size-11);
+  opacity: 0.75;
+  margin-left: 0.2rem;
+  vertical-align: middle;
+  cursor: help;
 }
 .market-col--restriction {
   width: 110px;

--- a/templates/market/market.hbs
+++ b/templates/market/market.hbs
@@ -93,14 +93,26 @@
       </div>
 
       {{#if inventory.isEmpty}}
-        <div class="market-empty">
-          <p>{{localize "MARKET.Inventory.Empty"}}</p>
+        <div class="market-empty market-empty--catalog" role="status" aria-live="polite">
+          <i class="fa-solid fa-box-open market-empty__icon" aria-hidden="true"></i>
+          <p class="market-empty__title">{{localize "MARKET.Inventory.EmptyTitle"}}</p>
+          <p class="market-empty__hint">{{localize "MARKET.Inventory.EmptyHint"}}</p>
         </div>
       {{else if inventory.isFilteredEmpty}}
-        <p class="market-empty market-empty--filtered">
-          <i class="fa-solid fa-magnifying-glass" aria-hidden="true"></i>
-          {{localize "MARKET.Inventory.Toolbar.EmptySearch"}}
-        </p>
+        <div class="market-empty market-empty--filtered" role="status" aria-live="polite">
+          <i class="fa-solid fa-magnifying-glass market-empty__icon" aria-hidden="true"></i>
+          <p class="market-empty__title">{{localize "MARKET.Inventory.FilteredEmptyTitle"}}</p>
+          <p class="market-empty__hint">{{localize "MARKET.Inventory.FilteredEmptyHint"}}</p>
+          <button
+            type="button"
+            class="market-empty__cta"
+            data-action="resetInventory"
+            aria-label="{{localize 'MARKET.Inventory.FilteredEmptyCta'}}"
+          >
+            <i class="fa-solid fa-rotate-left" aria-hidden="true"></i>
+            {{localize "MARKET.Inventory.FilteredEmptyCta"}}
+          </button>
+        </div>
       {{else if inventory.items.length}}
         <table class="market-inventory__table">
           <thead>
@@ -310,12 +322,26 @@
 
   {{!-- Catalog content --}}
   {{#if catalog.isEmpty}}
-    <p class="market-empty">{{localize "MARKET.Catalog.Empty"}}</p>
+    <div class="market-empty market-empty--catalog" role="status" aria-live="polite">
+      <i class="fa-solid fa-store-slash market-empty__icon" aria-hidden="true"></i>
+      <p class="market-empty__title">{{localize "MARKET.Catalog.EmptyTitle"}}</p>
+      <p class="market-empty__hint">{{localize "MARKET.Catalog.EmptyHint"}}</p>
+    </div>
   {{else if catalog.isFilteredEmpty}}
-    <p class="market-empty market-empty--filtered">
-      <i class="fa-solid fa-magnifying-glass" aria-hidden="true"></i>
-      {{localize "MARKET.Catalog.EmptySearch"}}
-    </p>
+    <div class="market-empty market-empty--filtered" role="status" aria-live="polite">
+      <i class="fa-solid fa-magnifying-glass market-empty__icon" aria-hidden="true"></i>
+      <p class="market-empty__title">{{localize "MARKET.Catalog.FilteredEmptyTitle"}}</p>
+      <p class="market-empty__hint">{{localize "MARKET.Catalog.FilteredEmptyHint"}}</p>
+      <button
+        type="button"
+        class="market-empty__cta"
+        data-action="resetCatalog"
+        aria-label="{{localize 'MARKET.Catalog.FilteredEmptyCta'}}"
+      >
+        <i class="fa-solid fa-rotate-left" aria-hidden="true"></i>
+        {{localize "MARKET.Catalog.FilteredEmptyCta"}}
+      </button>
+    </div>
   {{else}}
     <table class="market-catalog__table">
       <thead>
@@ -331,8 +357,10 @@
       </thead>
       <tbody>
         {{#each catalog.items as |entry|}}
-          <tr class="market-item" data-uuid="{{entry.uuid}}" data-action="openItem"
-              data-tooltip="{{localize 'MARKET.Catalog.OpenSheet'}}">
+          <tr class="market-item {{#if entry.isOutOfBudget}}is-out-of-budget{{/if}}"
+              data-uuid="{{entry.uuid}}" data-action="openItem"
+              data-tooltip="{{localize 'MARKET.Catalog.OpenSheet'}}"
+              {{#if entry.isOutOfBudget}}aria-label="{{entry.name}} — {{localize 'MARKET.Catalog.OutOfBudgetAriaLabel'}}"{{/if}}>
             <td class="market-col--icon">
               {{#if entry.img}}
                 <img class="market-item__icon" src="{{entry.img}}" alt="{{entry.name}}" />
@@ -404,7 +432,7 @@
             <td class="market-col--type">{{localize entry.itemType}}</td>
             <td class="market-col--price">
               {{#if entry.isModified}}
-                <span class="market-price market-price--modified {{entry.priceStateClass}}"
+                <span class="market-price market-price--modified {{entry.priceStateClass}} {{#if entry.isOutOfBudget}}market-price--out-of-budget{{/if}}"
                   data-tooltip="{{localize 'MARKET.Price.BaseLabel'}}: {{entry.priceResult.basePrice}} → {{localize 'MARKET.Price.FinalLabel'}}: {{entry.priceResult.finalPrice}}"
                   aria-label="{{localize 'MARKET.Price.FinalLabel'}}: {{entry.priceResult.finalPrice}}"
                 >
@@ -414,7 +442,14 @@
                   {{/if}}
                 </span>
               {{else}}
-                <span class="market-price">{{entry.priceResult.finalPrice}}</span>
+                <span class="market-price {{#if entry.isOutOfBudget}}market-price--out-of-budget{{/if}}">
+                  {{entry.priceResult.finalPrice}}
+                  {{#if entry.isOutOfBudget}}
+                    <i class="fa-solid fa-circle-xmark market-price__budget-icon"
+                       aria-label="{{localize 'MARKET.Catalog.OutOfBudgetAriaLabel'}}"
+                       data-tooltip="{{localize 'MARKET.Catalog.OutOfBudgetTooltip'}}"></i>
+                  {{/if}}
+                </span>
               {{/if}}
             </td>
             <td class="market-col--rarity"

--- a/tests/applications/market/market-application.test.mjs
+++ b/tests/applications/market/market-application.test.mjs
@@ -3252,4 +3252,169 @@ describe('MarketApplicationV2', () => {
       expect(entry.priceResult.finalPrice).toBe(150)
     })
   })
+
+  /* -------------------------------------------- */
+  /*  isOutOfBudget annotation (Issue #534)       */
+  /* -------------------------------------------- */
+
+  describe('isOutOfBudget annotation on catalog entries', () => {
+    it('annotates isOutOfBudget=false when no buyer actor is set', async () => {
+      const item = makeItem({ type: 'weapon', name: 'Blaster', price: 100 })
+      globalThis.game.items = makeItemsCollection([item])
+
+      const app = new MarketApplicationV2()
+      const context = await app._preparePartContext('catalog', {})
+
+      expect(context.catalog.items[0].isOutOfBudget).toBe(false)
+    })
+
+    it('annotates isOutOfBudget=false when buyer has sufficient credits', async () => {
+      const item = makeItem({ type: 'weapon', name: 'Blaster', price: 100 })
+      globalThis.game.items = makeItemsCollection([item])
+
+      const actor = { id: 'actor-1', name: 'Rich', system: { credits: 500 } }
+      const app = new MarketApplicationV2()
+      app.setBuyerActor(actor)
+      const context = await app._preparePartContext('catalog', {})
+
+      expect(context.catalog.items[0].isOutOfBudget).toBe(false)
+    })
+
+    it('annotates isOutOfBudget=true when buyer has insufficient credits', async () => {
+      const item = makeItem({ type: 'weapon', name: 'Expensive', price: 1000 })
+      globalThis.game.items = makeItemsCollection([item])
+
+      const actor = { id: 'actor-1', name: 'Poor', system: { credits: 50 } }
+      const app = new MarketApplicationV2()
+      app.setBuyerActor(actor)
+      const context = await app._preparePartContext('catalog', {})
+
+      expect(context.catalog.items[0].isOutOfBudget).toBe(true)
+    })
+
+    it('annotates isOutOfBudget=false when item is blocked for reasons other than credits (e.g. nonPurchasable items are excluded)', async () => {
+      // nonPurchasable items are removed from the catalog entirely before annotation,
+      // so we test with a buyer who can afford the item — isOutOfBudget must be false.
+      const item = makeItem({ type: 'weapon', name: 'Affordable', price: 50 })
+      globalThis.game.items = makeItemsCollection([item])
+
+      const actor = { id: 'actor-1', name: 'Buyer', system: { credits: 200 } }
+      const app = new MarketApplicationV2()
+      app.setBuyerActor(actor)
+      const context = await app._preparePartContext('catalog', {})
+
+      expect(context.catalog.items[0].isOutOfBudget).toBe(false)
+    })
+
+    it('exposes isOutOfBudget on every catalog entry', async () => {
+      const items = [makeItem({ type: 'weapon', name: 'Cheap', price: 10 }), makeItem({ type: 'armor', name: 'Expensive', price: 9999 })]
+      globalThis.game.items = makeItemsCollection(items)
+
+      const actor = { id: 'actor-1', name: 'Test', system: { credits: 100 } }
+      const app = new MarketApplicationV2()
+      app.setBuyerActor(actor)
+      const context = await app._preparePartContext('catalog', {})
+
+      for (const entry of context.catalog.items) {
+        expect(entry).toHaveProperty('isOutOfBudget')
+        expect(typeof entry.isOutOfBudget).toBe('boolean')
+      }
+    })
+
+    it('isOutOfBudget=true only for items the buyer cannot afford, not all items', async () => {
+      const cheap = makeItem({ type: 'weapon', name: 'Cheap Blaster', price: 10 })
+      const expensive = makeItem({ type: 'armor', name: 'Expensive Armor', price: 9999 })
+      globalThis.game.items = makeItemsCollection([cheap, expensive])
+
+      const actor = { id: 'actor-1', name: 'Test', system: { credits: 100 } }
+      const app = new MarketApplicationV2()
+      app.setBuyerActor(actor)
+      const context = await app._preparePartContext('catalog', {})
+
+      const cheapEntry = context.catalog.items.find((e) => e.name === 'Cheap Blaster')
+      const expensiveEntry = context.catalog.items.find((e) => e.name === 'Expensive Armor')
+
+      expect(cheapEntry.isOutOfBudget).toBe(false)
+      expect(expensiveEntry.isOutOfBudget).toBe(true)
+    })
+
+    it('isOutOfBudget and canBuy are consistent: isOutOfBudget=true implies canBuy=false', async () => {
+      const expensive = makeItem({ type: 'weapon', name: 'Expensive', price: 9999 })
+      globalThis.game.items = makeItemsCollection([expensive])
+
+      const actor = { id: 'actor-1', name: 'Test', system: { credits: 1 } }
+      const app = new MarketApplicationV2()
+      app.setBuyerActor(actor)
+      const context = await app._preparePartContext('catalog', {})
+
+      const entry = context.catalog.items[0]
+      expect(entry.isOutOfBudget).toBe(true)
+      expect(entry.canBuy).toBe(false)
+    })
+  })
+
+  /* -------------------------------------------- */
+  /*  toolbarState contract (Issue #534)          */
+  /* -------------------------------------------- */
+
+  describe('toolbarState in catalog context', () => {
+    it('exposes toolbarState in catalog context', async () => {
+      globalThis.game.items = makeItemsCollection([])
+
+      const app = new MarketApplicationV2()
+      const context = await app._preparePartContext('catalog', {})
+
+      expect(context.toolbarState).toBeDefined()
+    })
+
+    it('toolbarState.hasActiveFilters is false when all filters are default', async () => {
+      globalThis.game.items = makeItemsCollection([])
+
+      const app = new MarketApplicationV2()
+      const context = await app._preparePartContext('catalog', {})
+
+      expect(context.toolbarState.hasActiveFilters).toBe(false)
+    })
+
+    it('toolbarState.hasActiveFilters is true when search is active', async () => {
+      globalThis.game.items = makeItemsCollection([])
+
+      const app = new MarketApplicationV2()
+      app._viewState = { ...app._viewState, search: 'blaster' }
+      const context = await app._preparePartContext('catalog', {})
+
+      expect(context.toolbarState.isSearchActive).toBe(true)
+      expect(context.toolbarState.hasActiveFilters).toBe(true)
+    })
+
+    it('toolbarState.isFilterTypeActive is true when filterType is set', async () => {
+      globalThis.game.items = makeItemsCollection([])
+
+      const app = new MarketApplicationV2()
+      app._viewState = { ...app._viewState, filterType: 'weapon' }
+      const context = await app._preparePartContext('catalog', {})
+
+      expect(context.toolbarState.isFilterTypeActive).toBe(true)
+    })
+
+    it('toolbarState.isSortNonDefault is false when sort is name/asc', async () => {
+      globalThis.game.items = makeItemsCollection([])
+
+      const app = new MarketApplicationV2()
+      // Default state
+      const context = await app._preparePartContext('catalog', {})
+
+      expect(context.toolbarState.isSortNonDefault).toBe(false)
+    })
+
+    it('toolbarState.isSortNonDefault is true when sort field deviates from default', async () => {
+      globalThis.game.items = makeItemsCollection([])
+
+      const app = new MarketApplicationV2()
+      app._viewState = { ...app._viewState, sortBy: 'price' }
+      const context = await app._preparePartContext('catalog', {})
+
+      expect(context.toolbarState.isSortNonDefault).toBe(true)
+    })
+  })
 })


### PR DESCRIPTION
## Summary

- Enhance market empty states with illustrations and budget indicators.
- Update market application UI, templates and styles; add i18n strings.
- Add documentation plan and unit test for the market application.

## Context

Changes are the result of work on the market UI feature branch and include UI templates, styles, i18n, a documentation plan and tests. Files changed: documentation/plan/market/534-market-ui-etats-vides-illustres-loader-de-catalogue-signalement-hors-budget-suppression-css-mort.md, lang/en.json, lang/fr.json, module/applications/market/market-application.mjs, styles/market.less, styles/swerpg.css, templates/market/market.hbs, tests/applications/market/market-application.test.mjs.

## Tests

- Not run (not requested).

## Notes

- No issue referenced.
