### PR TITLE
feat(audit-log): distinguish XP and credit delta units

### DIFF
--- a/documentation/plan/audit-log/556-audit-log-repere-d-unite-xp-vs-credits-sur-le-delta.md
+++ b/documentation/plan/audit-log/556-audit-log-repere-d-unite-xp-vs-credits-sur-le-delta.md
@@ -1,0 +1,67 @@
+# Issue #556 — Audit Log : repère d’unité XP vs crédits sur le delta
+
+**Issue** : https://github.com/herveDarritchon/foundryvtt-swerpg/issues/556  
+**Domaine métier** : `audit-log`
+
+## Goal
+
+Rendre la colonne delta du journal d’audit immédiatement lisible en distinguant visuellement les variations d’XP des variations de crédits, sans changer la persistance des entrées, les familles de filtres ni l’export CSV.
+
+## Contexte utile
+
+- `documentation/audit/audit-log/audit-ui-ux-audit-log.md` rattache ce besoin à **AUDIT-UI-11** / **UX5** et décrit le problème actuel : `+50 XP` et `+25 cr` partagent le même traitement visuel dans la même colonne.
+- `module/applications/character-audit-log.mjs` sait déjà distinguer les entrées crédits (`item.purchase`, `item.sale`) des entrées XP lors du calcul de `formattedDelta` ; le point d’extension naturel est donc le view-model des entrées, pas le stockage métier.
+- `templates/applications/character-audit-log.hbs` rend aujourd’hui un unique `span.audit-log-entry__delta` avec `formattedDelta`, sans repère d’unité dédié.
+- `tests/applications/character-audit-log.test.mjs` couvre déjà la différence de contenu textuel entre deltas XP et crédits ; c’est l’ancrage naturel pour verrouiller le nouveau contrat visuel/métier.
+
+## Plan d’implémentation
+
+### Étape 1 — Exposer explicitement l’unité du delta dans le view-model Audit Log
+
+**Fichiers** : `module/applications/character-audit-log.mjs`, `lang/en.json`, `lang/fr.json`
+
+**What** :
+
+- Étendre les entrées préparées par `buildAuditLogEntries()` avec une métadonnée canonique d’unité (`xp` vs `credits`) et les dérivés nécessaires au rendu (`unitIcon`, `unitLabel`, classe CSS dédiée), au lieu de laisser le template déduire l’unité implicitement depuis la chaîne formatée.
+- Conserver `formattedDelta` comme source de vérité textuelle (`+50 XP`, `-25 cr`) pour ne pas casser le contrat existant, puis ajouter seulement les repères complémentaires nécessaires au rendu.
+- Prévoir un fallback explicite pour les cas neutres / inattendus afin que l’absence de repère n’introduise pas d’ambiguïté ou de régression silencieuse.
+
+**Résultat attendu** : l’application fournit un contrat homogène permettant d’afficher un repère d’unité sans toucher au modèle d’audit persistant.
+
+### Étape 2 — Rendre le repère d’unité dans la colonne delta sans perdre la lisibilité actuelle
+
+**Fichiers** : `templates/applications/character-audit-log.hbs`, `styles/applications.less`
+
+**What** :
+
+- Afficher dans la zone delta une icône ou un marqueur visuel distinct pour les XP et pour les crédits, en complément du texte signé existant et sans supprimer le suffixe d’unité.
+- Introduire les modificateurs de style minimaux pour que deux entrées de même variante métier mais d’unités différentes restent différenciables au premier coup d’œil, y compris en responsive.
+- Conserver une sémantique accessible : l’icône décorative reste masquée aux technologies d’assistance si le libellé textuel suffit, sinon un libellé dédié doit être exposé via l’attribut approprié.
+
+**Résultat attendu** : un achat et une dépense d’XP ne se ressemblent plus visuellement dans la colonne delta tout en conservant l’ergonomie existante du journal.
+
+### Étape 3 — Verrouiller la distinction XP / crédits et les cas limites de rendu
+
+**Fichiers** : `tests/applications/character-audit-log.test.mjs`
+
+**What** :
+
+- Ajouter des tests ciblés couvrant au minimum : entrée XP avec repère d’unité XP, entrée achat/vente avec repère crédits, conservation de `formattedDelta`, et maintien du comportement neutre pour delta nul.
+- Vérrouiller le contrat exposé au template (métadonnées d’unité, classes CSS ou labels associés) plutôt qu’un simple détail cosmétique fragile.
+- Prévoir dans la validation d’implémentation la vérification finale des critères de l’issue, dont le passage de `pnpm run build`, sans élargir le scope à d’autres améliorations UX du journal.
+
+**Résultat attendu** : la distinction XP / crédits devient stable, testable et non régressive.
+
+## Périmètre / hors périmètre
+
+### Inclus
+
+- Repère visuel distinct pour les deltas XP
+- Repère visuel distinct pour les deltas crédits
+- Ajustements limités au view-model, au template, aux styles et aux tests du journal d’audit
+
+### Exclus
+
+- Refonte du modèle métier d’audit ou de `flags.swerpg.logs`
+- Changement de l’export CSV, des familles de filtres ou du tri/regroupement des entrées
+- Ajout d’un panneau de détails, d’un nouveau filtre ou d’une refonte globale de la carte d’entrée

--- a/lang/en.json
+++ b/lang/en.json
@@ -358,6 +358,8 @@
   "SWERPG.AUDIT_LOG.VARIANT.GAIN": "Gained",
   "SWERPG.AUDIT_LOG.VARIANT.CHANGE": "Changed",
   "SWERPG.AUDIT_LOG.VARIANT.FAIL": "Failed",
+  "SWERPG.AUDIT_LOG.DELTA.UNIT.XP": "experience points",
+  "SWERPG.AUDIT_LOG.DELTA.UNIT.CREDITS": "credits",
   "SWERPG.SETTINGS.AUDIT_LOG_MAX_ENTRIES_NAME": "Audit Log max entries",
   "SWERPG.SETTINGS.AUDIT_LOG_MAX_ENTRIES_HINT": "Maximum number of entries stored in the character audit log (100-5000). Oldest entries are removed first when the limit is exceeded.",
   "SWERPG.SETTINGS.AUDIT_LOG_CHAT_SUMMARY_NAME": "Audit Log: group chat cards",

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -333,6 +333,8 @@
   "SWERPG.AUDIT_LOG.VARIANT.GAIN": "Gagné",
   "SWERPG.AUDIT_LOG.VARIANT.CHANGE": "Modifié",
   "SWERPG.AUDIT_LOG.VARIANT.FAIL": "Échoué",
+  "SWERPG.AUDIT_LOG.DELTA.UNIT.XP": "points d'expérience",
+  "SWERPG.AUDIT_LOG.DELTA.UNIT.CREDITS": "crédits",
   "SWERPG.SETTINGS.AUDIT_LOG_MAX_ENTRIES_NAME": "Nombre max d'entrées du journal",
   "SWERPG.SETTINGS.AUDIT_LOG_MAX_ENTRIES_HINT": "Nombre maximum d'entrées dans le journal d'évolution du personnage (100-5000). Les plus anciennes sont supprimées en premier lorsque la limite est dépassée.",
   "SWERPG.SETTINGS.AUDIT_LOG_CHAT_SUMMARY_NAME": "Journal d'audit : regrouper les cartes de chat",

--- a/module/applications/character-audit-log.mjs
+++ b/module/applications/character-audit-log.mjs
@@ -73,6 +73,52 @@ const AUDIT_LOG_VARIANT_GLYPHS = Object.freeze({
 })
 
 /**
+ * Canonical delta unit types for audit log entries.
+ */
+const AUDIT_LOG_DELTA_UNITS = Object.freeze({
+  xp: 'xp',
+  credits: 'credits',
+  neutral: 'neutral',
+})
+
+/**
+ * FontAwesome icon class for each delta unit.
+ */
+const AUDIT_LOG_DELTA_UNIT_ICONS = Object.freeze({
+  [AUDIT_LOG_DELTA_UNITS.xp]: 'fa-solid fa-bolt',
+  [AUDIT_LOG_DELTA_UNITS.credits]: 'fa-solid fa-coins',
+  [AUDIT_LOG_DELTA_UNITS.neutral]: '',
+})
+
+/**
+ * Return the canonical delta unit for a given audit entry type.
+ * @param {string} type
+ * @returns {'xp'|'credits'|'neutral'}
+ */
+function getAuditLogDeltaUnit(type) {
+  if (type === 'item.purchase' || type === 'item.sale') return AUDIT_LOG_DELTA_UNITS.credits
+  switch (type) {
+    case 'skill.train':
+    case 'skill.forget':
+    case 'characteristic.increase':
+    case 'xp.spend':
+    case 'xp.refund':
+    case 'xp.grant':
+    case 'xp.remove':
+    case 'talent.purchase':
+    case 'talent-node-purchase':
+    case 'talent-node-purchase-succeeded':
+    case 'talent-node-purchase-failed':
+    case 'talent-node-forget-succeeded':
+    case 'talent-node-forget-failed':
+    case 'advancement.level':
+      return AUDIT_LOG_DELTA_UNITS.xp
+    default:
+      return AUDIT_LOG_DELTA_UNITS.neutral
+  }
+}
+
+/**
  * Return the accessible i18n key for a variant glyph's aria-label.
  * @param {string} variant
  * @returns {string}
@@ -723,6 +769,16 @@ export function buildAuditLogEntries(actor, family = AUDIT_LOG_FAMILIES.all, { q
       const formattedDelta = isCreditEntry ? formatAuditLogCreditDelta(creditDelta) : formatAuditLogDelta(xpDelta)
       const visual = buildAuditLogEntryVisual(actor, entry)
 
+      const deltaUnit = getAuditLogDeltaUnit(entry.type)
+      const deltaUnitIcon = AUDIT_LOG_DELTA_UNIT_ICONS[deltaUnit] ?? ''
+      const deltaUnitLabelKey =
+        deltaUnit === AUDIT_LOG_DELTA_UNITS.xp
+          ? 'SWERPG.AUDIT_LOG.DELTA.UNIT.XP'
+          : deltaUnit === AUDIT_LOG_DELTA_UNITS.credits
+            ? 'SWERPG.AUDIT_LOG.DELTA.UNIT.CREDITS'
+            : ''
+      const deltaUnitLabel = deltaUnitLabelKey ? game.i18n.localize(deltaUnitLabelKey) : ''
+
       return {
         ...entry,
         family: entryFamily,
@@ -737,6 +793,10 @@ export function buildAuditLogEntries(actor, family = AUDIT_LOG_FAMILIES.all, { q
         formattedXpDelta: formatAuditLogDelta(xpDelta),
         xpDeltaClass: xpDelta > 0 ? 'is-gain' : xpDelta < 0 ? 'is-spend' : 'is-neutral',
         hasXpDelta: xpDelta !== 0,
+        deltaUnit,
+        deltaUnitIcon,
+        deltaUnitLabel,
+        deltaUnitClass: `audit-log-entry__delta--unit-${deltaUnit}`,
         ...visual,
         variantGlyph: getAuditLogVariantGlyph(visual.variant),
         variantGlyphLabel: game.i18n.localize(getVariantGlyphLabel(visual.variant)),

--- a/styles/applications.less
+++ b/styles/applications.less
@@ -739,6 +739,9 @@
 
   .audit-log-entry__delta {
     flex: none;
+    display: inline-flex;
+    align-items: center;
+    gap: 0.25rem;
     text-align: right;
     font-family: var(--font-h1);
     font-size: var(--font-size-12);
@@ -753,6 +756,16 @@
 
     &.is-neutral {
       color: var(--color-secondary);
+    }
+
+    // XP delta: bolt icon already shares entry color via currentColor inheritance
+    &.audit-log-entry__delta--unit-xp .audit-log-entry__delta-unit-icon {
+      opacity: 0.8;
+    }
+
+    // Credits delta: coin icon shares entry color via currentColor inheritance
+    &.audit-log-entry__delta--unit-credits .audit-log-entry__delta-unit-icon {
+      opacity: 0.8;
     }
   }
 
@@ -803,6 +816,7 @@
 
     .audit-log-entry__delta {
       text-align: left;
+      justify-content: flex-start;
     }
   }
 }

--- a/styles/swerpg.css
+++ b/styles/swerpg.css
@@ -1246,6 +1246,9 @@ input[type='range'] {
 }
 .swerpg.application.character-audit-log .audit-log-entry__delta {
   flex: none;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
   text-align: right;
   font-family: var(--font-h1);
   font-size: var(--font-size-12);
@@ -1258,6 +1261,12 @@ input[type='range'] {
 }
 .swerpg.application.character-audit-log .audit-log-entry__delta.is-neutral {
   color: var(--color-secondary);
+}
+.swerpg.application.character-audit-log .audit-log-entry__delta.audit-log-entry__delta--unit-xp .audit-log-entry__delta-unit-icon {
+  opacity: 0.8;
+}
+.swerpg.application.character-audit-log .audit-log-entry__delta.audit-log-entry__delta--unit-credits .audit-log-entry__delta-unit-icon {
+  opacity: 0.8;
 }
 .swerpg.application.character-audit-log .audit-log-entry--add .audit-log-entry__badge {
   color: var(--color-success);
@@ -1294,6 +1303,7 @@ input[type='range'] {
   }
   .swerpg.application.character-audit-log .audit-log-entry__delta {
     text-align: left;
+    justify-content: flex-start;
   }
 }
 /* ----------------------------------------- */

--- a/templates/applications/character-audit-log.hbs
+++ b/templates/applications/character-audit-log.hbs
@@ -131,7 +131,15 @@
 
               {{#if entry.hasDelta}}
                 <footer class='audit-log-entry__footer'>
-                  <span class='audit-log-entry__delta {{entry.deltaClass}}'>{{entry.formattedDelta}}</span>
+                  <span class='audit-log-entry__delta {{entry.deltaClass}} {{entry.deltaUnitClass}}'>
+                    {{#if entry.deltaUnitIcon}}
+                      <i class='{{entry.deltaUnitIcon}} audit-log-entry__delta-unit-icon' aria-hidden='true'></i>
+                    {{/if}}
+                    <span class='audit-log-entry__delta-value'>{{entry.formattedDelta}}</span>
+                    {{#if entry.deltaUnitLabel}}
+                      <span class='visually-hidden'>{{entry.deltaUnitLabel}}</span>
+                    {{/if}}
+                  </span>
                 </footer>
               {{/if}}
 

--- a/tests/applications/character-audit-log.test.mjs
+++ b/tests/applications/character-audit-log.test.mjs
@@ -2307,3 +2307,160 @@ describe('_prepareContext — isActiveFamilyEmpty and filter isEmpty/count', () 
     expect(lines).toHaveLength(3)
   })
 })
+
+/* ============================================ */
+/*  Delta unit metadata (XP vs credits)        */
+/* ============================================ */
+
+describe('buildAuditLogEntries — delta unit metadata', () => {
+  let buildAuditLogEntries
+
+  const baseTranslations = {
+    'SWERPG.AUDIT_LOG.FILTER.ALL': 'All',
+    'SWERPG.AUDIT_LOG.FILTER.SKILLS': 'Skills',
+    'SWERPG.AUDIT_LOG.FILTER.TALENTS': 'Talents',
+    'SWERPG.AUDIT_LOG.FILTER.XP': 'XP',
+    'SWERPG.AUDIT_LOG.FILTER.CHARACTERISTICS': 'Characteristics',
+    'SWERPG.AUDIT_LOG.FILTER.DETAILS': 'Core choices',
+    'SWERPG.AUDIT_LOG.FILTER.ADVANCEMENT': 'Advancement',
+    'SWERPG.AUDIT_LOG.FILTER.PURCHASES': 'Purchases',
+    'SWERPG.AUDIT_LOG.FILTER.SALES': 'Sales',
+    'SWERPG.AUDIT_LOG.TYPE.SKILL_TRAIN': 'Skill purchase',
+    'SWERPG.AUDIT_LOG.TYPE.XP_GRANT': 'XP granted',
+    'SWERPG.AUDIT_LOG.TYPE.ITEM_PURCHASE': 'Item purchased',
+    'SWERPG.AUDIT_LOG.TYPE.ITEM_SALE': 'Item sold',
+    'SWERPG.AUDIT_LOG.TYPE.UNKNOWN': 'Unknown event',
+    'SWERPG.AUDIT_LOG.NONE': 'None',
+    'SWERPG.AUDIT_LOG.UNKNOWN_VALUE': 'Unknown value',
+    'SWERPG.AUDIT_LOG.UNKNOWN_SKILL': 'Unknown skill',
+    'SWERPG.AUDIT_LOG.UNKNOWN_ITEM': 'Unknown item',
+    'SWERPG.AUDIT_LOG.DESCRIPTION.SKILL_TRAIN': 'Skill {skill}: rank {oldRank} -> {newRank}',
+    'SWERPG.AUDIT_LOG.DESCRIPTION.XP_GRANT': 'Granted {amount} XP',
+    'SWERPG.AUDIT_LOG.DESCRIPTION.ITEM_PURCHASE': 'Purchased {itemName} ({itemType}) for {price} credits',
+    'SWERPG.AUDIT_LOG.DESCRIPTION.ITEM_SALE': 'Sold {itemName} ({itemType}) for {resalePrice} credits ({fraction}% of base price)',
+    'SWERPG.AUDIT_LOG.DESCRIPTION.UNKNOWN': 'Unknown event ({type})',
+    'SWERPG.AUDIT_LOG.VARIANT.ADD': 'Added',
+    'SWERPG.AUDIT_LOG.VARIANT.GAIN': 'Gained',
+    'SWERPG.AUDIT_LOG.VARIANT.REMOVE': 'Removed',
+    'SWERPG.AUDIT_LOG.VARIANT.CHANGE': 'Changed',
+    'SWERPG.AUDIT_LOG.VARIANT.FAIL': 'Failed',
+    'SWERPG.AUDIT_LOG.DELTA.UNIT.XP': 'experience points',
+    'SWERPG.AUDIT_LOG.DELTA.UNIT.CREDITS': 'credits',
+  }
+
+  beforeEach(async () => {
+    setupFoundryMock({ translations: baseTranslations })
+    ;({ buildAuditLogEntries } = await import('../../module/applications/character-audit-log.mjs'))
+  })
+
+  afterEach(() => {
+    vi.resetModules()
+    vi.clearAllMocks()
+    teardownFoundryMock()
+  })
+
+  function makeActorWithLog(logs) {
+    return {
+      id: 'actor-delta-unit',
+      name: 'Test',
+      type: 'character',
+      isOwner: true,
+      system: {},
+      flags: { swerpg: { logs } },
+      testUserPermission: vi.fn(() => true),
+    }
+  }
+
+  it('XP entry (skill.train) carries deltaUnit=xp, deltaUnitIcon with fa-bolt, deltaUnitLabel, deltaUnitClass', () => {
+    const actor = makeActorWithLog([{ id: 'e1', timestamp: 100, type: 'skill.train', xpDelta: -10, data: { skillName: 'Piloting', oldRank: 1, newRank: 2 } }])
+
+    const { entries } = buildAuditLogEntries(actor, 'all')
+    const entry = entries[0]
+
+    expect(entry.deltaUnit).toBe('xp')
+    expect(entry.deltaUnitIcon).toContain('fa-bolt')
+    expect(entry.deltaUnitLabel).toBe('experience points')
+    expect(entry.deltaUnitClass).toBe('audit-log-entry__delta--unit-xp')
+  })
+
+  it('XP entry (xp.grant) carries deltaUnit=xp', () => {
+    const actor = makeActorWithLog([{ id: 'e1', timestamp: 100, type: 'xp.grant', xpDelta: 20, data: { amount: 20 } }])
+
+    const { entries } = buildAuditLogEntries(actor, 'all')
+    expect(entries[0].deltaUnit).toBe('xp')
+    expect(entries[0].deltaUnitIcon).toContain('fa-bolt')
+  })
+
+  it('credits entry (item.purchase) carries deltaUnit=credits, deltaUnitIcon with fa-coins, deltaUnitLabel, deltaUnitClass', () => {
+    const actor = makeActorWithLog([
+      {
+        id: 'p1',
+        timestamp: 100,
+        type: 'item.purchase',
+        xpDelta: 0,
+        creditDelta: -150,
+        data: { itemName: 'Blaster', itemType: 'weapon', price: 150, quantity: 1 },
+      },
+    ])
+
+    const { entries } = buildAuditLogEntries(actor, 'all')
+    const entry = entries[0]
+
+    expect(entry.deltaUnit).toBe('credits')
+    expect(entry.deltaUnitIcon).toContain('fa-coins')
+    expect(entry.deltaUnitLabel).toBe('credits')
+    expect(entry.deltaUnitClass).toBe('audit-log-entry__delta--unit-credits')
+  })
+
+  it('credits entry (item.sale) carries deltaUnit=credits', () => {
+    const actor = makeActorWithLog([
+      {
+        id: 's1',
+        timestamp: 200,
+        type: 'item.sale',
+        xpDelta: 0,
+        creditDelta: 75,
+        data: { itemName: 'Blaster', itemType: 'weapon', basePrice: 100, resalePrice: 75, fraction: 0.75, quantity: 1 },
+      },
+    ])
+
+    const { entries } = buildAuditLogEntries(actor, 'all')
+    expect(entries[0].deltaUnit).toBe('credits')
+    expect(entries[0].deltaUnitIcon).toContain('fa-coins')
+  })
+
+  it('formattedDelta is preserved for XP entries (backward compat)', () => {
+    const actor = makeActorWithLog([{ id: 'e1', timestamp: 100, type: 'skill.train', xpDelta: -10, data: { skillName: 'Piloting', oldRank: 1, newRank: 2 } }])
+
+    const { entries } = buildAuditLogEntries(actor, 'all')
+    expect(entries[0].formattedDelta).toBe('-10 XP')
+  })
+
+  it('formattedDelta is preserved for credits entries (backward compat)', () => {
+    const actor = makeActorWithLog([
+      {
+        id: 'p1',
+        timestamp: 100,
+        type: 'item.purchase',
+        xpDelta: 0,
+        creditDelta: -150,
+        data: { itemName: 'Blaster', itemType: 'weapon', price: 150, quantity: 1 },
+      },
+    ])
+
+    const { entries } = buildAuditLogEntries(actor, 'all')
+    expect(entries[0].formattedDelta).toBe('-150 cr')
+  })
+
+  it('neutral entry (unknown type with zero delta) carries deltaUnit=neutral and empty deltaUnitIcon', () => {
+    const actor = makeActorWithLog([{ id: 'e1', timestamp: 100, type: 'some.unknown.type', xpDelta: 0, data: {} }])
+
+    const { entries } = buildAuditLogEntries(actor, 'all')
+    const entry = entries[0]
+
+    expect(entry.deltaUnit).toBe('neutral')
+    expect(entry.deltaUnitIcon).toBe('')
+    expect(entry.deltaUnitLabel).toBe('')
+    expect(entry.deltaUnitClass).toBe('audit-log-entry__delta--unit-neutral')
+  })
+})


### PR DESCRIPTION
## Summary

- Add explicit XP and credits delta-unit metadata, icons, and localized labels to the audit log entry view-model.
- Render unit-specific markers in the audit log delta column and align the updated layout in responsive styles.
- Cover the new XP/credits/neutral delta-unit contract in tests and add the implementation plan for issue #556.

## Context

Closes #556

## Tests

- Not run (not requested).

## Notes

- Includes the compiled `styles/swerpg.css` update alongside the LESS source change.
