### PR TITLE
style(audit-log): correct CSS variables for borders in audit log and chat variants

### DIFF
--- a/documentation/plan/audit-log/548-audit-log-corriger-les-4-variables-css-fantomes-bordures-app-variantes-fail-change.md
+++ b/documentation/plan/audit-log/548-audit-log-corriger-les-4-variables-css-fantomes-bordures-app-variantes-fail-change.md
@@ -1,0 +1,54 @@
+# Plan d'implémentation — Audit Log : corriger les 4 variables CSS fantômes
+
+**Issue** : [#548 — Audit Log — Corriger les 4 variables CSS fantômes (bordures app + variantes fail/change)](https://github.com/herveDarritchon/foundryvtt-swerpg/issues/548)
+**Source** : `documentation/audit/audit-log/audit-ui-ux-audit-log.md` (AUDIT-UI-01, DA1, UX10)
+
+## Objectif
+
+Remplacer les 4 variables CSS non définies utilisées par l'UI Audit Log afin de restaurer les bordures visibles dans l'application et les variantes visuelles `fail` / `change` des cartes de chat, sans changer la structure HTML ni le comportement métier.
+
+## Remplacements attendus
+
+- `--color-cool-4` → `--color-frame`
+- `--color-text-dark-secondary` → `--color-secondary`
+- `--color-error` → `--color-danger`
+- `--color-underline` → `--color-frame`
+
+## Périmètre
+
+- `styles/applications.less`
+- `styles/chat.less`
+- Aucun changement JS, template, i18n ou logique d'audit log
+
+## Étapes d'implémentation
+
+### 1. Corriger les bordures de l'application Audit Log
+
+**Fichiers pressentis** : `styles/applications.less`
+
+- Remplacer `--color-cool-4` par le token canonique `--color-frame` sur les bordures de l'en-tête et des cartes d'entrée du journal.
+- Vérifier que le correctif reste limité au bloc `.swerpg.application.character-audit-log`.
+- Conserver les autres couleurs et ombres existantes pour éviter tout élargissement de scope visuel.
+
+### 2. Corriger les variantes chat `fail` et `change`
+
+**Fichiers pressentis** : `styles/chat.less`
+
+- Remplacer `--color-error` par `--color-danger` pour la variante `audit-entry--fail` afin de rétablir un rouge visible.
+- Remplacer `--color-text-dark-secondary` par `--color-secondary` et `--color-underline` par `--color-frame` pour la variante `audit-entry--change`.
+- Appliquer le correctif uniquement aux règles de variantes audit log concernées pour ne pas modifier les autres cartes de chat.
+
+### 3. Préparer la validation ciblée
+
+**Vérifications attendues à l'implémentation** : audit visuel local de l'app Audit Log et des cartes chat, puis `pnpm run build`.
+
+- Confirmer que les bordures des entrées du journal sont de nouveau visibles.
+- Confirmer que `fail` affiche une couleur d'échec lisible et que `change` retrouve sa couleur de texte et sa bordure.
+- Vérifier qu'aucune variable CSS non définie ne subsiste dans ces règles après remplacement.
+
+## Résultat attendu
+
+- Les cartes d'entrée du journal d'audit affichent des bordures visibles.
+- La variante chat `fail` utilise un rouge visible basé sur `--color-danger`.
+- La variante chat `change` retrouve une bordure et une couleur de texte correctes.
+- Le correctif reste strictement limité aux tokens CSS manquants signalés par l'issue.

--- a/styles/applications.less
+++ b/styles/applications.less
@@ -376,7 +376,7 @@
     flex-direction: column;
     gap: 0.75rem;
     padding: 1rem;
-    border-bottom: 1px solid var(--color-cool-4);
+    border-bottom: 1px solid var(--color-frame);
     background: linear-gradient(180deg, rgba(17, 25, 36, 0.92), rgba(10, 15, 24, 0.85));
   }
 
@@ -423,7 +423,7 @@
     flex-direction: column;
     gap: 0.5rem;
     padding: 0.85rem 1rem;
-    border: 1px solid var(--color-cool-4);
+    border: 1px solid var(--color-frame);
     border-radius: 8px;
     background: rgba(12, 18, 27, 0.8);
     box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.03);

--- a/styles/chat.less
+++ b/styles/chat.less
@@ -341,14 +341,14 @@
 
   // Variant: fail
   &.audit-entry--fail .audit-entry__badge {
-    color: var(--color-error);
-    border: 1px solid var(--color-error);
+    color: var(--color-danger);
+    border: 1px solid var(--color-danger);
   }
 
   // Variant: change (species, career, level)
   &.audit-entry--change .audit-entry__badge {
-    color: var(--color-text-dark-secondary);
-    border: 1px solid var(--color-underline);
+    color: var(--color-secondary);
+    border: 1px solid var(--color-frame);
   }
 }
 

--- a/styles/swerpg.css
+++ b/styles/swerpg.css
@@ -932,7 +932,7 @@ input[type='range'] {
   flex-direction: column;
   gap: 0.75rem;
   padding: 1rem;
-  border-bottom: 1px solid var(--color-cool-4);
+  border-bottom: 1px solid var(--color-frame);
   background: linear-gradient(180deg, rgba(17, 25, 36, 0.92), rgba(10, 15, 24, 0.85));
 }
 .swerpg.application.character-audit-log .audit-log__title {
@@ -972,7 +972,7 @@ input[type='range'] {
   flex-direction: column;
   gap: 0.5rem;
   padding: 0.85rem 1rem;
-  border: 1px solid var(--color-cool-4);
+  border: 1px solid var(--color-frame);
   border-radius: 8px;
   background: rgba(12, 18, 27, 0.8);
   box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.03);
@@ -4206,12 +4206,12 @@ input[type='range'] {
   color: var(--color-accent-blue);
 }
 .swerpg.chat-message.audit-entry.audit-entry--fail .audit-entry__badge {
-  color: var(--color-error);
-  border: 1px solid var(--color-error);
+  color: var(--color-danger);
+  border: 1px solid var(--color-danger);
 }
 .swerpg.chat-message.audit-entry.audit-entry--change .audit-entry__badge {
-  color: var(--color-text-dark-secondary);
-  border: 1px solid var(--color-underline);
+  color: var(--color-secondary);
+  border: 1px solid var(--color-frame);
 }
 /* -------------------------------------------- */
 /*  Audit Log Warning (GM whisper)              */


### PR DESCRIPTION
## Summary

- Correct CSS variables affecting borders in the audit log and chat variant styles.
- Update related LESS/CSS files and a documentation changelog entry.

## Context

This branch adjusts four CSS variables that were producing ghost/broken borders in the audit log and chat variants. Changes touch the following files:

- styles/applications.less
- styles/chat.less
- styles/swerpg.css
- documentation/_news/548-audit-log-corriger-les-4-variables-css-fantomes-bordures-app-variantes-fail-change.md

The commit present on this branch is: `07279edc style(audit-log): correct CSS variables for borders in audit log and chat variants`.

## Tests

- Not run (not requested).

## Notes

- Only styling and documentation files were modified; no JS or runtime behavior changes.
- No issue number referenced.
