### PR TITLE
fix(market): correct credit calculation during item sale to prevent budget inflation

### DIFF
--- a/documentation/plan/market/535-market-corriger-le-calcul-de-credits-en-mode-vente-economie-cassee.md
+++ b/documentation/plan/market/535-market-corriger-le-calcul-de-credits-en-mode-vente-economie-cassee.md
@@ -1,0 +1,45 @@
+# Market — Corriger le calcul de crédits en mode vente (économie cassée)
+
+**Issue** : [#535 — Market — Corriger le calcul de crédits en mode vente (économie cassée)](https://github.com/herveDarritchon/foundryvtt-swerpg/issues/535)
+
+## Objectif
+
+Empêcher la vente d’un item de gonfler artificiellement le budget disponible en distinguant correctement la valeur persistée `system.credits` (manual adjustment) de la valeur dérivée `creditBudget.availableCredits`.
+
+## Décisions de cadrage
+
+- La base de calcul persistée doit être `seller.system._source?.credits`, avec repli sur `seller.system?.credits ?? 0` si nécessaire.
+- Le montant écrit après vente doit être `manualAdjustmentAvant + resalePrice - basePrice` pour neutraliser le remboursement automatique de `totalSpent` causé par la suppression de l’item.
+- Les feedbacks métier (`remaining`, audit log, notification) doivent continuer à exprimer le **disponible dérivé** après vente, soit `availableBefore + resalePrice`.
+
+## Étapes d’implémentation
+
+### 1. Corriger le calcul persistant dans le flow `sellItem`
+
+**Fichiers cibles** : `module/applications/market/market-application.mjs`
+
+**What**
+
+- séparer explicitement `availableCreditsBefore` (affichage + invariant métier) de `manualAdjustmentBefore` (valeur persistée) ;
+- après `deleteEmbeddedDocuments`, calculer la nouvelle valeur de `system.credits` avec la formule compensée au lieu de réinjecter `availableCredits` ;
+- conserver une variable dédiée `availableCreditsAfter = availableCreditsBefore + resalePrice` pour la notification de succès, le log et la donnée transmise à l’audit.
+
+**Validation visée** : vendre un item de base 100 avec une revente à 25 n’augmente le disponible que de 25, sans gonfler le budget total.
+
+### 2. Verrouiller la régression par des tests ciblés
+
+**Fichiers cibles** : `tests/applications/market/market-application.test.mjs`, éventuellement `tests/utils/audit-log.test.mjs`
+
+**What**
+
+- adapter le test de vente existant pour vérifier que `actor.update()` reçoit la formule compensée, et non `availableCredits + resalePrice` ;
+- ajouter un cas où `creditBudget.availableCredits` et `system._source.credits` divergent pour reproduire le bug historique ;
+- vérifier l’invariant demandé par l’issue : `availableAfter = availableBefore + resalePrice`, y compris dans la valeur `creditsAfter` utilisée pour le feedback métier.
+
+**Validation visée** : la suite ciblée couvre le cas nominal, le cas avec budget dérivé ≠ valeur persistée, et l’invariant de non-régression demandé par l’issue.
+
+## Résultat attendu
+
+- `system.credits` n’est plus alimenté depuis une valeur dérivée.
+- La suppression de l’item ne provoque plus de double remboursement implicite.
+- Le disponible du personnage augmente uniquement du montant réel de revente.

--- a/module/applications/market/market-application.mjs
+++ b/module/applications/market/market-application.mjs
@@ -1190,10 +1190,20 @@ export default class MarketApplicationV2 extends api.HandlebarsApplicationMixin(
     }
 
     // Execute sale: delete item then credit actor
+    // The manual adjustment stored in system.credits is the raw base for writing.
+    // When the item is deleted, totalSpent drops by basePrice automatically (via _prepareCredits),
+    // which would inflate availableCredits by basePrice. To compensate, we write:
+    //   system.credits = manualAdjustmentBefore + resalePrice - basePrice
+    // so that availableCredits after = (manualAdjustmentBefore + resalePrice - basePrice) - (totalSpent - basePrice)
+    //                                = manualAdjustmentBefore + resalePrice - totalSpent
+    //                                = availableCreditsBefore + resalePrice  ✓
+    const manualAdjustmentBefore = seller.system?._source?.credits ?? seller.system?.credits ?? 0
+    const availableCreditsAfter = currentCredits + finalValuation.resalePrice
+    const newManualAdjustment = manualAdjustmentBefore + finalValuation.resalePrice - validation.basePrice
+
     try {
       await seller.deleteEmbeddedDocuments('Item', [item.id])
-      const newCredits = currentCredits + finalValuation.resalePrice
-      await seller.update({ 'system.credits': newCredits })
+      await seller.update({ 'system.credits': newManualAdjustment })
 
       // Record in audit log (non-blocking)
       try {
@@ -1205,7 +1215,7 @@ export default class MarketApplicationV2 extends api.HandlebarsApplicationMixin(
           resalePrice: finalValuation.resalePrice,
           fraction: finalValuation.fraction,
           negotiationOutcome: finalValuation.outcome,
-          creditsAfter: newCredits,
+          creditsAfter: availableCreditsAfter,
           itemId: item.id,
         })
       } catch (auditErr) {
@@ -1216,7 +1226,7 @@ export default class MarketApplicationV2 extends api.HandlebarsApplicationMixin(
         i18n.format('MARKET.Sale.Success', {
           name: item.name,
           price: finalValuation.resalePrice,
-          remaining: newCredits,
+          remaining: availableCreditsAfter,
         }),
       )
 
@@ -1227,7 +1237,7 @@ export default class MarketApplicationV2 extends api.HandlebarsApplicationMixin(
         itemName: item.name,
         basePrice: validation.basePrice,
         resalePrice: finalValuation.resalePrice,
-        creditsAfter: newCredits,
+        creditsAfter: availableCreditsAfter,
       })
 
       await this.render()

--- a/tests/applications/market/market-application.test.mjs
+++ b/tests/applications/market/market-application.test.mjs
@@ -2652,9 +2652,103 @@ describe('MarketApplicationV2', () => {
       await action.call(app, {}, target)
 
       expect(actor.deleteEmbeddedDocuments).toHaveBeenCalledWith('Item', ['w1'])
-      // Credits: 500 + Math.floor(100 * 0.25) = 525
-      expect(actor.update).toHaveBeenCalledWith({ 'system.credits': 525 })
+      // Compensated formula: manualAdjustment(500) + resalePrice(25) - basePrice(100) = 425
+      // This prevents double-credit when deleteEmbeddedDocuments triggers automatic totalSpent refund.
+      expect(actor.update).toHaveBeenCalledWith({ 'system.credits': 425 })
       expect(globalThis.ui.notifications.info).toHaveBeenCalled()
+
+      delete globalThis.foundry.applications.api.DialogV2.confirm
+    })
+
+    it('uses system._source.credits as the manual adjustment base when creditBudget diverges from raw credits', async () => {
+      // Bug reproduction: before the fix, selling with creditBudget.availableCredits=800 and
+      // system.credits=300 (manual adjustment) would write 800+25=825 into system.credits,
+      // inflating the budget by basePrice (500 from the automatic totalSpent refund).
+      // After the fix: writes _source.credits(300) + resalePrice(25) - basePrice(500) = -175 (capped by domain).
+      // The key invariant is that system.credits is NOT fed from creditBudget.availableCredits.
+      const item = {
+        id: 'w1',
+        name: 'Expensive Blaster',
+        type: 'weapon',
+        system: { price: 500 },
+      }
+      const itemsArray = [item]
+      const actor = {
+        id: 'actor-1',
+        name: 'Test',
+        system: {
+          // creditBudget.availableCredits diverges from the raw manual adjustment
+          creditBudget: { availableCredits: 800 },
+          credits: 300,
+          _source: { credits: 300 },
+        },
+        items: {
+          get: vi.fn((id) => itemsArray.find((i) => i.id === id)),
+          some: vi.fn((fn) => itemsArray.some(fn)),
+        },
+        deleteEmbeddedDocuments: vi.fn().mockResolvedValue([]),
+        update: vi.fn().mockResolvedValue(undefined),
+      }
+      globalThis.foundry.applications.api.DialogV2.confirm = vi.fn().mockResolvedValueOnce(true).mockResolvedValueOnce(false)
+
+      const app = new MarketApplicationV2()
+      app.render = vi.fn().mockResolvedValue(undefined)
+      app.setBuyerActor(actor)
+
+      const action = MarketApplicationV2.DEFAULT_OPTIONS.actions.sellItem
+      const target = { dataset: { itemId: 'w1' } }
+
+      await action.call(app, {}, target)
+
+      // Must use _source.credits (300) as base, NOT creditBudget.availableCredits (800)
+      // newManualAdjustment = 300 + Math.floor(500*0.25) - 500 = 300 + 125 - 500 = -75
+      expect(actor.update).toHaveBeenCalledWith({ 'system.credits': -75 })
+      // The update must NOT have been called with the inflated value (825)
+      expect(actor.update).not.toHaveBeenCalledWith({ 'system.credits': 825 })
+
+      delete globalThis.foundry.applications.api.DialogV2.confirm
+    })
+
+    it('availableCreditsAfter shown in success notification equals availableBefore + resalePrice', async () => {
+      // Invariant: the "remaining" credits in the notification must be availableBefore + resalePrice,
+      // not the raw system.credits value written to the document.
+      const item = {
+        id: 'w1',
+        name: 'Blaster',
+        type: 'weapon',
+        system: { price: 100 },
+      }
+      const itemsArray = [item]
+      const actor = {
+        id: 'actor-1',
+        name: 'Test',
+        system: {
+          creditBudget: { availableCredits: 600 },
+          credits: 200,
+          _source: { credits: 200 },
+        },
+        items: {
+          get: vi.fn((id) => itemsArray.find((i) => i.id === id)),
+          some: vi.fn((fn) => itemsArray.some(fn)),
+        },
+        deleteEmbeddedDocuments: vi.fn().mockResolvedValue([]),
+        update: vi.fn().mockResolvedValue(undefined),
+      }
+      globalThis.foundry.applications.api.DialogV2.confirm = vi.fn().mockResolvedValueOnce(true).mockResolvedValueOnce(false)
+
+      const app = new MarketApplicationV2()
+      app.render = vi.fn().mockResolvedValue(undefined)
+      app.setBuyerActor(actor)
+
+      const action = MarketApplicationV2.DEFAULT_OPTIONS.actions.sellItem
+      const target = { dataset: { itemId: 'w1' } }
+
+      await action.call(app, {}, target)
+
+      // resalePrice = Math.floor(100 * 0.25) = 25
+      // availableCreditsAfter = 600 + 25 = 625
+      // The success notification must show the derived available amount, not the raw system.credits value.
+      expect(globalThis.ui.notifications.info).toHaveBeenCalledWith(expect.stringContaining('625'))
 
       delete globalThis.foundry.applications.api.DialogV2.confirm
     })


### PR DESCRIPTION
## Summary

- Corrects credit calculation during item sale to prevent budget inflation.
- Adds a unit test exercising the sale flow and asserting the corrected credit handling.
- Updates documentation describing the market sale behavior and the fix.

## Context

This branch fixes a bug in the market sale flow that could result in a player's credits being incorrectly increased (budget inflation) when selling an item. The change touches the market application logic, adds a targeted unit test, and updates the documentation.

## Tests

- Not run (not requested).

## Notes

- Files changed: module/applications/market/market-application.mjs, module/applications/market/market-application.test.mjs, documentation/plan/535-market-corriger-le-calcul-de-crédits-en-mode-vente-economie-cassee.md
