### PR TITLE
feat: add mono-writer guard for audit hooks

### DIFF
--- a/documentation/plan/audit-log/560-audit-log-ajouter-un-garde-mono-ecrivain-sur-les-hooks-game-userid-userid.md
+++ b/documentation/plan/audit-log/560-audit-log-ajouter-un-garde-mono-ecrivain-sur-les-hooks-game-userid-userid.md
@@ -1,0 +1,53 @@
+# Issue #560 — Audit Log : ajouter un garde mono-écrivain sur les hooks (`game.userId === userId`)
+
+**Issue** : https://github.com/herveDarritchon/foundryvtt-swerpg/issues/560  
+**Domaine métier** : `audit-log`
+
+## Goal
+
+Empêcher les doublons d’entrées Audit Log, de cartes de chat et de whispers GM en session multi-utilisateur en réservant la capture, la composition et l’écriture des logs au seul client initiateur de l’action.
+
+## Contexte utile
+
+- `documentation/audit/audit-log/audit-feature-audit-log.md` identifie **AL1 / AUDIT-01** comme défaut critique : les hooks d’audit s’exécutent sur tous les clients connectés et produisent des écritures/chats dupliqués.
+- `module/utils/audit-log.mjs` concentre le flux concerné : `onPreUpdateActor()` alimente `pendingOldStates`, `onUpdateActor()` compose les entrées puis `writeLogEntries()` déclenche `actor.update()` et `sendChatForAuditEntries()`, et `onCreateItem()` écrit directement une entrée d’audit talent.
+- `tests/utils/audit-log.test.mjs` couvre déjà les handlers et constitue le point naturel pour verrouiller la régression multijoueur sans étendre le périmètre.
+- `module/documents/actor.mjs` applique déjà le pattern projet `if (game.userId === userId)` pour réserver des effets de bord au client initiateur ; l’issue peut s’aligner sur ce précédent.
+
+## Plan d’implémentation
+
+### Étape 1 — Appliquer le garde mono-écrivain sur les hooks d’audit
+
+**Fichiers** : `module/utils/audit-log.mjs`
+
+**What** :
+
+- Introduire un garde explicite et homogène pour les hooks Audit Log basé sur `game.userId === userId`, puis l’appliquer au minimum à `onPreUpdateActor()`, `onUpdateActor()` et `onCreateItem()`.
+- Faire en sorte que seul le client initiateur puisse alimenter `pendingOldStates`, composer les entrées, écrire `flags.swerpg.logs` et déclencher l’émission chat associée.
+- Préserver les autres gardes existants (`swerpgAuditLog`, actor non-character, audit-only update) et ne pas modifier le schéma des entrées ni la stratégie de stockage actuelle.
+
+**Résultat attendu** : un seul client produit l’effet de bord Audit Log pour une action donnée, avec conservation de l’attribution `userId` existante dans les entrées.
+
+### Étape 2 — Verrouiller la non-régression multijoueur dans les tests d’audit
+
+**Fichiers** : `tests/utils/audit-log.test.mjs`
+
+**What** :
+
+- Ajouter des tests ciblés démontrant qu’un client dont `game.userId !== userId` ne capture pas d’état pending, n’écrit pas dans l’acteur et n’émet pas d’effet de bord Audit Log sur `updateActor` et `createItem`.
+- Ajouter le cas positif miroir confirmant que le client initiateur continue de produire exactement une écriture d’audit pour le même événement.
+- Verrouiller le besoin métier prouvé par l’issue : absence de duplication, sans élargir la correction à l’intégrité du stockage, à l’export CSV ou à d’autres refactors d’architecture.
+
+**Résultat attendu** : la protection mono-écrivain est couverte par des tests unitaires explicites et protège durablement le correctif contre une régression future.
+
+## Périmètre / hors périmètre
+
+### Inclus
+
+- Garde mono-écrivain sur les hooks Audit Log concernés
+- Tests unitaires ciblés sur le comportement multijoueur côté audit
+
+### Exclus
+
+- Refonte du stockage `flags.swerpg.logs` ou arbitrage d’inviolabilité du journal
+- Migration de l’export CSV, refactor de taxonomie Audit Log, ou autres chantiers de backlog non requis par l’issue

--- a/module/utils/audit-log.mjs
+++ b/module/utils/audit-log.mjs
@@ -47,6 +47,16 @@ function isAuditInternalUpdate(options) {
   return options?.swerpgAuditLog === false
 }
 
+/**
+ * Return true when the local client is the one that initiated the action.
+ * Mirrors the pattern used in SwerpgActor._onUpdate to prevent duplicate side-effects
+ * across all connected clients in a multiplayer session.
+ * @param {string} userId The userId argument provided by the Foundry hook.
+ */
+function isInitiatingClient(userId) {
+  return game.userId === userId
+}
+
 /* -------------------------------------------- */
 /*  Clone utilitaire                            */
 /* -------------------------------------------- */
@@ -310,6 +320,7 @@ function readAuditChatSummaryEnabled() {
 
 export {
   isOnlyAuditChange,
+  isInitiatingClient,
   snapshotOldState,
   cloneValue,
   evictOldestIfNeeded,
@@ -344,6 +355,7 @@ export {
  * @param {string} userId
  */
 export function onPreUpdateActor(actor, changes, options, userId) {
+  if (!isInitiatingClient(userId)) return
   if (isAuditInternalUpdate(options)) return
   if (!isCharacterActor(actor)) return
   if (isOnlyAuditChange(changes)) return
@@ -369,6 +381,7 @@ export function onPreUpdateActor(actor, changes, options, userId) {
  * @param {string} userId
  */
 export function onUpdateActor(actor, changes, options, userId) {
+  if (!isInitiatingClient(userId)) return
   if (isAuditInternalUpdate(options)) return
   if (!isCharacterActor(actor)) return
   if (isOnlyAuditChange(changes)) return
@@ -395,6 +408,7 @@ export function onUpdateActor(actor, changes, options, userId) {
  * @param {string} userId
  */
 function onCreateItem(item, data, options, userId) {
+  if (!isInitiatingClient(userId)) return
   if (item.parent?.type !== 'character') return
   if (item.type !== 'talent') return
 

--- a/tests/utils/audit-log.test.mjs
+++ b/tests/utils/audit-log.test.mjs
@@ -37,6 +37,7 @@ beforeEach(() => {
 
   globalThis.game = {
     ...globalThis.game,
+    userId: 'gm-1',
     user: { id: 'gm-1', name: 'Game Master', isGM: true },
     i18n: {
       localize: (key) => key,
@@ -440,21 +441,21 @@ describe('onPreUpdateActor', () => {
   test('skips non-character actors', async () => {
     const { onPreUpdateActor } = await import('../../module/utils/audit-log.mjs')
     const npc = { type: 'npc', uuid: 'Actor.npc-001', _source: {} }
-    expect(() => onPreUpdateActor(npc, { system: { skills: { Athletics: 1 } } }, {}, 'user-1')).not.toThrow()
+    expect(() => onPreUpdateActor(npc, { system: { skills: { Athletics: 1 } } }, {}, 'gm-1')).not.toThrow()
   })
 
   test('skips when changes are only audit logs', async () => {
     const { onPreUpdateActor } = await import('../../module/utils/audit-log.mjs')
     const actor = makeCharacterActor()
     const changes = { flags: { swerpg: { logs: [{ timestamp: 1 }] } } }
-    expect(() => onPreUpdateActor(actor, changes, {}, 'user-1')).not.toThrow()
+    expect(() => onPreUpdateActor(actor, changes, {}, 'gm-1')).not.toThrow()
   })
 
   test('skips when swerpgAuditLog option is false', async () => {
     const { onPreUpdateActor } = await import('../../module/utils/audit-log.mjs')
     const actor = makeCharacterActor()
     const changes = { system: { skills: { Athletics: { rank: 3 } } } }
-    expect(() => onPreUpdateActor(actor, changes, { swerpgAuditLog: false }, 'user-1')).not.toThrow()
+    expect(() => onPreUpdateActor(actor, changes, { swerpgAuditLog: false }, 'gm-1')).not.toThrow()
   })
 
   test('captures old state snapshot for character skill changes', async () => {
@@ -466,7 +467,7 @@ describe('onPreUpdateActor', () => {
       },
     })
     const changes = { system: { skills: { Athletics: { rank: 3 } } } }
-    expect(() => onPreUpdateActor(actor, changes, {}, 'user-1')).not.toThrow()
+    expect(() => onPreUpdateActor(actor, changes, {}, 'gm-1')).not.toThrow()
   })
 })
 
@@ -478,20 +479,20 @@ describe('onUpdateActor', () => {
   test('skips non-character actors', async () => {
     const { onUpdateActor } = await import('../../module/utils/audit-log.mjs')
     const npc = { type: 'npc', uuid: 'Actor.npc-001', _source: {} }
-    expect(() => onUpdateActor(npc, { system: { skills: {} } }, {}, 'user-1')).not.toThrow()
+    expect(() => onUpdateActor(npc, { system: { skills: {} } }, {}, 'gm-1')).not.toThrow()
   })
 
   test('skips when swerpgAuditLog option is false', async () => {
     const { onUpdateActor } = await import('../../module/utils/audit-log.mjs')
     const actor = makeCharacterActor()
     const changes = { system: { skills: { Athletics: { rank: 3 } } } }
-    expect(() => onUpdateActor(actor, changes, { swerpgAuditLog: false }, 'user-1')).not.toThrow()
+    expect(() => onUpdateActor(actor, changes, { swerpgAuditLog: false }, 'gm-1')).not.toThrow()
   })
 
   test('does nothing when no pending entry exists', async () => {
     const { onUpdateActor } = await import('../../module/utils/audit-log.mjs')
     const actor = makeCharacterActor()
-    expect(() => onUpdateActor(actor, { system: { skills: { Athletics: { rank: 3 } } } }, {}, 'user-1')).not.toThrow()
+    expect(() => onUpdateActor(actor, { system: { skills: { Athletics: { rank: 3 } } } }, {}, 'gm-1')).not.toThrow()
   })
 
   test('ignores expired pending entries', async () => {
@@ -505,19 +506,19 @@ describe('onUpdateActor', () => {
       },
     })
 
-    onPreUpdateActor(actor, { system: { skills: { Athletics: { rank: 3 } } } }, {}, 'user-1')
+    onPreUpdateActor(actor, { system: { skills: { Athletics: { rank: 3 } } } }, {}, 'gm-1')
 
     const expiredTimestamp = Date.now() - 60000
-    const { pushPendingEntry, shiftPendingEntry } = await import('../../module/utils/audit-log.mjs')
+    const { pushPendingEntry } = await import('../../module/utils/audit-log.mjs')
     flushPending()
-    pushPendingEntry(actor, 'user-1', {
+    pushPendingEntry(actor, 'gm-1', {
       oldState: {},
       changes: {},
-      userId: 'user-1',
+      userId: 'gm-1',
       timestamp: expiredTimestamp,
     })
 
-    expect(() => onUpdateActor(actor, { system: { skills: { Athletics: { rank: 3 } } } }, {}, 'user-1')).not.toThrow()
+    expect(() => onUpdateActor(actor, { system: { skills: { Athletics: { rank: 3 } } } }, {}, 'gm-1')).not.toThrow()
     flushPending()
   })
 })
@@ -624,7 +625,7 @@ describe('onCreateItem', () => {
     const actor = makeCharacterActor()
     const item = makeTalentItem(actor)
 
-    await onCreateItem(item, {}, {}, 'user-1')
+    await onCreateItem(item, {}, {}, 'gm-1')
 
     expect(actor.update).toHaveBeenCalledTimes(1)
     const updateArg = actor.update.mock.calls[0][0]
@@ -639,7 +640,7 @@ describe('onCreateItem', () => {
         ranks: 1,
       },
       xpDelta: -10,
-      userId: 'user-1',
+      userId: 'gm-1',
     })
   })
 
@@ -650,7 +651,7 @@ describe('onCreateItem', () => {
     const actor = makeCharacterActor()
     const item = makeTalentItem(actor, { system: {} })
 
-    await onCreateItem(item, {}, {}, 'user-1')
+    await onCreateItem(item, {}, {}, 'gm-1')
 
     expect(actor.update).toHaveBeenCalledTimes(1)
     const updateArg = actor.update.mock.calls[0][0]
@@ -665,7 +666,7 @@ describe('onCreateItem', () => {
     const actor = makeCharacterActor()
     const item = makeTalentItem(actor, { type: 'weapon' })
 
-    await onCreateItem(item, {}, {}, 'user-1')
+    await onCreateItem(item, {}, {}, 'gm-1')
 
     expect(actor.update).not.toHaveBeenCalled()
   })
@@ -675,7 +676,7 @@ describe('onCreateItem', () => {
     const npc = { type: 'npc', id: 'npc-001', name: 'NPC', update: vi.fn(), system: {} }
     const item = makeTalentItem(npc)
 
-    await onCreateItem(item, {}, {}, 'user-1')
+    await onCreateItem(item, {}, {}, 'gm-1')
 
     expect(npc.update).not.toHaveBeenCalled()
   })
@@ -684,7 +685,7 @@ describe('onCreateItem', () => {
     const { onCreateItem } = await import('../../module/utils/audit-log.mjs')
     const item = makeTalentItem(null)
 
-    expect(() => onCreateItem(item, {}, {}, 'user-1')).not.toThrow()
+    expect(() => onCreateItem(item, {}, {}, 'gm-1')).not.toThrow()
   })
 
   test('includes valid snapshot fields', async () => {
@@ -704,7 +705,7 @@ describe('onCreateItem', () => {
     })
     const item = makeTalentItem(actor)
 
-    await onCreateItem(item, {}, {}, 'user-1')
+    await onCreateItem(item, {}, {}, 'gm-1')
 
     const updateArg = actor.update.mock.calls[0][0]
     const snapshot = updateArg['flags.swerpg.logs'][0].snapshot
@@ -2213,5 +2214,178 @@ describe('recordItemSale', () => {
   test('is exported from the module', async () => {
     const module = await import('../../module/utils/audit-log.mjs')
     expect(typeof module.recordItemSale).toBe('function')
+  })
+})
+
+/* ============================================ */
+/*  isInitiatingClient                          */
+/* ============================================ */
+
+describe('isInitiatingClient', () => {
+  test('returns true when game.userId matches userId', async () => {
+    const { isInitiatingClient } = await import('../../module/utils/audit-log.mjs')
+    globalThis.game.userId = 'user-1'
+    expect(isInitiatingClient('user-1')).toBe(true)
+  })
+
+  test('returns false when game.userId does not match userId', async () => {
+    const { isInitiatingClient } = await import('../../module/utils/audit-log.mjs')
+    globalThis.game.userId = 'user-1'
+    expect(isInitiatingClient('user-2')).toBe(false)
+  })
+})
+
+/* ============================================ */
+/*  Mono-writer guard — onPreUpdateActor        */
+/* ============================================ */
+
+describe('onPreUpdateActor — mono-writer guard', () => {
+  test('non-initiating client does not capture pending state', async () => {
+    const { onPreUpdateActor, flushPending, countPendingEntries } = await import('../../module/utils/audit-log.mjs')
+    flushPending()
+
+    globalThis.game.userId = 'user-1'
+
+    const actor = makeCharacterActor({
+      _source: {
+        system: { skills: { Athletics: { rank: 2 } }, characteristics: {}, progression: {}, details: {}, advancement: {} },
+        flags: {},
+      },
+    })
+
+    onPreUpdateActor(actor, { system: { skills: { Athletics: { rank: 3 } } } }, {}, 'user-2')
+
+    expect(countPendingEntries()).toBe(0)
+    flushPending()
+  })
+
+  test('initiating client captures pending state', async () => {
+    const { onPreUpdateActor, flushPending, countPendingEntries } = await import('../../module/utils/audit-log.mjs')
+    flushPending()
+
+    globalThis.game.userId = 'user-1'
+
+    const actor = makeCharacterActor({
+      _source: {
+        system: { skills: { Athletics: { rank: 2 } }, characteristics: {}, progression: {}, details: {}, advancement: {} },
+        flags: {},
+      },
+    })
+
+    onPreUpdateActor(actor, { system: { skills: { Athletics: { rank: 3 } } } }, {}, 'user-1')
+
+    expect(countPendingEntries()).toBe(1)
+    flushPending()
+  })
+})
+
+/* ============================================ */
+/*  Mono-writer guard — onUpdateActor           */
+/* ============================================ */
+
+describe('onUpdateActor — mono-writer guard', () => {
+  test('non-initiating client does not write audit entries', async () => {
+    const { onPreUpdateActor, onUpdateActor, flushPending } = await import('../../module/utils/audit-log.mjs')
+    flushPending()
+
+    // The initiating client captures the pending state
+    globalThis.game.userId = 'user-1'
+    const actor = makeCharacterActor({
+      _source: {
+        system: { skills: { Athletics: { rank: 2 } }, characteristics: {}, progression: {}, details: {}, advancement: {} },
+        flags: {},
+      },
+    })
+    onPreUpdateActor(actor, { system: { skills: { Athletics: { rank: 3 } } } }, {}, 'user-1')
+
+    // Switch to a different client for the update
+    globalThis.game.userId = 'user-2'
+    onUpdateActor(actor, { system: { skills: { Athletics: { rank: 3 } } } }, {}, 'user-2')
+
+    expect(actor.update).not.toHaveBeenCalled()
+    flushPending()
+  })
+
+  test('initiating client consumes the pending entry (not left in queue after onUpdateActor)', async () => {
+    const { onPreUpdateActor, onUpdateActor, flushPending, countPendingEntries } = await import('../../module/utils/audit-log.mjs')
+    flushPending()
+
+    globalThis.game.userId = 'user-1'
+    globalThis.foundry.utils.deepClone = vi.fn((o) => structuredClone(o))
+
+    const actor = makeCharacterActor({
+      _source: {
+        system: { skills: { Athletics: { rank: 2 } }, characteristics: {}, progression: {}, details: {}, advancement: {} },
+        flags: {},
+      },
+    })
+
+    onPreUpdateActor(actor, { system: { skills: { Athletics: { rank: 3 } } } }, {}, 'user-1')
+    expect(countPendingEntries()).toBe(1)
+
+    onUpdateActor(actor, { system: { skills: { Athletics: { rank: 3 } } } }, {}, 'user-1')
+
+    // The pending entry must be consumed regardless of whether composeEntries produces audit entries
+    expect(countPendingEntries()).toBe(0)
+    flushPending()
+  })
+})
+
+/* ============================================ */
+/*  Mono-writer guard — onCreateItem            */
+/* ============================================ */
+
+describe('onCreateItem — mono-writer guard', () => {
+  function makeCharacterActorWithSystem(overrides = {}) {
+    return {
+      type: 'character',
+      id: 'actor-001',
+      uuid: 'Actor.actor-001',
+      name: 'Test Character',
+      _source: {
+        system: { skills: {}, characteristics: {}, progression: { totalXP: 0, spentXP: 0 }, details: {}, advancement: {} },
+        flags: {},
+      },
+      system: {
+        progression: {
+          experience: { spent: 0, gained: 0, available: 0, total: 0 },
+          freeSkillRanks: {
+            career: { spent: 0, gained: 0, available: 0 },
+            specialization: { spent: 0, gained: 0, available: 0 },
+          },
+        },
+      },
+      update: vi.fn(),
+      ...overrides,
+    }
+  }
+
+  test('non-initiating client does not write audit entry', async () => {
+    const { onCreateItem } = await import('../../module/utils/audit-log.mjs')
+    globalThis.game.userId = 'user-1'
+
+    const actor = makeCharacterActorWithSystem()
+    const item = { type: 'talent', id: 'talent-001', name: 'Parry', parent: actor, system: { cost: 5, ranks: 1 } }
+
+    await onCreateItem(item, {}, {}, 'user-2')
+
+    expect(actor.update).not.toHaveBeenCalled()
+  })
+
+  test('initiating client writes exactly one audit entry', async () => {
+    const { onCreateItem } = await import('../../module/utils/audit-log.mjs')
+    globalThis.game.userId = 'user-1'
+    globalThis.foundry.utils.deepClone = vi.fn((o) => structuredClone(o))
+
+    const actor = makeCharacterActorWithSystem()
+    const item = { type: 'talent', id: 'talent-001', name: 'Parry', parent: actor, system: { cost: 5, ranks: 1 } }
+
+    await onCreateItem(item, {}, {}, 'user-1')
+
+    expect(actor.update).toHaveBeenCalledTimes(1)
+    const logs = actor.update.mock.calls[0][0]['flags.swerpg.logs']
+    expect(logs).toHaveLength(1)
+    expect(logs[0].type).toBe('talent.purchase')
+    expect(logs[0].userId).toBe('user-1')
   })
 })


### PR DESCRIPTION
## Summary

- Add a mono-writer guard to audit hooks so only the initiating client records actor and talent audit side-effects.
- Cover the multiplayer regression with targeted audit-log tests for non-initiating and initiating clients.
- Add the implementation plan for issue #560 under `documentation/plan/audit-log/`.

## Context

Closes #560

## Tests

- Not run (not requested).
