### PR TITLE
feat: enhance audit log empty state

### DIFF
--- a/documentation/plan/audit-log/557-audit-log-etat-vide-illustre-avec-amorce.md
+++ b/documentation/plan/audit-log/557-audit-log-etat-vide-illustre-avec-amorce.md
@@ -1,0 +1,67 @@
+# Issue #557 — Audit Log : état vide illustré avec amorce
+
+**Issue** : https://github.com/herveDarritchon/foundryvtt-swerpg/issues/557  
+**Domaine métier** : `audit-log`
+
+## Goal
+
+Rendre l’état vide natif du journal d’audit plus guidant et plus incarné avec un bloc illustré et une amorce explicite, sans toucher à l’écriture des entrées, aux filtres, ni à l’export CSV.
+
+## Contexte utile
+
+- `documentation/audit/audit-log/audit-ui-ux-audit-log.md` rattache ce besoin à **AUDIT-UI-12** / **UX8** et documente l’état actuel : `audit-log__empty` n’est aujourd’hui qu’un texte centré, sans illustration ni phrase d’accompagnement.
+- Les plans `552`, `555` et `556` ont déjà consolidé les variantes d’état vide filtré / famille vide et le view-model du journal ; l’issue #557 doit donc enrichir l’état vide principal sans réouvrir ces autres cas.
+- `templates/applications/character-audit-log.hbs` et `styles/applications.less` sont les points d’ancrage naturels du rendu illustré, avec `module/applications/character-audit-log.mjs` pour exposer au template un contrat d’état vide explicite.
+- `tests/applications/character-audit-log.test.mjs` est l’ancrage naturel pour verrouiller la distinction entre journal réellement vide et résultats vides dus aux filtres.
+
+## Plan d’implémentation
+
+### Étape 1 — Formaliser un contrat d’état vide illustrable côté Audit Log
+
+**Fichiers** : `module/applications/character-audit-log.mjs`, `lang/en.json`, `lang/fr.json`
+
+**What** :
+
+- Exposer au template un objet d’état vide canonique (`kind`, `title`, `hint`, `icon`, variantes éventuelles) au lieu de laisser Handlebars déduire le rendu depuis de simples booléens dispersés.
+- Réserver ce contrat enrichi au cas “journal réellement vide” tout en conservant des états distincts pour “aucun résultat” après filtres/recherche et pour “famille vide” déjà cadrés par les issues précédentes.
+- Ajouter les clés i18n minimales pour un titre et une phrase d’amorce localisés, sans hardcoder de microcopy dans le template.
+
+**Résultat attendu** : le template reçoit une source de vérité claire pour afficher un empty state illustré sans mélanger les différents cas de vide du journal.
+
+### Étape 2 — Remplacer le texte vide brut par un bloc illustré avec amorce
+
+**Fichiers** : `templates/applications/character-audit-log.hbs`, `styles/applications.less`
+
+**What** :
+
+- Remplacer le rendu minimal actuel par un bloc structuré d’état vide comprenant au moins une illustration/pictogramme, un titre et une phrase guide du type « Les évolutions du personnage apparaîtront ici ».
+- Garder le rendu cohérent avec le langage visuel déjà posé sur l’Audit Log (tokens, hiérarchie, contraste, responsive) sans lancer de refonte plus large de la carte d’entrée ou des toolbars.
+- Veiller à l’accessibilité : illustration décorative masquée si nécessaire, texte réellement utile exposé aux technologies d’assistance, et absence de dépendance à la couleur seule.
+
+**Résultat attendu** : un journal vide n’apparaît plus comme une zone morte, mais comme un état d’attente compréhensible et intentionnel.
+
+### Étape 3 — Verrouiller le rendu et la non-régression des autres états vides
+
+**Fichiers** : `tests/applications/character-audit-log.test.mjs`
+
+**What** :
+
+- Ajouter des tests ciblés couvrant au minimum : journal réellement vide avec contrat illustré complet, présence de la microcopy d’amorce, et maintien des messages dédiés pour les cas “aucun résultat” / “famille vide”.
+- Vérrouiller le contrat exposé au template (objet `emptyState` ou équivalent) plutôt qu’un simple détail cosmétique fragile.
+- Confirmer que l’évolution reste purement UI : aucune modification de persistance `flags.swerpg.logs`, de filtres métier ou d’export CSV.
+
+**Résultat attendu** : l’état vide illustré devient stable, testable et isolé des autres comportements déjà livrés sur le journal.
+
+## Périmètre / hors périmètre
+
+### Inclus
+
+- Bloc d’état vide illustré pour un journal réellement vide
+- Phrase d’amorce localisée
+- Ajustements limités au view-model, au template, aux styles et aux tests Audit Log
+
+### Exclus
+
+- Refonte des états vides filtrés ou des familles de filtres
+- Changement du stockage des entrées, de l’export CSV ou du pipeline d’écriture d’audit
+- Ajout d’un panneau de détails, de nouveaux filtres ou d’une refonte générale de l’application

--- a/lang/en.json
+++ b/lang/en.json
@@ -281,6 +281,8 @@
   "SWERPG.AUDIT_LOG.OPEN": "Open character evolution history",
   "SWERPG.AUDIT_LOG.NO_PERMISSION": "You may only view the history of characters you own.",
   "SWERPG.AUDIT_LOG.EMPTY": "No entries in the history yet.",
+  "SWERPG.AUDIT_LOG.EMPTY_TITLE": "No activity recorded yet",
+  "SWERPG.AUDIT_LOG.EMPTY_HINT": "Character evolutions will appear here as the character grows.",
   "SWERPG.AUDIT_LOG.EMPTY_FILTERED": "No entries match the current filters.",
   "SWERPG.AUDIT_LOG.EMPTY_FAMILY": "No entries for this category in the current context.",
   "SWERPG.AUDIT_LOG.SEARCH.LABEL": "Search",

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -256,6 +256,8 @@
   "SWERPG.AUDIT_LOG.OPEN": "Consulter l'historique d'évolution",
   "SWERPG.AUDIT_LOG.NO_PERMISSION": "Vous ne pouvez consulter l'historique que de vos propres personnages.",
   "SWERPG.AUDIT_LOG.EMPTY": "Aucune entrée dans l'historique pour l'instant.",
+  "SWERPG.AUDIT_LOG.EMPTY_TITLE": "Aucune activité enregistrée",
+  "SWERPG.AUDIT_LOG.EMPTY_HINT": "Les évolutions du personnage apparaîtront ici au fil de sa progression.",
   "SWERPG.AUDIT_LOG.EMPTY_FILTERED": "Aucune entrée ne correspond aux filtres actifs.",
   "SWERPG.AUDIT_LOG.EMPTY_FAMILY": "Aucune entrée pour cette catégorie dans le contexte actuel.",
   "SWERPG.AUDIT_LOG.SEARCH.LABEL": "Rechercher",

--- a/module/applications/character-audit-log.mjs
+++ b/module/applications/character-audit-log.mjs
@@ -937,6 +937,12 @@ export default class CharacterAuditLogApp extends api.HandlebarsApplicationMixin
       emptyLabel: game.i18n.localize('SWERPG.AUDIT_LOG.EMPTY'),
       emptyFilteredLabel: game.i18n.localize('SWERPG.AUDIT_LOG.EMPTY_FILTERED'),
       emptyFamilyLabel: game.i18n.localize('SWERPG.AUDIT_LOG.EMPTY_FAMILY'),
+      emptyState: {
+        kind: 'empty-log',
+        icon: 'fa-solid fa-scroll',
+        title: game.i18n.localize('SWERPG.AUDIT_LOG.EMPTY_TITLE'),
+        hint: game.i18n.localize('SWERPG.AUDIT_LOG.EMPTY_HINT'),
+      },
     }
   }
 

--- a/styles/applications.less
+++ b/styles/applications.less
@@ -808,6 +808,33 @@
     text-align: center;
   }
 
+  .audit-log__empty--log {
+    display: flex;
+    flex: 1;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 0.75rem;
+    padding: 3rem 2rem;
+    color: var(--color-secondary);
+    text-align: center;
+  }
+
+  .audit-log__empty-title {
+    font-family: var(--font-h2);
+    font-size: var(--font-size-14);
+    color: var(--color-primary);
+    margin: 0;
+  }
+
+  .audit-log__empty-hint {
+    font-family: var(--font-body);
+    font-size: var(--font-size-13);
+    color: var(--color-secondary);
+    margin: 0;
+    max-width: 28rem;
+  }
+
   @media (max-width: 640px) {
     .audit-log-entry__change {
       flex-direction: column;

--- a/styles/swerpg.css
+++ b/styles/swerpg.css
@@ -1296,6 +1296,30 @@ input[type='range'] {
   color: var(--color-secondary);
   text-align: center;
 }
+.swerpg.application.character-audit-log .audit-log__empty--log {
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 0.75rem;
+  padding: 3rem 2rem;
+  color: var(--color-secondary);
+  text-align: center;
+}
+.swerpg.application.character-audit-log .audit-log__empty-title {
+  font-family: var(--font-h2);
+  font-size: var(--font-size-14);
+  color: var(--color-primary);
+  margin: 0;
+}
+.swerpg.application.character-audit-log .audit-log__empty-hint {
+  font-family: var(--font-body);
+  font-size: var(--font-size-13);
+  color: var(--color-secondary);
+  margin: 0;
+  max-width: 28rem;
+}
 @media (max-width: 640px) {
   .swerpg.application.character-audit-log .audit-log-entry__change {
     flex-direction: column;

--- a/templates/applications/character-audit-log.hbs
+++ b/templates/applications/character-audit-log.hbs
@@ -159,8 +159,10 @@
       <p>{{emptyFilteredLabel}}</p>
     </section>
   {{else}}
-    <section class='audit-log__empty'>
-      <p>{{emptyLabel}}</p>
+    <section class='audit-log__empty audit-log__empty--log' aria-label='{{emptyState.title}}'>
+      <i class='{{emptyState.icon}} audit-log__empty-icon' aria-hidden='true'></i>
+      <h3 class='audit-log__empty-title'>{{emptyState.title}}</h3>
+      <p class='audit-log__empty-hint'>{{emptyState.hint}}</p>
     </section>
   {{/if}}
 </section>

--- a/tests/applications/character-audit-log.test.mjs
+++ b/tests/applications/character-audit-log.test.mjs
@@ -2464,3 +2464,136 @@ describe('buildAuditLogEntries — delta unit metadata', () => {
     expect(entry.deltaUnitClass).toBe('audit-log-entry__delta--unit-neutral')
   })
 })
+
+/* ============================================ */
+/*  Illustrated empty state — emptyState contract */
+/* ============================================ */
+
+describe('_prepareContext — illustrated emptyState contract', () => {
+  let CharacterAuditLogApp
+
+  const baseTranslations = {
+    'SWERPG.AUDIT_LOG.FILTER.ALL': 'All',
+    'SWERPG.AUDIT_LOG.FILTER.SKILLS': 'Skills',
+    'SWERPG.AUDIT_LOG.FILTER.TALENTS': 'Talents',
+    'SWERPG.AUDIT_LOG.FILTER.XP': 'XP',
+    'SWERPG.AUDIT_LOG.FILTER.CHARACTERISTICS': 'Characteristics',
+    'SWERPG.AUDIT_LOG.FILTER.DETAILS': 'Core choices',
+    'SWERPG.AUDIT_LOG.FILTER.ADVANCEMENT': 'Advancement',
+    'SWERPG.AUDIT_LOG.FILTER.PURCHASES': 'Purchases',
+    'SWERPG.AUDIT_LOG.FILTER.SALES': 'Sales',
+    'SWERPG.AUDIT_LOG.EMPTY': 'No entries in the history yet.',
+    'SWERPG.AUDIT_LOG.EMPTY_TITLE': 'No activity recorded yet',
+    'SWERPG.AUDIT_LOG.EMPTY_HINT': 'Character evolutions will appear here as the character grows.',
+    'SWERPG.AUDIT_LOG.EMPTY_FILTERED': 'No entries match the current filters.',
+    'SWERPG.AUDIT_LOG.EMPTY_FAMILY': 'No entries for this category in the current context.',
+    'SWERPG.AUDIT_LOG.TYPE.SKILL_TRAIN': 'Skill purchase',
+    'SWERPG.AUDIT_LOG.TYPE.UNKNOWN': 'Unknown event',
+    'SWERPG.AUDIT_LOG.NONE': 'None',
+    'SWERPG.AUDIT_LOG.UNKNOWN_VALUE': 'Unknown value',
+    'SWERPG.AUDIT_LOG.UNKNOWN_SKILL': 'Unknown skill',
+    'SWERPG.AUDIT_LOG.DESCRIPTION.SKILL_TRAIN': 'Skill {skill}: rank {oldRank} -> {newRank}',
+    'SWERPG.AUDIT_LOG.DESCRIPTION.UNKNOWN': 'Unknown event ({type})',
+    'SWERPG.AUDIT_LOG.VARIANT.ADD': 'Added',
+    'SWERPG.AUDIT_LOG.VARIANT.GAIN': 'Gained',
+    'SWERPG.AUDIT_LOG.VARIANT.REMOVE': 'Removed',
+    'SWERPG.AUDIT_LOG.VARIANT.CHANGE': 'Changed',
+    'SWERPG.AUDIT_LOG.VARIANT.FAIL': 'Failed',
+  }
+
+  beforeEach(async () => {
+    setupFoundryMock({ translations: baseTranslations })
+    ;({ default: CharacterAuditLogApp } = await import('../../module/applications/character-audit-log.mjs'))
+  })
+
+  afterEach(() => {
+    vi.resetModules()
+    vi.clearAllMocks()
+    teardownFoundryMock()
+  })
+
+  function makeActor(logs = []) {
+    return {
+      id: 'actor-empty-state',
+      name: 'Test',
+      type: 'character',
+      isOwner: true,
+      system: {},
+      flags: { swerpg: { logs } },
+      testUserPermission: vi.fn(() => true),
+    }
+  }
+
+  it('context always exposes emptyState with kind, icon, title and hint fields', async () => {
+    const actor = makeActor()
+    const app = new CharacterAuditLogApp({ document: actor })
+    const ctx = await app._prepareContext({})
+
+    expect(ctx.emptyState).toBeDefined()
+    expect(typeof ctx.emptyState.kind).toBe('string')
+    expect(typeof ctx.emptyState.icon).toBe('string')
+    expect(typeof ctx.emptyState.title).toBe('string')
+    expect(typeof ctx.emptyState.hint).toBe('string')
+  })
+
+  it('emptyState.kind is empty-log for the primary empty state', async () => {
+    const actor = makeActor()
+    const app = new CharacterAuditLogApp({ document: actor })
+    const ctx = await app._prepareContext({})
+
+    expect(ctx.emptyState.kind).toBe('empty-log')
+  })
+
+  it('emptyState.title is the localized EMPTY_TITLE key', async () => {
+    const actor = makeActor()
+    const app = new CharacterAuditLogApp({ document: actor })
+    const ctx = await app._prepareContext({})
+
+    expect(ctx.emptyState.title).toBe('No activity recorded yet')
+  })
+
+  it('emptyState.hint is the localized EMPTY_HINT key', async () => {
+    const actor = makeActor()
+    const app = new CharacterAuditLogApp({ document: actor })
+    const ctx = await app._prepareContext({})
+
+    expect(ctx.emptyState.hint).toBe('Character evolutions will appear here as the character grows.')
+  })
+
+  it('emptyState.icon is a non-empty FontAwesome class string', async () => {
+    const actor = makeActor()
+    const app = new CharacterAuditLogApp({ document: actor })
+    const ctx = await app._prepareContext({})
+
+    expect(ctx.emptyState.icon.length).toBeGreaterThan(0)
+    expect(ctx.emptyState.icon).toContain('fa-')
+  })
+
+  it('emptyState is present even when the journal has entries (not shown but contract is always available)', async () => {
+    const actor = makeActor([{ id: 'e1', timestamp: 100, type: 'skill.train', xpDelta: -10, data: { skillName: 'Piloting', oldRank: 1, newRank: 2 } }])
+    const app = new CharacterAuditLogApp({ document: actor })
+    const ctx = await app._prepareContext({})
+
+    // The contract is always populated; the template decides whether to show it
+    expect(ctx.emptyState).toBeDefined()
+    expect(ctx.emptyState.kind).toBe('empty-log')
+  })
+
+  it('hasEntries is false for a truly empty log, distinguishing it from a filtered empty result', async () => {
+    const emptyActor = makeActor()
+    const appEmpty = new CharacterAuditLogApp({ document: emptyActor })
+    const ctxEmpty = await appEmpty._prepareContext({})
+
+    expect(ctxEmpty.hasEntries).toBe(false)
+    expect(ctxEmpty.totalCount).toBe(0)
+
+    const actorWithLog = makeActor([{ id: 'e1', timestamp: 100, type: 'skill.train', xpDelta: -10, data: { skillName: 'Piloting', oldRank: 1, newRank: 2 } }])
+    const appWithLog = new CharacterAuditLogApp({ document: actorWithLog, filter: 'talents' })
+    const ctxFiltered = await appWithLog._prepareContext({})
+
+    // With entries but filtered to empty family — totalCount is non-zero
+    expect(ctxFiltered.hasEntries).toBe(true)
+    expect(ctxFiltered.totalCount).toBe(1)
+    expect(ctxFiltered.hasFilteredEntries).toBe(false)
+  })
+})


### PR DESCRIPTION
## Summary

- Add a localized illustrated primary empty state for the character audit log, backed by an explicit `emptyState` view-model contract.
- Update the audit log template and styles so an empty journal shows guidance instead of a bare text-only state.
- Add application tests covering the empty-state contract and the distinction from filtered and family-specific empty results.

## Context

Closes #557

## Tests

- Not run (not requested).
