### PR TITLE
feat(market): integrate global and type modifiers into pricing display

### DIFF
--- a/documentation/plan/market/542-market-brancher-les-modificateurs-mj-globaux-par-type-au-pricing-d-affichage.md
+++ b/documentation/plan/market/542-market-brancher-les-modificateurs-mj-globaux-par-type-au-pricing-d-affichage.md
@@ -1,0 +1,67 @@
+# Market — Brancher les modificateurs MJ globaux/par type au pricing d’affichage
+
+**Issue** : [#542 — Market — Brancher les modificateurs MJ globaux/par type au pricing d’affichage](https://github.com/herveDarritchon/foundryvtt-swerpg/issues/542)
+
+**Domaine métier** : `market`
+
+## Goal
+
+Faire en sorte que le prix affiché dans le Market reflète réellement les modificateurs MJ globaux et par type déjà portés par la configuration métier, afin que le catalogue rende un `finalPrice` cohérent, explicable et stable sans logique de calcul dupliquée côté UI.
+
+## Contexte utile
+
+- Le moteur de prix Market est déjà le point canonique pour composer les modificateurs de prix et produire un `priceResult` consommé par l’UI.
+- Le cadrage `plan-marketAdvancedGMConfiguration.prompt.md` prévoit explicitement deux familles de réglages MJ : un modificateur global et des modificateurs par type.
+- Les plans Market récents distinguent bien le calcul métier du simple habillage visuel : cette issue doit brancher les modificateurs au pricing d’affichage, pas rouvrir le design de la table ni la configuration du panel MJ.
+
+## Plan d’implémentation
+
+### Étape 1 — Stabiliser la lecture des modificateurs MJ dans le contexte Market
+
+**Fichiers** : `module/lib/market/market-settings.mjs`, `module/config/market.mjs`, `module/lib/market/price-engine.mjs`
+
+**What** :
+
+- formaliser le contrat lu par le pricing pour le modificateur global et le modificateur par type ;
+- garantir des fallbacks déterministes (`0` / aucun modificateur) quand la configuration est absente, partielle ou invalide ;
+- faire converger l’entrée du moteur de prix sur une seule source de vérité, sans calcul implicite dans l’application Market.
+
+**Résultat attendu** : le moteur de prix sait toujours quels modificateurs MJ appliquer à un item donné, de manière pure et prévisible.
+
+### Étape 2 — Brancher ces modificateurs sur le `priceResult` exposé au catalogue
+
+**Fichiers** : `module/applications/market/market-application.mjs`, `module/lib/market/market-entry.mjs` _(ou helper Market équivalent)_, `templates/market/market.hbs` _(uniquement si le contrat d’affichage doit être ajusté)_
+
+**What** :
+
+- injecter le modificateur global et le modificateur du type d’item dans le contexte envoyé au moteur de prix ;
+- vérifier que le `priceResult` utilisé pour l’affichage, le tri et le détail explicatif reflète bien la somme canonique des modificateurs ;
+- conserver l’UI existante autant que possible, en ne touchant au template que si une information supplémentaire doit être rendue explicite.
+
+**Résultat attendu** : une arme, une armure ou un équipement affiche désormais un prix final cohérent avec la configuration MJ globale + par type.
+
+### Étape 3 — Verrouiller la non-régression sur calcul et exposition UI
+
+**Fichiers** : `tests/lib/market/price-engine.test.mjs`, `tests/applications/market/market-application.test.mjs`
+
+**What** :
+
+- couvrir les cas global seul, par type seul, cumul global + type, et type non configuré ;
+- vérifier que les modificateurs apparaissent dans le `priceResult`/détail attendu et que le catalogue consomme bien `finalPrice` ;
+- ajouter un test applicatif ciblé garantissant que le prix affiché d’une entrée Market change quand la configuration MJ change.
+
+**Résultat attendu** : le branchement des modificateurs MJ au pricing d’affichage devient un contrat testé, sans régression silencieuse.
+
+## Périmètre / hors périmètre
+
+### Inclus
+
+- lecture des modificateurs MJ globaux et par type pour le pricing Market ;
+- branchement de ces modificateurs au `priceResult` affiché ;
+- tests ciblés moteur + application.
+
+### Exclus
+
+- création/refonte du panel de configuration MJ ;
+- refonte visuelle globale du Market ;
+- changement des autres modificateurs métier (rareté, disponibilité, négociation) hors impact direct de composition.

--- a/module/applications/market/market-application.mjs
+++ b/module/applications/market/market-application.mjs
@@ -2,7 +2,7 @@ import { createMarketEntry } from '../../lib/market/market-entry.mjs'
 import { isItemVisibleForMarket } from '../../lib/market/market-visibility.mjs'
 import { loadMarketCatalog } from '../../lib/market/catalog-loader.mjs'
 import { validatePurchase } from '../../lib/market/purchase.mjs'
-import { readMarketConfig, readMarketExcludedItems } from '../../lib/market/market-settings.mjs'
+import { readMarketConfig, readMarketExcludedItems, readMarketGlobalPriceModifier, readMarketTypeModifiers } from '../../lib/market/market-settings.mjs'
 import { evaluateObtainability } from '../../lib/market/rarity-engine.mjs'
 import { CONSEQUENCE_TYPES, evaluateMarketConsequences } from '../../lib/market/consequences.mjs'
 import { serializeConsequence } from '../../lib/market/consequence-persistence.mjs'
@@ -481,6 +481,9 @@ export default class MarketApplicationV2 extends api.HandlebarsApplicationMixin(
     const marketContext = { ...DEFAULT_MARKET_CONTEXT, marketType: activeMarketType }
     const marketConfig = readMarketConfig('swerpg')
     const excludedIds = readMarketExcludedItems('swerpg')
+    const globalModifier = readMarketGlobalPriceModifier('swerpg')
+    const typeModifiers = readMarketTypeModifiers('swerpg')
+    const priceOptions = { globalModifier, typeModifiers }
 
     // 1. Load world items
     const worldItems = Array.from(game.items).map((item) => itemToRawItem(item))
@@ -502,6 +505,7 @@ export default class MarketApplicationV2 extends api.HandlebarsApplicationMixin(
         config: marketConfig,
         marketContext,
         excludedIds,
+        priceOptions,
       })
     } catch (err) {
       logger.error('[Market] Catalog loading failed', err)
@@ -778,7 +782,14 @@ export default class MarketApplicationV2 extends api.HandlebarsApplicationMixin(
     try {
       const rawItem = itemToRawItem(item)
       const activeMarketType = this._viewState.activeMarketType ?? DEFAULT_MARKET_TYPE
-      entry = createMarketEntry(rawItem, { sourceType: 'world', sourceId: item.uuid ?? '' }, { ...DEFAULT_MARKET_CONTEXT, marketType: activeMarketType })
+      const globalModifier = readMarketGlobalPriceModifier('swerpg')
+      const typeModifiers = readMarketTypeModifiers('swerpg')
+      entry = createMarketEntry(
+        rawItem,
+        { sourceType: 'world', sourceId: item.uuid ?? '' },
+        { ...DEFAULT_MARKET_CONTEXT, marketType: activeMarketType },
+        { globalModifier, typeModifiers },
+      )
     } catch (err) {
       logger.warn(`[Market] Could not build market entry for "${uuid}" (negotiation): ${err.message}`)
       ui.notifications.error(game.i18n.localize('MARKET.Purchase.Error.ItemNotFound'))
@@ -869,7 +880,14 @@ export default class MarketApplicationV2 extends api.HandlebarsApplicationMixin(
     try {
       const rawItem = itemToRawItem(item)
       const activeMarketType = this._viewState.activeMarketType ?? DEFAULT_MARKET_TYPE
-      entry = createMarketEntry(rawItem, { sourceType: 'world', sourceId: item.uuid ?? '' }, { ...DEFAULT_MARKET_CONTEXT, marketType: activeMarketType })
+      const globalModifier = readMarketGlobalPriceModifier('swerpg')
+      const typeModifiers = readMarketTypeModifiers('swerpg')
+      entry = createMarketEntry(
+        rawItem,
+        { sourceType: 'world', sourceId: item.uuid ?? '' },
+        { ...DEFAULT_MARKET_CONTEXT, marketType: activeMarketType },
+        { globalModifier, typeModifiers },
+      )
     } catch (err) {
       logger.warn(`[Market] Could not build market entry for "${uuid}": ${err.message}`)
       ui.notifications.error(game.i18n.localize('MARKET.Purchase.Error.ItemNotFound'))

--- a/module/lib/market/catalog-loader.mjs
+++ b/module/lib/market/catalog-loader.mjs
@@ -21,9 +21,10 @@ import { createMarketEntry } from './market-entry.mjs'
  * @param {import('../../config/market.mjs').MarketConfig} options.config          Market runtime config
  * @param {Partial<import('../../config/market.mjs').MarketContext>} options.marketContext  Price context
  * @param {string[]} [options.excludedIds]  Array of item UUIDs manually excluded by the GM
+ * @param {import('./price-engine.mjs').PriceEngineOptions} [options.priceOptions]  Optional GM modifier options forwarded to the price engine
  * @returns {import('./market-entry.mjs').MarketEntry[]}  Eligible, deduplicated, priced entries
  */
-export function loadMarketCatalog({ worldItems, compendiumItems, config, marketContext, excludedIds = [] }) {
+export function loadMarketCatalog({ worldItems, compendiumItems, config, marketContext, excludedIds = [], priceOptions = {} }) {
   const excludedSet = new Set(excludedIds)
 
   // 1. Merge sources with proper source type tagging
@@ -38,7 +39,7 @@ export function loadMarketCatalog({ worldItems, compendiumItems, config, marketC
       try {
         // For world items, uuid is the source identifier; for compendium items, _sourceId (pack collection) is used.
         const sourceId = rawItem._sourceType === 'compendium' ? (rawItem._sourceId ?? '') : (rawItem.uuid ?? '')
-        return createMarketEntry(rawItem, { sourceType: rawItem._sourceType, sourceId }, marketContext)
+        return createMarketEntry(rawItem, { sourceType: rawItem._sourceType, sourceId }, marketContext, priceOptions)
       } catch {
         // createMarketEntry throws TypeError for non-purchasable item types — skip silently
         return null

--- a/module/lib/market/market-entry.mjs
+++ b/module/lib/market/market-entry.mjs
@@ -102,10 +102,11 @@ export function deriveAvailability(rarity, restrictionLevel) {
  * @param {RawItem}    rawItem       The raw item data to normalize
  * @param {SourceInfo} sourceInfo    Source metadata for this item
  * @param {Partial<import('../../config/market.mjs').MarketContext>} [marketContext]  Optional market context for price computation
+ * @param {import('./price-engine.mjs').PriceEngineOptions} [priceOptions]  Optional GM modifier options (typeModifiers, globalModifier)
  * @returns {MarketEntry}
  * @throws {TypeError} If itemType is not a key of PURCHASABLE_ITEM_TYPES
  */
-export function createMarketEntry(rawItem, sourceInfo, marketContext = {}) {
+export function createMarketEntry(rawItem, sourceInfo, marketContext = {}, priceOptions = {}) {
   const itemType = rawItem.type ?? rawItem.itemType ?? ''
 
   if (!(itemType in PURCHASABLE_ITEM_TYPES)) {
@@ -139,7 +140,7 @@ export function createMarketEntry(rawItem, sourceInfo, marketContext = {}) {
     sourceTypes: SOURCE_TYPES,
   })
 
-  const priceResult = calculateItemPrice({ basePrice, rarity, availability }, marketContext)
+  const priceResult = calculateItemPrice({ basePrice, rarity, availability, itemType }, marketContext, priceOptions)
 
   return {
     uuid: rawItem.uuid ?? '',

--- a/tests/applications/market/market-application.test.mjs
+++ b/tests/applications/market/market-application.test.mjs
@@ -1058,6 +1058,166 @@ describe('MarketApplicationV2', () => {
   })
 
   /* -------------------------------------------- */
+  /*  GM modifier wiring to displayed price       */
+  /* -------------------------------------------- */
+
+  describe('GM global and type modifiers wired to catalog pricing', () => {
+    it('global GM modifier of +20% increases finalPrice by 20%', async () => {
+      // base=100, rarity=0, globalModifier=20 → 100 * (1 + 0.2) = 120
+      const item = makeItem({ type: 'weapon', name: 'Blaster', price: 100, rarity: 0 })
+      item.system._source = { price: 100, rarity: 0 }
+      globalThis.game.items = makeItemsCollection([item])
+
+      // Configure game.settings.get to return the global modifier
+      globalThis.game.settings.get = vi.fn((systemId, key) => {
+        if (key === 'marketGlobalPriceModifier') return 20
+        if (key === 'marketTypeModifiers') return JSON.stringify({})
+        if (key === 'marketEnabledSources') return JSON.stringify(['compendium', 'world', 'import'])
+        if (key === 'marketAllowedItemTypes') return JSON.stringify(['weapon', 'armor', 'gear'])
+        if (key === 'marketDedupStrategy') return 'prefer-compendium'
+        if (key === 'marketExcludedItems') return JSON.stringify([])
+        return undefined
+      })
+
+      const app = new MarketApplicationV2()
+      const context = await app._preparePartContext('catalog', {})
+
+      expect(context.catalog.items).toHaveLength(1)
+      const entry = context.catalog.items[0]
+      expect(entry.priceResult.finalPrice).toBe(120)
+    })
+
+    it('global GM modifier of -10% decreases finalPrice by 10%', async () => {
+      // base=100, rarity=0, globalModifier=-10 → 100 * (1 - 0.1) = 90
+      const item = makeItem({ type: 'weapon', name: 'Blaster', price: 100, rarity: 0 })
+      item.system._source = { price: 100, rarity: 0 }
+      globalThis.game.items = makeItemsCollection([item])
+
+      globalThis.game.settings.get = vi.fn((systemId, key) => {
+        if (key === 'marketGlobalPriceModifier') return -10
+        if (key === 'marketTypeModifiers') return JSON.stringify({})
+        if (key === 'marketEnabledSources') return JSON.stringify(['compendium', 'world', 'import'])
+        if (key === 'marketAllowedItemTypes') return JSON.stringify(['weapon', 'armor', 'gear'])
+        if (key === 'marketDedupStrategy') return 'prefer-compendium'
+        if (key === 'marketExcludedItems') return JSON.stringify([])
+        return undefined
+      })
+
+      const app = new MarketApplicationV2()
+      const context = await app._preparePartContext('catalog', {})
+
+      expect(context.catalog.items).toHaveLength(1)
+      const entry = context.catalog.items[0]
+      expect(entry.priceResult.finalPrice).toBe(90)
+    })
+
+    it('per-type modifier applies only to the matching item type', async () => {
+      // weapon typeModifier=+10% → weapon=110, armor=100
+      const weapon = makeItem({ type: 'weapon', name: 'Blaster', price: 100, rarity: 0 })
+      weapon.system._source = { price: 100, rarity: 0 }
+      const armor = makeItem({ type: 'armor', name: 'Light Armor', price: 100, rarity: 0 })
+      armor.system._source = { price: 100, rarity: 0 }
+      globalThis.game.items = makeItemsCollection([weapon, armor])
+
+      globalThis.game.settings.get = vi.fn((systemId, key) => {
+        if (key === 'marketGlobalPriceModifier') return 0
+        if (key === 'marketTypeModifiers') return JSON.stringify({ weapon: { priceModifier: 0.1 } })
+        if (key === 'marketEnabledSources') return JSON.stringify(['compendium', 'world', 'import'])
+        if (key === 'marketAllowedItemTypes') return JSON.stringify(['weapon', 'armor', 'gear'])
+        if (key === 'marketDedupStrategy') return 'prefer-compendium'
+        if (key === 'marketExcludedItems') return JSON.stringify([])
+        return undefined
+      })
+
+      const app = new MarketApplicationV2()
+      const context = await app._preparePartContext('catalog', {})
+
+      const weaponEntry = context.catalog.items.find((e) => e.itemType === 'weapon')
+      const armorEntry = context.catalog.items.find((e) => e.itemType === 'armor')
+
+      expect(weaponEntry.priceResult.finalPrice).toBe(110)
+      expect(armorEntry.priceResult.finalPrice).toBe(100)
+    })
+
+    it('global modifier and type modifier stack — cumulative final price reflects both', async () => {
+      // weapon: base=100, globalModifier=10(+0.1), weapon typeModifier=0.1 → 100*(1+0.2)=120
+      const item = makeItem({ type: 'weapon', name: 'Blaster', price: 100, rarity: 0 })
+      item.system._source = { price: 100, rarity: 0 }
+      globalThis.game.items = makeItemsCollection([item])
+
+      globalThis.game.settings.get = vi.fn((systemId, key) => {
+        if (key === 'marketGlobalPriceModifier') return 10
+        if (key === 'marketTypeModifiers') return JSON.stringify({ weapon: { priceModifier: 0.1 } })
+        if (key === 'marketEnabledSources') return JSON.stringify(['compendium', 'world', 'import'])
+        if (key === 'marketAllowedItemTypes') return JSON.stringify(['weapon', 'armor', 'gear'])
+        if (key === 'marketDedupStrategy') return 'prefer-compendium'
+        if (key === 'marketExcludedItems') return JSON.stringify([])
+        return undefined
+      })
+
+      const app = new MarketApplicationV2()
+      const context = await app._preparePartContext('catalog', {})
+
+      expect(context.catalog.items).toHaveLength(1)
+      const entry = context.catalog.items[0]
+      expect(entry.priceResult.finalPrice).toBe(120)
+    })
+
+    it('zero global modifier and no type modifier produce same price as without any GM config', async () => {
+      const item = makeItem({ type: 'weapon', name: 'Blaster', price: 100, rarity: 0 })
+      item.system._source = { price: 100, rarity: 0 }
+      globalThis.game.items = makeItemsCollection([item])
+
+      globalThis.game.settings.get = vi.fn((systemId, key) => {
+        if (key === 'marketGlobalPriceModifier') return 0
+        if (key === 'marketTypeModifiers') return JSON.stringify({})
+        if (key === 'marketEnabledSources') return JSON.stringify(['compendium', 'world', 'import'])
+        if (key === 'marketAllowedItemTypes') return JSON.stringify(['weapon', 'armor', 'gear'])
+        if (key === 'marketDedupStrategy') return 'prefer-compendium'
+        if (key === 'marketExcludedItems') return JSON.stringify([])
+        return undefined
+      })
+
+      const app = new MarketApplicationV2()
+      const context = await app._preparePartContext('catalog', {})
+
+      expect(context.catalog.items).toHaveLength(1)
+      expect(context.catalog.items[0].priceResult.finalPrice).toBe(100)
+    })
+
+    it('catalog cache is invalidated and GM modifier is re-read on market type change', async () => {
+      const item = makeItem({ type: 'weapon', name: 'Blaster', price: 100, rarity: 0 })
+      item.system._source = { price: 100, rarity: 0 }
+      globalThis.game.items = makeItemsCollection([item])
+
+      let globalModifier = 0
+      globalThis.game.settings.get = vi.fn((systemId, key) => {
+        if (key === 'marketGlobalPriceModifier') return globalModifier
+        if (key === 'marketTypeModifiers') return JSON.stringify({})
+        if (key === 'marketEnabledSources') return JSON.stringify(['compendium', 'world', 'import'])
+        if (key === 'marketAllowedItemTypes') return JSON.stringify(['weapon', 'armor', 'gear'])
+        if (key === 'marketDedupStrategy') return 'prefer-compendium'
+        if (key === 'marketExcludedItems') return JSON.stringify([])
+        return undefined
+      })
+
+      const app = new MarketApplicationV2()
+
+      // First render: modifier=0 → price=100
+      const ctx1 = await app._preparePartContext('catalog', {})
+      expect(ctx1.catalog.items[0].priceResult.finalPrice).toBe(100)
+
+      // Change modifier to +20 and invalidate cache (simulates GM changing configuration)
+      globalModifier = 20
+      app._catalogCache = null
+
+      // Second render: modifier=20 → price=120
+      const ctx2 = await app._preparePartContext('catalog', {})
+      expect(ctx2.catalog.items[0].priceResult.finalPrice).toBe(120)
+    })
+  })
+
+  /* -------------------------------------------- */
   /*  openItem action                             */
   /* -------------------------------------------- */
 

--- a/tests/lib/market/market-entry.test.mjs
+++ b/tests/lib/market/market-entry.test.mjs
@@ -179,6 +179,74 @@ describe('createMarketEntry', () => {
     })
   })
 
+  describe('priceOptions forwarding (GM modifiers)', () => {
+    test('applies globalModifier from priceOptions', () => {
+      // base=100, rarity=0, globalModifier=20 → 100 * (1 + 0.2) = 120
+      const entry = createMarketEntry(makeRawItem({ basePrice: 100, rarity: 0, restrictionLevel: 'none' }), validSourceInfo, {}, { globalModifier: 20 })
+      expect(entry.priceResult.finalPrice).toBe(120)
+    })
+
+    test('applies negative globalModifier from priceOptions', () => {
+      // base=100, rarity=0, globalModifier=-10 → 100 * (1 - 0.1) = 90
+      const entry = createMarketEntry(makeRawItem({ basePrice: 100, rarity: 0, restrictionLevel: 'none' }), validSourceInfo, {}, { globalModifier: -10 })
+      expect(entry.priceResult.finalPrice).toBe(90)
+    })
+
+    test('applies typeModifier for matching item type', () => {
+      // base=100, rarity=0, weapon typeModifier=0.1 → 100 * (1 + 0.1) = 110
+      const entry = createMarketEntry(
+        makeRawItem({ type: 'weapon', basePrice: 100, rarity: 0, restrictionLevel: 'none' }),
+        validSourceInfo,
+        {},
+        { typeModifiers: { weapon: { priceModifier: 0.1 } } },
+      )
+      expect(entry.priceResult.finalPrice).toBe(110)
+    })
+
+    test('does not apply typeModifier for non-matching item type', () => {
+      // base=100, rarity=0, weapon typeModifier=0.5, but item is armor → no change
+      const entry = createMarketEntry(
+        makeRawItem({ type: 'armor', basePrice: 100, rarity: 0, restrictionLevel: 'none' }),
+        validSourceInfo,
+        {},
+        { typeModifiers: { weapon: { priceModifier: 0.5 } } },
+      )
+      expect(entry.priceResult.finalPrice).toBe(100)
+    })
+
+    test('stacks globalModifier and typeModifier together', () => {
+      // base=100, rarity=0, globalModifier=10(+0.1) + weapon typeModifier=0.1 → 100 * (1 + 0.2) = 120
+      const entry = createMarketEntry(
+        makeRawItem({ type: 'weapon', basePrice: 100, rarity: 0, restrictionLevel: 'none' }),
+        validSourceInfo,
+        {},
+        { globalModifier: 10, typeModifiers: { weapon: { priceModifier: 0.1 } } },
+      )
+      expect(entry.priceResult.finalPrice).toBe(120)
+    })
+
+    test('priceResult.finalPrice is same as without options when priceOptions is empty', () => {
+      const raw = makeRawItem({ basePrice: 100, rarity: 0, restrictionLevel: 'none' })
+      const withoutOptions = createMarketEntry(raw, validSourceInfo)
+      const withEmptyOptions = createMarketEntry(raw, validSourceInfo, {}, {})
+      expect(withoutOptions.priceResult.finalPrice).toBe(withEmptyOptions.priceResult.finalPrice)
+    })
+
+    test('typeModifier appears in modifiers array with label "marketType"', () => {
+      // The type modifier is combined into the marketTypeModifier slot in pricing.mjs,
+      // so it appears under the "marketType" label in the breakdown.
+      const entry = createMarketEntry(
+        makeRawItem({ type: 'weapon', basePrice: 100, rarity: 0, restrictionLevel: 'none' }),
+        validSourceInfo,
+        {},
+        { typeModifiers: { weapon: { priceModifier: 0.15 } } },
+      )
+      const step = entry.priceResult.modifiers.find((m) => m.label === 'marketType')
+      expect(step).toBeDefined()
+      expect(step.modifier).toBeCloseTo(0.15)
+    })
+  })
+
   describe('name normalization', () => {
     test('preserves valid name', () => {
       const entry = createMarketEntry(makeRawItem({ name: 'Vibroblade' }), validSourceInfo)


### PR DESCRIPTION
## Summary

- Intègre les modificateurs globaux et par type dans l'affichage des prix du marché.
- Met à jour module/lib/market et l'application market pour calculer et afficher ces modificateurs.
- Ajoute des tests unitaires pour market-application et market-entry et un fichier de plan de documentation.

## Context

- Diff vs develop : ajout de la logique d'agrégation des modificateurs côté catalogue/market-entry et adaptation de l'UI `market-application`.
- Documentation : plan d'implémentation ajouté sous documentation/plan/market/.

## Tests

- Not run (not requested).

## Notes

- Fichiers ajoutés / mis à jour : module/lib/market/catalog-loader.mjs, module/lib/market/market-entry.mjs, module/applications/market/market-application.mjs, tests/...  
- Aucune action destructive ou force-push nécessaire ; la branche est déjà poussée sur origin.
