### PR TITLE
feat(market): align rarity source for world and compendium items

### DIFF
--- a/documentation/plan/market/545-market-aligner-la-source-de-rarity-entre-items-du-monde-et-du-compendium.md
+++ b/documentation/plan/market/545-market-aligner-la-source-de-rarity-entre-items-du-monde-et-du-compendium.md
@@ -1,0 +1,66 @@
+# Issue #545 — Market : aligner la source de rarity entre items du monde et du compendium
+
+**Issue** : https://github.com/herveDarritchon/foundryvtt-swerpg/issues/545  
+**Domaine métier** : `market`
+
+## Goal
+
+Garantir que le Market lise la rareté depuis une source canonique identique pour les items du monde et les items de compendium, afin d’éviter des écarts de prix, de tri, d’affichage et de disponibilité selon l’origine du document.
+
+## Contexte utile
+
+- `module/applications/market/market-application.mjs` convertit les items du monde via `itemToRawItem()` et lit déjà le prix depuis `system._source?.price` pour éviter les valeurs dérivées.
+- Ce même mapper lit encore `rarity` depuis `system.rarity`, alors que les items du monde peuvent exposer une valeur préparée différente de la valeur persistée.
+- `module/applications/market/compendium-source-adapter.mjs` charge les items de compendium depuis l’index Foundry, ce qui revient à consommer une valeur de rareté issue de la source persistée.
+- La rareté pilote plusieurs comportements Market : tri, pips d’affichage, disponibilité dérivée, obtainability et pricing.
+
+## Plan d’implémentation
+
+### Étape 1 — Poser un contrat unique d’extraction de la rareté Market
+
+**Fichiers** : `module/applications/market/market-application.mjs`, `module/applications/market/compendium-source-adapter.mjs`
+
+**What** :
+
+- Définir explicitement l’ordre de fallback attendu pour la rareté brute côté Market (`source persistée` puis `valeur runtime` puis `0`).
+- Aligner le mapping des items du monde sur le même principe que celui déjà appliqué au prix, pour éviter qu’un item monde utilise une valeur dérivée quand un item compendium utilise une valeur source.
+- Vérifier qu’aucun deuxième mapper Market ne reconstruit sa propre règle de lecture de `rarity` en parallèle.
+
+**Résultat attendu** : le catalogue reçoit une valeur de rareté homogène, indépendante du fait que l’item vienne du monde ou d’un compendium.
+
+### Étape 2 — Répercuter l’alignement sur le pipeline catalogue sans élargir le scope
+
+**Fichiers** : `module/applications/market/market-application.mjs`, éventuellement helper Market ciblé si une factorisation minimale évite la duplication
+
+**What** :
+
+- Faire passer toutes les entrées du catalogue par cette lecture canonique avant `loadMarketCatalog()`.
+- Vérifier le contrat des champs consommateurs déjà branchés sur `entry.rarity` : tri par rareté, `rarityPips`, availability dérivée, obtainability et pricing.
+- Limiter la tranche à l’alignement de la source de donnée ; ne pas modifier les règles métier de calcul elles-mêmes.
+
+**Résultat attendu** : les mêmes données d’entrée produisent les mêmes comportements Market quel que soit le type de source.
+
+### Étape 3 — Verrouiller la non-régression par tests ciblés
+
+**Fichiers** : `tests/applications/market/market-application.test.mjs`, tests Market ciblés supplémentaires seulement si un contrat pur doit être isolé
+
+**What** :
+
+- Ajouter un cas où un item du monde expose une différence entre `system._source.rarity` et `system.rarity`, et vérifier que le Market retient bien la valeur canonique attendue.
+- Ajouter/adapter un cas compendium équivalent pour confirmer que monde et compendium convergent vers la même rareté d’entrée.
+- Couvrir au moins un effet observable de bout en bout sur le catalogue (tri rareté, pips, prix ou disponibilité) pour éviter une correction purement cosmétique du mapper.
+
+**Résultat attendu** : la régression est capturée par des tests qui protègent explicitement l’alignement monde/compendium.
+
+## Périmètre / hors périmètre
+
+### Inclus
+
+- Alignement de la lecture de `rarity` dans les adaptateurs Market
+- Sécurisation du pipeline catalogue et des tests ciblés associés
+
+### Exclus
+
+- Refonte du moteur de pricing ou des règles d’obtainability
+- Changement du schéma item ou migration de données
+- Modifications UI autres que les effets indirects d’une rareté désormais cohérente

--- a/module/applications/market/market-application.mjs
+++ b/module/applications/market/market-application.mjs
@@ -99,7 +99,11 @@ function itemToRawItem(item) {
     // always receives the raw base price, not the post-derivation value.
     // This mirrors the pattern used by _prepareCredits() in character.mjs.
     basePrice: system._source?.price ?? system.price ?? 0,
-    rarity: system.rarity ?? 0,
+    // Read the schema source rarity (same canonical fallback as price) so that world items and
+    // compendium index entries (which expose the persisted value directly) are treated identically.
+    // A world item with a prepareDerivedData override on rarity would otherwise diverge from the
+    // compendium path, causing inconsistent sort, pips, availability and pricing.
+    rarity: system._source?.rarity ?? system.rarity ?? 0,
     quality: system.quality ?? '',
     restrictionLevel: system.restrictionLevel ?? '',
     nonPurchasable: system.nonPurchasable === true,

--- a/tests/applications/market/market-application.test.mjs
+++ b/tests/applications/market/market-application.test.mjs
@@ -2348,6 +2348,133 @@ describe('MarketApplicationV2', () => {
   })
 
   /* -------------------------------------------- */
+  /*  Canonical rarity source: world vs compendium */
+  /* -------------------------------------------- */
+
+  describe('canonical rarity source alignment — world items vs compendium items', () => {
+    it('uses system._source.rarity (not system.rarity) for a world item when both differ', async () => {
+      // Simulate a world item where prepareDerivedData has overridden system.rarity to a higher value.
+      // The Market must always use the persisted source value (system._source.rarity).
+      const item = makeItem({ type: 'weapon', name: 'Test Blaster', price: 100 })
+      // _source holds the persisted schema value (rarity=2)
+      item.system._source = { price: 100, rarity: 2 }
+      // system.rarity is overridden by prepareDerivedData to a different value (rarity=5)
+      item.system.rarity = 5
+      globalThis.game.items = makeItemsCollection([item])
+
+      const app = new MarketApplicationV2()
+      const context = await app._preparePartContext('catalog', {})
+
+      expect(context.catalog.items).toHaveLength(1)
+      // Market must retain the canonical source value, not the derived value
+      expect(context.catalog.items[0].rarity).toBe(2)
+    })
+
+    it('falls back to system.rarity when system._source.rarity is absent', async () => {
+      // World item without a _source object: fallback to system.rarity
+      const item = makeItem({ type: 'weapon', name: 'Fallback Blaster', price: 100, rarity: 3 })
+      // No _source on system — simulates an item that has never had prepareDerivedData run
+      // or a simple mock without _source.
+      item.system._source = undefined
+      globalThis.game.items = makeItemsCollection([item])
+
+      const app = new MarketApplicationV2()
+      const context = await app._preparePartContext('catalog', {})
+
+      expect(context.catalog.items).toHaveLength(1)
+      expect(context.catalog.items[0].rarity).toBe(3)
+    })
+
+    it('world item with _source.rarity=2 and compendium item with rarity=2 produce the same entry rarity', async () => {
+      // World item: _source.rarity=2, system.rarity=5 (derived override)
+      const worldItem = makeItem({ type: 'weapon', name: 'World Blaster', price: 100, rarity: 5 })
+      worldItem.system._source = { price: 100, rarity: 2 }
+      globalThis.game.items = makeItemsCollection([worldItem])
+
+      // Compendium item: index entry with system.rarity=2 (already the persisted value)
+      loadCompendiumItemsMock.mockResolvedValue([
+        {
+          uuid: 'Compendium.swerpg.items.Item.compBlaster',
+          name: 'Compendium Blaster',
+          img: '',
+          type: 'weapon',
+          basePrice: 100,
+          rarity: 2,
+          quality: '',
+          restrictionLevel: 'none',
+          nonPurchasable: false,
+          broken: false,
+          _sourceId: 'swerpg.items',
+        },
+      ])
+
+      const app = new MarketApplicationV2()
+      const context = await app._preparePartContext('catalog', {})
+
+      const worldEntry = context.catalog.items.find((e) => e.name === 'World Blaster')
+      const compendiumEntry = context.catalog.items.find((e) => e.name === 'Compendium Blaster')
+
+      expect(worldEntry).toBeDefined()
+      expect(compendiumEntry).toBeDefined()
+      // Both must expose the same canonical rarity value
+      expect(worldEntry.rarity).toBe(2)
+      expect(compendiumEntry.rarity).toBe(2)
+    })
+
+    it('rarity divergence between world and compendium is eliminated: sort by rarity treats both identically', async () => {
+      // World item: _source.rarity=2 (canonical), system.rarity=6 (derived override)
+      const worldItem = makeItem({ type: 'weapon', name: 'World Rare', price: 100, rarity: 6 })
+      worldItem.system._source = { price: 100, rarity: 2 }
+      globalThis.game.items = makeItemsCollection([worldItem])
+
+      // Compendium item at canonical rarity=5 (no override — index gives the persisted value)
+      loadCompendiumItemsMock.mockResolvedValue([
+        {
+          uuid: 'Compendium.swerpg.items.Item.compRare',
+          name: 'Compendium Rare',
+          img: '',
+          type: 'weapon',
+          basePrice: 80,
+          rarity: 5,
+          quality: '',
+          restrictionLevel: 'none',
+          nonPurchasable: false,
+          broken: false,
+          _sourceId: 'swerpg.items',
+        },
+      ])
+
+      const app = new MarketApplicationV2()
+      app._viewState = { ...app._viewState, sortBy: 'rarity', sortDirection: 'asc' }
+      const context = await app._preparePartContext('catalog', {})
+
+      const entries = context.catalog.items
+      expect(entries).toHaveLength(2)
+
+      // With canonical rarity: World=2, Compendium=5 → World comes first ascending
+      // Without the fix (using system.rarity=6 for World): World=6, Compendium=5 → Compendium first
+      expect(entries[0].name).toBe('World Rare')
+      expect(entries[0].rarity).toBe(2)
+      expect(entries[1].name).toBe('Compendium Rare')
+      expect(entries[1].rarity).toBe(5)
+    })
+
+    it('rarityPips reflect the canonical source rarity, not the derived runtime value', async () => {
+      // World item: _source.rarity=2 → expect 2 pips; system.rarity=7 would give 7 pips if wrong
+      const item = makeItem({ type: 'weapon', name: 'Pip Test', price: 100, rarity: 7 })
+      item.system._source = { price: 100, rarity: 2 }
+      globalThis.game.items = makeItemsCollection([item])
+
+      const app = new MarketApplicationV2()
+      const context = await app._preparePartContext('catalog', {})
+
+      const entry = context.catalog.items[0]
+      expect(entry.rarity).toBe(2)
+      expect(entry.rarityPips).toHaveLength(2)
+    })
+  })
+
+  /* -------------------------------------------- */
   /*  Adaptive restriction filter dropdown        */
   /* -------------------------------------------- */
 


### PR DESCRIPTION
## Summary

- Align `itemToRawItem()` to read `rarity` from `system._source?.rarity` first (persisted value) before falling back to `system.rarity`, matching the same canonical fallback pattern already used for `price`
- Eliminates divergence between world items (which could expose a `prepareDerivedData`-overridden value) and compendium index entries (which expose the persisted value directly)
- Fixes inconsistent sort, pip display, availability derivation, obtainability, and pricing when the same item exists in both sources with different derived vs persisted rarity

## Tests

- Not run (not requested by user — Vitest tests exist in the suite).

## Notes

Issue: Closes #545
