### PR TITLE
feat(audit-log): unify visual language between app and chat

### DIFF
--- a/documentation/plan/audit-log/550-audit-log-unifier-le-langage-visuel-app-et-chat-badge-prev-next-variante-avatar.md
+++ b/documentation/plan/audit-log/550-audit-log-unifier-le-langage-visuel-app-et-chat-badge-prev-next-variante-avatar.md
@@ -1,0 +1,68 @@
+# Issue #550 — Audit Log : unifier le langage visuel app ↔ chat (badge `prev→next`, variante, avatar)
+
+**Issue** : https://github.com/herveDarritchon/foundryvtt-swerpg/issues/550  
+**Domaine métier** : `audit-log`
+
+## Goal
+
+Porter dans l'application Character Audit Log les repères visuels déjà présents dans la carte de chat — avatar, variante sémantique et transition `previousValue → nextValue` — afin que l'écran de référence adopte le même langage visuel sans changer le modèle métier ni l'export CSV.
+
+## Contexte utile
+
+- L'audit design `documentation/audit/audit-log/audit-ui-ux-audit-log.md` classe ce besoin en **AUDIT-UI-03** et pointe que l'app est aujourd'hui moins expressive que le chat.
+- `templates/applications/character-audit-log.hbs` rend actuellement une entrée minimale : date, type, description et delta.
+- `templates/chat/audit-entry.hbs` et `_buildChatContext()` dans `module/utils/audit-log.mjs` portent déjà le contrat visuel cible : `actorImg`, `eventLabel`, `previousValue`, `nextValue`, `variant`, méta.
+- `buildAuditLogEntries()` dans `module/applications/character-audit-log.mjs` expose déjà le tri, le filtrage, `typeLabel`, `formattedDelta` et `deltaClass`, mais pas encore ce view-model visuel enrichi.
+
+## Plan d’implémentation
+
+### Étape 1 — Enrichir le view-model de l’application avec le contrat visuel Audit Log
+
+**Fichiers** : `module/applications/character-audit-log.mjs`, `module/utils/audit-log.mjs` _(si mutualisation minimale utile)_
+
+**What** :
+
+- Définir pour chaque entrée affichée dans l'app les champs de présentation nécessaires à la carte unifiée : `variant`, `eventLabel`, `previousValue`, `nextValue`, `actorImg`/`actorName`, présence d'un badge de transition.
+- Réutiliser autant que possible le mapping métier déjà codé par `_buildChatContext()` pour éviter une dérive app/chat sur les types `skill.*`, `species.set`, `career.set`, `advancement.level`, `item.purchase`, `item.sale`, `talent-node-*`.
+- Conserver inchangés le tri anté-chronologique, le filtrage par famille, le calcul des deltas XP/crédits et l'export CSV.
+
+**Résultat attendu** : l'app dispose d'un view-model compatible avec le langage visuel du chat, sans régression sur les données déjà exposées.
+
+### Étape 2 — Recomposer le template de l’app autour d’une carte d’entrée plus riche
+
+**Fichiers** : `templates/applications/character-audit-log.hbs`
+
+**What** :
+
+- Remplacer la ligne minimaliste actuelle par une structure qui affiche avatar, bloc méta, badge `prev→next`/`nextValue`, description et delta.
+- Appliquer une classe de variante au niveau de l'entrée (`audit-log-entry--{{entry.variant}}` ou équivalent) pour que l'app partage la même sémantique visuelle que le chat.
+- Prévoir un fallback propre pour les entrées sans `previousValue` afin d'afficher seulement le badge cible sur les cas d'ajout/retrait.
+
+**Résultat attendu** : la lecture d'une entrée dans l'app retrouve les mêmes repères visuels que dans le chat tout en conservant les informations d'audit existantes.
+
+### Étape 3 — Aligner le style app sur les variantes Audit Log et verrouiller la non-régression
+
+**Fichiers** : `styles/applications.less`, `tests/applications/character-audit-log.test.mjs`
+
+**What** :
+
+- Ajouter les styles app pour avatar, badge, flèche et variantes `add` / `remove` / `gain` / `change` / `fail` en réutilisant les tokens déjà employés côté chat.
+- Garder le delta comme information complémentaire à droite, sans casser le responsive existant de l'application.
+- Étendre les tests de `buildAuditLogEntries()` pour verrouiller les nouveaux champs de présentation sur quelques types représentatifs (`skill.train`, `species.set`, `item.purchase`, `talent-node-purchase-failed`) et prévoir une validation visuelle ciblée de l'app pendant l'implémentation.
+
+**Résultat attendu** : l'app et le chat parlent le même langage visuel, avec un contrat de présentation explicitement couvert.
+
+## Périmètre / hors périmètre
+
+### Inclus
+
+- Enrichissement visuel de l'application Audit Log
+- Réutilisation des variantes, du badge `prev→next` et de l'avatar déjà présents dans le chat
+- Non-régression du tri, des filtres et des deltas
+
+### Exclus
+
+- Refonte de la carte de chat
+- Ajout d'icônes par famille/type (`AUDIT-UI-04`)
+- Recherche, regroupement par date ou détails dépliables
+- Changement du modèle de données d'audit log ou de l'export CSV

--- a/module/applications/character-audit-log.mjs
+++ b/module/applications/character-audit-log.mjs
@@ -314,6 +314,160 @@ export function buildAuditLogDescription(entry) {
 }
 
 /**
+ * Build the visual presentation fields for a single audit log entry.
+ * Mirrors the contract of `_buildChatContext()` in `audit-log.mjs` so that the
+ * application and the chat card share the same visual language.
+ *
+ * @param {Actor|object} actor
+ * @param {object} entry  A single raw audit log entry
+ * @returns {{ variant: string, eventLabel: string, previousValue: string|null, nextValue: string, hasPreviousValue: boolean }}
+ */
+export function buildAuditLogEntryVisual(actor, entry) {
+  const type = entry.type
+  const data = entry.data ?? {}
+
+  const visual = {
+    actorImg: actor.img ?? '',
+    actorName: actor.name ?? '',
+    variant: 'change',
+    eventLabel: '',
+    previousValue: null,
+    nextValue: '',
+    hasPreviousValue: false,
+  }
+
+  switch (type) {
+    case 'skill.train': {
+      visual.eventLabel = game.i18n.localize('SWERPG.AUDIT_LOG.TYPE.SKILL_TRAIN')
+      visual.previousValue = String(data.oldRank ?? 0)
+      visual.nextValue = String(data.newRank ?? 0)
+      visual.variant = data.isFree === true ? 'gain' : 'add'
+      break
+    }
+
+    case 'skill.forget': {
+      visual.eventLabel = game.i18n.localize('SWERPG.AUDIT_LOG.TYPE.SKILL_FORGET')
+      visual.previousValue = String(data.oldRank ?? 0)
+      visual.nextValue = String(data.newRank ?? 0)
+      visual.variant = 'remove'
+      break
+    }
+
+    case 'characteristic.increase': {
+      visual.eventLabel = game.i18n.localize('SWERPG.AUDIT_LOG.TYPE.CHARACTERISTIC_INCREASE')
+      visual.previousValue = String(data.oldValue ?? 0)
+      visual.nextValue = String(data.newValue ?? 0)
+      visual.variant = 'add'
+      break
+    }
+
+    case 'xp.spend':
+    case 'xp.refund':
+    case 'xp.grant':
+    case 'xp.remove': {
+      const isGain = type === 'xp.grant' || type === 'xp.refund'
+      const labelKey =
+        type === 'xp.spend'
+          ? 'SWERPG.AUDIT_LOG.TYPE.XP_SPEND'
+          : type === 'xp.refund'
+            ? 'SWERPG.AUDIT_LOG.TYPE.XP_REFUND'
+            : type === 'xp.grant'
+              ? 'SWERPG.AUDIT_LOG.TYPE.XP_GRANT'
+              : 'SWERPG.AUDIT_LOG.TYPE.XP_REMOVE'
+      visual.eventLabel = game.i18n.localize(labelKey)
+      visual.nextValue = isGain ? `+${data.amount ?? 0} XP` : `-${data.amount ?? 0} XP`
+      visual.variant = isGain ? 'gain' : 'remove'
+      break
+    }
+
+    case 'species.set':
+    case 'career.set': {
+      const isSpecies = type === 'species.set'
+      visual.eventLabel = game.i18n.localize(isSpecies ? 'SWERPG.AUDIT_LOG.TYPE.SPECIES_SET' : 'SWERPG.AUDIT_LOG.TYPE.CAREER_SET')
+      const noneLabel = game.i18n.localize('SWERPG.AUDIT_LOG.NONE')
+      visual.previousValue = data.oldSpecies ?? data.oldCareer ?? noneLabel
+      visual.nextValue = data.newSpecies ?? data.newCareer ?? noneLabel
+      visual.variant = 'change'
+      break
+    }
+
+    case 'specialization.add':
+    case 'specialization.remove': {
+      const isAdd = type === 'specialization.add'
+      visual.eventLabel = game.i18n.localize(isAdd ? 'SWERPG.AUDIT_LOG.TYPE.SPECIALIZATION_ADD' : 'SWERPG.AUDIT_LOG.TYPE.SPECIALIZATION_REMOVE')
+      visual.nextValue = data.specializationName ?? data.specializationId ?? ''
+      visual.variant = isAdd ? 'add' : 'remove'
+      break
+    }
+
+    case 'talent.purchase': {
+      visual.eventLabel = game.i18n.localize('SWERPG.AUDIT_LOG.TYPE.TALENT_PURCHASE')
+      visual.nextValue = data.talentName ?? data.talentId ?? ''
+      visual.variant = 'add'
+      break
+    }
+
+    case 'talent-node-purchase-succeeded':
+    case 'talent-node-purchase-failed':
+    case 'talent-node-forget-succeeded':
+    case 'talent-node-forget-failed': {
+      const isSuccess = type.endsWith('succeeded')
+      const isPurchase = type.includes('purchase')
+      visual.eventLabel = game.i18n.localize(`SWERPG.AUDIT_LOG.TYPE.${type.replace(/[-.]/g, '_').toUpperCase()}`)
+      if (isSuccess) {
+        visual.nextValue = data.talentId ?? data.nodeId ?? ''
+        visual.variant = isPurchase ? 'add' : 'remove'
+      } else {
+        visual.nextValue = data.nodeId ?? ''
+        visual.variant = 'fail'
+      }
+      break
+    }
+
+    case 'talent-node-purchase': {
+      visual.eventLabel = game.i18n.localize('SWERPG.AUDIT_LOG.TYPE.TALENT_NODE_PURCHASE')
+      visual.nextValue = data.talentId ?? data.nodeId ?? ''
+      visual.variant = 'add'
+      break
+    }
+
+    case 'advancement.level': {
+      visual.eventLabel = game.i18n.localize('SWERPG.AUDIT_LOG.TYPE.ADVANCEMENT_LEVEL')
+      visual.previousValue = String(data.oldLevel ?? 0)
+      visual.nextValue = String(data.newLevel ?? 0)
+      visual.variant = 'change'
+      break
+    }
+
+    case 'item.purchase': {
+      visual.eventLabel = game.i18n.localize('SWERPG.AUDIT_LOG.TYPE.ITEM_PURCHASE')
+      visual.nextValue = `${data.itemName ?? ''} (${data.itemType ?? ''})`
+      visual.variant = 'add'
+      break
+    }
+
+    case 'item.sale': {
+      visual.eventLabel = game.i18n.localize('SWERPG.AUDIT_LOG.TYPE.ITEM_SALE')
+      visual.nextValue = `${data.itemName ?? ''} (${data.itemType ?? ''})`
+      visual.variant = 'gain'
+      break
+    }
+
+    default: {
+      const xpDelta = entry.xpDelta ?? 0
+      visual.eventLabel = game.i18n.localize('SWERPG.AUDIT_LOG.TYPE.UNKNOWN')
+      visual.nextValue = buildAuditLogDescription(entry)
+      visual.variant = xpDelta > 0 ? 'gain' : xpDelta < 0 ? 'remove' : 'change'
+      break
+    }
+  }
+
+  visual.hasPreviousValue = visual.previousValue !== null
+
+  return visual
+}
+
+/**
  * Build the display-ready audit log entries for a character.
  * @param {Actor|object} actor
  * @param {string} [filter=AUDIT_LOG_FAMILIES.all]
@@ -331,6 +485,7 @@ export function buildAuditLogEntries(actor, filter = AUDIT_LOG_FAMILIES.all) {
       const creditDelta = Number(entry.creditDelta) || 0
       const deltaValue = isCreditEntry ? creditDelta : xpDelta
       const formattedDelta = isCreditEntry ? formatAuditLogCreditDelta(creditDelta) : formatAuditLogDelta(xpDelta)
+      const visual = buildAuditLogEntryVisual(actor, entry)
 
       return {
         ...entry,
@@ -345,6 +500,7 @@ export function buildAuditLogEntries(actor, filter = AUDIT_LOG_FAMILIES.all) {
         formattedXpDelta: formatAuditLogDelta(xpDelta),
         xpDeltaClass: xpDelta > 0 ? 'is-gain' : xpDelta < 0 ? 'is-spend' : 'is-neutral',
         hasXpDelta: xpDelta !== 0,
+        ...visual,
       }
     })
     .filter((entry) => filter === AUDIT_LOG_FAMILIES.all || entry.family === filter)

--- a/styles/applications.less
+++ b/styles/applications.less
@@ -425,38 +425,115 @@
     padding: 0.85rem 1rem;
     border: 1px solid var(--color-frame);
     border-radius: 8px;
-    background: rgba(12, 18, 27, 0.8);
-    box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.03);
+    background: rgba(12, 18, 27, 0.8); // tokens-allow-raw
+    box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.03); // tokens-allow-raw
+  }
+
+  .audit-log-entry__header {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+  }
+
+  .audit-log-entry__avatar {
+    width: 36px;
+    height: 36px;
+    border-radius: 4px;
+    border: 1px solid var(--color-frame);
+    flex: none;
   }
 
   .audit-log-entry__meta {
+    flex: 1;
+    min-width: 0;
     display: flex;
-    flex-wrap: wrap;
-    justify-content: space-between;
-    gap: 0.5rem;
-    color: var(--color-secondary);
+    flex-direction: column;
+    gap: 0.1rem;
+  }
+
+  .audit-log-entry__date {
+    display: block;
+    color: var(--color-tertiary);
     font-size: var(--font-size-11);
     text-transform: uppercase;
     letter-spacing: 0.04em;
   }
 
+  .audit-log-entry__type {
+    display: block;
+    font-family: var(--font-h2);
+    font-size: var(--font-size-13);
+    color: var(--color-text);
+    line-height: 1.3;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
   .audit-log-entry__body {
     display: flex;
+    flex-direction: column;
+    gap: 0.35rem;
+  }
+
+  .audit-log-entry__change {
+    display: flex;
     align-items: center;
-    justify-content: space-between;
-    gap: 1rem;
+    gap: 0.4rem;
+    flex-wrap: wrap;
+    min-width: 0;
+  }
+
+  .audit-log-entry__previous {
+    font-family: var(--font-h1);
+    font-size: var(--font-size-11);
+    color: var(--color-text-dark-secondary, var(--color-secondary));
+    max-width: 45%;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    opacity: 0.7;
+  }
+
+  .audit-log-entry__arrow {
+    flex: none;
+    color: var(--color-secondary);
+    font-size: var(--font-size-11);
+  }
+
+  .audit-log-entry__badge {
+    font-family: var(--font-h1);
+    font-size: 1rem;
+    padding: 0.15rem 0.5rem;
+    border-radius: 3px;
+    background: var(--color-frame-bg);
+    max-width: 100%;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    min-width: 0;
   }
 
   .audit-log-entry__description {
     margin: 0;
-    color: var(--color-text);
+    font-size: var(--font-size-11);
+    color: var(--color-secondary);
+    font-style: italic;
+    word-break: break-word;
+  }
+
+  .audit-log-entry__footer {
+    display: flex;
+    justify-content: flex-end;
+    padding-top: 0.3rem;
+    border-top: 1px solid var(--color-frame);
   }
 
   .audit-log-entry__delta {
     flex: none;
-    min-width: 5rem;
     text-align: right;
     font-family: var(--font-h1);
+    font-size: var(--font-size-12);
 
     &.is-gain {
       color: var(--color-success);
@@ -471,6 +548,36 @@
     }
   }
 
+  // Variant: add (train, purchase)
+  .audit-log-entry--add .audit-log-entry__badge {
+    color: var(--color-success);
+    border: 1px solid var(--color-success);
+  }
+
+  // Variant: remove (forget, remove)
+  .audit-log-entry--remove .audit-log-entry__badge {
+    color: var(--color-box-warm-1);
+    border: 1px solid var(--color-box-warm-1);
+  }
+
+  // Variant: gain (free rank, xp gain)
+  .audit-log-entry--gain .audit-log-entry__badge {
+    color: var(--color-accent-blue);
+    border: 1px solid var(--color-accent-blue);
+  }
+
+  // Variant: fail
+  .audit-log-entry--fail .audit-log-entry__badge {
+    color: var(--color-danger);
+    border: 1px solid var(--color-danger);
+  }
+
+  // Variant: change (species, career, level)
+  .audit-log-entry--change .audit-log-entry__badge {
+    color: var(--color-secondary);
+    border: 1px solid var(--color-frame);
+  }
+
   .audit-log__empty {
     display: grid;
     flex: 1;
@@ -481,13 +588,12 @@
   }
 
   @media (max-width: 640px) {
-    .audit-log-entry__body {
+    .audit-log-entry__change {
       flex-direction: column;
       align-items: flex-start;
     }
 
     .audit-log-entry__delta {
-      min-width: auto;
       text-align: left;
     }
   }

--- a/styles/swerpg.css
+++ b/styles/swerpg.css
@@ -977,31 +977,99 @@ input[type='range'] {
   background: rgba(12, 18, 27, 0.8);
   box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.03);
 }
-.swerpg.application.character-audit-log .audit-log-entry__meta {
+.swerpg.application.character-audit-log .audit-log-entry__header {
   display: flex;
-  flex-wrap: wrap;
-  justify-content: space-between;
+  align-items: center;
   gap: 0.5rem;
-  color: var(--color-secondary);
+}
+.swerpg.application.character-audit-log .audit-log-entry__avatar {
+  width: 36px;
+  height: 36px;
+  border-radius: 4px;
+  border: 1px solid var(--color-frame);
+  flex: none;
+}
+.swerpg.application.character-audit-log .audit-log-entry__meta {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.1rem;
+}
+.swerpg.application.character-audit-log .audit-log-entry__date {
+  display: block;
+  color: var(--color-tertiary);
   font-size: var(--font-size-11);
   text-transform: uppercase;
   letter-spacing: 0.04em;
 }
+.swerpg.application.character-audit-log .audit-log-entry__type {
+  display: block;
+  font-family: var(--font-h2);
+  font-size: var(--font-size-13);
+  color: var(--color-text);
+  line-height: 1.3;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
 .swerpg.application.character-audit-log .audit-log-entry__body {
   display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+.swerpg.application.character-audit-log .audit-log-entry__change {
+  display: flex;
   align-items: center;
-  justify-content: space-between;
-  gap: 1rem;
+  gap: 0.4rem;
+  flex-wrap: wrap;
+  min-width: 0;
+}
+.swerpg.application.character-audit-log .audit-log-entry__previous {
+  font-family: var(--font-h1);
+  font-size: var(--font-size-11);
+  color: var(--color-text-dark-secondary, var(--color-secondary));
+  max-width: 45%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  opacity: 0.7;
+}
+.swerpg.application.character-audit-log .audit-log-entry__arrow {
+  flex: none;
+  color: var(--color-secondary);
+  font-size: var(--font-size-11);
+}
+.swerpg.application.character-audit-log .audit-log-entry__badge {
+  font-family: var(--font-h1);
+  font-size: 1rem;
+  padding: 0.15rem 0.5rem;
+  border-radius: 3px;
+  background: var(--color-frame-bg);
+  max-width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  min-width: 0;
 }
 .swerpg.application.character-audit-log .audit-log-entry__description {
   margin: 0;
-  color: var(--color-text);
+  font-size: var(--font-size-11);
+  color: var(--color-secondary);
+  font-style: italic;
+  word-break: break-word;
+}
+.swerpg.application.character-audit-log .audit-log-entry__footer {
+  display: flex;
+  justify-content: flex-end;
+  padding-top: 0.3rem;
+  border-top: 1px solid var(--color-frame);
 }
 .swerpg.application.character-audit-log .audit-log-entry__delta {
   flex: none;
-  min-width: 5rem;
   text-align: right;
   font-family: var(--font-h1);
+  font-size: var(--font-size-12);
 }
 .swerpg.application.character-audit-log .audit-log-entry__delta.is-gain {
   color: var(--color-success);
@@ -1012,6 +1080,26 @@ input[type='range'] {
 .swerpg.application.character-audit-log .audit-log-entry__delta.is-neutral {
   color: var(--color-secondary);
 }
+.swerpg.application.character-audit-log .audit-log-entry--add .audit-log-entry__badge {
+  color: var(--color-success);
+  border: 1px solid var(--color-success);
+}
+.swerpg.application.character-audit-log .audit-log-entry--remove .audit-log-entry__badge {
+  color: var(--color-box-warm-1);
+  border: 1px solid var(--color-box-warm-1);
+}
+.swerpg.application.character-audit-log .audit-log-entry--gain .audit-log-entry__badge {
+  color: var(--color-accent-blue);
+  border: 1px solid var(--color-accent-blue);
+}
+.swerpg.application.character-audit-log .audit-log-entry--fail .audit-log-entry__badge {
+  color: var(--color-danger);
+  border: 1px solid var(--color-danger);
+}
+.swerpg.application.character-audit-log .audit-log-entry--change .audit-log-entry__badge {
+  color: var(--color-secondary);
+  border: 1px solid var(--color-frame);
+}
 .swerpg.application.character-audit-log .audit-log__empty {
   display: grid;
   flex: 1;
@@ -1021,12 +1109,11 @@ input[type='range'] {
   text-align: center;
 }
 @media (max-width: 640px) {
-  .swerpg.application.character-audit-log .audit-log-entry__body {
+  .swerpg.application.character-audit-log .audit-log-entry__change {
     flex-direction: column;
     align-items: flex-start;
   }
   .swerpg.application.character-audit-log .audit-log-entry__delta {
-    min-width: auto;
     text-align: left;
   }
 }

--- a/templates/applications/character-audit-log.hbs
+++ b/templates/applications/character-audit-log.hbs
@@ -37,16 +37,36 @@
   {{#if hasEntries}}
     <section class='audit-log__entries'>
       {{#each entries as |entry|}}
-        <article class='audit-log-entry'>
-          <div class='audit-log-entry__meta'>
-            <span class='audit-log-entry__date'>{{entry.formattedTimestamp}}</span>
-            <span class='audit-log-entry__type'>{{entry.typeLabel}}</span>
-          </div>
+        <article class='audit-log-entry audit-log-entry--{{entry.variant}}'>
+
+          <header class='audit-log-entry__header'>
+            {{#if entry.actorImg}}
+              <img class='audit-log-entry__avatar' src='{{entry.actorImg}}' alt='{{entry.actorName}}'>
+            {{/if}}
+            <div class='audit-log-entry__meta'>
+              <span class='audit-log-entry__date'>{{entry.formattedTimestamp}}</span>
+              <span class='audit-log-entry__type'>{{entry.eventLabel}}</span>
+            </div>
+          </header>
 
           <div class='audit-log-entry__body'>
+            <div class='audit-log-entry__change'>
+              {{#if entry.hasPreviousValue}}
+                <span class='audit-log-entry__previous' title='{{entry.previousValue}}'>{{entry.previousValue}}</span>
+                <span class='audit-log-entry__arrow' aria-hidden='true'>→</span>
+              {{/if}}
+              <span class='audit-log-entry__badge' title='{{entry.nextValue}}'>{{entry.nextValue}}</span>
+            </div>
+
             <p class='audit-log-entry__description'>{{entry.description}}</p>
-            <span class='audit-log-entry__delta {{entry.deltaClass}}'>{{entry.formattedDelta}}</span>
           </div>
+
+          {{#if entry.hasDelta}}
+            <footer class='audit-log-entry__footer'>
+              <span class='audit-log-entry__delta {{entry.deltaClass}}'>{{entry.formattedDelta}}</span>
+            </footer>
+          {{/if}}
+
         </article>
       {{/each}}
     </section>

--- a/tests/applications/character-audit-log.test.mjs
+++ b/tests/applications/character-audit-log.test.mjs
@@ -927,3 +927,171 @@ describe('audit log integration: item.purchase audit → filter → CSV', () => 
     expect(entries[0].data.itemId).toBeUndefined()
   })
 })
+
+/* ============================================ */
+/*  buildAuditLogEntryVisual view-model fields  */
+/* ============================================ */
+
+describe('buildAuditLogEntryVisual', () => {
+  let buildAuditLogEntryVisual
+  let buildAuditLogEntries
+
+  const actor = {
+    id: 'actor-visual',
+    name: 'Lira Odan',
+    img: 'systems/swerpg/assets/lira.webp',
+    type: 'character',
+    isOwner: true,
+    system: {},
+    flags: { swerpg: { logs: [] } },
+    testUserPermission: vi.fn(() => true),
+  }
+
+  beforeEach(async () => {
+    setupFoundryMock({
+      translations: {
+        'SWERPG.AUDIT_LOG.TYPE.SKILL_TRAIN': 'Skill trained',
+        'SWERPG.AUDIT_LOG.TYPE.SKILL_FORGET': 'Skill forgotten',
+        'SWERPG.AUDIT_LOG.TYPE.CHARACTERISTIC_INCREASE': 'Characteristic increased',
+        'SWERPG.AUDIT_LOG.TYPE.XP_SPEND': 'XP spent',
+        'SWERPG.AUDIT_LOG.TYPE.XP_REFUND': 'XP refunded',
+        'SWERPG.AUDIT_LOG.TYPE.XP_GRANT': 'XP granted',
+        'SWERPG.AUDIT_LOG.TYPE.XP_REMOVE': 'XP removed',
+        'SWERPG.AUDIT_LOG.TYPE.SPECIES_SET': 'Species set',
+        'SWERPG.AUDIT_LOG.TYPE.CAREER_SET': 'Career set',
+        'SWERPG.AUDIT_LOG.TYPE.SPECIALIZATION_ADD': 'Specialization added',
+        'SWERPG.AUDIT_LOG.TYPE.SPECIALIZATION_REMOVE': 'Specialization removed',
+        'SWERPG.AUDIT_LOG.TYPE.TALENT_PURCHASE': 'Talent purchased',
+        'SWERPG.AUDIT_LOG.TYPE.TALENT_NODE_PURCHASE': 'Talent node purchase',
+        'SWERPG.AUDIT_LOG.TYPE.TALENT_NODE_PURCHASE_SUCCEEDED': 'Talent node purchased',
+        'SWERPG.AUDIT_LOG.TYPE.TALENT_NODE_PURCHASE_FAILED': 'Talent node purchase failed',
+        'SWERPG.AUDIT_LOG.TYPE.TALENT_NODE_FORGET_SUCCEEDED': 'Talent node forgotten',
+        'SWERPG.AUDIT_LOG.TYPE.TALENT_NODE_FORGET_FAILED': 'Talent node forget failed',
+        'SWERPG.AUDIT_LOG.TYPE.ADVANCEMENT_LEVEL': 'Level advanced',
+        'SWERPG.AUDIT_LOG.TYPE.ITEM_PURCHASE': 'Item purchased',
+        'SWERPG.AUDIT_LOG.TYPE.ITEM_SALE': 'Item sold',
+        'SWERPG.AUDIT_LOG.TYPE.UNKNOWN': 'Unknown event',
+        'SWERPG.AUDIT_LOG.NONE': 'None',
+        'SWERPG.AUDIT_LOG.FILTER.ALL': 'All',
+        'SWERPG.AUDIT_LOG.FILTER.PURCHASES': 'Purchases',
+        'SWERPG.AUDIT_LOG.FILTER.SKILLS': 'Skills',
+        'SWERPG.AUDIT_LOG.FILTER.TALENTS': 'Talents',
+        'SWERPG.AUDIT_LOG.UNKNOWN_ITEM': 'Unknown item',
+        'SWERPG.AUDIT_LOG.UNKNOWN_VALUE': 'Unknown value',
+        'SWERPG.AUDIT_LOG.UNKNOWN_SKILL': 'Unknown skill',
+        'SWERPG.AUDIT_LOG.UNKNOWN_SPECIALIZATION': 'Unknown specialization',
+        'SWERPG.AUDIT_LOG.DESCRIPTION.SKILL_TRAIN': 'Skill {skill}: rank {oldRank} -> {newRank}',
+        'SWERPG.AUDIT_LOG.DESCRIPTION.ITEM_PURCHASE': 'Purchased {itemName} ({itemType}) for {price} credits',
+        'SWERPG.AUDIT_LOG.DESCRIPTION.TALENT_NODE_PURCHASE_FAILED': 'Talent node purchase failed: {reasonCode} (node {nodeId})',
+        'SWERPG.AUDIT_LOG.DESCRIPTION.UNKNOWN': 'Unknown event ({type})',
+      },
+    })
+    ;({ buildAuditLogEntryVisual, buildAuditLogEntries } = await import('../../module/applications/character-audit-log.mjs'))
+  })
+
+  afterEach(() => {
+    vi.resetModules()
+    vi.clearAllMocks()
+    teardownFoundryMock()
+  })
+
+  it('skill.train — variant add, previousValue/nextValue as rank strings, hasPreviousValue true', () => {
+    const entry = { type: 'skill.train', data: { skillName: 'Piloting', oldRank: 1, newRank: 2, cost: 10 } }
+    const visual = buildAuditLogEntryVisual(actor, entry)
+
+    expect(visual.variant).toBe('add')
+    expect(visual.eventLabel).toBe('Skill trained')
+    expect(visual.previousValue).toBe('1')
+    expect(visual.nextValue).toBe('2')
+    expect(visual.hasPreviousValue).toBe(true)
+    expect(visual.actorImg).toBe('systems/swerpg/assets/lira.webp')
+    expect(visual.actorName).toBe('Lira Odan')
+  })
+
+  it('skill.train with isFree — variant gain', () => {
+    const entry = { type: 'skill.train', data: { skillName: 'Piloting', oldRank: 0, newRank: 1, isFree: true } }
+    const visual = buildAuditLogEntryVisual(actor, entry)
+
+    expect(visual.variant).toBe('gain')
+  })
+
+  it('species.set — variant change, previousValue and nextValue from data', () => {
+    const entry = { type: 'species.set', data: { oldSpecies: 'Human', newSpecies: 'Bothan' } }
+    const visual = buildAuditLogEntryVisual(actor, entry)
+
+    expect(visual.variant).toBe('change')
+    expect(visual.eventLabel).toBe('Species set')
+    expect(visual.previousValue).toBe('Human')
+    expect(visual.nextValue).toBe('Bothan')
+    expect(visual.hasPreviousValue).toBe(true)
+  })
+
+  it('species.set — previousValue falls back to None label when oldSpecies is absent', () => {
+    const entry = { type: 'species.set', data: { newSpecies: "Twi'lek" } }
+    const visual = buildAuditLogEntryVisual(actor, entry)
+
+    expect(visual.previousValue).toBe('None')
+    expect(visual.hasPreviousValue).toBe(true)
+  })
+
+  it('item.purchase — variant add, nextValue contains item name', () => {
+    const entry = { type: 'item.purchase', data: { itemName: 'Blaster Pistol', itemType: 'weapon', price: 100, quantity: 1 } }
+    const visual = buildAuditLogEntryVisual(actor, entry)
+
+    expect(visual.variant).toBe('add')
+    expect(visual.eventLabel).toBe('Item purchased')
+    expect(visual.nextValue).toBe('Blaster Pistol (weapon)')
+    expect(visual.hasPreviousValue).toBe(false)
+  })
+
+  it('talent-node-purchase-failed — variant fail, nextValue is nodeId', () => {
+    const entry = { type: 'talent-node-purchase-failed', data: { nodeId: 'r1c1', reasonCode: 'not-enough-xp' } }
+    const visual = buildAuditLogEntryVisual(actor, entry)
+
+    expect(visual.variant).toBe('fail')
+    expect(visual.eventLabel).toBe('Talent node purchase failed')
+    expect(visual.nextValue).toBe('r1c1')
+    expect(visual.hasPreviousValue).toBe(false)
+  })
+
+  it('buildAuditLogEntries spreads visual fields into each entry', () => {
+    const actorWithLogs = {
+      ...actor,
+      flags: {
+        swerpg: {
+          logs: [{ id: 'e1', timestamp: 100, type: 'skill.train', xpDelta: -10, data: { skillName: 'Piloting', oldRank: 1, newRank: 2, cost: 10 } }],
+        },
+      },
+    }
+
+    const entries = buildAuditLogEntries(actorWithLogs, 'all')
+    expect(entries).toHaveLength(1)
+
+    const entry = entries[0]
+    expect(entry.variant).toBe('add')
+    expect(entry.eventLabel).toBe('Skill trained')
+    expect(entry.previousValue).toBe('1')
+    expect(entry.nextValue).toBe('2')
+    expect(entry.hasPreviousValue).toBe(true)
+    expect(entry.actorImg).toBe('systems/swerpg/assets/lira.webp')
+    expect(entry.actorName).toBe('Lira Odan')
+  })
+
+  it('advancement.level — variant change, previousValue/nextValue as level strings', () => {
+    const entry = { type: 'advancement.level', data: { oldLevel: 3, newLevel: 4 } }
+    const visual = buildAuditLogEntryVisual(actor, entry)
+
+    expect(visual.variant).toBe('change')
+    expect(visual.previousValue).toBe('3')
+    expect(visual.nextValue).toBe('4')
+    expect(visual.hasPreviousValue).toBe(true)
+  })
+
+  it('talent-node-purchase-succeeded — variant add, nextValue is talentId', () => {
+    const entry = { type: 'talent-node-purchase-succeeded', data: { talentId: 'grit', specializationId: 'spec-bodyguard', cost: 10 } }
+    const visual = buildAuditLogEntryVisual(actor, entry)
+
+    expect(visual.variant).toBe('add')
+    expect(visual.nextValue).toBe('grit')
+  })
+})


### PR DESCRIPTION
## Summary

- Unify visual language between the audit-log application and the chat badge (styles + template + application code).
- Add the character audit-log application implementation and its Handlebars template.
- Include a unit test and a documentation plan for the audit-log changes.

## Context

This branch implements the audit-log UI consolidation described in documentation/plan/audit-log/550-audit-log-unifier-le-langage-visuel-app-et-chat-badge-prev-next-variante-avatar.md.

## Tests

- Not run (not requested).

## Notes

- Key files changed: module/applications/character-audit-log.mjs, templates/applications/character-audit-log.hbs, styles/applications.less, styles/swerpg.css, tests/applications/character-audit-log.test.mjs, documentation/plan/audit-log/550-audit-log-unifier-le-langage-visuel-app-et-chat-badge-prev-next-variante-avatar.md
