### PR TITLE
feat(market): enforce availability check in negotiate flow to prevent bypass

### DIFF
--- a/documentation/plan/market/536-market-appliquer-le-jet-de-disponibilite-dans-le-flux-negocier-anti-bypass.md
+++ b/documentation/plan/market/536-market-appliquer-le-jet-de-disponibilite-dans-le-flux-negocier-anti-bypass.md
@@ -1,0 +1,70 @@
+# Issue #536 — Market : appliquer le jet de disponibilité dans le flux « négocier » (anti-bypass)
+
+**Issue** : https://github.com/herveDarritchon/foundryvtt-swerpg/issues/536  
+**Domaine métier** : `market`
+
+## Goal
+
+Supprimer le contournement du jet de disponibilité dans le parcours `négocier`, en garantissant qu’un item rare/restreint déclenche le même contrôle obligatoire que le parcours `acheter`, avant l’ouverture de la négociation, sans régression sur l’achat standard.
+
+## Contexte utile
+
+- `module/applications/market/market-application.mjs` fait déjà le contrôle de disponibilité dans `#onBuyItem`, mais `#onNegotiateItem` ouvre directement `NegotiationDialog.prompt()` puis appelle `#executePurchase`.
+- `#executePurchase` est commun aux deux flux, mais il intervient après la négociation ; y déplacer le contrôle changerait l’ordre UX attendu par l’issue, qui demande un jet avant la négociation.
+- `module/lib/market/availability-check.mjs` couvre déjà les règles métier pures (`resolveAvailabilityCheck`) ; le défaut est un problème d’orchestration du flux Market, pas de matrice métier.
+- `tests/applications/market/market-application.test.mjs` couvre déjà largement `buyItem` et `negotiateItem`, mais pas encore l’anti-bypass du jet de disponibilité sur `négocier`.
+
+## Plan d’implémentation
+
+### Étape 1 — Factoriser le garde-fou de disponibilité au niveau du flux Market
+
+**Fichiers** : `module/applications/market/market-application.mjs`
+
+**What** :
+
+- Extraire la séquence de contrôle de disponibilité (résolution `resolveAvailabilityCheck`, ouverture de `AvailabilityCheckDialog`, abort sur annulation/échec, notification associée) dans un helper privé réutilisable par les deux actions UI.
+- Garder `#executePurchase` centré sur l’exécution d’achat (conséquences, confirmation, mutation inventaire) pour éviter de déplacer le contrôle trop tard dans le parcours `négocier`.
+- Préserver le comportement déjà livré pour `buyItem`, y compris les effets déjà branchés autour du résultat du check.
+
+**Résultat attendu** : la règle de disponibilité n’est plus dupliquée à la main dans un seul handler ; elle devient un prérequis partagé des parcours d’achat Market.
+
+### Étape 2 — Appliquer le contrôle avant `NegotiationDialog` dans le parcours « négocier »
+
+**Fichiers** : `module/applications/market/market-application.mjs`
+
+**What** :
+
+- Brancher le helper partagé dans `#onNegotiateItem` juste après la reconstruction de `entry` et avant l’appel à `NegotiationDialog.prompt()`.
+- Faire en sorte qu’un check annulé/raté stoppe le flux sans ouvrir la négociation, conformément au critère d’acceptation anti-bypass.
+- Conserver ensuite le flux existant : négociation, construction de `negotiatedEntry`, puis `#executePurchase` avec le prix négocié.
+
+**Résultat attendu** : cliquer sur `Négocier` pour un item rare/restreint ne contourne plus le jet obligatoire, et l’ordre UX devient cohérent avec l’issue.
+
+### Étape 3 — Verrouiller la non-régression par des tests d’orchestration ciblés
+
+**Fichiers** : `tests/applications/market/market-application.test.mjs`
+
+**What** :
+
+- Ajouter un mock dédié de `AvailabilityCheckDialog.prompt()` pour pouvoir piloter le résultat du jet dans les tests du flux Market.
+- Ajouter au moins les cas ciblés suivants :
+  - `negotiateItem` déclenche le check avant `NegotiationDialog` pour un item rare/restreint ;
+  - `negotiateItem` s’arrête si le check est annulé ou échoue ;
+  - `buyItem` conserve son comportement existant et ne subit pas de régression de séquencement.
+- Prévoir la validation finale par `pnpm test` lors de l’implémentation, sans élargir le ticket à une refonte du moteur `availability-check`.
+
+**Résultat attendu** : le bug anti-bypass est couvert par des tests applicatifs explicites et le comportement historique de `acheter` reste protégé.
+
+## Périmètre / hors périmètre
+
+### Inclus
+
+- Orchestration commune du jet de disponibilité dans les handlers Market
+- Application du contrôle au flux `négocier` avant ouverture de la négociation
+- Tests ciblés sur l’ordre d’exécution et l’abandon du flux
+
+### Exclus
+
+- Changement des règles métier de `resolveAvailabilityCheck`
+- Refonte de `AvailabilityCheckDialog`, `NegotiationDialog` ou du moteur de prix
+- Modification du parcours de confirmation / conséquences hors besoin strict du correctif

--- a/module/applications/market/market-application.mjs
+++ b/module/applications/market/market-application.mjs
@@ -720,6 +720,14 @@ export default class MarketApplicationV2 extends api.HandlebarsApplicationMixin(
       return
     }
 
+    // Availability check: run before opening the negotiation dialog.
+    // Rare/restricted items require a successful skill test; if the check is cancelled or fails,
+    // the negotiation is blocked entirely (anti-bypass enforcement).
+    // Commerce outcome price modifier is NOT applied here — the negotiated price is determined
+    // later in the negotiation step and supersedes any pre-negotiation modifier.
+    const availabilityPassedEntry = await MarketApplicationV2.#runAvailabilityCheck.call(this, { entry, buyer, uuid, applyCommerceOutcome: false })
+    if (availabilityPassedEntry === null) return
+
     const negotiationResult = await NegotiationDialog.prompt({ entry, buyer })
     if (!negotiationResult?.confirmed) {
       logger.debug('[Market] Negotiation cancelled by user', { uuid })
@@ -798,59 +806,87 @@ export default class MarketApplicationV2 extends api.HandlebarsApplicationMixin(
       return
     }
 
-    // Availability check: items with high rarity or restricted status require a skill test before purchase.
+    const checkedEntry = await MarketApplicationV2.#runAvailabilityCheck.call(this, { entry, buyer, uuid })
+    if (checkedEntry === null) return
+
+    await MarketApplicationV2.#executePurchase.call(this, { item, entry: checkedEntry, buyer })
+  }
+
+  /**
+   * Run the availability check gate shared by the buy and negotiate flows.
+   *
+   * Resolves the check spec, shows `AvailabilityCheckDialog` when required, and applies the
+   * commerce outcome modifier to the entry price (buy flow only — the negotiate flow receives
+   * the same pre-negotiation check but the price modifier is intentionally omitted because the
+   * negotiation price is determined afterwards).
+   *
+   * Returns the (possibly price-modified) entry when the check passes or is not required.
+   * Returns `null` when the check is required but the user cancelled or the roll failed,
+   * signalling the caller to abort the flow.
+   *
+   * @this {MarketApplicationV2}
+   * @param {object} params
+   * @param {import('../../lib/market/market-entry.mjs').MarketEntry} params.entry  The market entry to check.
+   * @param {Actor}  params.buyer   The buyer actor.
+   * @param {string} params.uuid    Item UUID — used only for debug logging.
+   * @param {boolean} [params.applyCommerceOutcome=true]  When false, skip the price-modifier step (negotiate flow).
+   * @returns {Promise<import('../../lib/market/market-entry.mjs').MarketEntry|null>}
+   */
+  static async #runAvailabilityCheck({ entry, buyer, uuid, applyCommerceOutcome = true }) {
     const checkSpec = resolveAvailabilityCheck({
       rarity: entry.rarity,
       restrictionLevel: entry.restrictionLevel,
     })
 
-    if (checkSpec.required) {
-      const checkResult = await AvailabilityCheckDialog.prompt({ entry, buyer, checkSpec })
+    if (!checkSpec.required) return entry
 
-      if (!checkResult?.passed) {
-        logger.debug('[Market] Availability check not passed — purchase aborted', { uuid, checkSpec })
-        const skillName = SYSTEM.SKILLS[checkSpec.skillKey]?.name ?? checkSpec.skillKey
-        ui.notifications.warn(
-          game.i18n.format('MARKET.AvailabilityCheck.FailedNotification', {
-            skill: skillName,
-            item: entry.name,
-          }),
-        )
-        return
-      }
+    const checkResult = await AvailabilityCheckDialog.prompt({ entry, buyer, checkSpec })
 
-      logger.info('[Market] Availability check passed — proceeding with purchase', { uuid, skillKey: checkSpec.skillKey })
-
-      // Apply commerce outcome if the check result carries narrative dice data (Tranche 2).
-      // Non-blocking: if testResult is absent or malformed, the purchase proceeds unchanged.
-      const testResult = checkResult?.testResult ?? null
-      if (testResult) {
-        try {
-          const commerceOutcome = computeCommerceOutcome(testResult)
-          const basePrice = entry.priceResult.finalPrice
-          const modifiedPrice = Math.max(0, Math.floor(basePrice * (1 + commerceOutcome.priceModifier)))
-          entry = {
-            ...entry,
-            priceResult: {
-              ...entry.priceResult,
-              finalPrice: modifiedPrice,
-              appliedOutcome: commerceOutcome,
-            },
-          }
-          logger.info('[Market] Commerce outcome applied', {
-            uuid,
-            outcomeLabel: commerceOutcome.outcomeLabel,
-            priceModifier: commerceOutcome.priceModifier,
-            basePrice,
-            modifiedPrice,
-          })
-        } catch (outcomeErr) {
-          logger.warn('[Market] Could not apply commerce outcome — proceeding with base price', outcomeErr)
-        }
-      }
+    if (!checkResult?.passed) {
+      logger.debug('[Market] Availability check not passed — flow aborted', { uuid, checkSpec })
+      const skillName = SYSTEM.SKILLS[checkSpec.skillKey]?.name ?? checkSpec.skillKey
+      ui.notifications.warn(
+        game.i18n.format('MARKET.AvailabilityCheck.FailedNotification', {
+          skill: skillName,
+          item: entry.name,
+        }),
+      )
+      return null
     }
 
-    await MarketApplicationV2.#executePurchase.call(this, { item, entry, buyer })
+    logger.info('[Market] Availability check passed', { uuid, skillKey: checkSpec.skillKey })
+
+    if (!applyCommerceOutcome) return entry
+
+    // Apply commerce outcome if the check result carries narrative dice data (Tranche 2).
+    // Non-blocking: if testResult is absent or malformed, the purchase proceeds unchanged.
+    const testResult = checkResult?.testResult ?? null
+    if (!testResult) return entry
+
+    try {
+      const commerceOutcome = computeCommerceOutcome(testResult)
+      const basePrice = entry.priceResult.finalPrice
+      const modifiedPrice = Math.max(0, Math.floor(basePrice * (1 + commerceOutcome.priceModifier)))
+      const modifiedEntry = {
+        ...entry,
+        priceResult: {
+          ...entry.priceResult,
+          finalPrice: modifiedPrice,
+          appliedOutcome: commerceOutcome,
+        },
+      }
+      logger.info('[Market] Commerce outcome applied', {
+        uuid,
+        outcomeLabel: commerceOutcome.outcomeLabel,
+        priceModifier: commerceOutcome.priceModifier,
+        basePrice,
+        modifiedPrice,
+      })
+      return modifiedEntry
+    } catch (outcomeErr) {
+      logger.warn('[Market] Could not apply commerce outcome — proceeding with base price', outcomeErr)
+      return entry
+    }
   }
 
   /**

--- a/tests/applications/market/market-application.test.mjs
+++ b/tests/applications/market/market-application.test.mjs
@@ -16,6 +16,12 @@ vi.mock('../../../module/applications/market/consequences-dialog.mjs', () => ({
   },
 }))
 
+vi.mock('../../../module/applications/market/availability-check-dialog.mjs', () => ({
+  default: {
+    prompt: vi.fn(),
+  },
+}))
+
 /* -------------------------------------------- */
 /*  Helpers                                     */
 /* -------------------------------------------- */
@@ -69,6 +75,7 @@ describe('MarketApplicationV2', () => {
   let MarketApplicationV2
   let NegotiationDialogMock
   let ConsequencesDialogMock
+  let AvailabilityCheckDialogMock
 
   beforeEach(async () => {
     setupFoundryMock({
@@ -119,10 +126,15 @@ describe('MarketApplicationV2', () => {
     ;({ default: MarketApplicationV2 } = await import('../../../module/applications/market/market-application.mjs'))
     ;({ default: NegotiationDialogMock } = await import('../../../module/applications/market/negotiation-dialog.mjs'))
     ;({ default: ConsequencesDialogMock } = await import('../../../module/applications/market/consequences-dialog.mjs'))
+    ;({ default: AvailabilityCheckDialogMock } = await import('../../../module/applications/market/availability-check-dialog.mjs'))
 
     // Default: consequences dialog confirms with no consequences (no narrative risks).
     // Tests that need different behavior override this before calling the action.
     ConsequencesDialogMock.prompt.mockResolvedValue({ confirmed: true, acceptedTypes: [], rejectedTypes: [] })
+
+    // Default: availability check passes (not required for low-rarity, non-restricted items).
+    // Tests involving rare/restricted items override this to simulate specific check results.
+    AvailabilityCheckDialogMock.prompt.mockResolvedValue({ passed: true, testResult: null })
   })
 
   afterEach(() => {
@@ -1259,6 +1271,31 @@ describe('MarketApplicationV2', () => {
       delete globalThis.fromUuid
       delete globalThis.foundry.applications.api.DialogV2.confirm
     })
+
+    it('[non-regression] buyItem still triggers AvailabilityCheckDialog for a rare item and aborts if it fails', async () => {
+      const actor = { id: 'actor-1', name: 'Test', system: { credits: 500 } }
+      // rarity=4 triggers check in buy flow too
+      const item = makeItem({ uuid: 'Item.rare', type: 'weapon', price: 200, rarity: 4, restrictionLevel: 'none' })
+      item.toObject = vi.fn(() => ({ type: 'weapon', name: item.name, system: item.system }))
+      globalThis.fromUuid = vi.fn().mockResolvedValue(item)
+
+      // Check fails
+      AvailabilityCheckDialogMock.prompt.mockResolvedValue({ passed: false, testResult: null })
+
+      const app = new MarketApplicationV2()
+      app.setBuyerActor(actor)
+      const action = MarketApplicationV2.DEFAULT_OPTIONS.actions.buyItem
+      const target = { closest: vi.fn(() => ({ dataset: { uuid: 'Item.rare' } })) }
+
+      await action.call(app, {}, target)
+
+      expect(AvailabilityCheckDialogMock.prompt).toHaveBeenCalled()
+      // Purchase must be aborted — no confirmation dialog opened
+      expect(globalThis.foundry?.applications?.api?.DialogV2?.confirm ?? vi.fn()).not.toHaveBeenCalled()
+      expect(globalThis.ui.notifications.warn).toHaveBeenCalled()
+
+      delete globalThis.fromUuid
+    })
   })
 
   /* -------------------------------------------- */
@@ -1435,6 +1472,152 @@ describe('MarketApplicationV2', () => {
       await action.call(app, {}, target)
 
       expect(globalThis.ui.notifications.warn).toHaveBeenCalledWith('MARKET.Negotiation.Outcome.DisasterNotification')
+
+      delete globalThis.fromUuid
+      delete globalThis.foundry.applications.api.DialogV2.confirm
+    })
+
+    /* -------------------------------------------- */
+    /*  Anti-bypass: availability check in negotiate */
+    /* -------------------------------------------- */
+
+    it('triggers AvailabilityCheckDialog before NegotiationDialog for a rare item (rarity >= 4)', async () => {
+      const actor = { id: 'actor-1', name: 'Test', system: { credits: 500 } }
+      // rarity=4 triggers availability check (AVAILABILITY_CHECK_RARITY_THRESHOLD = 4)
+      const item = makeItem({ uuid: 'Item.rare', type: 'weapon', price: 200, rarity: 4, restrictionLevel: 'none' })
+      item.toObject = vi.fn(() => ({ type: 'weapon', name: item.name, system: item.system }))
+      globalThis.fromUuid = vi.fn().mockResolvedValue(item)
+
+      // Check passes — proceed to negotiation
+      AvailabilityCheckDialogMock.prompt.mockResolvedValue({ passed: true, testResult: null })
+      // Negotiation cancelled to isolate the call order check
+      NegotiationDialogMock.prompt.mockResolvedValue(null)
+
+      const callOrder = []
+      AvailabilityCheckDialogMock.prompt.mockImplementation(async () => {
+        callOrder.push('availabilityCheck')
+        return { passed: true, testResult: null }
+      })
+      NegotiationDialogMock.prompt.mockImplementation(async () => {
+        callOrder.push('negotiation')
+        return null
+      })
+
+      const app = new MarketApplicationV2()
+      app.setBuyerActor(actor)
+      const action = MarketApplicationV2.DEFAULT_OPTIONS.actions.negotiateItem
+      const target = { closest: vi.fn(() => ({ dataset: { uuid: 'Item.rare' } })) }
+
+      await action.call(app, {}, target)
+
+      // AvailabilityCheckDialog must be called before NegotiationDialog
+      expect(callOrder[0]).toBe('availabilityCheck')
+      expect(callOrder[1]).toBe('negotiation')
+
+      delete globalThis.fromUuid
+    })
+
+    it('triggers AvailabilityCheckDialog before NegotiationDialog for a restricted item', async () => {
+      const actor = { id: 'actor-1', name: 'Test', system: { credits: 500 } }
+      // restrictionLevel=restricted always requires a check regardless of rarity
+      const item = makeItem({ uuid: 'Item.restricted', type: 'weapon', price: 150, rarity: 1, restrictionLevel: 'restricted' })
+      item.toObject = vi.fn(() => ({ type: 'weapon', name: item.name, system: item.system }))
+      globalThis.fromUuid = vi.fn().mockResolvedValue(item)
+
+      // Use black-market so restricted items are visible
+      const callOrder = []
+      AvailabilityCheckDialogMock.prompt.mockImplementation(async () => {
+        callOrder.push('availabilityCheck')
+        return { passed: true, testResult: null }
+      })
+      NegotiationDialogMock.prompt.mockImplementation(async () => {
+        callOrder.push('negotiation')
+        return null
+      })
+
+      const app = new MarketApplicationV2()
+      app.setBuyerActor(actor)
+      app._viewState = { ...app._viewState, activeMarketType: 'black-market' }
+      const action = MarketApplicationV2.DEFAULT_OPTIONS.actions.negotiateItem
+      const target = { closest: vi.fn(() => ({ dataset: { uuid: 'Item.restricted' } })) }
+
+      await action.call(app, {}, target)
+
+      expect(callOrder[0]).toBe('availabilityCheck')
+      expect(callOrder[1]).toBe('negotiation')
+
+      delete globalThis.fromUuid
+    })
+
+    it('aborts negotiate flow — does not open NegotiationDialog — when availability check is cancelled', async () => {
+      const actor = { id: 'actor-1', name: 'Test', system: { credits: 500 } }
+      const item = makeItem({ uuid: 'Item.rare', type: 'weapon', price: 200, rarity: 4, restrictionLevel: 'none' })
+      item.toObject = vi.fn(() => ({ type: 'weapon', name: item.name, system: item.system }))
+      globalThis.fromUuid = vi.fn().mockResolvedValue(item)
+
+      // User cancels the availability check (returns null)
+      AvailabilityCheckDialogMock.prompt.mockResolvedValue(null)
+
+      const app = new MarketApplicationV2()
+      app.setBuyerActor(actor)
+      const action = MarketApplicationV2.DEFAULT_OPTIONS.actions.negotiateItem
+      const target = { closest: vi.fn(() => ({ dataset: { uuid: 'Item.rare' } })) }
+
+      await action.call(app, {}, target)
+
+      // NegotiationDialog must NOT have been opened
+      expect(NegotiationDialogMock.prompt).not.toHaveBeenCalled()
+
+      delete globalThis.fromUuid
+    })
+
+    it('aborts negotiate flow — does not open NegotiationDialog — when availability check fails (passed=false)', async () => {
+      const actor = { id: 'actor-1', name: 'Test', system: { credits: 500 } }
+      const item = makeItem({ uuid: 'Item.rare', type: 'weapon', price: 200, rarity: 4, restrictionLevel: 'none' })
+      item.toObject = vi.fn(() => ({ type: 'weapon', name: item.name, system: item.system }))
+      globalThis.fromUuid = vi.fn().mockResolvedValue(item)
+
+      // Roll failed
+      AvailabilityCheckDialogMock.prompt.mockResolvedValue({ passed: false, testResult: null })
+
+      const app = new MarketApplicationV2()
+      app.setBuyerActor(actor)
+      const action = MarketApplicationV2.DEFAULT_OPTIONS.actions.negotiateItem
+      const target = { closest: vi.fn(() => ({ dataset: { uuid: 'Item.rare' } })) }
+
+      await action.call(app, {}, target)
+
+      expect(NegotiationDialogMock.prompt).not.toHaveBeenCalled()
+      expect(globalThis.ui.notifications.warn).toHaveBeenCalled()
+
+      delete globalThis.fromUuid
+    })
+
+    it('does NOT call AvailabilityCheckDialog for a common item (rarity < 4, no restriction) in negotiate flow', async () => {
+      const actor = {
+        id: 'actor-1',
+        name: 'Test',
+        system: { credits: 500 },
+        createEmbeddedDocuments: vi.fn().mockResolvedValue([]),
+      }
+      // rarity=0, restrictionLevel=none — no check required
+      const item = makeItem({ uuid: 'Item.common', type: 'weapon', price: 100, rarity: 0, restrictionLevel: 'none' })
+      item.toObject = vi.fn(() => ({ type: 'weapon', name: item.name, system: item.system }))
+      globalThis.fromUuid = vi.fn().mockResolvedValue(item)
+
+      // Negotiation succeeds immediately
+      NegotiationDialogMock.prompt.mockResolvedValue({ confirmed: true, finalPrice: 90, outcome: 'success', successRanks: 1 })
+      globalThis.foundry.applications.api.DialogV2.confirm = vi.fn().mockResolvedValue(false)
+
+      const app = new MarketApplicationV2()
+      app.setBuyerActor(actor)
+      const action = MarketApplicationV2.DEFAULT_OPTIONS.actions.negotiateItem
+      const target = { closest: vi.fn(() => ({ dataset: { uuid: 'Item.common' } })) }
+
+      await action.call(app, {}, target)
+
+      // For a common item no check dialog is required
+      expect(AvailabilityCheckDialogMock.prompt).not.toHaveBeenCalled()
 
       delete globalThis.fromUuid
       delete globalThis.foundry.applications.api.DialogV2.confirm


### PR DESCRIPTION
## Summary

- Enforce availability check in the market negotiate flow to prevent bypass (module/applications/market/market-application.mjs).
- Add unit tests covering the negotiate/availability logic (tests/applications/market/market-application.test.mjs).
- Add documentation plan describing the change (documentation/plan/market/536-market-appliquer-le-jet-de-disponibilite-dans-le-flux-negocier-anti-bypass.md).

## Context

The negotiate flow could previously bypass availability constraints in edge cases. This PR applies the existing availability validation to the negotiation path to ensure offers respect availability.

## Tests

- Not run (not requested).

## Notes

- New tests are included in the branch but were not executed locally as part of this PR creation.
- No user-facing configuration changes; change is limited to market application logic and tests.
