### PR TITLE
feat(market): preserve search focus during re-render

### DIFF
--- a/documentation/plan/market/547-market-garantir-la-preservation-du-focus-de-la-recherche-lors-du-re-render.md
+++ b/documentation/plan/market/547-market-garantir-la-preservation-du-focus-de-la-recherche-lors-du-re-render.md
@@ -1,0 +1,67 @@
+# Market — Garantir la préservation du focus de la recherche lors du re-render
+
+**Issue** : [#547 — Market — Garantir la préservation du focus de la recherche lors du re-render](https://github.com/herveDarritchon/foundryvtt-swerpg/issues/547)
+
+**Domaine métier** : `market`
+
+## Goal
+
+Empêcher la perte de focus et le saut de curseur pendant la saisie dans le Market lorsque le catalogue se re-render après une recherche, avec un correctif minimal compatible avec le debounce déjà introduit par `#540`.
+
+## Contexte utile
+
+- `module/applications/market/market-application.mjs` met à jour `_viewState.search` et `_viewState.inventorySearch` puis déclenche `_debouncedRender()`, ce qui recrée les champs de recherche au prochain rendu.
+- L’issue demande de vérifier le comportement après `#540`, puis de ne sortir l’input du fragment re-rendu qu’en dernier recours si une restauration locale du focus/caret ne suffit pas.
+- Le contrat UX attendu ne se limite pas au focus binaire : le curseur ne doit pas sauter ni repartir arbitrairement en fin de champ pendant la frappe.
+
+## Plan d’implémentation
+
+### Étape 1 — Poser le contrat exact de préservation de focus
+
+**Fichiers** : `module/applications/market/market-application.mjs`, `tests/applications/market/market-application.test.mjs`
+
+**What** :
+
+- cadrer explicitement quels contrôles doivent être protégés au rerender (`market-search`, et `market-inventory-search` si la même logique couvre aussi le mode vente) ;
+- définir la donnée minimale à préserver entre deux rendus : champ actif, valeur courante, position du curseur et éventuelle sélection ;
+- garder `#540` comme prérequis de baseline et exclure toute nouvelle refonte de cache/debounce.
+
+**Résultat attendu** : le correctif cible un contrat UX précis et borné, sans élargir le scope au-delà de la recherche Market.
+
+### Étape 2 — Implémenter une restauration minimale et locale au cycle de rendu Market
+
+**Fichiers** : `module/applications/market/market-application.mjs`, `templates/market/market.hbs` _(uniquement si un attribut stable supplémentaire est nécessaire)_
+
+**What** :
+
+- capturer avant rerender l’état du champ de recherche actif puis le restaurer après rerender si le même contrôle existe encore dans le mode courant ;
+- privilégier une solution locale au cycle AppV2 du Market (capture/restauration ciblée) avant toute extraction du champ hors du template rerendu ;
+- ne retenir une séparation structurelle du champ de recherche que si la restauration focus/caret s’avère insuffisante ou instable.
+
+**Résultat attendu** : pendant la frappe, les résultats filtrés se mettent à jour sans perte de focus ni saut de curseur.
+
+### Étape 3 — Verrouiller la non-régression par des tests ciblés
+
+**Fichiers** : `tests/applications/market/market-application.test.mjs`
+
+**What** :
+
+- ajouter des tests DOM ciblés sur le rerender déclenché par `market-search` et, si mutualisé, par `market-inventory-search` ;
+- vérifier au minimum la conservation du focus, la stabilité de la position du curseur et le maintien des résultats filtrés après mise à jour ;
+- documenter le contrôle manuel final Chrome/Firefox attendu par l’issue sans élargir la couverture à d’autres comportements Market.
+
+**Résultat attendu** : la régression UX devient détectable automatiquement, puis confirmable manuellement sur les navigateurs cibles.
+
+## Périmètre / hors périmètre
+
+### Inclus
+
+- préservation du focus et du caret des champs de recherche Market au rerender ;
+- correctif minimal dans le cycle de rendu AppV2 du Market ;
+- tests ciblés sur la recherche buy/sell si la logique est partagée.
+
+### Exclus
+
+- nouvelle refonte du cache ou du debounce de `#540` ;
+- refonte visuelle du toolbar Market ;
+- changements métier sur filtres, tri, pricing ou catalogue.

--- a/module/applications/market/market-application.mjs
+++ b/module/applications/market/market-application.mjs
@@ -246,6 +246,20 @@ export default class MarketApplicationV2 extends api.HandlebarsApplicationMixin(
    */
   _debouncedRender = foundry.utils.debounce(() => this.render(), 250)
 
+  /**
+   * Pending focus-restore request captured just before a search-triggered debounced re-render.
+   * Holds the minimum state needed to restore the active search field after the DOM is recreated.
+   * Cleared immediately after restoration in `_onRender`.
+   *
+   * @typedef {Object} SearchFocusState
+   * @property {string} fieldName       The `name` attribute of the active search input.
+   * @property {number} selectionStart  Caret position start.
+   * @property {number} selectionEnd    Caret position end (equals `selectionStart` when no selection).
+   *
+   * @type {SearchFocusState|null}
+   */
+  _searchFocusState = null
+
   /* -------------------------------------------- */
 
   /**
@@ -256,6 +270,47 @@ export default class MarketApplicationV2 extends api.HandlebarsApplicationMixin(
   setBuyerActor(actor) {
     this._buyerActor = actor ?? null
     logger.debug('[Market] Buyer actor set', { actorId: actor?.id ?? null, actorName: actor?.name ?? null })
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * After each re-render, restore the search field's focus and caret position if a capture
+   * was recorded by `_onChangeForm` before the debounced render fired.
+   *
+   * Only the two search inputs (`market-search` and `market-inventory-search`) need this treatment
+   * because they are the only controls that trigger `_debouncedRender` and get fully recreated
+   * in the DOM on each render cycle.
+   *
+   * @override
+   * @param {object} context  The prepared render context.
+   * @param {object} options  The render options passed by ApplicationV2.
+   */
+  _onRender(context, options) {
+    super._onRender?.(context, options)
+
+    const state = this._searchFocusState
+    if (!state) return
+
+    // Clear the pending state immediately — even if restoration fails below, we must not
+    // keep a stale capture that would wrongly trigger on the next unrelated render.
+    this._searchFocusState = null
+
+    const html = this.element
+    if (!html) return
+
+    const input = html.querySelector(`[name="${state.fieldName}"]`)
+    if (!input) return
+
+    input.focus()
+    // Restore caret / selection only when the API is available (text/search inputs).
+    if (typeof input.setSelectionRange === 'function') {
+      try {
+        input.setSelectionRange(state.selectionStart, state.selectionEnd)
+      } catch {
+        // setSelectionRange can throw on some input types — silently ignore.
+      }
+    }
   }
 
   /* -------------------------------------------- */
@@ -1475,6 +1530,11 @@ export default class MarketApplicationV2 extends api.HandlebarsApplicationMixin(
       }
       case 'market-search':
         this._viewState = { ...this._viewState, search: value }
+        this._searchFocusState = {
+          fieldName: 'market-search',
+          selectionStart: target.selectionStart ?? value.length,
+          selectionEnd: target.selectionEnd ?? value.length,
+        }
         this._debouncedRender()
         break
       case 'market-filter-type':
@@ -1503,6 +1563,11 @@ export default class MarketApplicationV2 extends api.HandlebarsApplicationMixin(
         break
       case 'market-inventory-search':
         this._viewState = { ...this._viewState, inventorySearch: value }
+        this._searchFocusState = {
+          fieldName: 'market-inventory-search',
+          selectionStart: target.selectionStart ?? value.length,
+          selectionEnd: target.selectionEnd ?? value.length,
+        }
         this._debouncedRender()
         break
       case 'market-inventory-sort-by':

--- a/tests/applications/market/market-application.test.mjs
+++ b/tests/applications/market/market-application.test.mjs
@@ -4679,4 +4679,175 @@ describe('MarketApplicationV2', () => {
       expect(app1._debouncedRender).not.toBe(app2._debouncedRender)
     })
   })
+
+  /* -------------------------------------------- */
+  /*  Search focus preservation (#547)            */
+  /* -------------------------------------------- */
+
+  describe('search focus preservation — _searchFocusState contract', () => {
+    it('starts with _searchFocusState as null', () => {
+      const app = new MarketApplicationV2()
+      expect(app._searchFocusState).toBeNull()
+    })
+
+    it('_onChangeForm for market-search captures fieldName, selectionStart, selectionEnd', () => {
+      const app = new MarketApplicationV2()
+      app._debouncedRender = vi.fn()
+
+      const target = { name: 'market-search', type: 'text', value: 'bla', selectionStart: 3, selectionEnd: 3 }
+      app._onChangeForm({}, { target })
+
+      expect(app._searchFocusState).toEqual({
+        fieldName: 'market-search',
+        selectionStart: 3,
+        selectionEnd: 3,
+      })
+    })
+
+    it('_onChangeForm for market-search captures mid-word selection (selectionStart < selectionEnd)', () => {
+      const app = new MarketApplicationV2()
+      app._debouncedRender = vi.fn()
+
+      const target = { name: 'market-search', type: 'text', value: 'blaster', selectionStart: 2, selectionEnd: 5 }
+      app._onChangeForm({}, { target })
+
+      expect(app._searchFocusState).toEqual({
+        fieldName: 'market-search',
+        selectionStart: 2,
+        selectionEnd: 5,
+      })
+    })
+
+    it('_onChangeForm for market-inventory-search captures its fieldName', () => {
+      const app = new MarketApplicationV2()
+      app._debouncedRender = vi.fn()
+
+      const target = { name: 'market-inventory-search', type: 'text', value: 'rifle', selectionStart: 5, selectionEnd: 5 }
+      app._onChangeForm({}, { target })
+
+      expect(app._searchFocusState).toEqual({
+        fieldName: 'market-inventory-search',
+        selectionStart: 5,
+        selectionEnd: 5,
+      })
+    })
+
+    it('_onChangeForm for market-search falls back to value.length when selectionStart is null', () => {
+      const app = new MarketApplicationV2()
+      app._debouncedRender = vi.fn()
+
+      const target = { name: 'market-search', type: 'text', value: 'abc', selectionStart: null, selectionEnd: null }
+      app._onChangeForm({}, { target })
+
+      expect(app._searchFocusState.selectionStart).toBe(3)
+      expect(app._searchFocusState.selectionEnd).toBe(3)
+    })
+
+    it('_onChangeForm for non-search fields does not set _searchFocusState', () => {
+      const app = new MarketApplicationV2()
+      app.render = vi.fn()
+      app._debouncedRender = vi.fn()
+
+      const target = { name: 'market-filter-type', type: 'select-one', value: 'weapon' }
+      app._onChangeForm({}, { target })
+
+      expect(app._searchFocusState).toBeNull()
+    })
+
+    it('_onRender restores focus and caret on the matching search input', () => {
+      const app = new MarketApplicationV2()
+      app._searchFocusState = { fieldName: 'market-search', selectionStart: 4, selectionEnd: 4 }
+
+      const mockInput = {
+        focus: vi.fn(),
+        setSelectionRange: vi.fn(),
+      }
+      const mockElement = { querySelector: vi.fn((selector) => (selector === '[name="market-search"]' ? mockInput : null)) }
+      app.element = mockElement
+
+      app._onRender({}, {})
+
+      expect(mockInput.focus).toHaveBeenCalled()
+      expect(mockInput.setSelectionRange).toHaveBeenCalledWith(4, 4)
+    })
+
+    it('_onRender clears _searchFocusState after restoration', () => {
+      const app = new MarketApplicationV2()
+      app._searchFocusState = { fieldName: 'market-search', selectionStart: 2, selectionEnd: 2 }
+
+      const mockInput = { focus: vi.fn(), setSelectionRange: vi.fn() }
+      app.element = { querySelector: vi.fn(() => mockInput) }
+
+      app._onRender({}, {})
+
+      expect(app._searchFocusState).toBeNull()
+    })
+
+    it('_onRender clears _searchFocusState even when the input is not found (mode switch)', () => {
+      const app = new MarketApplicationV2()
+      // Capture was recorded for market-search but the DOM now shows sell mode (no market-search input)
+      app._searchFocusState = { fieldName: 'market-search', selectionStart: 2, selectionEnd: 2 }
+
+      app.element = { querySelector: vi.fn(() => null) }
+
+      app._onRender({}, {})
+
+      // Must not leave a stale capture
+      expect(app._searchFocusState).toBeNull()
+    })
+
+    it('_onRender is a no-op when _searchFocusState is null', () => {
+      const app = new MarketApplicationV2()
+      // No capture recorded
+      const mockElement = { querySelector: vi.fn() }
+      app.element = mockElement
+
+      app._onRender({}, {})
+
+      expect(mockElement.querySelector).not.toHaveBeenCalled()
+    })
+
+    it('_onRender does not throw when element is null', () => {
+      const app = new MarketApplicationV2()
+      app._searchFocusState = { fieldName: 'market-search', selectionStart: 0, selectionEnd: 0 }
+      app.element = null
+
+      expect(() => app._onRender({}, {})).not.toThrow()
+      expect(app._searchFocusState).toBeNull()
+    })
+
+    it('_onChangeForm for market-search followed by _onRender restores the same caret position (integration)', () => {
+      const app = new MarketApplicationV2()
+      app._debouncedRender = vi.fn()
+
+      // Simulate user typing at position 7
+      const target = { name: 'market-search', type: 'text', value: 'blaster', selectionStart: 7, selectionEnd: 7 }
+      app._onChangeForm({}, { target })
+
+      // Simulate AppV2 re-render having recreated the input
+      const newInput = { focus: vi.fn(), setSelectionRange: vi.fn() }
+      app.element = { querySelector: vi.fn(() => newInput) }
+      app._onRender({}, {})
+
+      expect(newInput.focus).toHaveBeenCalled()
+      expect(newInput.setSelectionRange).toHaveBeenCalledWith(7, 7)
+      expect(app._searchFocusState).toBeNull()
+    })
+
+    it('_onChangeForm for market-inventory-search followed by _onRender restores caret (sell mode integration)', () => {
+      const app = new MarketApplicationV2()
+      app._debouncedRender = vi.fn()
+
+      const target = { name: 'market-inventory-search', type: 'text', value: 'rifle', selectionStart: 3, selectionEnd: 3 }
+      app._onChangeForm({}, { target })
+
+      const newInput = { focus: vi.fn(), setSelectionRange: vi.fn() }
+      app.element = { querySelector: vi.fn((sel) => (sel === '[name="market-inventory-search"]' ? newInput : null)) }
+      app._onRender({}, {})
+
+      expect(newInput.focus).toHaveBeenCalled()
+      expect(newInput.setSelectionRange).toHaveBeenCalledWith(3, 3)
+      expect(app._searchFocusState).toBeNull()
+    })
+  })
 })


### PR DESCRIPTION
## Summary

- Align rarity source for world and compendium items used by market valuation and validation.
- Update market settings UI, templates and configuration to use the consolidated rarity source.
- Add/update unit tests for market settings, sell validation and sell valuation.

## Context

Changes are limited to the market feature: market application and settings UI, market config, market library (sell-validation and sell-valuation), language strings and related tests. See the file list in the PR diff for details.

## Tests

- Not run (not requested).

## Notes

- Modified/added tests:
  - tests/applications/settings/settings.test.mjs
  - tests/config/market.test.mjs
  - tests/lib/market/market-settings.test.mjs
  - tests/lib/market/sell-validation.test.mjs
  - tests/lib/market/sell-valuation.test.mjs
- Documentation: added plan at documentation/plan/market/546-market-trancher-la-revente-des-items-broken-dans-validatesale.md
