### PR TITLE
feat(market): integrate NegotiationDialog with StandardCheck for negotiation rolls

### DIFF
--- a/documentation/plan/market/537-market-brancher-negotiationdialog-sur-un-vrai-standardcheck-supprimer-la-saisie-manuelle.md
+++ b/documentation/plan/market/537-market-brancher-negotiationdialog-sur-un-vrai-standardcheck-supprimer-la-saisie-manuelle.md
@@ -1,0 +1,67 @@
+# Issue #537 — Market : brancher `NegotiationDialog` sur un vrai `StandardCheck` (supprimer la saisie manuelle)
+
+**Issue** : https://github.com/herveDarritchon/foundryvtt-swerpg/issues/537  
+**Domaine métier** : `market`
+
+## Goal
+
+Supprimer la saisie manuelle des résultats de négociation dans `NegotiationDialog` et la remplacer par un vrai lancer `StandardCheck`, afin de préserver l'intégrité économique du Market tout en gardant le contrat de résultat déjà consommé par les flux d'achat et de vente.
+
+## Contexte utile
+
+- `module/applications/market/negotiation-dialog.mjs` repose aujourd'hui sur `successRanks` et `isDisaster` saisis à la main dans le formulaire.
+- `module/applications/market/availability-check-dialog.mjs` montre déjà le pattern cible : construire un `StandardCheck`, ouvrir le dialogue de roll réel, puis dériver un résultat applicatif.
+- `module/lib/market/negotiation.mjs` porte déjà la logique pure de pricing (`computeNegotiatedPrice`, `rarityToDifficulty`) ; le bug est surtout un problème d'orchestration UI et de dérivation du résultat du jet.
+- `tests/applications/market/negotiation-dialog.test.mjs` reste aujourd'hui centré sur `mapOutcomeToSale` ; il manque une couverture sur le vrai flux de roll.
+
+## Plan d'implémentation
+
+### Étape 1 — Remplacer l'état manuel par un état dérivé d'un vrai roll
+
+**Fichiers** : `module/applications/market/negotiation-dialog.mjs`, `module/lib/market/negotiation.mjs` _(si un helper partagé de dérivation devient utile)_
+
+**What** :
+
+- Introduire dans `NegotiationDialog` un état de roll négocié (roll exécuté + résultat dérivé) au lieu de piloter le calcul depuis des champs saisis manuellement.
+- Réutiliser `StandardCheck` avec la compétence sélectionnée, la caractéristique de l'acteur, et une difficulté dérivée de `rarityToDifficulty`, sur le modèle déjà utilisé par `AvailabilityCheckDialog`.
+- Dériver ensuite les données métier attendues par le pricing : `successRanks` depuis l'écart au `dc` et `isDisaster` depuis l'état critique du roll, tout en conservant le shape final `{ confirmed, finalPrice, outcome, successRanks }`.
+
+**Résultat attendu** : `NegotiationDialog` ne dépend plus d'une auto-déclaration utilisateur et fournit toujours le même contrat de sortie aux appels Market existants.
+
+### Étape 2 — Refaire l'UX du dialog autour d'une action de roll réelle
+
+**Fichiers** : `templates/market/negotiation-dialog.hbs`, `module/applications/market/negotiation-dialog.mjs`, `lang/en.json`, `lang/fr.json`
+
+**What** :
+
+- Supprimer les contrôles manuels `successRanks` / `isDisaster` du template.
+- Garder la sélection de compétence, ajouter une action explicite pour lancer le test, puis afficher l'état/résultat réel du jet et le prix recalculé en achat comme en vente.
+- Adapter les libellés i18n si nécessaire (appel à l'action, état du jet, consigne avant confirmation) sans changer les clés déjà utilisées par le flux existant lorsqu'elles restent valides.
+
+**Résultat attendu** : l'utilisateur lance un vrai test de négociation depuis le dialog, voit son résultat appliqué au prix, puis confirme l'achat/la vente sans pouvoir éditer manuellement l'issue du jet.
+
+### Étape 3 — Verrouiller la dérivation du roll et la non-régression du contrat
+
+**Fichiers** : `tests/applications/market/negotiation-dialog.test.mjs`, `tests/applications/market/market-application.test.mjs` _(si une vérification d'intégration légère est nécessaire)_
+
+**What** :
+
+- Ajouter des tests sur le flux réel du dialog : annulation du roll, succès simple, échec, désastre/critical failure, et triomphe côté vente.
+- Vérifier que la dérivation `roll -> successRanks/isDisaster/outcome/finalPrice` reste cohérente en mode achat et en mode vente.
+- Protéger le contrat public de `NegotiationDialog.prompt()` pour éviter toute régression dans `MarketApplicationV2`, qui ne doit pas avoir à connaître les détails du roll interne.
+
+**Résultat attendu** : la sécurité fonctionnelle du correctif est couverte par des tests ciblés sur le dialogue et le point d'intégration Market.
+
+## Périmètre / hors périmètre
+
+### Inclus
+
+- Remplacement de la saisie manuelle par un `StandardCheck` réel dans `NegotiationDialog`
+- Dérivation métier du résultat de roll pour le pricing achat/vente
+- Ajustements UI/i18n strictement nécessaires au nouveau parcours
+
+### Exclus
+
+- Refonte du moteur de prix Market
+- Changement des règles de rareté, de disponibilité ou du flow anti-bypass déjà traité en #536
+- Refonte de `StandardCheck` ou de `StandardCheckDialog` au-delà de leur réutilisation

--- a/lang/en.json
+++ b/lang/en.json
@@ -1646,9 +1646,8 @@
         "OriginalPrice": "Original price",
         "Difficulty": "Difficulty",
         "SkillLabel": "Skill",
-        "SuccessRanksLabel": "Success ranks",
-        "DisasterLabel": "Disaster",
-        "DisasterTooltip": "Check if the roll produced a Disaster result — the vendor is offended and raises the price.",
+        "RollInstruction": "Select a skill and roll to negotiate the price.",
+        "RollButton": "Roll Negotiation",
         "NegotiatedPrice": "Negotiated price",
         "Confirm": "Buy at this price",
         "Cancel": "Cancel",
@@ -1656,6 +1655,8 @@
         "ConfirmSell": "Sell at this price",
         "NegotiatedPriceSell": "Sale Price"
       },
+      "RollTitle": "Negotiation Check: {skill}",
+      "RollFlavor": "Attempting to negotiate a better price.",
       "Skill": {
         "Negotiation": "Negotiation",
         "Persuasion": "Persuasion",
@@ -1664,6 +1665,7 @@
       "Outcome": {
         "Success": "Success! The vendor agrees to a lower price.",
         "Failure": "No deal. The price remains unchanged.",
+        "Triumph": "Triumph! The vendor is very impressed and offers the best price.",
         "Disaster": "Disaster! The vendor is offended and raises the price.",
         "SuccessNotification": "Negotiation successful! New price: {price} credits.",
         "DisasterNotification": "Negotiation backfired! The vendor raised the price."

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -1542,9 +1542,8 @@
         "OriginalPrice": "Prix initial",
         "Difficulty": "Difficulté",
         "SkillLabel": "Compétence",
-        "SuccessRanksLabel": "Rangs de succès",
-        "DisasterLabel": "Désastre",
-        "DisasterTooltip": "Cochez si le jet a produit un Désastre — le vendeur est offensé et augmente le prix.",
+        "RollInstruction": "Sélectionnez une compétence et lancez le dé pour négocier le prix.",
+        "RollButton": "Lancer la négociation",
         "NegotiatedPrice": "Prix négocié",
         "Confirm": "Acheter à ce prix",
         "Cancel": "Annuler",
@@ -1552,6 +1551,8 @@
         "ConfirmSell": "Vendre à ce prix",
         "NegotiatedPriceSell": "Prix de vente"
       },
+      "RollTitle": "Test de négociation : {skill}",
+      "RollFlavor": "Tentative de négociation d'un meilleur prix.",
       "Skill": {
         "Negotiation": "Négociation",
         "Persuasion": "Persuasion",
@@ -1560,6 +1561,7 @@
       "Outcome": {
         "Success": "Succès ! Le vendeur accepte un prix réduit.",
         "Failure": "Échec. Le prix reste inchangé.",
+        "Triumph": "Triomphe ! Le vendeur est très impressionné et propose le meilleur prix.",
         "Disaster": "Désastre ! Le vendeur est offensé et augmente le prix.",
         "SuccessNotification": "Négociation réussie ! Nouveau prix : {price} crédits.",
         "DisasterNotification": "La négociation a mal tourné ! Le vendeur a augmenté le prix."

--- a/module/applications/market/negotiation-dialog.mjs
+++ b/module/applications/market/negotiation-dialog.mjs
@@ -1,3 +1,4 @@
+import StandardCheck from '../../dice/standard-check.mjs'
 import { computeNegotiatedPrice, rarityToDifficulty, NEGOTIATION_SKILLS } from '../../lib/market/negotiation.mjs'
 import { computeResalePrice } from '../../lib/market/sell-valuation.mjs'
 import { logger } from '../../utils/logger.mjs'
@@ -13,6 +14,15 @@ const { api } = foundry.applications
  * @property {string}   outcome       One of 'success', 'failure', 'disaster' (buy mode) or 'success', 'failure', 'triumph', 'disaster' (sale mode).
  * @property {number}   successRanks  Net success ranks used.
  */
+
+/* -------------------------------------------- */
+
+/**
+ * DC table mapping FFG difficulty levels (1–5) to d20 difficulty class values.
+ * Mirrors the same table used by AvailabilityCheckDialog.
+ * @type {Readonly<Record<number, number>>}
+ */
+const DIFFICULTY_TO_DC = Object.freeze({ 1: 8, 2: 11, 3: 14, 4: 17, 5: 20 })
 
 /* -------------------------------------------- */
 
@@ -50,19 +60,41 @@ export function mapOutcomeToSale({ successRanks, isDisaster }) {
 /* -------------------------------------------- */
 
 /**
+ * Derive `successRanks` and `isDisaster` from a completed StandardCheck roll result.
+ *
+ * - successRanks: the positive margin above dc (total - dc), clamped to 0 minimum.
+ * - isDisaster:   true when the roll is a critical failure (total strictly below dc - threshold).
+ *
+ * @param {StandardCheck} roll   An evaluated StandardCheck instance.
+ * @returns {{ successRanks: number, isDisaster: boolean }}
+ */
+export function deriveNegotiationRollState(roll) {
+  const margin = roll.total - roll.data.dc
+  const successRanks = Math.max(0, margin)
+  const isDisaster = roll.isCriticalFailure === true
+  return { successRanks, isDisaster }
+}
+
+/* -------------------------------------------- */
+
+/**
  * Dialog allowing the buyer to attempt a price negotiation before confirming purchase,
  * or the seller to negotiate a better resale price.
+ *
+ * The negotiation outcome is now derived from a real StandardCheck roll.
+ * Manual successRanks/isDisaster inputs have been removed. The user must roll
+ * the check before confirming, and cannot manually override the result.
  *
  * When `forSale` is true, the dialog uses `computeResalePrice` with a mapped outcome
  * instead of `computeNegotiatedPrice`, and adjusts labels/title accordingly.
  *
- * Usage — buy mode (unchanged):
+ * Usage — buy mode:
  * ```js
  * const result = await NegotiationDialog.prompt({ entry, buyer })
  * if (result?.confirmed) { // use result.finalPrice }
  * ```
  *
- * Usage — sale mode (new):
+ * Usage — sale mode:
  * ```js
  * const result = await NegotiationDialog.prompt({ entry, buyer: seller, forSale: true })
  * ```
@@ -82,6 +114,7 @@ export default class NegotiationDialog extends api.HandlebarsApplicationMixin(ap
       width: 420,
     },
     actions: {
+      rollNegotiation: NegotiationDialog.#onRollNegotiation,
       confirmNegotiation: NegotiationDialog.#onConfirmNegotiation,
       cancelNegotiation: NegotiationDialog.#onCancelNegotiation,
     },
@@ -115,10 +148,17 @@ export default class NegotiationDialog extends api.HandlebarsApplicationMixin(ap
   #forSale = false
 
   /**
-   * Current form state: selected skill, success ranks, disaster flag.
-   * @type {{ skillKey: string, successRanks: number, isDisaster: boolean }}
+   * Current skill selection.
+   * @type {{ skillKey: string }}
    */
-  #formState = { skillKey: NEGOTIATION_SKILLS[0], successRanks: 0, isDisaster: false }
+  #formState = { skillKey: NEGOTIATION_SKILLS[0] }
+
+  /**
+   * Derived roll state, set after the StandardCheck is completed.
+   * Null means no roll has been performed yet.
+   * @type {{ successRanks: number, isDisaster: boolean }|null}
+   */
+  #rollState = null
 
   /**
    * Resolve callback — called when the dialog closes with a result.
@@ -169,26 +209,29 @@ export default class NegotiationDialog extends api.HandlebarsApplicationMixin(ap
     const rarity = entry?.rarity ?? 0
     const difficulty = rarityToDifficulty(rarity)
 
-    let negotiationResult
-    if (this.#forSale) {
-      const outcome = mapOutcomeToSale(this.#formState)
-      const saleResult = computeResalePrice({
-        basePrice: originalPrice,
-        negotiationOutcome: outcome,
-      })
-      // Normalize to shape expected by the template (finalPrice)
-      negotiationResult = {
-        outcome: saleResult.outcome,
-        finalPrice: saleResult.resalePrice,
-        originalPrice: saleResult.basePrice,
-        successRanks: this.#formState.successRanks,
+    const hasRolled = this.#rollState !== null
+    let negotiationResult = null
+
+    if (hasRolled) {
+      if (this.#forSale) {
+        const outcome = mapOutcomeToSale(this.#rollState)
+        const saleResult = computeResalePrice({
+          basePrice: originalPrice,
+          negotiationOutcome: outcome,
+        })
+        negotiationResult = {
+          outcome: saleResult.outcome,
+          finalPrice: saleResult.resalePrice,
+          originalPrice: saleResult.basePrice,
+          successRanks: this.#rollState.successRanks,
+        }
+      } else {
+        negotiationResult = computeNegotiatedPrice({
+          originalPrice,
+          successRanks: this.#rollState.successRanks,
+          isDisaster: this.#rollState.isDisaster,
+        })
       }
-    } else {
-      negotiationResult = computeNegotiatedPrice({
-        originalPrice,
-        successRanks: this.#formState.successRanks,
-        isDisaster: this.#formState.isDisaster,
-      })
     }
 
     context.entry = { name: entry?.name ?? '', rarity, originalPrice }
@@ -199,6 +242,7 @@ export default class NegotiationDialog extends api.HandlebarsApplicationMixin(ap
       selected: key === this.#formState.skillKey,
     }))
     context.formState = { ...this.#formState }
+    context.hasRolled = hasRolled
     context.negotiationResult = negotiationResult
     context.forSale = this.#forSale
 
@@ -213,30 +257,11 @@ export default class NegotiationDialog extends api.HandlebarsApplicationMixin(ap
     const html = this.element
     if (!html) return
 
-    // Skill selector
+    // Skill selector — only active before rolling
     const skillSelect = html.querySelector('.negotiation-skill-select')
     if (skillSelect) {
       skillSelect.addEventListener('change', (event) => {
         this.#formState = { ...this.#formState, skillKey: event.currentTarget.value }
-        this.render()
-      })
-    }
-
-    // Success ranks input
-    const ranksInput = html.querySelector('.negotiation-ranks-input')
-    if (ranksInput) {
-      ranksInput.addEventListener('change', (event) => {
-        const value = parseInt(event.currentTarget.value, 10)
-        this.#formState = { ...this.#formState, successRanks: Number.isFinite(value) && value >= 0 ? value : 0 }
-        this.render()
-      })
-    }
-
-    // Disaster checkbox
-    const disasterCheck = html.querySelector('.negotiation-disaster-check')
-    if (disasterCheck) {
-      disasterCheck.addEventListener('change', (event) => {
-        this.#formState = { ...this.#formState, isDisaster: event.currentTarget.checked }
         this.render()
       })
     }
@@ -245,17 +270,90 @@ export default class NegotiationDialog extends api.HandlebarsApplicationMixin(ap
   /* -------------------------------------------- */
 
   /**
+   * Handle the Roll Negotiation action: build the StandardCheck pool and open the roll dialog.
+   * Derives successRanks and isDisaster from the roll result, then re-renders.
+   * @this {NegotiationDialog}
+   * @param {PointerEvent} _event
+   * @param {HTMLElement}  _target
+   */
+  static async #onRollNegotiation(_event, _target) {
+    const actor = this.#buyer
+    const skillKey = this.#formState.skillKey
+    const skill = SYSTEM.SKILLS[skillKey]
+
+    if (!skill) {
+      logger.error(`[Market] NegotiationDialog: skill "${skillKey}" not found in SYSTEM.SKILLS`)
+      return
+    }
+
+    const entry = this.#entry
+    const rarity = entry?.rarity ?? 0
+    const difficulty = rarityToDifficulty(rarity)
+    const dc = DIFFICULTY_TO_DC[difficulty] ?? 14
+
+    const skillRank = actor?.system?.skills?.[skillKey]?.rank?.value ?? 0
+    const characteristicKey = skill.characteristic?.key ?? skill.characteristic
+    const characteristicValue = actor?.system?.characteristics?.[characteristicKey]?.rank?.value ?? 0
+
+    const roll = new StandardCheck({
+      actorId: actor?.id ?? null,
+      skill: skillRank,
+      ability: characteristicValue,
+      dc,
+      type: skillKey,
+    })
+
+    logger.debug('[Market] Negotiation roll initiated', {
+      skillKey,
+      skillRank,
+      characteristicValue,
+      dc,
+      actorId: actor?.id,
+    })
+
+    const result = await roll.dialog({
+      title: game.i18n.format('MARKET.Negotiation.RollTitle', { skill: skill.name }),
+      flavor: game.i18n.localize('MARKET.Negotiation.RollFlavor'),
+    })
+
+    if (result === null) {
+      // User cancelled the roll dialog — stay open without a result
+      logger.debug('[Market] Negotiation roll cancelled by user')
+      return
+    }
+
+    this.#rollState = deriveNegotiationRollState(result)
+
+    logger.debug('[Market] Negotiation roll completed', {
+      total: result.total,
+      dc,
+      successRanks: this.#rollState.successRanks,
+      isDisaster: this.#rollState.isDisaster,
+    })
+
+    this.render()
+  }
+
+  /* -------------------------------------------- */
+
+  /**
    * Confirm the negotiated price and close the dialog.
+   * Only callable after a roll has been performed.
    * @this {NegotiationDialog}
    * @param {PointerEvent} _event
    * @param {HTMLElement} _target
    */
   static async #onConfirmNegotiation(_event, _target) {
+    if (!this.#rollState) {
+      logger.warn('[Market] NegotiationDialog: confirm called without a roll result — ignored')
+      return
+    }
+
     const originalPrice = this.#entry?.priceResult?.finalPrice ?? 0
 
     let negotiationResult
     if (this.#forSale) {
-      const outcome = mapOutcomeToSale(this.#formState)
+      const outcome = mapOutcomeToSale(this.#rollState)
       const saleResult = computeResalePrice({
         basePrice: originalPrice,
         negotiationOutcome: outcome,
@@ -264,20 +362,20 @@ export default class NegotiationDialog extends api.HandlebarsApplicationMixin(ap
         outcome: saleResult.outcome,
         finalPrice: saleResult.resalePrice,
         originalPrice: saleResult.basePrice,
-        successRanks: this.#formState.successRanks,
+        successRanks: this.#rollState.successRanks,
       }
     } else {
       negotiationResult = computeNegotiatedPrice({
         originalPrice,
-        successRanks: this.#formState.successRanks,
-        isDisaster: this.#formState.isDisaster,
+        successRanks: this.#rollState.successRanks,
+        isDisaster: this.#rollState.isDisaster,
       })
     }
 
     logger.debug('[Market] Negotiation confirmed', {
       skill: this.#formState.skillKey,
-      successRanks: this.#formState.successRanks,
-      isDisaster: this.#formState.isDisaster,
+      successRanks: this.#rollState.successRanks,
+      isDisaster: this.#rollState.isDisaster,
       outcome: negotiationResult.outcome,
       originalPrice,
       finalPrice: negotiationResult.finalPrice,

--- a/templates/market/negotiation-dialog.hbs
+++ b/templates/market/negotiation-dialog.hbs
@@ -1,4 +1,4 @@
-{{!-- Negotiation Dialog — Market Phase 7.1 --}}
+{{!-- Negotiation Dialog — Market Phase 7.2 (real StandardCheck roll) --}}
 <div class="market-negotiation-dialog__body" data-application-part="form">
   <div class="negotiation-item-info">
     <p class="negotiation-item-name">{{entry.name}}</p>
@@ -20,6 +20,7 @@
         id="negotiation-skill"
         class="negotiation-skill-select"
         aria-label="{{localize 'MARKET.Negotiation.Dialog.SkillLabel'}}"
+        {{#if hasRolled}}disabled{{/if}}
       >
         {{#each skillOptions as |opt|}}
           <option value="{{opt.value}}" {{#if opt.selected}}selected{{/if}}>
@@ -29,95 +30,94 @@
       </select>
     </div>
 
-    <div class="form-group">
-      <label for="negotiation-ranks" class="negotiation-form-label">
-        {{localize "MARKET.Negotiation.Dialog.SuccessRanksLabel"}}
-      </label>
-      <input
-        id="negotiation-ranks"
-        type="number"
-        class="negotiation-ranks-input"
-        min="0"
-        max="6"
-        value="{{formState.successRanks}}"
-        aria-label="{{localize 'MARKET.Negotiation.Dialog.SuccessRanksLabel'}}"
-      />
-    </div>
-
-    <div class="form-group negotiation-disaster-group">
-      <label class="negotiation-form-label negotiation-disaster-label"
-        data-tooltip="{{localize 'MARKET.Negotiation.Dialog.DisasterTooltip'}}">
-        <input
-          type="checkbox"
-          class="negotiation-disaster-check"
-          {{#if formState.isDisaster}}checked{{/if}}
-          aria-label="{{localize 'MARKET.Negotiation.Dialog.DisasterLabel'}}"
-        />
-        {{localize "MARKET.Negotiation.Dialog.DisasterLabel"}}
-        <i class="fa-solid fa-skull" aria-hidden="true"></i>
-      </label>
-    </div>
+    {{#unless hasRolled}}
+      <div class="negotiation-roll-prompt">
+        <p class="negotiation-roll-instruction">{{localize "MARKET.Negotiation.Dialog.RollInstruction"}}</p>
+        <button
+          type="button"
+          class="negotiation-btn negotiation-btn--roll"
+          data-action="rollNegotiation"
+          aria-label="{{localize 'MARKET.Negotiation.Dialog.RollButton'}}"
+        >
+          <i class="fa-solid fa-dice-d20" aria-hidden="true"></i>
+          {{localize "MARKET.Negotiation.Dialog.RollButton"}}
+        </button>
+      </div>
+    {{/unless}}
   </div>
 
-  <div class="negotiation-result {{negotiationResult.outcome}}">
-    {{#if (eq negotiationResult.outcome "success")}}
-      <div class="negotiation-result-icon"><i class="fa-solid fa-circle-check" aria-hidden="true"></i></div>
-      <div class="negotiation-result-text">
-        <p class="negotiation-result-outcome">{{localize "MARKET.Negotiation.Outcome.Success"}}</p>
-        <p class="negotiation-result-price">
-          {{#if ../forSale}}
+  {{#if hasRolled}}
+    <div class="negotiation-result {{negotiationResult.outcome}}">
+      {{#if (eq negotiationResult.outcome "success")}}
+        <div class="negotiation-result-icon"><i class="fa-solid fa-circle-check" aria-hidden="true"></i></div>
+        <div class="negotiation-result-text">
+          <p class="negotiation-result-outcome">{{localize "MARKET.Negotiation.Outcome.Success"}}</p>
+          <p class="negotiation-result-price">
+            {{#if ../forSale}}
+              {{localize "MARKET.Negotiation.Dialog.NegotiatedPriceSell"}}:
+            {{else}}
+              {{localize "MARKET.Negotiation.Dialog.NegotiatedPrice"}}:
+            {{/if}}
+            <strong class="negotiation-price--success">{{negotiationResult.finalPrice}}</strong>
+            <span class="negotiation-price-diff">(−{{negotiationResult.originalPrice}})</span>
+          </p>
+        </div>
+      {{else if (eq negotiationResult.outcome "disaster")}}
+        <div class="negotiation-result-icon"><i class="fa-solid fa-circle-xmark" aria-hidden="true"></i></div>
+        <div class="negotiation-result-text">
+          <p class="negotiation-result-outcome">{{localize "MARKET.Negotiation.Outcome.Disaster"}}</p>
+          <p class="negotiation-result-price">
+            {{#if ../forSale}}
+              {{localize "MARKET.Negotiation.Dialog.NegotiatedPriceSell"}}:
+            {{else}}
+              {{localize "MARKET.Negotiation.Dialog.NegotiatedPrice"}}:
+            {{/if}}
+            <strong class="negotiation-price--disaster">{{negotiationResult.finalPrice}}</strong>
+            <span class="negotiation-price-diff">(+{{entry.originalPrice}})</span>
+          </p>
+        </div>
+      {{else if (eq negotiationResult.outcome "triumph")}}
+        <div class="negotiation-result-icon"><i class="fa-solid fa-star" aria-hidden="true"></i></div>
+        <div class="negotiation-result-text">
+          <p class="negotiation-result-outcome">{{localize "MARKET.Negotiation.Outcome.Triumph"}}</p>
+          <p class="negotiation-result-price">
             {{localize "MARKET.Negotiation.Dialog.NegotiatedPriceSell"}}:
-          {{else}}
-            {{localize "MARKET.Negotiation.Dialog.NegotiatedPrice"}}:
-          {{/if}}
-          <strong class="negotiation-price--success">{{negotiationResult.finalPrice}}</strong>
-          <span class="negotiation-price-diff">(−{{negotiationResult.originalPrice}})</span>
-        </p>
-      </div>
-    {{else if (eq negotiationResult.outcome "disaster")}}
-      <div class="negotiation-result-icon"><i class="fa-solid fa-circle-xmark" aria-hidden="true"></i></div>
-      <div class="negotiation-result-text">
-        <p class="negotiation-result-outcome">{{localize "MARKET.Negotiation.Outcome.Disaster"}}</p>
-        <p class="negotiation-result-price">
-          {{#if ../forSale}}
-            {{localize "MARKET.Negotiation.Dialog.NegotiatedPriceSell"}}:
-          {{else}}
-            {{localize "MARKET.Negotiation.Dialog.NegotiatedPrice"}}:
-          {{/if}}
-          <strong class="negotiation-price--disaster">{{negotiationResult.finalPrice}}</strong>
-          <span class="negotiation-price-diff">(+{{entry.originalPrice}})</span>
-        </p>
-      </div>
-    {{else}}
-      <div class="negotiation-result-icon"><i class="fa-solid fa-circle-minus" aria-hidden="true"></i></div>
-      <div class="negotiation-result-text">
-        <p class="negotiation-result-outcome">{{localize "MARKET.Negotiation.Outcome.Failure"}}</p>
-        <p class="negotiation-result-price">
-          {{#if ../forSale}}
-            {{localize "MARKET.Negotiation.Dialog.NegotiatedPriceSell"}}:
-          {{else}}
-            {{localize "MARKET.Negotiation.Dialog.NegotiatedPrice"}}:
-          {{/if}}
-          <strong>{{negotiationResult.finalPrice}}</strong>
-        </p>
-      </div>
-    {{/if}}
-  </div>
+            <strong class="negotiation-price--triumph">{{negotiationResult.finalPrice}}</strong>
+          </p>
+        </div>
+      {{else}}
+        <div class="negotiation-result-icon"><i class="fa-solid fa-circle-minus" aria-hidden="true"></i></div>
+        <div class="negotiation-result-text">
+          <p class="negotiation-result-outcome">{{localize "MARKET.Negotiation.Outcome.Failure"}}</p>
+          <p class="negotiation-result-price">
+            {{#if ../forSale}}
+              {{localize "MARKET.Negotiation.Dialog.NegotiatedPriceSell"}}:
+            {{else}}
+              {{localize "MARKET.Negotiation.Dialog.NegotiatedPrice"}}:
+            {{/if}}
+            <strong>{{negotiationResult.finalPrice}}</strong>
+          </p>
+        </div>
+      {{/if}}
+    </div>
+  {{/if}}
 
   <div class="negotiation-actions">
-    <button
-      type="button"
-      class="negotiation-btn negotiation-btn--confirm"
-      data-action="confirmNegotiation"
-      aria-label="{{#if forSale}}{{localize 'MARKET.Negotiation.Dialog.ConfirmSell'}}{{else}}{{localize 'MARKET.Negotiation.Dialog.Confirm'}}{{/if}}"
-    >
-      <i class="fa-solid fa-coins" aria-hidden="true"></i>
-      {{#if forSale}}
-        {{localize "MARKET.Negotiation.Dialog.ConfirmSell"}}
-      {{else}}
-        {{localize "MARKET.Negotiation.Dialog.Confirm"}}
-      {{/if}}
-    </button>
+    {{#if hasRolled}}
+      <button
+        type="button"
+        class="negotiation-btn negotiation-btn--confirm"
+        data-action="confirmNegotiation"
+        aria-label="{{#if forSale}}{{localize 'MARKET.Negotiation.Dialog.ConfirmSell'}}{{else}}{{localize 'MARKET.Negotiation.Dialog.Confirm'}}{{/if}}"
+      >
+        <i class="fa-solid fa-coins" aria-hidden="true"></i>
+        {{#if forSale}}
+          {{localize "MARKET.Negotiation.Dialog.ConfirmSell"}}
+        {{else}}
+          {{localize "MARKET.Negotiation.Dialog.Confirm"}}
+        {{/if}}
+      </button>
+    {{/if}}
     <button
       type="button"
       class="negotiation-btn negotiation-btn--cancel"

--- a/tests/applications/market/negotiation-dialog.test.mjs
+++ b/tests/applications/market/negotiation-dialog.test.mjs
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest'
 
-import { mapOutcomeToSale, TRIUMPH_THRESHOLD } from '../../../module/applications/market/negotiation-dialog.mjs'
+import { deriveNegotiationRollState, mapOutcomeToSale, TRIUMPH_THRESHOLD } from '../../../module/applications/market/negotiation-dialog.mjs'
+import { computeNegotiatedPrice } from '../../../module/lib/market/negotiation.mjs'
 import { computeResalePrice } from '../../../module/lib/market/sell-valuation.mjs'
 
 /* -------------------------------------------- */
@@ -109,6 +110,170 @@ describe('sale price computation via mapOutcomeToSale + computeResalePrice', () 
     const result = computeResalePrice({ basePrice: BASE_PRICE, negotiationOutcome: outcome })
     expect(result.outcome).toBe('disaster')
     expect(result.fraction).toBe(0.1)
+    expect(result.resalePrice).toBe(10)
+  })
+})
+
+/* -------------------------------------------- */
+/*  deriveNegotiationRollState                  */
+/* -------------------------------------------- */
+
+/**
+ * Build a minimal StandardCheck-like result object for testing.
+ * Only the fields consumed by deriveNegotiationRollState are needed.
+ * @param {object} params
+ * @param {number} params.total             Roll total.
+ * @param {number} params.dc                Difficulty class.
+ * @param {boolean} [params.criticalFailure] Whether to simulate a critical failure.
+ */
+function makeRollResult({ total, dc, criticalFailure = false }) {
+  return {
+    total,
+    data: { dc },
+    isCriticalFailure: criticalFailure,
+  }
+}
+
+describe('deriveNegotiationRollState', () => {
+  /* -------------------------------------------- */
+  /*  successRanks derivation                     */
+  /* -------------------------------------------- */
+
+  describe('successRanks', () => {
+    it('returns 0 successRanks when total equals dc (no margin)', () => {
+      const roll = makeRollResult({ total: 14, dc: 14 })
+      const { successRanks } = deriveNegotiationRollState(roll)
+      expect(successRanks).toBe(0)
+    })
+
+    it('returns 0 successRanks when total is below dc (failure)', () => {
+      const roll = makeRollResult({ total: 10, dc: 14 })
+      const { successRanks } = deriveNegotiationRollState(roll)
+      expect(successRanks).toBe(0)
+    })
+
+    it('returns positive successRanks equal to the positive margin above dc', () => {
+      const roll = makeRollResult({ total: 17, dc: 14 })
+      const { successRanks } = deriveNegotiationRollState(roll)
+      expect(successRanks).toBe(3)
+    })
+
+    it('returns 1 successRank when total exceeds dc by 1', () => {
+      const roll = makeRollResult({ total: 15, dc: 14 })
+      const { successRanks } = deriveNegotiationRollState(roll)
+      expect(successRanks).toBe(1)
+    })
+
+    it('returns high successRanks for large margin (e.g. triumph territory)', () => {
+      const roll = makeRollResult({ total: 22, dc: 14 })
+      const { successRanks } = deriveNegotiationRollState(roll)
+      expect(successRanks).toBe(8)
+    })
+  })
+
+  /* -------------------------------------------- */
+  /*  isDisaster derivation                       */
+  /* -------------------------------------------- */
+
+  describe('isDisaster', () => {
+    it('returns isDisaster=false when isCriticalFailure is false', () => {
+      const roll = makeRollResult({ total: 8, dc: 14, criticalFailure: false })
+      const { isDisaster } = deriveNegotiationRollState(roll)
+      expect(isDisaster).toBe(false)
+    })
+
+    it('returns isDisaster=true when isCriticalFailure is true', () => {
+      const roll = makeRollResult({ total: 3, dc: 14, criticalFailure: true })
+      const { isDisaster } = deriveNegotiationRollState(roll)
+      expect(isDisaster).toBe(true)
+    })
+
+    it('returns isDisaster=false for a normal failure (not critical)', () => {
+      const roll = makeRollResult({ total: 12, dc: 14, criticalFailure: false })
+      const { isDisaster } = deriveNegotiationRollState(roll)
+      expect(isDisaster).toBe(false)
+    })
+  })
+})
+
+/* -------------------------------------------- */
+/*  Full roll flow: deriveNegotiationRollState  */
+/*  → mapOutcomeToSale/computeNegotiatedPrice   */
+/* -------------------------------------------- */
+
+describe('roll-derived negotiation flow — buy mode', () => {
+  const BASE_PRICE = 100
+
+  it('simple failure (total=dc) → outcome=failure, price unchanged', () => {
+    const roll = makeRollResult({ total: 14, dc: 14 })
+    const state = deriveNegotiationRollState(roll)
+    const result = computeNegotiatedPrice({ originalPrice: BASE_PRICE, ...state })
+    expect(result.outcome).toBe('failure')
+    expect(result.finalPrice).toBe(100)
+  })
+
+  it('simple success (1 rank above dc) → outcome=success, price discounted 5%', () => {
+    const roll = makeRollResult({ total: 15, dc: 14 })
+    const state = deriveNegotiationRollState(roll)
+    const result = computeNegotiatedPrice({ originalPrice: BASE_PRICE, ...state })
+    expect(result.outcome).toBe('success')
+    expect(result.finalPrice).toBe(95)
+  })
+
+  it('strong success (4 ranks above dc) → outcome=success, price discounted 20%', () => {
+    const roll = makeRollResult({ total: 18, dc: 14 })
+    const state = deriveNegotiationRollState(roll)
+    const result = computeNegotiatedPrice({ originalPrice: BASE_PRICE, ...state })
+    expect(result.outcome).toBe('success')
+    expect(result.finalPrice).toBe(80)
+  })
+
+  it('disaster (critical failure) → outcome=disaster, price increased 10%', () => {
+    const roll = makeRollResult({ total: 3, dc: 14, criticalFailure: true })
+    const state = deriveNegotiationRollState(roll)
+    const result = computeNegotiatedPrice({ originalPrice: BASE_PRICE, ...state })
+    expect(result.outcome).toBe('disaster')
+    expect(result.finalPrice).toBe(110)
+  })
+})
+
+describe('roll-derived negotiation flow — sale mode', () => {
+  const BASE_PRICE = 100
+
+  it('simple failure → outcome=failure, resale 25%', () => {
+    const roll = makeRollResult({ total: 10, dc: 14 })
+    const state = deriveNegotiationRollState(roll)
+    const outcome = mapOutcomeToSale(state)
+    const result = computeResalePrice({ basePrice: BASE_PRICE, negotiationOutcome: outcome })
+    expect(result.outcome).toBe('failure')
+    expect(result.resalePrice).toBe(25)
+  })
+
+  it('simple success (1–3 ranks) → outcome=success, resale 50%', () => {
+    const roll = makeRollResult({ total: 16, dc: 14 })
+    const state = deriveNegotiationRollState(roll)
+    const outcome = mapOutcomeToSale(state)
+    const result = computeResalePrice({ basePrice: BASE_PRICE, negotiationOutcome: outcome })
+    expect(result.outcome).toBe('success')
+    expect(result.resalePrice).toBe(50)
+  })
+
+  it('triumph (≥4 ranks above dc) → outcome=triumph, resale 75%', () => {
+    // total=18, dc=14 → margin=4 = TRIUMPH_THRESHOLD
+    const roll = makeRollResult({ total: 18, dc: 14 })
+    const state = deriveNegotiationRollState(roll)
+    const outcome = mapOutcomeToSale(state)
+    const result = computeResalePrice({ basePrice: BASE_PRICE, negotiationOutcome: outcome })
+    expect(result.outcome).toBe('triumph')
+    expect(result.resalePrice).toBe(75)
+  })
+
+  it('disaster (critical failure) → outcome=disaster, resale 10%', () => {
+    const roll = makeRollResult({ total: 3, dc: 14, criticalFailure: true })
+    const state = deriveNegotiationRollState(roll)
+    const outcome = mapOutcomeToSale(state)
+    const result = computeResalePrice({ basePrice: BASE_PRICE, negotiationOutcome: outcome })
+    expect(result.outcome).toBe('disaster')
     expect(result.resalePrice).toBe(10)
   })
 })


### PR DESCRIPTION
Closes #537

## Summary

Replaces manual input of success ranks and disaster flag in  with a real  roll, matching the pattern already used by . The user now selects a skill, clicks a roll action, and sees the computed negotiation outcome directly, without being able to edit the result.

## Key changes

- **negotiation-dialog.mjs**: Replaced  manual fields (, ) with a  state ( roll instance). Added  action that builds a  from actor skill/characteristic +  DC, opens the real roll dialog, and derives  /  from the roll result.
- **negotiation-dialog.hbs**: Removed manual ranks input and disaster checkbox. Added roll button and result display showing the roll outcome, success ranks, and the recalculated price.
- **lang/en.json, lang/fr.json**: Added keys for roll action label and roll result display.
- **negotiation-dialog.test.mjs**: Added tests for roll-derived outcome derivation function ().