### PR TITLE
feat: enhance audit log family filters with counts

### DIFF
--- a/documentation/plan/audit-log/555-audit-log-compteur-ou-desactivation-des-familles-de-filtres-vides.md
+++ b/documentation/plan/audit-log/555-audit-log-compteur-ou-desactivation-des-familles-de-filtres-vides.md
@@ -1,0 +1,67 @@
+# Issue #555 — Audit Log : compteur ou désactivation des familles de filtres vides
+
+**Issue** : https://github.com/herveDarritchon/foundryvtt-swerpg/issues/555  
+**Domaine métier** : `audit-log`
+
+## Goal
+
+Rendre les filtres de familles du journal d’audit auto-explicatifs en signalant clairement les familles sans entrée, tout en conservant la consultation locale existante, le stockage des entrées et l’export CSV inchangés.
+
+## Contexte utile
+
+- `documentation/audit/audit-log/audit-ui-ux-audit-log.md` rattache ce besoin à **AUDIT-UI-10** / **UX6**.
+- `module/applications/character-audit-log.mjs` calcule déjà les entrées affichées, les filtres actifs et les compteurs globaux (`totalCount`, `filteredCount`), mais les boutons de familles n’exposent aujourd’hui ni volume ni état vide.
+- `templates/applications/character-audit-log.hbs` distingue déjà journal vide vs résultat filtré vide ; le besoin ajoute un troisième cas : famille sélectionnée sans entrée correspondante.
+- `tests/applications/character-audit-log.test.mjs` est l’ancrage naturel pour verrouiller les compteurs par famille et l’état vide informatif.
+
+## Plan d’implémentation
+
+### Étape 1 — Canoniser les compteurs et états de disponibilité par famille dans le view-model
+
+**Fichiers** : `module/applications/character-audit-log.mjs`
+
+**What** :
+
+- Étendre la préparation du contexte pour calculer, pour chaque famille, un `count` et un `isEmpty` à partir du corpus déjà filtré par recherche texte/plage de dates, mais avant application du filtre de famille actif.
+- Exposer une métadonnée homogène par bouton (`id`, `label`, `icon`, `count`, `isEmpty`, `isPressed`, `cssClass`) afin que le template n’ait pas à recalculer la disponibilité métier.
+- Définir explicitement le contrat d’état vide de famille : une famille vide reste identifiable et sa sélection doit produire un état informatif dédié, pas une liste vide silencieuse.
+
+**Résultat attendu** : l’application dispose d’une source de vérité unique pour les compteurs par famille et pour la distinction entre vide global, vide filtré et vide de famille.
+
+### Étape 2 — Brancher les compteurs/états vides sur la toolbar et le rendu Audit Log
+
+**Fichiers** : `templates/applications/character-audit-log.hbs`, `styles/applications.less`, `lang/en.json`, `lang/fr.json`
+
+**What** :
+
+- Afficher sur chaque bouton de famille un compteur lisible (badge ou suffixe) et une atténuation visuelle des familles vides sans masquer la famille ni casser la navigation existante.
+- Prévoir une sémantique accessible cohérente (`aria-label`, état visuel, éventuel `aria-disabled`) sans utiliser un `disabled` HTML dur si cela empêche de satisfaire le critère “cliquer une famille vide affiche un message informatif”.
+- Ajouter un message dédié quand la famille active ne contient aucune entrée dans le contexte courant, distinct du message “aucun résultat” lié à la recherche et du message “journal vide”.
+
+**Résultat attendu** : l’utilisateur voit immédiatement quelles familles sont disponibles et comprend pourquoi une famille donnée n’affiche rien.
+
+### Étape 3 — Verrouiller la logique de comptage et les cas limites UX
+
+**Fichiers** : `tests/applications/character-audit-log.test.mjs`
+
+**What** :
+
+- Ajouter des tests couvrant au minimum : compteurs par famille sur un journal mixte, compteurs recalculés avec recherche texte/plage de dates, sélection d’une famille vide, et maintien du rendu normal pour une famille non vide.
+- Verrouiller la distinction entre trois états : journal réellement vide, résultat filtré vide, famille active vide avec message explicatif.
+- Confirmer que le nouveau comportement reste purement côté application et n’affecte ni les entrées d’audit persistées ni l’export CSV.
+
+**Résultat attendu** : le contrat UX des filtres de familles devient stable, compréhensible et non régressif.
+
+## Périmètre / hors périmètre
+
+### Inclus
+
+- Compteurs et/ou atténuation visuelle des familles de filtres vides
+- Message informatif explicite lors de la sélection d’une famille vide
+- Prise en compte des filtres déjà existants (texte, dates) dans la disponibilité affichée
+
+### Exclus
+
+- Changement du modèle métier, du stockage `flags.swerpg.logs` ou de l’export CSV
+- Refonte des familles de filtres ou du mapping des types d’audit
+- Pagination, requêtes serveur ou modification du pipeline d’écriture du journal

--- a/lang/en.json
+++ b/lang/en.json
@@ -282,6 +282,7 @@
   "SWERPG.AUDIT_LOG.NO_PERMISSION": "You may only view the history of characters you own.",
   "SWERPG.AUDIT_LOG.EMPTY": "No entries in the history yet.",
   "SWERPG.AUDIT_LOG.EMPTY_FILTERED": "No entries match the current filters.",
+  "SWERPG.AUDIT_LOG.EMPTY_FAMILY": "No entries for this category in the current context.",
   "SWERPG.AUDIT_LOG.SEARCH.LABEL": "Search",
   "SWERPG.AUDIT_LOG.SEARCH.PLACEHOLDER": "Search entries…",
   "SWERPG.AUDIT_LOG.SEARCH.CLEAR": "Clear filters",

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -257,6 +257,7 @@
   "SWERPG.AUDIT_LOG.NO_PERMISSION": "Vous ne pouvez consulter l'historique que de vos propres personnages.",
   "SWERPG.AUDIT_LOG.EMPTY": "Aucune entrée dans l'historique pour l'instant.",
   "SWERPG.AUDIT_LOG.EMPTY_FILTERED": "Aucune entrée ne correspond aux filtres actifs.",
+  "SWERPG.AUDIT_LOG.EMPTY_FAMILY": "Aucune entrée pour cette catégorie dans le contexte actuel.",
   "SWERPG.AUDIT_LOG.SEARCH.LABEL": "Rechercher",
   "SWERPG.AUDIT_LOG.SEARCH.PLACEHOLDER": "Rechercher des entrées…",
   "SWERPG.AUDIT_LOG.SEARCH.CLEAR": "Effacer les filtres",

--- a/module/applications/character-audit-log.mjs
+++ b/module/applications/character-audit-log.mjs
@@ -707,7 +707,7 @@ function entryMatchesDateRange(entry, fromTs, toTs) {
  * @param {string} [searchOptions.query='']          Text search query (raw, will be normalized)
  * @param {string|null} [searchOptions.dateFrom=null] ISO date string (YYYY-MM-DD) for range start
  * @param {string|null} [searchOptions.dateTo=null]   ISO date string (YYYY-MM-DD) for range end
- * @returns {{ entries: Array<object>, totalCount: number, filteredCount: number }}
+ * @returns {{ entries: Array<object>, totalCount: number, filteredCount: number, familyCounts: Record<string, number> }}
  */
 export function buildAuditLogEntries(actor, family = AUDIT_LOG_FAMILIES.all, { query = '', dateFrom = null, dateTo = null } = {}) {
   const logs = foundry.utils.getProperty(actor, AUDIT_LOG_PATH) ?? []
@@ -750,14 +750,26 @@ export function buildAuditLogEntries(actor, family = AUDIT_LOG_FAMILIES.all, { q
   // For toTs, advance to end-of-day (23:59:59.999) so the date is inclusive
   const toTs = dateTo ? parseDateBound(dateTo) + 86399999 : null
 
-  const filteredEntries = allEntries.filter((entry) => {
-    if (family !== AUDIT_LOG_FAMILIES.all && entry.family !== family) return false
+  // Corpus filtered by text/date only — used to compute per-family counts independently of the active family filter.
+  const searchFilteredEntries = allEntries.filter((entry) => {
     if (!entryMatchesTextQuery(entry, normalizedQuery)) return false
     if (!entryMatchesDateRange(entry, fromTs, toTs)) return false
     return true
   })
 
-  return { entries: filteredEntries, totalCount, filteredCount: filteredEntries.length }
+  // Per-family counts within the search-filtered corpus (before applying family filter).
+  // The 'all' family count equals the total number of search-filtered entries.
+  const familyCounts = { [AUDIT_LOG_FAMILIES.all]: searchFilteredEntries.length }
+  for (const entry of searchFilteredEntries) {
+    familyCounts[entry.family] = (familyCounts[entry.family] ?? 0) + 1
+  }
+
+  const filteredEntries = searchFilteredEntries.filter((entry) => {
+    if (family !== AUDIT_LOG_FAMILIES.all && entry.family !== family) return false
+    return true
+  })
+
+  return { entries: filteredEntries, totalCount, filteredCount: filteredEntries.length, familyCounts }
 }
 
 export default class CharacterAuditLogApp extends api.HandlebarsApplicationMixin(api.DocumentSheetV2) {
@@ -814,7 +826,7 @@ export default class CharacterAuditLogApp extends api.HandlebarsApplicationMixin
   }
 
   async _prepareContext(_options) {
-    const { entries, totalCount, filteredCount } = buildAuditLogEntries(this.actor, this.filter, {
+    const { entries, totalCount, filteredCount, familyCounts } = buildAuditLogEntries(this.actor, this.filter, {
       query: this.searchQuery,
       dateFrom: this.dateFrom,
       dateTo: this.dateTo,
@@ -825,6 +837,10 @@ export default class CharacterAuditLogApp extends api.HandlebarsApplicationMixin
 
     const sections = buildAuditLogDateSections(entries)
 
+    // isActiveFamilyEmpty: true when the active family filter has no entries in the
+    // current search-filtered corpus, distinct from "no results from search" and "log is empty".
+    const isActiveFamilyEmpty = this.filter !== AUDIT_LOG_FAMILIES.all && (familyCounts[this.filter] ?? 0) === 0
+
     return {
       actor: this.actor,
       document: this.document,
@@ -834,13 +850,19 @@ export default class CharacterAuditLogApp extends api.HandlebarsApplicationMixin
       canViewAuditLog: canViewAuditLog(this.actor),
       canExport: canViewAuditLog(this.actor),
       activeFilter: this.filter,
-      filters: AUDIT_LOG_FILTER_ORDER.map((filterId) => ({
-        id: filterId,
-        label: game.i18n.localize(AUDIT_LOG_FILTER_LABELS[filterId]),
-        icon: getAuditLogFamilyIcon(filterId),
-        cssClass: filterId === this.filter ? 'is-active' : '',
-        isPressed: filterId === this.filter,
-      })),
+      filters: AUDIT_LOG_FILTER_ORDER.map((filterId) => {
+        const count = familyCounts[filterId] ?? 0
+        const isEmpty = count === 0
+        return {
+          id: filterId,
+          label: game.i18n.localize(AUDIT_LOG_FILTER_LABELS[filterId]),
+          icon: getAuditLogFamilyIcon(filterId),
+          count,
+          isEmpty,
+          cssClass: [filterId === this.filter ? 'is-active' : '', isEmpty ? 'is-empty' : ''].filter(Boolean).join(' '),
+          isPressed: filterId === this.filter,
+        }
+      }),
       searchQuery: this.searchQuery,
       dateFrom: this.dateFrom ?? '',
       dateTo: this.dateTo ?? '',
@@ -851,8 +873,10 @@ export default class CharacterAuditLogApp extends api.HandlebarsApplicationMixin
       totalCount,
       filteredCount,
       isFiltered,
+      isActiveFamilyEmpty,
       emptyLabel: game.i18n.localize('SWERPG.AUDIT_LOG.EMPTY'),
       emptyFilteredLabel: game.i18n.localize('SWERPG.AUDIT_LOG.EMPTY_FILTERED'),
+      emptyFamilyLabel: game.i18n.localize('SWERPG.AUDIT_LOG.EMPTY_FAMILY'),
     }
   }
 

--- a/styles/applications.less
+++ b/styles/applications.less
@@ -407,6 +407,10 @@
       --button-border-color: var(--color-primary);
       box-shadow: 0 0 10px rgba(79, 168, 255, 0.22); // tokens-allow-raw
     }
+
+    &.is-empty {
+      opacity: 0.45;
+    }
   }
 
   .audit-log__filter-icon {
@@ -414,6 +418,21 @@
     font-size: var(--font-size-11);
     margin-right: 0.2em;
     opacity: 0.8;
+  }
+
+  .audit-log__filter-count {
+    flex: none;
+    font-size: var(--font-size-10);
+    font-family: var(--font-h2);
+    color: var(--color-secondary);
+    background: var(--color-frame-bg);
+    border: 1px solid var(--color-frame);
+    border-radius: 2em;
+    padding: 0 0.35em;
+    min-width: 1.4em;
+    text-align: center;
+    line-height: 1.5;
+    margin-left: 0.25em;
   }
 
   .audit-log__toolbar {
@@ -506,6 +525,16 @@
   }
 
   .audit-log__empty--filtered {
+    display: grid;
+    flex: 1;
+    place-items: center;
+    padding: 2rem;
+    color: var(--color-secondary);
+    text-align: center;
+    gap: 0.5rem;
+  }
+
+  .audit-log__empty--family {
     display: grid;
     flex: 1;
     place-items: center;

--- a/styles/swerpg.css
+++ b/styles/swerpg.css
@@ -959,11 +959,28 @@ input[type='range'] {
   --button-border-color: var(--color-primary);
   box-shadow: 0 0 10px rgba(79, 168, 255, 0.22);
 }
+.swerpg.application.character-audit-log .audit-log__filter.is-empty {
+  opacity: 0.45;
+}
 .swerpg.application.character-audit-log .audit-log__filter-icon {
   flex: none;
   font-size: var(--font-size-11);
   margin-right: 0.2em;
   opacity: 0.8;
+}
+.swerpg.application.character-audit-log .audit-log__filter-count {
+  flex: none;
+  font-size: var(--font-size-10);
+  font-family: var(--font-h2);
+  color: var(--color-secondary);
+  background: var(--color-frame-bg);
+  border: 1px solid var(--color-frame);
+  border-radius: 2em;
+  padding: 0 0.35em;
+  min-width: 1.4em;
+  text-align: center;
+  line-height: 1.5;
+  margin-left: 0.25em;
 }
 .swerpg.application.character-audit-log .audit-log__toolbar {
   display: flex;
@@ -1044,6 +1061,15 @@ input[type='range'] {
   font-size: var(--font-size-11);
 }
 .swerpg.application.character-audit-log .audit-log__empty--filtered {
+  display: grid;
+  flex: 1;
+  place-items: center;
+  padding: 2rem;
+  color: var(--color-secondary);
+  text-align: center;
+  gap: 0.5rem;
+}
+.swerpg.application.character-audit-log .audit-log__empty--family {
   display: grid;
   flex: 1;
   place-items: center;

--- a/templates/applications/character-audit-log.hbs
+++ b/templates/applications/character-audit-log.hbs
@@ -13,9 +13,11 @@
           data-action='setFilter'
           data-filter='{{filter.id}}'
           aria-pressed='{{filter.isPressed}}'
+          aria-label='{{filter.label}} ({{filter.count}})'
         >
           <i class='{{filter.icon}} audit-log__filter-icon' aria-hidden='true'></i>
           {{filter.label}}
+          <span class='audit-log__filter-count' aria-hidden='true'>{{filter.count}}</span>
         </button>
       {{/each}}
     </div>
@@ -137,6 +139,11 @@
           {{/each}}
         </div>
       {{/each}}
+    </section>
+  {{else if isActiveFamilyEmpty}}
+    <section class='audit-log__empty audit-log__empty--family'>
+      <i class='fa-solid fa-filter audit-log__empty-icon' aria-hidden='true'></i>
+      <p>{{emptyFamilyLabel}}</p>
     </section>
   {{else if hasEntries}}
     <section class='audit-log__empty audit-log__empty--filtered'>

--- a/tests/applications/character-audit-log.test.mjs
+++ b/tests/applications/character-audit-log.test.mjs
@@ -1184,7 +1184,7 @@ describe('audit log filter isPressed and icon in _prepareContext', () => {
     const ctx = await app._prepareContext({})
 
     const talentsFilter = ctx.filters.find((f) => f.id === 'talents')
-    expect(talentsFilter.cssClass).toBe('is-active')
+    expect(talentsFilter.cssClass).toContain('is-active')
     expect(talentsFilter.isPressed).toBe(true)
   })
 
@@ -1972,5 +1972,338 @@ describe('buildAuditLogDateSections', () => {
     expect(ctx.sections[0].entries).toHaveLength(1)
 
     vi.useRealTimers()
+  })
+})
+
+/* ============================================ */
+/*  Per-family counts and empty family state   */
+/* ============================================ */
+
+describe('buildAuditLogEntries — familyCounts and filter isEmpty', () => {
+  let buildAuditLogEntries
+
+  const baseTranslations = {
+    'SWERPG.AUDIT_LOG.FILTER.ALL': 'All',
+    'SWERPG.AUDIT_LOG.FILTER.SKILLS': 'Skills',
+    'SWERPG.AUDIT_LOG.FILTER.TALENTS': 'Talents',
+    'SWERPG.AUDIT_LOG.FILTER.XP': 'XP',
+    'SWERPG.AUDIT_LOG.FILTER.CHARACTERISTICS': 'Characteristics',
+    'SWERPG.AUDIT_LOG.FILTER.DETAILS': 'Core choices',
+    'SWERPG.AUDIT_LOG.FILTER.ADVANCEMENT': 'Advancement',
+    'SWERPG.AUDIT_LOG.FILTER.PURCHASES': 'Purchases',
+    'SWERPG.AUDIT_LOG.FILTER.SALES': 'Sales',
+    'SWERPG.AUDIT_LOG.TYPE.SKILL_TRAIN': 'Skill purchase',
+    'SWERPG.AUDIT_LOG.TYPE.XP_GRANT': 'XP granted',
+    'SWERPG.AUDIT_LOG.TYPE.ITEM_PURCHASE': 'Item purchased',
+    'SWERPG.AUDIT_LOG.TYPE.UNKNOWN': 'Unknown event',
+    'SWERPG.AUDIT_LOG.NONE': 'None',
+    'SWERPG.AUDIT_LOG.UNKNOWN_VALUE': 'Unknown value',
+    'SWERPG.AUDIT_LOG.UNKNOWN_SKILL': 'Unknown skill',
+    'SWERPG.AUDIT_LOG.UNKNOWN_ITEM': 'Unknown item',
+    'SWERPG.AUDIT_LOG.DESCRIPTION.SKILL_TRAIN': 'Skill {skill}: rank {oldRank} -> {newRank}',
+    'SWERPG.AUDIT_LOG.DESCRIPTION.XP_GRANT': 'Granted {amount} XP',
+    'SWERPG.AUDIT_LOG.DESCRIPTION.ITEM_PURCHASE': 'Purchased {itemName} ({itemType}) for {price} credits',
+    'SWERPG.AUDIT_LOG.DESCRIPTION.UNKNOWN': 'Unknown event ({type})',
+    'SWERPG.AUDIT_LOG.VARIANT.ADD': 'Added',
+    'SWERPG.AUDIT_LOG.VARIANT.GAIN': 'Gained',
+    'SWERPG.AUDIT_LOG.VARIANT.REMOVE': 'Removed',
+    'SWERPG.AUDIT_LOG.VARIANT.CHANGE': 'Changed',
+    'SWERPG.AUDIT_LOG.VARIANT.FAIL': 'Failed',
+  }
+
+  beforeEach(async () => {
+    setupFoundryMock({ translations: baseTranslations })
+    ;({ buildAuditLogEntries } = await import('../../module/applications/character-audit-log.mjs'))
+  })
+
+  afterEach(() => {
+    vi.resetModules()
+    vi.clearAllMocks()
+    teardownFoundryMock()
+  })
+
+  function makeActorWithLogs(logs) {
+    return {
+      id: 'actor-family-counts',
+      name: 'Vara Kesh',
+      type: 'character',
+      isOwner: true,
+      system: {},
+      flags: { swerpg: { logs } },
+      testUserPermission: vi.fn(() => true),
+    }
+  }
+
+  it('familyCounts contains count per family on a mixed journal', () => {
+    const actor = makeActorWithLogs([
+      { id: 'e1', timestamp: 100, type: 'skill.train', xpDelta: -10, data: { skillName: 'Piloting', oldRank: 1, newRank: 2 } },
+      { id: 'e2', timestamp: 200, type: 'skill.train', xpDelta: -5, data: { skillName: 'Gunnery', oldRank: 0, newRank: 1 } },
+      { id: 'e3', timestamp: 300, type: 'xp.grant', xpDelta: 20, data: { amount: 20 } },
+    ])
+
+    const { familyCounts } = buildAuditLogEntries(actor, 'all')
+
+    expect(familyCounts.all).toBe(3)
+    expect(familyCounts.skills).toBe(2)
+    expect(familyCounts.xp).toBe(1)
+    // Families with no entries are absent from the counts map
+    expect(familyCounts.talents).toBeUndefined()
+  })
+
+  it('familyCounts[all] equals total entries when no text/date filter', () => {
+    const actor = makeActorWithLogs([
+      { id: 'e1', timestamp: 100, type: 'skill.train', xpDelta: -10, data: { skillName: 'Piloting', oldRank: 1, newRank: 2 } },
+      { id: 'e2', timestamp: 200, type: 'xp.grant', xpDelta: 20, data: { amount: 20 } },
+    ])
+
+    const { familyCounts, totalCount } = buildAuditLogEntries(actor, 'all')
+    expect(familyCounts.all).toBe(totalCount)
+  })
+
+  it('familyCounts is recalculated when text search reduces the corpus', () => {
+    const actor = makeActorWithLogs([
+      { id: 'e1', timestamp: 100, type: 'skill.train', xpDelta: -10, data: { skillName: 'Piloting', oldRank: 1, newRank: 2 } },
+      { id: 'e2', timestamp: 200, type: 'skill.train', xpDelta: -5, data: { skillName: 'Gunnery', oldRank: 0, newRank: 1 } },
+      { id: 'e3', timestamp: 300, type: 'xp.grant', xpDelta: 20, data: { amount: 20 } },
+    ])
+
+    // Only e1 matches "piloting"
+    const { familyCounts } = buildAuditLogEntries(actor, 'all', { query: 'piloting' })
+    expect(familyCounts.all).toBe(1)
+    expect(familyCounts.skills).toBe(1)
+    expect(familyCounts.xp).toBeUndefined()
+  })
+
+  it('familyCounts is independent of the active family filter', () => {
+    const actor = makeActorWithLogs([
+      { id: 'e1', timestamp: 100, type: 'skill.train', xpDelta: -10, data: { skillName: 'Piloting', oldRank: 1, newRank: 2 } },
+      { id: 'e2', timestamp: 200, type: 'xp.grant', xpDelta: 20, data: { amount: 20 } },
+    ])
+
+    // When viewing skills only, familyCounts still reflects ALL families
+    const { familyCounts, entries } = buildAuditLogEntries(actor, 'skills')
+    expect(entries).toHaveLength(1)
+    expect(familyCounts.skills).toBe(1)
+    expect(familyCounts.xp).toBe(1)
+    expect(familyCounts.all).toBe(2)
+  })
+
+  it('selecting a family with no entries returns an empty entries array but familyCounts still has other families', () => {
+    const actor = makeActorWithLogs([{ id: 'e1', timestamp: 100, type: 'skill.train', xpDelta: -10, data: { skillName: 'Piloting', oldRank: 1, newRank: 2 } }])
+
+    const { entries, filteredCount, familyCounts } = buildAuditLogEntries(actor, 'talents')
+    expect(entries).toHaveLength(0)
+    expect(filteredCount).toBe(0)
+    expect(familyCounts.skills).toBe(1)
+    expect(familyCounts.talents).toBeUndefined()
+  })
+})
+
+/* ============================================ */
+/*  isActiveFamilyEmpty and filter isEmpty     */
+/*  in _prepareContext view-model              */
+/* ============================================ */
+
+describe('_prepareContext — isActiveFamilyEmpty and filter isEmpty/count', () => {
+  let CharacterAuditLogApp
+
+  const baseTranslations = {
+    'SWERPG.AUDIT_LOG.FILTER.ALL': 'All',
+    'SWERPG.AUDIT_LOG.FILTER.SKILLS': 'Skills',
+    'SWERPG.AUDIT_LOG.FILTER.TALENTS': 'Talents',
+    'SWERPG.AUDIT_LOG.FILTER.XP': 'XP',
+    'SWERPG.AUDIT_LOG.FILTER.CHARACTERISTICS': 'Characteristics',
+    'SWERPG.AUDIT_LOG.FILTER.DETAILS': 'Core choices',
+    'SWERPG.AUDIT_LOG.FILTER.ADVANCEMENT': 'Advancement',
+    'SWERPG.AUDIT_LOG.FILTER.PURCHASES': 'Purchases',
+    'SWERPG.AUDIT_LOG.FILTER.SALES': 'Sales',
+    'SWERPG.AUDIT_LOG.EMPTY': 'No entries',
+    'SWERPG.AUDIT_LOG.EMPTY_FILTERED': 'No match',
+    'SWERPG.AUDIT_LOG.EMPTY_FAMILY': 'No entries for this category.',
+    'SWERPG.AUDIT_LOG.TYPE.SKILL_TRAIN': 'Skill purchase',
+    'SWERPG.AUDIT_LOG.TYPE.XP_GRANT': 'XP granted',
+    'SWERPG.AUDIT_LOG.TYPE.UNKNOWN': 'Unknown event',
+    'SWERPG.AUDIT_LOG.NONE': 'None',
+    'SWERPG.AUDIT_LOG.UNKNOWN_VALUE': 'Unknown value',
+    'SWERPG.AUDIT_LOG.UNKNOWN_SKILL': 'Unknown skill',
+    'SWERPG.AUDIT_LOG.DESCRIPTION.SKILL_TRAIN': 'Skill {skill}: rank {oldRank} -> {newRank}',
+    'SWERPG.AUDIT_LOG.DESCRIPTION.XP_GRANT': 'Granted {amount} XP',
+    'SWERPG.AUDIT_LOG.DESCRIPTION.UNKNOWN': 'Unknown event ({type})',
+    'SWERPG.AUDIT_LOG.VARIANT.ADD': 'Added',
+    'SWERPG.AUDIT_LOG.VARIANT.GAIN': 'Gained',
+    'SWERPG.AUDIT_LOG.VARIANT.REMOVE': 'Removed',
+    'SWERPG.AUDIT_LOG.VARIANT.CHANGE': 'Changed',
+    'SWERPG.AUDIT_LOG.VARIANT.FAIL': 'Failed',
+  }
+
+  beforeEach(async () => {
+    setupFoundryMock({ translations: baseTranslations })
+    ;({ default: CharacterAuditLogApp } = await import('../../module/applications/character-audit-log.mjs'))
+  })
+
+  afterEach(() => {
+    vi.resetModules()
+    vi.clearAllMocks()
+    teardownFoundryMock()
+  })
+
+  function makeActor(logs = []) {
+    return {
+      id: 'actor-empty-family',
+      name: 'Test',
+      type: 'character',
+      isOwner: true,
+      system: {},
+      flags: { swerpg: { logs } },
+      testUserPermission: vi.fn(() => true),
+    }
+  }
+
+  it('isActiveFamilyEmpty is false when active filter is all', async () => {
+    const actor = makeActor([{ id: 'e1', timestamp: 100, type: 'skill.train', xpDelta: -10, data: { skillName: 'Piloting', oldRank: 1, newRank: 2 } }])
+    const app = new CharacterAuditLogApp({ document: actor })
+    const ctx = await app._prepareContext({})
+    expect(ctx.isActiveFamilyEmpty).toBe(false)
+  })
+
+  it('isActiveFamilyEmpty is false when the active family has entries', async () => {
+    const actor = makeActor([{ id: 'e1', timestamp: 100, type: 'skill.train', xpDelta: -10, data: { skillName: 'Piloting', oldRank: 1, newRank: 2 } }])
+    const app = new CharacterAuditLogApp({ document: actor, filter: 'skills' })
+    const ctx = await app._prepareContext({})
+    expect(ctx.isActiveFamilyEmpty).toBe(false)
+  })
+
+  it('isActiveFamilyEmpty is true when the active family has no entries in the corpus', async () => {
+    const actor = makeActor([{ id: 'e1', timestamp: 100, type: 'skill.train', xpDelta: -10, data: { skillName: 'Piloting', oldRank: 1, newRank: 2 } }])
+    const app = new CharacterAuditLogApp({ document: actor, filter: 'talents' })
+    const ctx = await app._prepareContext({})
+    expect(ctx.isActiveFamilyEmpty).toBe(true)
+    expect(ctx.hasFilteredEntries).toBe(false)
+  })
+
+  it('isActiveFamilyEmpty is true even when other families have entries', async () => {
+    const actor = makeActor([
+      { id: 'e1', timestamp: 100, type: 'skill.train', xpDelta: -10, data: { skillName: 'Piloting', oldRank: 1, newRank: 2 } },
+      { id: 'e2', timestamp: 200, type: 'xp.grant', xpDelta: 20, data: { amount: 20 } },
+    ])
+    const app = new CharacterAuditLogApp({ document: actor, filter: 'talents' })
+    const ctx = await app._prepareContext({})
+    expect(ctx.isActiveFamilyEmpty).toBe(true)
+  })
+
+  it('context exposes emptyFamilyLabel as a string', async () => {
+    const actor = makeActor()
+    const app = new CharacterAuditLogApp({ document: actor })
+    const ctx = await app._prepareContext({})
+    expect(typeof ctx.emptyFamilyLabel).toBe('string')
+    expect(ctx.emptyFamilyLabel.length).toBeGreaterThan(0)
+  })
+
+  it('each filter exposes count and isEmpty fields', async () => {
+    const actor = makeActor([{ id: 'e1', timestamp: 100, type: 'skill.train', xpDelta: -10, data: { skillName: 'Piloting', oldRank: 1, newRank: 2 } }])
+    const app = new CharacterAuditLogApp({ document: actor })
+    const ctx = await app._prepareContext({})
+
+    for (const filter of ctx.filters) {
+      expect(typeof filter.count).toBe('number')
+      expect(typeof filter.isEmpty).toBe('boolean')
+    }
+  })
+
+  it('skills filter has count=1 and isEmpty=false when one skill entry exists', async () => {
+    const actor = makeActor([{ id: 'e1', timestamp: 100, type: 'skill.train', xpDelta: -10, data: { skillName: 'Piloting', oldRank: 1, newRank: 2 } }])
+    const app = new CharacterAuditLogApp({ document: actor })
+    const ctx = await app._prepareContext({})
+
+    const skillsFilter = ctx.filters.find((f) => f.id === 'skills')
+    expect(skillsFilter.count).toBe(1)
+    expect(skillsFilter.isEmpty).toBe(false)
+  })
+
+  it('talents filter has count=0 and isEmpty=true when no talent entries exist', async () => {
+    const actor = makeActor([{ id: 'e1', timestamp: 100, type: 'skill.train', xpDelta: -10, data: { skillName: 'Piloting', oldRank: 1, newRank: 2 } }])
+    const app = new CharacterAuditLogApp({ document: actor })
+    const ctx = await app._prepareContext({})
+
+    const talentsFilter = ctx.filters.find((f) => f.id === 'talents')
+    expect(talentsFilter.count).toBe(0)
+    expect(talentsFilter.isEmpty).toBe(true)
+  })
+
+  it('all filter count reflects all entries regardless of active family', async () => {
+    const actor = makeActor([
+      { id: 'e1', timestamp: 100, type: 'skill.train', xpDelta: -10, data: { skillName: 'Piloting', oldRank: 1, newRank: 2 } },
+      { id: 'e2', timestamp: 200, type: 'xp.grant', xpDelta: 20, data: { amount: 20 } },
+    ])
+    const app = new CharacterAuditLogApp({ document: actor, filter: 'skills' })
+    const ctx = await app._prepareContext({})
+
+    const allFilter = ctx.filters.find((f) => f.id === 'all')
+    expect(allFilter.count).toBe(2)
+    expect(allFilter.isEmpty).toBe(false)
+  })
+
+  it('empty filter has is-empty in cssClass', async () => {
+    const actor = makeActor([{ id: 'e1', timestamp: 100, type: 'skill.train', xpDelta: -10, data: { skillName: 'Piloting', oldRank: 1, newRank: 2 } }])
+    const app = new CharacterAuditLogApp({ document: actor })
+    const ctx = await app._prepareContext({})
+
+    const talentsFilter = ctx.filters.find((f) => f.id === 'talents')
+    expect(talentsFilter.cssClass).toContain('is-empty')
+  })
+
+  it('non-empty filter does not have is-empty in cssClass', async () => {
+    const actor = makeActor([{ id: 'e1', timestamp: 100, type: 'skill.train', xpDelta: -10, data: { skillName: 'Piloting', oldRank: 1, newRank: 2 } }])
+    const app = new CharacterAuditLogApp({ document: actor })
+    const ctx = await app._prepareContext({})
+
+    const skillsFilter = ctx.filters.find((f) => f.id === 'skills')
+    expect(skillsFilter.cssClass).not.toContain('is-empty')
+  })
+
+  it('active empty filter has both is-active and is-empty in cssClass', async () => {
+    const actor = makeActor([{ id: 'e1', timestamp: 100, type: 'skill.train', xpDelta: -10, data: { skillName: 'Piloting', oldRank: 1, newRank: 2 } }])
+    const app = new CharacterAuditLogApp({ document: actor, filter: 'talents' })
+    const ctx = await app._prepareContext({})
+
+    const talentsFilter = ctx.filters.find((f) => f.id === 'talents')
+    expect(talentsFilter.cssClass).toContain('is-active')
+    expect(talentsFilter.cssClass).toContain('is-empty')
+    expect(talentsFilter.isPressed).toBe(true)
+  })
+
+  it('family filter counts respect text search — empty family after search has isEmpty=true', async () => {
+    const actor = makeActor([
+      { id: 'e1', timestamp: 100, type: 'skill.train', xpDelta: -10, data: { skillName: 'Piloting', oldRank: 1, newRank: 2 } },
+      { id: 'e2', timestamp: 200, type: 'xp.grant', xpDelta: 20, data: { amount: 20 } },
+    ])
+    const app = new CharacterAuditLogApp({ document: actor })
+    // Text search for 'piloting' matches only the skills entry → xp family becomes empty
+    app.searchQuery = 'piloting'
+    const ctx = await app._prepareContext({})
+
+    const xpFilter = ctx.filters.find((f) => f.id === 'xp')
+    expect(xpFilter.count).toBe(0)
+    expect(xpFilter.isEmpty).toBe(true)
+
+    const skillsFilter = ctx.filters.find((f) => f.id === 'skills')
+    expect(skillsFilter.count).toBe(1)
+    expect(skillsFilter.isEmpty).toBe(false)
+  })
+
+  it('CSV export contract is not affected by familyCounts — all log entries remain exportable', async () => {
+    // This verifies that the familyCounts change in buildAuditLogEntries does not
+    // affect the CSV export path, which reads from raw logs independently.
+    const { buildCsvContent } = await import('../../module/applications/character-audit-log.mjs')
+
+    const actor = makeActor([
+      { id: 'e1', timestamp: 100, type: 'skill.train', xpDelta: -10, data: { skillName: 'Piloting', oldRank: 1, newRank: 2 } },
+      { id: 'e2', timestamp: 200, type: 'xp.grant', xpDelta: 20, data: { amount: 20 } },
+    ])
+
+    const csv = buildCsvContent(actor)
+    const lines = csv.split('\n')
+    // Header + 2 rows — all entries regardless of family
+    expect(lines).toHaveLength(3)
   })
 })


### PR DESCRIPTION
## Summary

- Add per-family audit log counts computed from the text/date-filtered corpus before applying the active family filter.
- Show family counts and empty-state styling in the audit log toolbar, plus a dedicated empty-family message and translations.
- Extend audit log tests to cover family counts, empty-family behavior, and the unchanged CSV export contract.

## Context

Closes #555

## Tests

- Not run (not requested).

## Notes

- Includes the implementation plan file for issue #555 under `documentation/plan/audit-log/`.
