### PR TITLE
feat(market): manage quantity in purchase and sale with total credit adjustment

### DIFF
--- a/documentation/plan/market/539-market-gerer-la-quantite-en-achat-et-vente-decrement-de-pile-credit-x-n.md
+++ b/documentation/plan/market/539-market-gerer-la-quantite-en-achat-et-vente-decrement-de-pile-credit-x-n.md
@@ -1,0 +1,69 @@
+# Market — Gérer la quantité en achat et vente (décrément de pile, crédit × n)
+
+**Issue** : [#539 — Market — Gérer la quantité en achat et vente (décrément de pile, crédit × n)](https://github.com/herveDarritchon/foundryvtt-swerpg/issues/539)
+
+**Domaine métier** : `market`
+
+## Goal
+
+Permettre d’acheter et de vendre plusieurs unités d’un item physique via le Market, avec un débit/crédit total multiplié par la quantité choisie et une vente partielle qui décrémente `system.quantity` au lieu de supprimer toute la pile.
+
+## Contexte utile
+
+- Les items physiques portent déjà `system.quantity` et le budget dérivé du personnage calcule bien `price × quantity` dans `SwerpgCharacter._prepareCredits()`.
+- Le flow d’achat Market est encore câblé en dur sur `quantity: 1`.
+- Le flow de vente supprime actuellement tout l’item (`deleteEmbeddedDocuments`) et l’audit de vente ne transporte pas encore de quantité.
+
+## Plan d’implémentation
+
+### Étape 1 — Introduire une quantité explicite dans les parcours achat/vente
+
+**Fichiers** : `module/applications/market/market-application.mjs`, `templates/market/market.hbs`, `templates/market/market-inventory.hbs`, `lang/en.json`, `lang/fr.json` _(et un petit dialog réutilisable si nécessaire)_
+
+**What** :
+
+- ajouter un sélecteur de quantité entier `>= 1` réutilisable entre achat et vente ;
+- borner la vente par la pile réellement possédée (`system.quantity`) et afficher cette pile dans la vue inventaire ;
+- faire apparaître dans les confirmations le total calculé sur `prix unitaire × quantité`.
+
+**Résultat attendu** : l’utilisateur choisit une quantité valide avant mutation, sans ambiguïté entre prix unitaire et total.
+
+### Étape 2 — Faire porter la quantité par les validations et les mutations métier
+
+**Fichiers** : `module/lib/market/purchase.mjs`, `module/lib/market/sell-validation.mjs`, `module/applications/market/market-application.mjs`
+
+**What** :
+
+- étendre les helpers purs pour accepter `quantity` et retourner les montants totaux (`finalPrice × n`, `resalePrice × n`, `creditsAfter`) ;
+- en achat, créer l’item embarqué avec `system.quantity = n` au lieu d’un achat implicitement unitaire ;
+- en vente, calculer le crédit total sur `n`, décrémenter `system.quantity` quand une pile reste, et ne supprimer le document que lorsque la quantité vendue épuise la pile ;
+- adapter la formule compensée de `system.credits` pour raisonner sur `basePrice × n`, afin de préserver l’invariant `availableCreditsAfter = availableCreditsBefore + resaleTotal`.
+
+**Résultat attendu** : acheter 3 unités débite 3× le prix final ; vendre 2 unités d’une pile de 5 crédite 2× la revente et laisse une pile de 3.
+
+### Étape 3 — Propager la quantité dans l’audit, les feedbacks et les tests de non-régression
+
+**Fichiers** : `module/utils/audit-log.mjs`, `tests/applications/market/market-application.test.mjs`, `tests/lib/market/purchase.test.mjs`, `tests/lib/market/sell-validation.test.mjs`, `tests/utils/audit-log.test.mjs`
+
+**What** :
+
+- ajouter `quantity` au contrat de `recordItemSale()` pour l’aligner avec `recordItemPurchase()` ;
+- vérifier que notifications, logs et snapshots d’audit reflètent le total financier et la quantité réelle ;
+- couvrir les cas `achat x n`, `crédits insuffisants pour n`, `vente partielle avec décrément`, `vente totale avec suppression`, et l’invariant crédits dérivés/non dérivés.
+
+**Résultat attendu** : le comportement multi-quantité est verrouillé côté achat, vente et traçabilité.
+
+## Périmètre / hors périmètre
+
+### Inclus
+
+- choix d’une quantité en achat et en vente ;
+- débit/crédit multiplié par `n` ;
+- décrément de pile en vente partielle ;
+- audit et feedbacks cohérents avec la quantité.
+
+### Exclus
+
+- fusion automatique avec une pile existante différente lors d’un achat ;
+- gestion d’un stock limité côté catalogue monde ;
+- refonte du moteur de négociation ou du pricing unitaire.

--- a/lang/en.json
+++ b/lang/en.json
@@ -1560,9 +1560,11 @@
     },
     "Purchase": {
       "BuyButton": "Buy",
+      "QuantityLabel": "Quantity",
       "Confirm": {
         "Title": "Purchase {name}",
         "Content": "Buy {name} for {price} credits? You have {credits} and will have {remaining} after.",
+        "ContentMultiple": "Buy {quantity}× {name} at {unitPrice} each (total: {total} credits)? You have {credits} and will have {remaining} after.",
         "Buy": "Buy ({price} credits)",
         "Cancel": "Cancel"
       },
@@ -1771,6 +1773,7 @@
       "Confirm": {
         "Title": "Sell {name}",
         "Content": "Confirm sale of {name} for {price} credits. Current credits: {credits} → {remaining} after sale.",
+        "ContentMultiple": "Confirm sale of {quantity}× {name} at {unitPrice} each (total: {total} credits). Current credits: {credits} → {remaining} after sale.",
         "Sell": "Sell for {price} credits",
         "Cancel": "Cancel"
       },
@@ -1822,6 +1825,8 @@
       "Description": "Select items from your inventory to sell.",
       "BasePrice": "Base Price",
       "ResaleEstimate": "Resale (25%)",
+      "Quantity": "Qty",
+      "QuantityLabel": "Quantity to sell",
       "SellAriaLabel": "Sell",
       "SellButton": "Sell",
       "Empty": "Your inventory contains no sellable items.",

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -1456,9 +1456,11 @@
     },
     "Purchase": {
       "BuyButton": "Acheter",
+      "QuantityLabel": "Quantité",
       "Confirm": {
         "Title": "Acheter {name}",
         "Content": "Acheter {name} pour {price} crédits ? Vous avez {credits} crédits et il vous en restera {remaining}.",
+        "ContentMultiple": "Acheter {quantity}× {name} à {unitPrice} l'unité (total : {total} crédits) ? Vous avez {credits} crédits et il vous en restera {remaining}.",
         "Buy": "Acheter ({price} crédits)",
         "Cancel": "Annuler"
       },
@@ -1667,6 +1669,7 @@
       "Confirm": {
         "Title": "Vendre {name}",
         "Content": "Confirmer la vente de {name} pour {price} crédits. Crédits actuels : {credits} → {remaining} après vente.",
+        "ContentMultiple": "Confirmer la vente de {quantity}× {name} à {unitPrice} l'unité (total : {total} crédits). Crédits actuels : {credits} → {remaining} après vente.",
         "Sell": "Vendre pour {price} crédits",
         "Cancel": "Annuler"
       },
@@ -1718,6 +1721,8 @@
       "Description": "Sélectionnez des articles de votre inventaire à vendre.",
       "BasePrice": "Prix de base",
       "ResaleEstimate": "Revente (25%)",
+      "Quantity": "Qté",
+      "QuantityLabel": "Quantité à vendre",
       "SellAriaLabel": "Vendre",
       "SellButton": "Vendre",
       "Empty": "Votre inventaire ne contient aucun article vendable.",

--- a/module/applications/market/market-application.mjs
+++ b/module/applications/market/market-application.mjs
@@ -750,7 +750,12 @@ export default class MarketApplicationV2 extends api.HandlebarsApplicationMixin(
       ui.notifications.warn(i18n.localize('MARKET.Negotiation.Outcome.DisasterNotification'))
     }
 
-    await MarketApplicationV2.#executePurchase.call(this, { item, entry: negotiatedEntry, buyer })
+    // Read quantity from the sibling input within the same row
+    const negotiateRow = target.closest('[data-uuid]')
+    const negotiateQtyInput = negotiateRow?.querySelector('.market-item__quantity-input')
+    const negotiateQuantity = negotiateQtyInput ? Math.max(1, parseInt(negotiateQtyInput.value, 10) || 1) : 1
+
+    await MarketApplicationV2.#executePurchase.call(this, { item, entry: negotiatedEntry, buyer, quantity: negotiateQuantity })
   }
 
   /**
@@ -808,7 +813,11 @@ export default class MarketApplicationV2 extends api.HandlebarsApplicationMixin(
     const checkedEntry = await MarketApplicationV2.#runAvailabilityCheck.call(this, { entry, buyer, uuid })
     if (checkedEntry === null) return
 
-    await MarketApplicationV2.#executePurchase.call(this, { item, entry: checkedEntry, buyer })
+    // Read quantity from the quantity input within the same row (row already declared above)
+    const quantityInput = row?.querySelector('.market-item__quantity-input')
+    const quantity = quantityInput ? Math.max(1, parseInt(quantityInput.value, 10) || 1) : 1
+
+    await MarketApplicationV2.#executePurchase.call(this, { item, entry: checkedEntry, buyer, quantity })
   }
 
   /**
@@ -894,13 +903,15 @@ export default class MarketApplicationV2 extends api.HandlebarsApplicationMixin(
    *
    * @this {MarketApplicationV2}
    * @param {object} params
-   * @param {Item}   params.item     The resolved Foundry Item document.
+   * @param {Item}   params.item       The resolved Foundry Item document.
    * @param {import('../../lib/market/market-entry.mjs').MarketEntry} params.entry  The market entry (may have negotiated price).
-   * @param {Actor}  params.buyer    The buyer actor.
+   * @param {Actor}  params.buyer      The buyer actor.
+   * @param {number} [params.quantity=1]  Number of units to purchase.
    * @returns {Promise<void>}
    */
-  static async #executePurchase({ item, entry, buyer }) {
-    const validation = validatePurchase({ actor: buyer, entry })
+  static async #executePurchase({ item, entry, buyer, quantity = 1 }) {
+    const qty = Number.isInteger(quantity) && quantity >= 1 ? quantity : 1
+    const validation = validatePurchase({ actor: buyer, entry, quantity: qty })
     if (!validation.canPurchase) {
       const msgKey = validation.messageKey ?? 'MARKET.Purchase.Error.InsufficientCredits'
       ui.notifications.warn(game.i18n.localize(msgKey))
@@ -915,21 +926,33 @@ export default class MarketApplicationV2 extends api.HandlebarsApplicationMixin(
       return
     }
 
-    // Confirmation dialog
+    // Confirmation dialog — show unit price and total when qty > 1
     const i18n = game.i18n
     const currentCredits = buyer.system?.creditBudget?.availableCredits ?? buyer.system?.credits ?? 0
+    const confirmContent =
+      qty > 1
+        ? i18n.format('MARKET.Purchase.Confirm.ContentMultiple', {
+            name: entry.name,
+            quantity: qty,
+            unitPrice: validation.finalPrice,
+            total: validation.totalPrice,
+            credits: currentCredits,
+            remaining: validation.creditsAfter,
+          })
+        : i18n.format('MARKET.Purchase.Confirm.Content', {
+            name: entry.name,
+            price: validation.finalPrice,
+            credits: currentCredits,
+            remaining: validation.creditsAfter,
+          })
+
     const confirmed = await foundry.applications.api.DialogV2.confirm({
       window: {
         title: i18n.format('MARKET.Purchase.Confirm.Title', { name: entry.name }),
       },
-      content: `<p>${i18n.format('MARKET.Purchase.Confirm.Content', {
-        name: entry.name,
-        price: validation.finalPrice,
-        credits: currentCredits,
-        remaining: validation.creditsAfter,
-      })}</p>`,
+      content: `<p>${confirmContent}</p>`,
       yes: {
-        label: i18n.format('MARKET.Purchase.Confirm.Buy', { price: validation.finalPrice }),
+        label: i18n.format('MARKET.Purchase.Confirm.Buy', { price: validation.totalPrice }),
         icon: 'fa-solid fa-coins',
       },
       no: {
@@ -941,17 +964,18 @@ export default class MarketApplicationV2 extends api.HandlebarsApplicationMixin(
     if (!confirmed) return
 
     // Re-validate at mutation time (credits might have changed since dialog opened)
-    const finalValidation = validatePurchase({ actor: buyer, entry })
+    const finalValidation = validatePurchase({ actor: buyer, entry, quantity: qty })
     if (!finalValidation.canPurchase) {
       ui.notifications.warn(game.i18n.localize(finalValidation.messageKey ?? 'MARKET.Purchase.Error.InsufficientCredits'))
       return
     }
 
     try {
-      // Add a copy of the item to the buyer's inventory.
-      // Credit deduction is now derived automatically via _prepareCredits() when the item
+      // Add a copy of the item to the buyer's inventory with the requested quantity.
+      // Credit deduction is derived automatically via _prepareCredits() when the item
       // is added — no direct update of system.credits is needed.
       const itemData = item.toObject()
+      itemData.system = { ...itemData.system, quantity: qty }
       await buyer.createEmbeddedDocuments('Item', [itemData])
 
       // Phase 7a: Store all accepted consequences as actor flags (generalised from blackMarketDebt only)
@@ -960,7 +984,7 @@ export default class MarketApplicationV2 extends api.HandlebarsApplicationMixin(
       for (const acceptedType of consequencesResult.acceptedTypes) {
         const consequence = allConsequences.find((c) => c.type === acceptedType)
         if (consequence) {
-          await MarketApplicationV2.#storeMarketConsequence({ buyer, consequence, finalPrice: finalValidation.finalPrice })
+          await MarketApplicationV2.#storeMarketConsequence({ buyer, consequence, finalPrice: finalValidation.totalPrice })
         }
       }
 
@@ -971,7 +995,7 @@ export default class MarketApplicationV2 extends api.HandlebarsApplicationMixin(
           itemName: entry.name,
           itemType: item.type,
           price: finalValidation.finalPrice,
-          quantity: 1,
+          quantity: qty,
           creditsAfter: finalValidation.creditsAfter,
           itemId: item.id,
           outcome: entry.priceResult?.appliedOutcome ?? null,
@@ -983,7 +1007,7 @@ export default class MarketApplicationV2 extends api.HandlebarsApplicationMixin(
       ui.notifications.info(
         i18n.format('MARKET.Purchase.Success', {
           name: entry.name,
-          price: finalValidation.finalPrice,
+          price: finalValidation.totalPrice,
           remaining: finalValidation.creditsAfter,
         }),
       )
@@ -993,7 +1017,9 @@ export default class MarketApplicationV2 extends api.HandlebarsApplicationMixin(
         actorName: buyer.name,
         itemUuid: entry.uuid,
         itemName: entry.name,
-        price: finalValidation.finalPrice,
+        unitPrice: finalValidation.finalPrice,
+        quantity: qty,
+        totalPrice: finalValidation.totalPrice,
         creditsAfter: finalValidation.creditsAfter,
         acceptedConsequences: consequencesResult.acceptedTypes,
       })
@@ -1058,6 +1084,8 @@ export default class MarketApplicationV2 extends api.HandlebarsApplicationMixin(
       const valuation = computeResalePrice({ basePrice, negotiationOutcome: 'failure' })
       const typeConfig = PURCHASABLE_ITEM_TYPES[item.type]
 
+      const quantity = item.system?.quantity ?? 1
+
       allItems.push({
         id: item.id,
         name: item.name,
@@ -1067,6 +1095,7 @@ export default class MarketApplicationV2 extends api.HandlebarsApplicationMixin(
         basePrice,
         resaleEstimate: valuation.resalePrice,
         resaleFraction: Math.round(valuation.fraction * 100),
+        quantity,
       })
     }
 
@@ -1159,33 +1188,54 @@ export default class MarketApplicationV2 extends api.HandlebarsApplicationMixin(
       return
     }
 
-    // Validate sale eligibility
+    // Validate sale eligibility — also resolves maxQuantity from system.quantity
     const validation = validateSale({ actor: seller, item })
     if (!validation.canSell) {
       ui.notifications.warn(game.i18n.localize(validation.messageKey))
       return
     }
 
+    // Read quantity from the sibling input within the same row
+    const sellRow = target.closest('[data-item-id]')
+    const sellQtyInput = sellRow?.querySelector('.market-item__quantity-input')
+    const rawQty = sellQtyInput ? parseInt(sellQtyInput.value, 10) : 1
+    const maxQuantity = validation.maxQuantity ?? 1
+    const sellQuantity = Math.min(Math.max(1, isNaN(rawQty) ? 1 : rawQty), maxQuantity)
+
     // Compute base resale estimate (25% — may be improved by negotiation)
+    // resalePrice here is the per-unit resale price; total = resalePrice × sellQuantity
     const baseValuation = computeResalePrice({ basePrice: validation.basePrice, negotiationOutcome: 'failure' })
+    const baseResaleTotal = baseValuation.resalePrice * sellQuantity
 
     // Confirmation dialog
     const i18n = game.i18n
     const currentCredits = seller.system?.creditBudget?.availableCredits ?? seller.system?.credits ?? 0
-    const creditsAfterBase = currentCredits + baseValuation.resalePrice
+    const creditsAfterBase = currentCredits + baseResaleTotal
+
+    const confirmContent =
+      sellQuantity > 1
+        ? i18n.format('MARKET.Sell.Confirm.ContentMultiple', {
+            name: item.name,
+            quantity: sellQuantity,
+            unitPrice: baseValuation.resalePrice,
+            total: baseResaleTotal,
+            credits: currentCredits,
+            remaining: creditsAfterBase,
+          })
+        : i18n.format('MARKET.Sell.Confirm.Content', {
+            name: item.name,
+            price: baseResaleTotal,
+            credits: currentCredits,
+            remaining: creditsAfterBase,
+          })
 
     const confirmed = await foundry.applications.api.DialogV2.confirm({
       window: {
         title: i18n.format('MARKET.Sell.Confirm.Title', { name: item.name }),
       },
-      content: `<p>${i18n.format('MARKET.Sell.Confirm.Content', {
-        name: item.name,
-        price: baseValuation.resalePrice,
-        credits: currentCredits,
-        remaining: creditsAfterBase,
-      })}</p>`,
+      content: `<p>${confirmContent}</p>`,
       yes: {
-        label: i18n.format('MARKET.Sell.Confirm.Sell', { price: baseValuation.resalePrice }),
+        label: i18n.format('MARKET.Sell.Confirm.Sell', { price: baseResaleTotal }),
         icon: 'fa-solid fa-coins',
       },
       no: {
@@ -1212,32 +1262,48 @@ export default class MarketApplicationV2 extends api.HandlebarsApplicationMixin(
       },
     })
 
-    let finalValuation = baseValuation
+    let finalUnitValuation = baseValuation
     if (offerNegotiation) {
       const negotiationResult = await NegotiationDialog.prompt({ entry: { name: item.name, rarity: item.system?.rarity ?? 0 }, buyer: seller, forSale: true })
 
       if (negotiationResult?.confirmed) {
-        finalValuation = computeResalePrice({
+        finalUnitValuation = computeResalePrice({
           basePrice: validation.basePrice,
           negotiationOutcome: negotiationResult.outcome,
         })
       }
     }
 
-    // Execute sale: delete item then credit actor
-    // The manual adjustment stored in system.credits is the raw base for writing.
-    // When the item is deleted, totalSpent drops by basePrice automatically (via _prepareCredits),
-    // which would inflate availableCredits by basePrice. To compensate, we write:
-    //   system.credits = manualAdjustmentBefore + resalePrice - basePrice
-    // so that availableCredits after = (manualAdjustmentBefore + resalePrice - basePrice) - (totalSpent - basePrice)
-    //                                = manualAdjustmentBefore + resalePrice - totalSpent
-    //                                = availableCreditsBefore + resalePrice  ✓
+    const resaleTotalPrice = finalUnitValuation.resalePrice * sellQuantity
+    const isFullSale = sellQuantity >= maxQuantity
+
+    // Execute sale:
+    // - Full sale (sellQuantity === maxQuantity): delete the item.
+    //   When the item is deleted, totalSpent drops by basePrice × maxQuantity (via _prepareCredits),
+    //   which would inflate availableCredits by that amount. To compensate, we write:
+    //   system.credits = manualAdjustmentBefore + resaleTotalPrice - (basePrice × sellQuantity)
+    //   so that availableCredits after = manualAdjustmentBefore + resaleTotalPrice - totalSpent  ✓
+    //
+    // - Partial sale (sellQuantity < maxQuantity): decrement system.quantity; do NOT delete.
+    //   The item stays in totalSpent, but at a reduced quantity:
+    //   system.credits = manualAdjustmentBefore + resaleTotalPrice
+    //   (totalSpent decreases by basePrice × sellQuantity via _prepareCredits, so no further adjustment needed)
     const manualAdjustmentBefore = seller.system?._source?.credits ?? seller.system?.credits ?? 0
-    const availableCreditsAfter = currentCredits + finalValuation.resalePrice
-    const newManualAdjustment = manualAdjustmentBefore + finalValuation.resalePrice - validation.basePrice
+    const availableCreditsAfter = currentCredits + resaleTotalPrice
+
+    let newManualAdjustment
+    if (isFullSale) {
+      newManualAdjustment = manualAdjustmentBefore + resaleTotalPrice - validation.basePrice * sellQuantity
+    } else {
+      newManualAdjustment = manualAdjustmentBefore + resaleTotalPrice
+    }
 
     try {
-      await seller.deleteEmbeddedDocuments('Item', [item.id])
+      if (isFullSale) {
+        await seller.deleteEmbeddedDocuments('Item', [item.id])
+      } else {
+        await item.update({ 'system.quantity': maxQuantity - sellQuantity })
+      }
       await seller.update({ 'system.credits': newManualAdjustment })
 
       // Record in audit log (non-blocking)
@@ -1247,9 +1313,10 @@ export default class MarketApplicationV2 extends api.HandlebarsApplicationMixin(
           itemName: item.name,
           itemType: item.type,
           basePrice: validation.basePrice,
-          resalePrice: finalValuation.resalePrice,
-          fraction: finalValuation.fraction,
-          negotiationOutcome: finalValuation.outcome,
+          resalePrice: resaleTotalPrice,
+          fraction: finalUnitValuation.fraction,
+          quantity: sellQuantity,
+          negotiationOutcome: finalUnitValuation.outcome,
           creditsAfter: availableCreditsAfter,
           itemId: item.id,
         })
@@ -1260,7 +1327,7 @@ export default class MarketApplicationV2 extends api.HandlebarsApplicationMixin(
       ui.notifications.info(
         i18n.format('MARKET.Sale.Success', {
           name: item.name,
-          price: finalValuation.resalePrice,
+          price: resaleTotalPrice,
           remaining: availableCreditsAfter,
         }),
       )
@@ -1271,7 +1338,9 @@ export default class MarketApplicationV2 extends api.HandlebarsApplicationMixin(
         itemId: item.id,
         itemName: item.name,
         basePrice: validation.basePrice,
-        resalePrice: finalValuation.resalePrice,
+        quantity: sellQuantity,
+        resaleTotalPrice,
+        isFullSale,
         creditsAfter: availableCreditsAfter,
       })
 

--- a/module/lib/market/purchase.mjs
+++ b/module/lib/market/purchase.mjs
@@ -12,13 +12,16 @@
  *   Plain actor-like object. Credit balance is read from `system.creditBudget.availableCredits` (derived budget)
  *   when available, falling back to `system.credits` for backward compatibility.
  * @property {{ uuid: string, name: string, priceResult: { finalPrice: number } }} entry  Market entry to purchase.
+ * @property {number} [quantity=1]  Number of units to purchase. Must be a positive integer. Defaults to 1.
  */
 
 /**
  * @typedef {Object} PurchaseResult
  * @property {boolean}  canPurchase        Whether all pre-conditions are satisfied.
  * @property {string}   reason             Machine-readable reason key (empty string when canPurchase is true).
- * @property {number}   [finalPrice]       The price that will be charged (present when canPurchase is true).
+ * @property {number}   [finalPrice]       Unit price (present when canPurchase is true).
+ * @property {number}   [totalPrice]       Total price = finalPrice × quantity (present when canPurchase is true).
+ * @property {number}   [quantity]         The validated quantity (present when canPurchase is true).
  * @property {number}   [creditsAfter]     Remaining credits after purchase (present when canPurchase is true).
  * @property {string}   [messageKey]       i18n key for the user-facing message (present when canPurchase is false).
  */
@@ -42,7 +45,7 @@ function resolveActorCredits(actor) {
 }
 
 /**
- * Validate whether an actor can purchase a market entry at the given price.
+ * Validate whether an actor can purchase a market entry at the given price and quantity.
  *
  * Credit balance resolution (in priority order):
  * 1. `actor.system.creditBudget.availableCredits` — derived credit budget (preferred)
@@ -51,13 +54,14 @@ function resolveActorCredits(actor) {
  * Rules (in order of evaluation):
  * 1. Actor must be provided.
  * 2. Entry must be provided and have a resolvable UUID.
- * 3. `entry.priceResult.finalPrice` must be a non-negative finite integer — the canonical price; no recalculation allowed.
- * 4. Actor credits must be sufficient.
+ * 3. `entry.priceResult.finalPrice` must be a non-negative finite integer — the canonical unit price; no recalculation allowed.
+ * 4. `quantity` must be a positive integer >= 1.
+ * 5. Actor credits must be sufficient for the total price (finalPrice × quantity).
  *
  * @param {PurchaseInput} input
  * @returns {PurchaseResult}
  */
-export function validatePurchase({ actor, entry } = {}) {
+export function validatePurchase({ actor, entry, quantity = 1 } = {}) {
   if (!actor || typeof actor !== 'object') {
     return {
       canPurchase: false,
@@ -83,8 +87,11 @@ export function validatePurchase({ actor, entry } = {}) {
     }
   }
 
+  const qty = Number.isInteger(quantity) && quantity >= 1 ? quantity : 1
+  const totalPrice = finalPrice * qty
+
   const credits = resolveActorCredits(actor)
-  if (typeof credits !== 'number' || !Number.isFinite(credits) || credits < finalPrice) {
+  if (typeof credits !== 'number' || !Number.isFinite(credits) || credits < totalPrice) {
     return {
       canPurchase: false,
       reason: 'insufficient-credits',
@@ -96,6 +103,8 @@ export function validatePurchase({ actor, entry } = {}) {
     canPurchase: true,
     reason: '',
     finalPrice,
-    creditsAfter: credits - finalPrice,
+    totalPrice,
+    quantity: qty,
+    creditsAfter: credits - totalPrice,
   }
 }

--- a/module/lib/market/sell-validation.mjs
+++ b/module/lib/market/sell-validation.mjs
@@ -13,10 +13,11 @@ import { PURCHASABLE_ITEM_TYPES } from '../../config/market.mjs'
 
 /**
  * @typedef {Object} SaleValidationResult
- * @property {boolean} canSell      Whether all pre-conditions are satisfied.
- * @property {string}  reason       Machine-readable reason key (empty string when canSell is true).
- * @property {string}  [messageKey] i18n key for the user-facing message (present when canSell is false).
- * @property {number}  [basePrice]  Resolved base price (present when canSell is true).
+ * @property {boolean} canSell       Whether all pre-conditions are satisfied.
+ * @property {string}  reason        Machine-readable reason key (empty string when canSell is true).
+ * @property {string}  [messageKey]  i18n key for the user-facing message (present when canSell is false).
+ * @property {number}  [basePrice]   Resolved base price (present when canSell is true).
+ * @property {number}  [maxQuantity] Maximum sellable quantity = item's current stack size (present when canSell is true).
  */
 
 /* -------------------------------------------- */
@@ -86,9 +87,12 @@ export function validateSale({ actor, item } = {}) {
     }
   }
 
+  const maxQuantity = item.system?.quantity ?? 1
+
   return {
     canSell: true,
     reason: '',
     basePrice,
+    maxQuantity,
   }
 }

--- a/module/utils/audit-log.mjs
+++ b/module/utils/audit-log.mjs
@@ -543,13 +543,17 @@ async function recordItemPurchase(actor, { itemName, itemType, price, quantity =
  * @param {string} saleData.itemName
  * @param {string} saleData.itemType
  * @param {number} saleData.basePrice
- * @param {number} saleData.resalePrice
+ * @param {number} saleData.resalePrice      Total resale credit received (resaleUnitPrice × quantity).
  * @param {number} saleData.fraction
+ * @param {number} [saleData.quantity=1]     Number of units sold.
  * @param {string} [saleData.negotiationOutcome='failure']
  * @param {number} saleData.creditsAfter
  * @param {string} [saleData.itemId]
  */
-async function recordItemSale(actor, { itemName, itemType, basePrice, resalePrice, fraction, negotiationOutcome = 'failure', creditsAfter, itemId }) {
+async function recordItemSale(
+  actor,
+  { itemName, itemType, basePrice, resalePrice, fraction, quantity = 1, negotiationOutcome = 'failure', creditsAfter, itemId },
+) {
   const ts = Date.now()
   const creditsBefore = actor.system?.creditBudget?.availableCredits ?? actor.system?.credits ?? null
   const creditsDelta = creditsBefore !== null && creditsAfter !== null ? creditsAfter - creditsBefore : null
@@ -565,6 +569,7 @@ async function recordItemSale(actor, { itemName, itemType, basePrice, resalePric
         basePrice,
         resalePrice,
         fraction,
+        quantity,
         negotiationOutcome,
         itemId,
       },

--- a/templates/market/market.hbs
+++ b/templates/market/market.hbs
@@ -122,6 +122,7 @@
               <th class="market-col--type">{{localize "MARKET.Catalog.Column.Type"}}</th>
               <th class="market-col--price">{{localize "MARKET.Inventory.BasePrice"}}</th>
               <th class="market-col--price">{{localize "MARKET.Inventory.ResaleEstimate"}}</th>
+              <th class="market-col--quantity">{{localize "MARKET.Inventory.Quantity"}}</th>
               <th class="market-col--sell" aria-label="{{localize 'MARKET.Inventory.SellButton'}}"></th>
             </tr>
           </thead>
@@ -138,6 +139,19 @@
                 <td class="market-col--price">{{item.basePrice}}</td>
                 <td class="market-col--price">
                   <span class="market-resale-estimate">{{item.resaleEstimate}} ({{item.resaleFraction}}%)</span>
+                </td>
+                <td class="market-col--quantity">
+                  <label class="sr-only" for="sell-qty-{{item.id}}">{{localize "MARKET.Inventory.QuantityLabel"}}</label>
+                  <input
+                    id="sell-qty-{{item.id}}"
+                    class="market-item__quantity-input"
+                    type="number"
+                    min="1"
+                    max="{{item.quantity}}"
+                    value="1"
+                    aria-label="{{localize 'MARKET.Inventory.QuantityLabel'}}"
+                  />
+                  <span class="market-item__quantity-max">/{{item.quantity}}</span>
                 </td>
                 <td class="market-col--sell">
                   <button
@@ -472,6 +486,16 @@
             </td>
             {{#if ../buyer}}
               <td class="market-col--buy">
+                <label class="sr-only" for="buy-qty-{{entry.uuid}}">{{localize "MARKET.Purchase.QuantityLabel"}}</label>
+                <input
+                  id="buy-qty-{{entry.uuid}}"
+                  class="market-item__quantity-input"
+                  type="number"
+                  min="1"
+                  value="1"
+                  {{#unless entry.canBuy}}disabled aria-disabled="true"{{/unless}}
+                  aria-label="{{localize 'MARKET.Purchase.QuantityLabel'}}"
+                />
                 {{#if entry.isNegotiable}}
                   <button
                     type="button"

--- a/tests/applications/market/market-application.test.mjs
+++ b/tests/applications/market/market-application.test.mjs
@@ -1161,7 +1161,7 @@ describe('MarketApplicationV2', () => {
       const app = new MarketApplicationV2()
       app.setBuyerActor(actor)
       const action = MarketApplicationV2.DEFAULT_OPTIONS.actions.buyItem
-      const target = { closest: vi.fn(() => ({ dataset: { uuid: 'Item.expensive' } })) }
+      const target = { closest: vi.fn(() => ({ dataset: { uuid: 'Item.expensive' }, querySelector: vi.fn().mockReturnValue(null) })) }
 
       await action.call(app, {}, target)
 
@@ -1188,7 +1188,7 @@ describe('MarketApplicationV2', () => {
       const app = new MarketApplicationV2()
       app.setBuyerActor(actor)
       const action = MarketApplicationV2.DEFAULT_OPTIONS.actions.buyItem
-      const target = { closest: vi.fn(() => ({ dataset: { uuid: 'Item.cheap' } })) }
+      const target = { closest: vi.fn(() => ({ dataset: { uuid: 'Item.cheap' }, querySelector: vi.fn().mockReturnValue(null) })) }
 
       await action.call(app, {}, target)
 
@@ -1215,7 +1215,7 @@ describe('MarketApplicationV2', () => {
       app.render = vi.fn().mockResolvedValue(undefined)
       app.setBuyerActor(actor)
       const action = MarketApplicationV2.DEFAULT_OPTIONS.actions.buyItem
-      const target = { closest: vi.fn(() => ({ dataset: { uuid: 'Item.cheap' } })) }
+      const target = { closest: vi.fn(() => ({ dataset: { uuid: 'Item.cheap' }, querySelector: vi.fn().mockReturnValue(null) })) }
 
       await action.call(app, {}, target)
 
@@ -1268,7 +1268,7 @@ describe('MarketApplicationV2', () => {
       const app = new MarketApplicationV2()
       app.setBuyerActor(actor)
       const action = MarketApplicationV2.DEFAULT_OPTIONS.actions.buyItem
-      const target = { closest: vi.fn(() => ({ dataset: { uuid: 'Item.cheap' } })) }
+      const target = { closest: vi.fn(() => ({ dataset: { uuid: 'Item.cheap' }, querySelector: vi.fn().mockReturnValue(null) })) }
 
       await action.call(app, {}, target)
 
@@ -1377,7 +1377,7 @@ describe('MarketApplicationV2', () => {
       const app = new MarketApplicationV2()
       app.setBuyerActor(actor)
       const action = MarketApplicationV2.DEFAULT_OPTIONS.actions.negotiateItem
-      const target = { closest: vi.fn(() => ({ dataset: { uuid: 'Item.cheap' } })) }
+      const target = { closest: vi.fn(() => ({ dataset: { uuid: 'Item.cheap' }, querySelector: vi.fn().mockReturnValue(null) })) }
 
       await action.call(app, {}, target)
 
@@ -1398,7 +1398,7 @@ describe('MarketApplicationV2', () => {
       const app = new MarketApplicationV2()
       app.setBuyerActor(actor)
       const action = MarketApplicationV2.DEFAULT_OPTIONS.actions.negotiateItem
-      const target = { closest: vi.fn(() => ({ dataset: { uuid: 'Item.cheap' } })) }
+      const target = { closest: vi.fn(() => ({ dataset: { uuid: 'Item.cheap' }, querySelector: vi.fn().mockReturnValue(null) })) }
 
       await action.call(app, {}, target)
 
@@ -1425,7 +1425,7 @@ describe('MarketApplicationV2', () => {
       const app = new MarketApplicationV2()
       app.setBuyerActor(actor)
       const action = MarketApplicationV2.DEFAULT_OPTIONS.actions.negotiateItem
-      const target = { closest: vi.fn(() => ({ dataset: { uuid: 'Item.cheap' } })) }
+      const target = { closest: vi.fn(() => ({ dataset: { uuid: 'Item.cheap' }, querySelector: vi.fn().mockReturnValue(null) })) }
 
       await action.call(app, {}, target)
 
@@ -1449,7 +1449,7 @@ describe('MarketApplicationV2', () => {
       const app = new MarketApplicationV2()
       app.setBuyerActor(actor)
       const action = MarketApplicationV2.DEFAULT_OPTIONS.actions.negotiateItem
-      const target = { closest: vi.fn(() => ({ dataset: { uuid: 'Item.cheap' } })) }
+      const target = { closest: vi.fn(() => ({ dataset: { uuid: 'Item.cheap' }, querySelector: vi.fn().mockReturnValue(null) })) }
 
       await action.call(app, {}, target)
 
@@ -1474,7 +1474,7 @@ describe('MarketApplicationV2', () => {
       const app = new MarketApplicationV2()
       app.setBuyerActor(actor)
       const action = MarketApplicationV2.DEFAULT_OPTIONS.actions.negotiateItem
-      const target = { closest: vi.fn(() => ({ dataset: { uuid: 'Item.cheap' } })) }
+      const target = { closest: vi.fn(() => ({ dataset: { uuid: 'Item.cheap' }, querySelector: vi.fn().mockReturnValue(null) })) }
 
       await action.call(app, {}, target)
 
@@ -1619,7 +1619,7 @@ describe('MarketApplicationV2', () => {
       const app = new MarketApplicationV2()
       app.setBuyerActor(actor)
       const action = MarketApplicationV2.DEFAULT_OPTIONS.actions.negotiateItem
-      const target = { closest: vi.fn(() => ({ dataset: { uuid: 'Item.common' } })) }
+      const target = { closest: vi.fn(() => ({ dataset: { uuid: 'Item.common' }, querySelector: vi.fn().mockReturnValue(null) })) }
 
       await action.call(app, {}, target)
 
@@ -2802,7 +2802,7 @@ describe('MarketApplicationV2', () => {
       app.setBuyerActor(actor)
 
       const action = MarketApplicationV2.DEFAULT_OPTIONS.actions.sellItem
-      const target = { dataset: { itemId: 'w1' } }
+      const target = { dataset: { itemId: 'w1' }, closest: vi.fn(() => ({ querySelector: vi.fn().mockReturnValue(null) })) }
 
       await action.call(app, {}, target)
 
@@ -2839,7 +2839,7 @@ describe('MarketApplicationV2', () => {
       app.setBuyerActor(actor)
 
       const action = MarketApplicationV2.DEFAULT_OPTIONS.actions.sellItem
-      const target = { dataset: { itemId: 'w1' } }
+      const target = { dataset: { itemId: 'w1' }, closest: vi.fn(() => ({ querySelector: vi.fn().mockReturnValue(null) })) }
 
       await action.call(app, {}, target)
 
@@ -2888,7 +2888,7 @@ describe('MarketApplicationV2', () => {
       app.setBuyerActor(actor)
 
       const action = MarketApplicationV2.DEFAULT_OPTIONS.actions.sellItem
-      const target = { dataset: { itemId: 'w1' } }
+      const target = { dataset: { itemId: 'w1' }, closest: vi.fn(() => ({ querySelector: vi.fn().mockReturnValue(null) })) }
 
       await action.call(app, {}, target)
 
@@ -2933,7 +2933,7 @@ describe('MarketApplicationV2', () => {
       app.setBuyerActor(actor)
 
       const action = MarketApplicationV2.DEFAULT_OPTIONS.actions.sellItem
-      const target = { dataset: { itemId: 'w1' } }
+      const target = { dataset: { itemId: 'w1' }, closest: vi.fn(() => ({ querySelector: vi.fn().mockReturnValue(null) })) }
 
       await action.call(app, {}, target)
 
@@ -3086,7 +3086,7 @@ describe('MarketApplicationV2', () => {
       const app = new MarketApplicationV2()
       app.setBuyerActor(actor)
       const action = MarketApplicationV2.DEFAULT_OPTIONS.actions.buyItem
-      const target = { closest: vi.fn(() => ({ dataset: { uuid: 'Item.cheap' } })) }
+      const target = { closest: vi.fn(() => ({ dataset: { uuid: 'Item.cheap' }, querySelector: vi.fn().mockReturnValue(null) })) }
 
       await action.call(app, {}, target)
 
@@ -3114,7 +3114,7 @@ describe('MarketApplicationV2', () => {
       const app = new MarketApplicationV2()
       app.setBuyerActor(actor)
       const action = MarketApplicationV2.DEFAULT_OPTIONS.actions.buyItem
-      const target = { closest: vi.fn(() => ({ dataset: { uuid: 'Item.cheap' } })) }
+      const target = { closest: vi.fn(() => ({ dataset: { uuid: 'Item.cheap' }, querySelector: vi.fn().mockReturnValue(null) })) }
 
       await action.call(app, {}, target)
 
@@ -3150,7 +3150,7 @@ describe('MarketApplicationV2', () => {
       const app = new MarketApplicationV2()
       app.setBuyerActor(actor)
       const action = MarketApplicationV2.DEFAULT_OPTIONS.actions.buyItem
-      const target = { closest: vi.fn(() => ({ dataset: { uuid: 'Item.cheap' } })) }
+      const target = { closest: vi.fn(() => ({ dataset: { uuid: 'Item.cheap' }, querySelector: vi.fn().mockReturnValue(null) })) }
 
       await action.call(app, {}, target)
 
@@ -3191,7 +3191,7 @@ describe('MarketApplicationV2', () => {
       const app = new MarketApplicationV2()
       app.setBuyerActor(actor)
       const action = MarketApplicationV2.DEFAULT_OPTIONS.actions.buyItem
-      const target = { closest: vi.fn(() => ({ dataset: { uuid: 'Item.cheap' } })) }
+      const target = { closest: vi.fn(() => ({ dataset: { uuid: 'Item.cheap' }, querySelector: vi.fn().mockReturnValue(null) })) }
 
       await action.call(app, {}, target)
 
@@ -3226,7 +3226,7 @@ describe('MarketApplicationV2', () => {
       const app = new MarketApplicationV2()
       app.setBuyerActor(actor)
       const action = MarketApplicationV2.DEFAULT_OPTIONS.actions.buyItem
-      const target = { closest: vi.fn(() => ({ dataset: { uuid: 'Item.new' } })) }
+      const target = { closest: vi.fn(() => ({ dataset: { uuid: 'Item.new' }, querySelector: vi.fn().mockReturnValue(null) })) }
 
       await action.call(app, {}, target)
 

--- a/tests/lib/market/purchase.test.mjs
+++ b/tests/lib/market/purchase.test.mjs
@@ -67,6 +67,12 @@ describe('validatePurchase', () => {
       expect(result.creditsAfter).toBe(400)
     })
 
+    it('includes totalPrice equal to finalPrice when quantity defaults to 1', () => {
+      const result = validatePurchase({ actor: makeActor({ credits: 500 }), entry: makeEntry({ finalPrice: 100 }) })
+      expect(result.totalPrice).toBe(100)
+      expect(result.quantity).toBe(1)
+    })
+
     it('allows purchase when credits exactly equal the price', () => {
       const result = validatePurchase({ actor: makeActor({ credits: 100 }), entry: makeEntry({ finalPrice: 100 }) })
       expect(result.canPurchase).toBe(true)
@@ -190,6 +196,61 @@ describe('validatePurchase', () => {
 
       expect(JSON.stringify(actor)).toBe(actorBefore)
       expect(JSON.stringify(entry)).toBe(entryBefore)
+    })
+  })
+
+  /* -------------------------------------------- */
+  /*  Multi-quantity purchase                      */
+  /* -------------------------------------------- */
+
+  describe('multi-quantity purchase', () => {
+    it('charges totalPrice = finalPrice × quantity for quantity > 1', () => {
+      const result = validatePurchase({ actor: makeActor({ credits: 500 }), entry: makeEntry({ finalPrice: 100 }), quantity: 3 })
+      expect(result.canPurchase).toBe(true)
+      expect(result.finalPrice).toBe(100)
+      expect(result.totalPrice).toBe(300)
+      expect(result.quantity).toBe(3)
+      expect(result.creditsAfter).toBe(200)
+    })
+
+    it('blocks purchase when credits are insufficient for quantity × price', () => {
+      const result = validatePurchase({ actor: makeActor({ credits: 250 }), entry: makeEntry({ finalPrice: 100 }), quantity: 3 })
+      expect(result.canPurchase).toBe(false)
+      expect(result.reason).toBe('insufficient-credits')
+    })
+
+    it('allows purchase when credits exactly equal quantity × price', () => {
+      const result = validatePurchase({ actor: makeActor({ credits: 300 }), entry: makeEntry({ finalPrice: 100 }), quantity: 3 })
+      expect(result.canPurchase).toBe(true)
+      expect(result.creditsAfter).toBe(0)
+    })
+
+    it('treats non-integer quantity as 1', () => {
+      const result = validatePurchase({ actor: makeActor({ credits: 500 }), entry: makeEntry({ finalPrice: 100 }), quantity: 2.5 })
+      expect(result.canPurchase).toBe(true)
+      expect(result.quantity).toBe(1)
+      expect(result.totalPrice).toBe(100)
+    })
+
+    it('treats zero quantity as 1', () => {
+      const result = validatePurchase({ actor: makeActor({ credits: 500 }), entry: makeEntry({ finalPrice: 100 }), quantity: 0 })
+      expect(result.canPurchase).toBe(true)
+      expect(result.quantity).toBe(1)
+      expect(result.totalPrice).toBe(100)
+    })
+
+    it('treats negative quantity as 1', () => {
+      const result = validatePurchase({ actor: makeActor({ credits: 500 }), entry: makeEntry({ finalPrice: 100 }), quantity: -2 })
+      expect(result.canPurchase).toBe(true)
+      expect(result.quantity).toBe(1)
+      expect(result.totalPrice).toBe(100)
+    })
+
+    it('handles quantity=1 explicitly like the default', () => {
+      const result = validatePurchase({ actor: makeActor({ credits: 500 }), entry: makeEntry({ finalPrice: 100 }), quantity: 1 })
+      expect(result.canPurchase).toBe(true)
+      expect(result.totalPrice).toBe(100)
+      expect(result.quantity).toBe(1)
     })
   })
 

--- a/tests/lib/market/sell-validation.test.mjs
+++ b/tests/lib/market/sell-validation.test.mjs
@@ -10,12 +10,12 @@ import { validateSale } from '../../../module/lib/market/sell-validation.mjs'
  * Build a minimal item-like plain object that can be sold.
  * @param {object} [overrides]
  */
-function makeItem({ id = 'item-1', uuid = 'Item.item-1', type = 'weapon', price = 100 } = {}) {
+function makeItem({ id = 'item-1', uuid = 'Item.item-1', type = 'weapon', price = 100, quantity = 1 } = {}) {
   return {
     id,
     uuid,
     type,
-    system: { price },
+    system: { price, quantity },
   }
 }
 
@@ -84,6 +84,22 @@ describe('validateSale', () => {
       const result = validateSale({ actor, item })
       expect(result.canSell).toBe(true)
       expect(result.basePrice).toBe(0)
+    })
+
+    it('returns maxQuantity equal to item system.quantity', () => {
+      const item = makeItem({ price: 100, quantity: 5 })
+      const actor = makeActorWithItem(item)
+      const result = validateSale({ actor, item })
+      expect(result.canSell).toBe(true)
+      expect(result.maxQuantity).toBe(5)
+    })
+
+    it('returns maxQuantity of 1 when system.quantity is absent', () => {
+      const item = { id: 'item-1', uuid: 'Item.item-1', type: 'weapon', system: { price: 100 } }
+      const actor = makeActorWithItem(item)
+      const result = validateSale({ actor, item })
+      expect(result.canSell).toBe(true)
+      expect(result.maxQuantity).toBe(1)
     })
 
     it('matches by uuid when item has no id match but uuid matches', () => {

--- a/tests/utils/audit-log.test.mjs
+++ b/tests/utils/audit-log.test.mjs
@@ -1876,3 +1876,161 @@ describe('recordItemPurchase', () => {
     expect(entry.snapshot.creditsDelta).toBeNull()
   })
 })
+
+/* ============================================ */
+/*  recordItemSale                              */
+/* ============================================ */
+
+describe('recordItemSale', () => {
+  /**
+   *
+   * @param overrides
+   */
+  function makeActor(overrides = {}) {
+    return {
+      type: 'character',
+      id: 'actor-001',
+      name: 'Test Character',
+      _source: {
+        system: {
+          skills: {},
+          characteristics: {},
+          progression: { totalXP: 0, spentXP: 0 },
+          details: {},
+          advancement: {},
+        },
+        flags: {},
+      },
+      system: {
+        credits: 100,
+        progression: {
+          experience: { spent: 0, gained: 0, available: 0, total: 0 },
+          freeSkillRanks: {
+            career: { spent: 0, gained: 0, available: 0 },
+            specialization: { spent: 0, gained: 0, available: 0 },
+          },
+        },
+      },
+      update: vi.fn(),
+      ...overrides,
+    }
+  }
+
+  test('creates an item.sale entry with all required fields', async () => {
+    const { recordItemSale } = await import('../../module/utils/audit-log.mjs')
+    globalThis.foundry.utils.deepClone = vi.fn((o) => structuredClone(o))
+    globalThis.game.users = { get: vi.fn(() => ({ id: 'gm-1', name: 'Game Master' })) }
+
+    const actor = makeActor()
+    await recordItemSale(actor, {
+      itemName: 'Blaster Pistol',
+      itemType: 'weapon',
+      basePrice: 400,
+      resalePrice: 100,
+      fraction: 0.25,
+      quantity: 1,
+      creditsAfter: 200,
+    })
+
+    expect(actor.update).toHaveBeenCalledTimes(1)
+    const updateArg = actor.update.mock.calls[0][0]
+    const logs = updateArg['flags.swerpg.logs']
+    expect(logs).toHaveLength(1)
+    const entry = logs[0]
+    expect(entry.type).toBe('item.sale')
+    expect(entry.data).toMatchObject({
+      itemName: 'Blaster Pistol',
+      itemType: 'weapon',
+      basePrice: 400,
+      resalePrice: 100,
+      fraction: 0.25,
+      quantity: 1,
+    })
+    expect(entry.creditDelta).toBe(100)
+    expect(entry.xpDelta).toBe(0)
+  })
+
+  test('defaults quantity to 1 when not provided', async () => {
+    const { recordItemSale } = await import('../../module/utils/audit-log.mjs')
+    globalThis.foundry.utils.deepClone = vi.fn((o) => structuredClone(o))
+
+    const actor = makeActor()
+    await recordItemSale(actor, {
+      itemName: 'Blaster Pistol',
+      itemType: 'weapon',
+      basePrice: 400,
+      resalePrice: 100,
+      fraction: 0.25,
+      creditsAfter: 200,
+    })
+
+    const updateArg = actor.update.mock.calls[0][0]
+    const entry = updateArg['flags.swerpg.logs'][0]
+    expect(entry.data.quantity).toBe(1)
+  })
+
+  test('stores quantity > 1 in entry.data for multi-unit sale', async () => {
+    const { recordItemSale } = await import('../../module/utils/audit-log.mjs')
+    globalThis.foundry.utils.deepClone = vi.fn((o) => structuredClone(o))
+
+    const actor = makeActor()
+    await recordItemSale(actor, {
+      itemName: 'Stun Grenade',
+      itemType: 'gear',
+      basePrice: 100,
+      resalePrice: 75, // total resale for 3 units = 25 each × 3
+      fraction: 0.25,
+      quantity: 3,
+      creditsAfter: 175,
+    })
+
+    const updateArg = actor.update.mock.calls[0][0]
+    const entry = updateArg['flags.swerpg.logs'][0]
+    expect(entry.data.quantity).toBe(3)
+    expect(entry.creditDelta).toBe(75) // total resale
+  })
+
+  test('creditDelta equals resalePrice (total, not per-unit)', async () => {
+    const { recordItemSale } = await import('../../module/utils/audit-log.mjs')
+    globalThis.foundry.utils.deepClone = vi.fn((o) => structuredClone(o))
+
+    const actor = makeActor()
+    await recordItemSale(actor, {
+      itemName: 'Armor',
+      itemType: 'armor',
+      basePrice: 200,
+      resalePrice: 150, // this is the total amount received
+      fraction: 0.25,
+      quantity: 2,
+      creditsAfter: 250,
+    })
+
+    const updateArg = actor.update.mock.calls[0][0]
+    const entry = updateArg['flags.swerpg.logs'][0]
+    expect(entry.creditDelta).toBe(150)
+  })
+
+  test('defaults negotiationOutcome to failure when not provided', async () => {
+    const { recordItemSale } = await import('../../module/utils/audit-log.mjs')
+    globalThis.foundry.utils.deepClone = vi.fn((o) => structuredClone(o))
+
+    const actor = makeActor()
+    await recordItemSale(actor, {
+      itemName: 'Gear',
+      itemType: 'gear',
+      basePrice: 50,
+      resalePrice: 12,
+      fraction: 0.25,
+      creditsAfter: 112,
+    })
+
+    const updateArg = actor.update.mock.calls[0][0]
+    const entry = updateArg['flags.swerpg.logs'][0]
+    expect(entry.data.negotiationOutcome).toBe('failure')
+  })
+
+  test('is exported from the module', async () => {
+    const module = await import('../../module/utils/audit-log.mjs')
+    expect(typeof module.recordItemSale).toBe('function')
+  })
+})


### PR DESCRIPTION
## Summary

- Implement market quantity management for purchases and sales, adjusting total credit when decrementing stack quantity.
- Add validation and unit tests for purchase/sell flows and audit logging.
- Update localization strings (en/fr) and template for market UI.

## Context

Closes #539

This PR implements the feature described on the branch 539-market-gérer-la-quantité-en-achat-et-vente-décrément-de-pile-crédit-n. Changes touch market application logic, purchase/sell validations, templates, localization and tests.

## Tests

- Not run (not requested).

## Notes

- Key files changed: module/applications/market/market-application.mjs, module/lib/market/purchase.mjs, module/lib/market/sell-validation.mjs, templates/market/market.hbs, tests/lib/market/*.test.mjs, tests/utils/audit-log.test.mjs, lang/en.json, lang/fr.json.
- No secrets or generated files detected in the diff. Reviewers: pay attention to rounding/credit adjustment edge cases in market logic.
