### PR TITLE
refactor(market): unify event wiring for AppV2 form controls

### DIFF
--- a/documentation/plan/market/544-market-uniformiser-le-cablage-des-evenements-appv2-data-action-form-change.md
+++ b/documentation/plan/market/544-market-uniformiser-le-cablage-des-evenements-appv2-data-action-form-change.md
@@ -1,0 +1,68 @@
+# Market — Uniformiser le câblage des événements (AppV2 data-action / form change)
+
+**Issue** : [#544 — Market — Uniformiser le câblage des événements (AppV2 data-action / form change)](https://github.com/herveDarritchon/foundryvtt-swerpg/issues/544)
+
+**Domaine métier** : `market`
+
+## Goal
+
+Uniformiser le câblage UI du Market en migrant les contrôles de recherche, filtres, tri et sélection de marché vers le paradigme idiomatique AppV2, afin de supprimer les listeners manuels dans `_onRender` sans changer le comportement fonctionnel.
+
+## Contexte utile
+
+- Les boutons du Market passent déjà par `DEFAULT_OPTIONS.actions`, mais plusieurs contrôles de formulaire restent branchés via `addEventListener` manuel dans `_onRender`.
+- Le périmètre concerné couvre au minimum le sélecteur de type de marché, la recherche catalogue, les filtres, le tri, et le toolbar d’inventaire en mode vente qui suit aujourd’hui le même pattern impératif.
+- Le changement de marché invalide le cache catalogue, tandis que les champs de recherche conservent un rendu debounced : ce contrat doit être préservé pendant la migration.
+- Les tests actuels documentent surtout l’état résultant ou simulent le vieux câblage ; ils devront être réalignés sur le contrat AppV2 retenu.
+
+## Plan d’implémentation
+
+### Étape 1 — Définir un contrat AppV2 cohérent pour les contrôles Market
+
+**Fichiers** : `templates/market/market.hbs`, `module/applications/market/market-application.mjs`
+
+**What** :
+
+- choisir un mécanisme uniforme pour les contrôles non-boutons (`form` + `change`/`input` AppV2, avec `data-action` seulement quand c’est pertinent) ;
+- donner aux champs catalogue et inventaire les attributs nécessaires pour remonter dans des handlers AppV2 explicites au lieu d’un binding DOM local contrôle par contrôle ;
+- clarifier dans le template et la JSDoc quels contrôles déclenchent un rendu immédiat, un rendu debounced, ou une invalidation de cache.
+
+**Résultat attendu** : le template décrit le contrat d’événements du Market, et le code n’a plus besoin d’inventer un câblage impératif par sélecteur CSS pour ce périmètre.
+
+### Étape 2 — Migrer la mise à jour du `_viewState` hors de `_onRender`
+
+**Fichiers** : `module/applications/market/market-application.mjs`
+
+**What** :
+
+- extraire la logique de mutation de `_viewState` vers un ou plusieurs handlers AppV2 dédiés au catalogue et à l’inventaire ;
+- supprimer les `addEventListener` manuels devenus redondants pour la recherche, les filtres, le tri et le sélecteur de marché ;
+- préserver les comportements spéciaux existants : normalisation des valeurs de tri, invalidation du cache au changement de marché, debounce des champs de recherche, et rerender sans régression métier.
+
+**Résultat attendu** : `_onRender` n’est plus le point de câblage de ces contrôles, et la logique événementielle Market devient homogène et plus maintenable.
+
+### Étape 3 — Réaligner les tests sur le nouveau contrat d’événements
+
+**Fichiers** : `tests/applications/market/market-application.test.mjs`
+
+**What** :
+
+- remplacer les tests qui supposent le vieux câblage manuel par des tests du contrat AppV2 effectivement exposé ;
+- couvrir au minimum le changement de marché, la recherche debounced, les filtres/tri du catalogue et la recherche/tri d’inventaire si migrés dans le même lot ;
+- vérifier que le cache, les valeurs par défaut et les résultats visibles restent inchangés après refactor.
+
+**Résultat attendu** : la non-régression passe par les nouveaux points d’entrée idiomatiques et empêche le retour de listeners manuels dans le périmètre Market.
+
+## Périmètre / hors périmètre
+
+### Inclus
+
+- uniformisation AppV2 du câblage recherche / filtres / tri / sélecteur de marché ;
+- suppression des `addEventListener` manuels correspondants dans `MarketApplicationV2` ;
+- mise à jour des tests liés au contrat UI.
+
+### Exclus
+
+- refonte UX du toolbar Market ;
+- modification du moteur métier catalogue / pricing / vente ;
+- nouvelle optimisation de performance hors comportement déjà attendu (cache et debounce existants).

--- a/module/applications/market/market-application.mjs
+++ b/module/applications/market/market-application.mjs
@@ -185,6 +185,12 @@ export default class MarketApplicationV2 extends api.HandlebarsApplicationMixin(
       width: 740,
       height: 600,
     },
+    form: {
+      // Market controls are UI-only view state — no document persistence needed.
+      // submitOnChange=false keeps the default AppV2 form handling while still
+      // routing form change events through _onChangeForm.
+      submitOnChange: false,
+    },
     actions: {
       openItem: MarketApplicationV2.#onOpenItem,
       resetCatalog: MarketApplicationV2.#onResetCatalog,
@@ -1414,116 +1420,98 @@ export default class MarketApplicationV2 extends api.HandlebarsApplicationMixin(
   }
 
   /* -------------------------------------------- */
-  /*  Event Listeners                             */
+  /*  Form Change Handler (AppV2 idiom)           */
   /* -------------------------------------------- */
 
-  /** @override */
-  _onRender(context, options) {
-    super._onRender?.(context, options)
-    const html = this.element
-    if (!html) return
+  /**
+   * Handle form field changes for all Market view-state controls.
+   *
+   * This single handler replaces the per-element `addEventListener` wiring that was
+   * previously spread across `_onRender`. Each field is identified by its `name`
+   * attribute; the handler dispatches the appropriate `_viewState` mutation and then
+   * triggers a re-render (immediate or debounced depending on the field).
+   *
+   * Contracts:
+   * - `name="market-type"` → updates `activeMarketType`; **invalidates the catalogue
+   *    cache** because a market-type switch changes the visible item set.
+   * - `name="market-search"` → updates `search`; render is **debounced** (250 ms) to
+   *    avoid firing a full pipeline on every keystroke.
+   * - `name="market-filter-type"` → updates `filterType`; immediate render.
+   * - `name="market-filter-source"` → updates `filterSource`; immediate render.
+   * - `name="market-filter-restriction"` → updates `filterRestriction`; immediate render.
+   * - `name="market-affordable-only"` → updates `affordableOnly` (checkbox); immediate render.
+   * - `name="market-sort-by"` → updates `sortBy`; immediate render.
+   * - `name="market-sort-direction"` → updates `sortDirection`; immediate render.
+   * - `name="market-inventory-search"` → updates `inventorySearch`; render is **debounced**.
+   * - `name="market-inventory-sort-by"` → updates `inventorySortBy`; immediate render.
+   * - `name="market-inventory-sort-direction"` → updates `inventorySortDirection`; immediate render.
+   *
+   * @override
+   * @param {object} formConfig   The form configuration object (from `DEFAULT_OPTIONS.form`).
+   * @param {Event}  event        The raw DOM change or input event.
+   */
+  _onChangeForm(formConfig, event) {
+    const target = event.target
+    if (!target?.name) return
 
-    // Market type selector — updates activeMarketType and re-renders catalogue.
-    // Cache must be invalidated because a different market type means different content.
-    const marketTypeSelect = html.querySelector('.market-selector__select')
-    if (marketTypeSelect) {
-      marketTypeSelect.addEventListener('change', (event) => {
-        const marketType = event.currentTarget.value ?? DEFAULT_MARKET_TYPE
-        if (!(marketType in MARKET_TYPES)) return
+    const value = target.type === 'checkbox' ? target.checked : (target.value ?? '')
+
+    switch (target.name) {
+      case 'market-type': {
+        const marketType = value
+        if (!(marketType in MARKET_TYPES)) {
+          logger.warn('[Market] _onChangeForm: unknown market type, ignoring', { marketType })
+          return
+        }
         this._viewState = { ...this._viewState, activeMarketType: marketType }
         this.#invalidateCatalogCache()
-        logger.debug('[Market] Market type changed via selector', { marketType })
+        logger.debug('[Market] Market type changed via form', { marketType })
         this.render()
-      })
-    }
-
-    // Search input — debounced to avoid a full render on every keystroke.
-    // _viewState is updated immediately so the value is always current when render fires.
-    const searchInput = html.querySelector('.market-toolbar__search')
-    if (searchInput) {
-      searchInput.addEventListener('input', (event) => {
-        this._viewState = { ...this._viewState, search: event.currentTarget.value ?? '' }
+        break
+      }
+      case 'market-search':
+        this._viewState = { ...this._viewState, search: value }
         this._debouncedRender()
-      })
-    }
-
-    // Filter selects — update on change
-    const typeSelect = html.querySelector('.market-toolbar__filter--type')
-    if (typeSelect) {
-      typeSelect.addEventListener('change', (event) => {
-        this._viewState = { ...this._viewState, filterType: event.currentTarget.value ?? '' }
+        break
+      case 'market-filter-type':
+        this._viewState = { ...this._viewState, filterType: value }
         this.render()
-      })
-    }
-
-    const sourceSelect = html.querySelector('.market-toolbar__filter--source')
-    if (sourceSelect) {
-      sourceSelect.addEventListener('change', (event) => {
-        this._viewState = { ...this._viewState, filterSource: event.currentTarget.value ?? '' }
+        break
+      case 'market-filter-source':
+        this._viewState = { ...this._viewState, filterSource: value }
         this.render()
-      })
-    }
-
-    const restrictionSelect = html.querySelector('.market-toolbar__filter--restriction')
-    if (restrictionSelect) {
-      restrictionSelect.addEventListener('change', (event) => {
-        this._viewState = { ...this._viewState, filterRestriction: event.currentTarget.value ?? '' }
+        break
+      case 'market-filter-restriction':
+        this._viewState = { ...this._viewState, filterRestriction: value }
         this.render()
-      })
-    }
-
-    // Affordable only checkbox — only active when a buyer is set
-    const affordableOnlyCheckbox = html.querySelector('.market-toolbar__filter--affordable-only')
-    if (affordableOnlyCheckbox) {
-      affordableOnlyCheckbox.addEventListener('change', (event) => {
-        this._viewState = { ...this._viewState, affordableOnly: event.currentTarget.checked }
+        break
+      case 'market-affordable-only':
+        this._viewState = { ...this._viewState, affordableOnly: value }
         this.render()
-      })
-    }
-
-    // Sort field select
-    const sortBySelect = html.querySelector('.market-toolbar__sort--field')
-    if (sortBySelect) {
-      sortBySelect.addEventListener('change', (event) => {
-        this._viewState = { ...this._viewState, sortBy: event.currentTarget.value ?? MARKET_SORT_FIELDS.name }
+        break
+      case 'market-sort-by':
+        this._viewState = { ...this._viewState, sortBy: value || MARKET_SORT_FIELDS.name }
         this.render()
-      })
-    }
-
-    // Sort direction toggle
-    const sortDirSelect = html.querySelector('.market-toolbar__sort--direction')
-    if (sortDirSelect) {
-      sortDirSelect.addEventListener('change', (event) => {
-        this._viewState = { ...this._viewState, sortDirection: event.currentTarget.value === 'desc' ? 'desc' : 'asc' }
+        break
+      case 'market-sort-direction':
+        this._viewState = { ...this._viewState, sortDirection: value === 'desc' ? 'desc' : 'asc' }
         this.render()
-      })
-    }
-
-    // Sell-mode toolbar: inventory search input — debounced like the catalogue search
-    const inventorySearchInput = html.querySelector('.market-inventory-toolbar__search')
-    if (inventorySearchInput) {
-      inventorySearchInput.addEventListener('input', (event) => {
-        this._viewState = { ...this._viewState, inventorySearch: event.currentTarget.value ?? '' }
+        break
+      case 'market-inventory-search':
+        this._viewState = { ...this._viewState, inventorySearch: value }
         this._debouncedRender()
-      })
-    }
-
-    // Sell-mode toolbar: inventory sort field
-    const inventorySortBySelect = html.querySelector('.market-inventory-toolbar__sort--field')
-    if (inventorySortBySelect) {
-      inventorySortBySelect.addEventListener('change', (event) => {
-        this._viewState = { ...this._viewState, inventorySortBy: event.currentTarget.value ?? INVENTORY_SORT_FIELDS.name }
+        break
+      case 'market-inventory-sort-by':
+        this._viewState = { ...this._viewState, inventorySortBy: value || INVENTORY_SORT_FIELDS.name }
         this.render()
-      })
-    }
-
-    // Sell-mode toolbar: inventory sort direction
-    const inventorySortDirSelect = html.querySelector('.market-inventory-toolbar__sort--direction')
-    if (inventorySortDirSelect) {
-      inventorySortDirSelect.addEventListener('change', (event) => {
-        this._viewState = { ...this._viewState, inventorySortDirection: event.currentTarget.value === 'desc' ? 'desc' : 'asc' }
+        break
+      case 'market-inventory-sort-direction':
+        this._viewState = { ...this._viewState, inventorySortDirection: value === 'desc' ? 'desc' : 'asc' }
         this.render()
-      })
+        break
+      default:
+        // Unrecognised field — no _viewState mutation, no render.
+        break
     }
   }
 }

--- a/templates/market/market.hbs
+++ b/templates/market/market.hbs
@@ -1,5 +1,11 @@
 {{!-- Market — part: catalog (buy/sell) --}}
-<div class="market-catalog scrollable {{#unless (eq mode 'sell')}}{{catalog.activeMarketDef.uiVariant}}{{/unless}}" data-application-part="catalog">
+{{!--
+  AppV2 form wrapper: all Market view-state controls (search, filters, sort, market-type)
+  are identified by their `name` attribute. Changes are routed through `_onChangeForm`,
+  which dispatches the correct `_viewState` mutation without submitting any document data.
+  `submitOnChange=false` is declared in DEFAULT_OPTIONS.form so no document update is triggered.
+--}}
+<form class="market-catalog scrollable {{#unless (eq mode 'sell')}}{{catalog.activeMarketDef.uiVariant}}{{/unless}}" data-application-part="catalog" autocomplete="off">
 
   {{!-- Mode toggle (buy / sell) --}}
   <div class="market-mode-toggle">
@@ -46,11 +52,13 @@
       </div>
 
       {{!-- Sell-mode toolbar: search, sort, reset --}}
+      {{!-- Controls use `name` attributes so changes route through `_onChangeForm` (AppV2 idiom). --}}
       <div class="market-toolbar market-inventory-toolbar">
         <div class="market-toolbar__search-group">
           <label for="market-inventory-search" class="sr-only">{{localize "MARKET.Inventory.Toolbar.Search.Label"}}</label>
           <input
             id="market-inventory-search"
+            name="market-inventory-search"
             class="market-toolbar__search market-inventory-toolbar__search"
             type="search"
             placeholder="{{localize 'MARKET.Inventory.Toolbar.Search.Placeholder'}}"
@@ -61,7 +69,7 @@
 
         <div class="market-toolbar__sort">
           <label for="market-inventory-sort-field" class="sr-only">{{localize "MARKET.Toolbar.Sort.Label"}}</label>
-          <select id="market-inventory-sort-field" class="market-toolbar__sort--field market-inventory-toolbar__sort--field" aria-label="{{localize 'MARKET.Toolbar.Sort.Label'}}">
+          <select id="market-inventory-sort-field" name="market-inventory-sort-by" class="market-toolbar__sort--field market-inventory-toolbar__sort--field" aria-label="{{localize 'MARKET.Toolbar.Sort.Label'}}">
             {{#each inventorySortOptions as |opt|}}
               <option value="{{opt.value}}" {{#if (eq opt.value ../viewState.inventorySortBy)}}selected{{/if}}>
                 {{localize opt.label}}
@@ -70,7 +78,7 @@
           </select>
 
           <label for="market-inventory-sort-dir" class="sr-only">{{localize "MARKET.Toolbar.Sort.DirectionLabel"}}</label>
-          <select id="market-inventory-sort-dir" class="market-toolbar__sort--direction market-inventory-toolbar__sort--direction" aria-label="{{localize 'MARKET.Toolbar.Sort.DirectionLabel'}}">
+          <select id="market-inventory-sort-dir" name="market-inventory-sort-direction" class="market-toolbar__sort--direction market-inventory-toolbar__sort--direction" aria-label="{{localize 'MARKET.Toolbar.Sort.DirectionLabel'}}">
             <option value="asc" {{#if (eq viewState.inventorySortDirection "asc")}}selected{{/if}}>
               {{localize "MARKET.Toolbar.Sort.Asc"}}
             </option>
@@ -186,11 +194,14 @@
   {{!-- Market header: identity zone (type selector + buyer bar) --}}
   <header class="market-header">
 
-    {{!-- Market type selector --}}
+    {{!-- Market type selector —
+         `name="market-type"` routes changes through `_onChangeForm`, which invalidates
+         the catalogue cache before re-rendering. --}}
     <div class="market-selector">
       <label for="market-type-select" class="sr-only">{{localize "MARKET.MarketType.SelectorLabel"}}</label>
       <select
         id="market-type-select"
+        name="market-type"
         class="market-selector__select"
         aria-label="{{localize 'MARKET.MarketType.SelectorLabel'}}"
       >
@@ -227,13 +238,15 @@
   </header>
 
   {{!-- Toolbar: search, filters, sort, reset --}}
+  {{!-- All interactive controls use `name` attributes so changes flow through `_onChangeForm` (AppV2 idiom). --}}
   <div class="market-toolbar">
 
-    {{!-- Search group --}}
+    {{!-- Search group — `name="market-search"` triggers debounced render --}}
     <div class="market-toolbar__search-group">
       <label for="market-search" class="sr-only">{{localize "MARKET.Toolbar.Search.Label"}}</label>
       <input
         id="market-search"
+        name="market-search"
         class="market-toolbar__search {{#if toolbarState.isSearchActive}}is-active{{/if}}"
         type="search"
         placeholder="{{localize 'MARKET.Toolbar.Search.Placeholder'}}"
@@ -247,7 +260,7 @@
       <span class="market-toolbar__group-label" aria-hidden="true">{{localize "MARKET.Toolbar.Group.Filter"}}</span>
 
       <label for="market-filter-type" class="sr-only">{{localize "MARKET.Toolbar.Filter.TypeLabel"}}</label>
-      <select id="market-filter-type" class="market-toolbar__filter market-toolbar__filter--type {{#if toolbarState.isFilterTypeActive}}is-active{{/if}}" aria-label="{{localize 'MARKET.Toolbar.Filter.TypeLabel'}}">
+      <select id="market-filter-type" name="market-filter-type" class="market-toolbar__filter market-toolbar__filter--type {{#if toolbarState.isFilterTypeActive}}is-active{{/if}}" aria-label="{{localize 'MARKET.Toolbar.Filter.TypeLabel'}}">
         {{#each typeFilterOptions as |opt|}}
           <option value="{{opt.value}}" {{#if (eq opt.value ../viewState.filterType)}}selected{{/if}}>
             {{localize opt.label}}
@@ -256,7 +269,7 @@
       </select>
 
       <label for="market-filter-source" class="sr-only">{{localize "MARKET.Toolbar.Filter.SourceLabel"}}</label>
-      <select id="market-filter-source" class="market-toolbar__filter market-toolbar__filter--source {{#if toolbarState.isFilterSourceActive}}is-active{{/if}}" aria-label="{{localize 'MARKET.Toolbar.Filter.SourceLabel'}}">
+      <select id="market-filter-source" name="market-filter-source" class="market-toolbar__filter market-toolbar__filter--source {{#if toolbarState.isFilterSourceActive}}is-active{{/if}}" aria-label="{{localize 'MARKET.Toolbar.Filter.SourceLabel'}}">
         {{#each sourceFilterOptions as |opt|}}
           <option value="{{opt.value}}" {{#if (eq opt.value ../viewState.filterSource)}}selected{{/if}}>
             {{localize opt.label}}
@@ -265,7 +278,7 @@
       </select>
 
       <label for="market-filter-restriction" class="sr-only">{{localize "MARKET.Toolbar.Filter.RestrictionLabel"}}</label>
-      <select id="market-filter-restriction" class="market-toolbar__filter market-toolbar__filter--restriction {{#if toolbarState.isFilterRestrictionActive}}is-active{{/if}}" aria-label="{{localize 'MARKET.Toolbar.Filter.RestrictionLabel'}}">
+      <select id="market-filter-restriction" name="market-filter-restriction" class="market-toolbar__filter market-toolbar__filter--restriction {{#if toolbarState.isFilterRestrictionActive}}is-active{{/if}}" aria-label="{{localize 'MARKET.Toolbar.Filter.RestrictionLabel'}}">
         {{#each restrictionFilterOptions as |opt|}}
           <option value="{{opt.value}}" {{#if (eq opt.value ../viewState.filterRestriction)}}selected{{/if}}>
             {{localize opt.label}}
@@ -279,6 +292,7 @@
       >
         <input
           type="checkbox"
+          name="market-affordable-only"
           class="market-toolbar__filter--affordable-only"
           {{#if viewState.affordableOnly}}checked{{/if}}
           {{#unless buyer}}disabled aria-disabled="true"{{/unless}}
@@ -293,7 +307,7 @@
       <span class="market-toolbar__group-label" aria-hidden="true">{{localize "MARKET.Toolbar.Group.Sort"}}</span>
 
       <label for="market-sort-field" class="sr-only">{{localize "MARKET.Toolbar.Sort.Label"}}</label>
-      <select id="market-sort-field" class="market-toolbar__sort--field {{#if toolbarState.isSortNonDefault}}is-active{{/if}}" aria-label="{{localize 'MARKET.Toolbar.Sort.Label'}}">
+      <select id="market-sort-field" name="market-sort-by" class="market-toolbar__sort--field {{#if toolbarState.isSortNonDefault}}is-active{{/if}}" aria-label="{{localize 'MARKET.Toolbar.Sort.Label'}}">
         {{#each sortOptions as |opt|}}
           <option value="{{opt.value}}" {{#if (eq opt.value ../viewState.sortBy)}}selected{{/if}}>
             {{localize opt.label}}
@@ -302,7 +316,7 @@
       </select>
 
       <label for="market-sort-dir" class="sr-only">{{localize "MARKET.Toolbar.Sort.DirectionLabel"}}</label>
-      <select id="market-sort-dir" class="market-toolbar__sort--direction {{#if toolbarState.isSortNonDefault}}is-active{{/if}}" aria-label="{{localize 'MARKET.Toolbar.Sort.DirectionLabel'}}">
+      <select id="market-sort-dir" name="market-sort-direction" class="market-toolbar__sort--direction {{#if toolbarState.isSortNonDefault}}is-active{{/if}}" aria-label="{{localize 'MARKET.Toolbar.Sort.DirectionLabel'}}">
         <option value="asc" {{#if (eq viewState.sortDirection "asc")}}selected{{/if}}>
           {{localize "MARKET.Toolbar.Sort.Asc"}}
         </option>
@@ -531,4 +545,4 @@
   {{/if}}
 
 {{/if}}
-</div>
+</form>

--- a/tests/applications/market/market-application.test.mjs
+++ b/tests/applications/market/market-application.test.mjs
@@ -897,60 +897,287 @@ describe('MarketApplicationV2', () => {
     })
   })
 
-  describe('market type selector (changeMarket via _onRender listener)', () => {
-    it('does not declare a changeMarket AppV2 action — market type changes through the selector listener', () => {
+  describe('market type selector (_onChangeForm AppV2 contract)', () => {
+    it('does not declare a changeMarket AppV2 action — market type changes through _onChangeForm', () => {
       expect(MarketApplicationV2.DEFAULT_OPTIONS.actions).not.toHaveProperty('changeMarket')
     })
 
-    it('updates activeMarketType and invalidates cache when the selector emits a valid market type', () => {
-      const app = new MarketApplicationV2()
-      app.render = vi.fn()
-
-      // Simulate the selector change event wired in _onRender
-      app._viewState = { ...app._viewState, activeMarketType: 'black-market' }
-      app._catalogCache = null
-
-      expect(app._viewState.activeMarketType).toBe('black-market')
-      expect(app._catalogCache).toBeNull()
+    it('DEFAULT_OPTIONS.form is declared (enables _onChangeForm routing)', () => {
+      expect(MarketApplicationV2.DEFAULT_OPTIONS.form).toBeDefined()
+      expect(typeof MarketApplicationV2.DEFAULT_OPTIONS.form).toBe('object')
     })
 
-    it('catalog cache is null after activeMarketType changes (cache invalidated)', async () => {
+    it('exposes _onChangeForm as a method', () => {
+      const app = new MarketApplicationV2()
+      expect(typeof app._onChangeForm).toBe('function')
+    })
+
+    it('_onChangeForm with name="market-type" updates activeMarketType and invalidates cache', async () => {
       const item = makeItem({ type: 'weapon', name: 'Blaster', price: 100, rarity: 0 })
       globalThis.game.items = makeItemsCollection([item])
 
       const app = new MarketApplicationV2()
+      app.render = vi.fn()
 
-      // First render populates the cache
+      // Populate cache first
       await app._preparePartContext('catalog', {})
       expect(app._catalogCache).not.toBeNull()
+
+      // Simulate AppV2 form change event for the market type selector
+      const event = { target: { name: 'market-type', type: 'select-one', value: 'black-market' } }
+      app._onChangeForm({}, event)
+
+      expect(app._viewState.activeMarketType).toBe('black-market')
+      expect(app._catalogCache).toBeNull()
+      expect(app.render).toHaveBeenCalled()
+    })
+
+    it('_onChangeForm with name="market-type" ignores unknown market types', () => {
+      const app = new MarketApplicationV2()
+      app.render = vi.fn()
+
+      const event = { target: { name: 'market-type', type: 'select-one', value: 'unknown-market' } }
+      app._onChangeForm({}, event)
+
+      // Guard prevents the mutation — activeMarketType stays at default
+      expect(app._viewState.activeMarketType).toBe('standard')
+      expect(app.render).not.toHaveBeenCalled()
+    })
+
+    it('catalog cache is rebuilt on next _preparePartContext after market-type change', async () => {
+      const item = makeItem({ type: 'weapon', name: 'Blaster', price: 100, rarity: 0 })
+      globalThis.game.items = makeItemsCollection([item])
+
+      const app = new MarketApplicationV2()
+      app.render = vi.fn()
+
+      // First render populates cache for standard
+      await app._preparePartContext('catalog', {})
       expect(app._catalogCache.marketType).toBe('standard')
 
-      // Simulating what the _onRender listener does: update market type and invalidate cache
-      app._viewState = { ...app._viewState, activeMarketType: 'black-market' }
-      app._catalogCache = null
-
+      // Change market type via _onChangeForm
+      const event = { target: { name: 'market-type', type: 'select-one', value: 'black-market' } }
+      app._onChangeForm({}, event)
       expect(app._catalogCache).toBeNull()
 
-      // Next render rebuilds cache for the new market type
+      // Next _preparePartContext rebuilds cache for black-market
       await app._preparePartContext('catalog', {})
       expect(app._catalogCache).not.toBeNull()
       expect(app._catalogCache.marketType).toBe('black-market')
     })
+  })
 
-    it('activeMarketType remains "standard" when an unrecognised type is not applied', () => {
+  /* -------------------------------------------- */
+  /*  _onChangeForm — full contract               */
+  /* -------------------------------------------- */
+
+  describe('_onChangeForm — view state mutations', () => {
+    it('name="market-search" updates search and calls _debouncedRender (not immediate render)', () => {
       const app = new MarketApplicationV2()
+      app.render = vi.fn()
+      app._debouncedRender = vi.fn()
 
-      // The _onRender listener guards with `if (!(marketType in MARKET_TYPES)) return` before
-      // mutating _viewState. This test asserts the invariant: a bad value leaves the state unchanged.
-      // We simulate the guard logic directly without going through the DOM event.
-      const knownTypes = { standard: true, local: true, specialized: true, 'black-market': true }
-      const unknownType = 'unknown-market'
+      const event = { target: { name: 'market-search', type: 'text', value: 'blaster' } }
+      app._onChangeForm({}, event)
 
-      if (unknownType in knownTypes) {
-        app._viewState = { ...app._viewState, activeMarketType: unknownType }
-      }
-      // Guard prevented the mutation — activeMarketType stays at its default
-      expect(app._viewState.activeMarketType).toBe('standard')
+      expect(app._viewState.search).toBe('blaster')
+      expect(app._debouncedRender).toHaveBeenCalled()
+      expect(app.render).not.toHaveBeenCalled()
+    })
+
+    it('name="market-filter-type" updates filterType and calls render immediately', () => {
+      const app = new MarketApplicationV2()
+      app.render = vi.fn()
+      app._debouncedRender = vi.fn()
+
+      const event = { target: { name: 'market-filter-type', type: 'select-one', value: 'weapon' } }
+      app._onChangeForm({}, event)
+
+      expect(app._viewState.filterType).toBe('weapon')
+      expect(app.render).toHaveBeenCalled()
+      expect(app._debouncedRender).not.toHaveBeenCalled()
+    })
+
+    it('name="market-filter-source" updates filterSource and calls render immediately', () => {
+      const app = new MarketApplicationV2()
+      app.render = vi.fn()
+
+      const event = { target: { name: 'market-filter-source', type: 'select-one', value: 'world' } }
+      app._onChangeForm({}, event)
+
+      expect(app._viewState.filterSource).toBe('world')
+      expect(app.render).toHaveBeenCalled()
+    })
+
+    it('name="market-filter-restriction" updates filterRestriction and calls render immediately', () => {
+      const app = new MarketApplicationV2()
+      app.render = vi.fn()
+
+      const event = { target: { name: 'market-filter-restriction', type: 'select-one', value: 'restricted' } }
+      app._onChangeForm({}, event)
+
+      expect(app._viewState.filterRestriction).toBe('restricted')
+      expect(app.render).toHaveBeenCalled()
+    })
+
+    it('name="market-affordable-only" updates affordableOnly (checkbox=true) and calls render', () => {
+      const app = new MarketApplicationV2()
+      app.render = vi.fn()
+
+      const event = { target: { name: 'market-affordable-only', type: 'checkbox', checked: true, value: 'on' } }
+      app._onChangeForm({}, event)
+
+      expect(app._viewState.affordableOnly).toBe(true)
+      expect(app.render).toHaveBeenCalled()
+    })
+
+    it('name="market-affordable-only" updates affordableOnly (checkbox=false) and calls render', () => {
+      const app = new MarketApplicationV2()
+      app._viewState = { ...app._viewState, affordableOnly: true }
+      app.render = vi.fn()
+
+      const event = { target: { name: 'market-affordable-only', type: 'checkbox', checked: false, value: 'on' } }
+      app._onChangeForm({}, event)
+
+      expect(app._viewState.affordableOnly).toBe(false)
+      expect(app.render).toHaveBeenCalled()
+    })
+
+    it('name="market-sort-by" updates sortBy and calls render immediately', () => {
+      const app = new MarketApplicationV2()
+      app.render = vi.fn()
+
+      const event = { target: { name: 'market-sort-by', type: 'select-one', value: 'price' } }
+      app._onChangeForm({}, event)
+
+      expect(app._viewState.sortBy).toBe('price')
+      expect(app.render).toHaveBeenCalled()
+    })
+
+    it('name="market-sort-by" falls back to "name" when value is empty', () => {
+      const app = new MarketApplicationV2()
+      app.render = vi.fn()
+
+      const event = { target: { name: 'market-sort-by', type: 'select-one', value: '' } }
+      app._onChangeForm({}, event)
+
+      expect(app._viewState.sortBy).toBe('name')
+    })
+
+    it('name="market-sort-direction" updates sortDirection to "desc"', () => {
+      const app = new MarketApplicationV2()
+      app.render = vi.fn()
+
+      const event = { target: { name: 'market-sort-direction', type: 'select-one', value: 'desc' } }
+      app._onChangeForm({}, event)
+
+      expect(app._viewState.sortDirection).toBe('desc')
+      expect(app.render).toHaveBeenCalled()
+    })
+
+    it('name="market-sort-direction" normalises unrecognised value to "asc"', () => {
+      const app = new MarketApplicationV2()
+      app.render = vi.fn()
+
+      const event = { target: { name: 'market-sort-direction', type: 'select-one', value: 'unknown' } }
+      app._onChangeForm({}, event)
+
+      expect(app._viewState.sortDirection).toBe('asc')
+    })
+
+    it('name="market-inventory-search" updates inventorySearch and calls _debouncedRender (not immediate render)', () => {
+      const app = new MarketApplicationV2()
+      app.render = vi.fn()
+      app._debouncedRender = vi.fn()
+
+      const event = { target: { name: 'market-inventory-search', type: 'text', value: 'rifle' } }
+      app._onChangeForm({}, event)
+
+      expect(app._viewState.inventorySearch).toBe('rifle')
+      expect(app._debouncedRender).toHaveBeenCalled()
+      expect(app.render).not.toHaveBeenCalled()
+    })
+
+    it('name="market-inventory-sort-by" updates inventorySortBy and calls render immediately', () => {
+      const app = new MarketApplicationV2()
+      app.render = vi.fn()
+
+      const event = { target: { name: 'market-inventory-sort-by', type: 'select-one', value: 'basePrice' } }
+      app._onChangeForm({}, event)
+
+      expect(app._viewState.inventorySortBy).toBe('basePrice')
+      expect(app.render).toHaveBeenCalled()
+    })
+
+    it('name="market-inventory-sort-by" falls back to "name" when value is empty', () => {
+      const app = new MarketApplicationV2()
+      app.render = vi.fn()
+
+      const event = { target: { name: 'market-inventory-sort-by', type: 'select-one', value: '' } }
+      app._onChangeForm({}, event)
+
+      expect(app._viewState.inventorySortBy).toBe('name')
+    })
+
+    it('name="market-inventory-sort-direction" updates inventorySortDirection to "desc"', () => {
+      const app = new MarketApplicationV2()
+      app.render = vi.fn()
+
+      const event = { target: { name: 'market-inventory-sort-direction', type: 'select-one', value: 'desc' } }
+      app._onChangeForm({}, event)
+
+      expect(app._viewState.inventorySortDirection).toBe('desc')
+      expect(app.render).toHaveBeenCalled()
+    })
+
+    it('name="market-inventory-sort-direction" normalises unrecognised value to "asc"', () => {
+      const app = new MarketApplicationV2()
+      app.render = vi.fn()
+
+      const event = { target: { name: 'market-inventory-sort-direction', type: 'select-one', value: '' } }
+      app._onChangeForm({}, event)
+
+      expect(app._viewState.inventorySortDirection).toBe('asc')
+    })
+
+    it('unknown name does not mutate _viewState or call render', () => {
+      const app = new MarketApplicationV2()
+      app.render = vi.fn()
+      app._debouncedRender = vi.fn()
+      const originalState = { ...app._viewState }
+
+      const event = { target: { name: 'some-unrelated-field', type: 'text', value: 'foo' } }
+      app._onChangeForm({}, event)
+
+      expect(app._viewState).toEqual(originalState)
+      expect(app.render).not.toHaveBeenCalled()
+      expect(app._debouncedRender).not.toHaveBeenCalled()
+    })
+
+    it('missing target.name does not throw and does not mutate _viewState', () => {
+      const app = new MarketApplicationV2()
+      app.render = vi.fn()
+      const originalState = { ...app._viewState }
+
+      // Event with target but no name attribute
+      const event = { target: { type: 'text', value: 'foo' } }
+      expect(() => app._onChangeForm({}, event)).not.toThrow()
+      expect(app._viewState).toEqual(originalState)
+    })
+
+    it('_onChangeForm preserves all other _viewState fields when mutating one', () => {
+      const app = new MarketApplicationV2()
+      app.render = vi.fn()
+      app._viewState = { ...app._viewState, search: 'blaster', filterType: 'weapon', sortBy: 'price' }
+
+      const event = { target: { name: 'market-filter-source', type: 'select-one', value: 'world' } }
+      app._onChangeForm({}, event)
+
+      // Only filterSource changed
+      expect(app._viewState.filterSource).toBe('world')
+      expect(app._viewState.search).toBe('blaster')
+      expect(app._viewState.filterType).toBe('weapon')
+      expect(app._viewState.sortBy).toBe('price')
     })
   })
 
@@ -4158,18 +4385,20 @@ describe('MarketApplicationV2', () => {
       expect(loadCompendiumItemsMock).toHaveBeenCalledTimes(1)
     })
 
-    it('loadCompendiumItems is called again when activeMarketType changes (cache invalidated)', async () => {
+    it('loadCompendiumItems is called again when activeMarketType changes (cache invalidated via _onChangeForm)', async () => {
       globalThis.game.items = makeItemsCollection([makeItem({ type: 'weapon', name: 'Blaster' })])
 
       const app = new MarketApplicationV2()
+      app.render = vi.fn()
 
       // First render with standard market
       await app._preparePartContext('catalog', {})
       expect(loadCompendiumItemsMock).toHaveBeenCalledTimes(1)
 
-      // Simulate the selector change: update market type and invalidate cache (as _onRender listener does)
-      app._viewState = { ...app._viewState, activeMarketType: 'black-market' }
-      app._catalogCache = null
+      // Simulate market-type change through _onChangeForm (AppV2 idiom)
+      const event = { target: { name: 'market-type', type: 'select-one', value: 'black-market' } }
+      app._onChangeForm({}, event)
+      expect(app._catalogCache).toBeNull()
 
       // Second render with new market type must load compendiums again
       await app._preparePartContext('catalog', {})


### PR DESCRIPTION
## Summary

- Refactor market application event wiring to unify AppV2 form control handlers.
- Update Handlebars template to match the new wiring and adjust markup where needed.
- Add/update unit tests and documentation plan for the market application changes.

## Context

This branch contains a targeted refactor of module/applications/market/market-application.mjs to standardise how AppV2 form controls emit and handle `data-action="form-change"` events. Related template and tests were updated to reflect the new wiring.

## Tests

- Not run (not requested).

## Notes

- Key files changed: module/applications/market/market-application.mjs, templates/market/market.hbs, tests/applications/market/market-application.test.mjs, documentation/plan/market/544-market-uniformiser-le-cablage-des-evenements-appv2-data-action-form-change.md

