### PR TITLE
feat: migrate audit log CSV export to foundry.utils.saveDataToFile

### DIFF
--- a/documentation/plan/audit-log/561-audit-log-migrer-lexport-csv-vers-foundry-utils-savedatatofile.md
+++ b/documentation/plan/audit-log/561-audit-log-migrer-lexport-csv-vers-foundry-utils-savedatatofile.md
@@ -1,0 +1,54 @@
+# Issue #561 — Audit Log : migrer l’export CSV vers `foundry.utils.saveDataToFile`
+
+**Issue** : https://github.com/herveDarritchon/foundryvtt-swerpg/issues/561  
+**Domaine métier** : `audit-log`
+
+## Goal
+
+Sécuriser l’export CSV Audit Log sur la cible Foundry v14 en remplaçant l’appel implicite au global déprécié par l’API namespacée `foundry.utils.saveDataToFile`, sans changer le contenu exporté, le nom du fichier ni les permissions d’accès.
+
+## Contexte utile
+
+- `documentation/audit/audit-log/audit-feature-audit-log.md` identifie ce point comme **AL2 / AUDIT-02** : l’export CSV repose encore sur `saveDataToFile(...)` global, documenté comme déprécié au profit de `foundry.utils.saveDataToFile`.
+- `module/applications/character-audit-log.mjs` concentre déjà tout le flux d’export : `#onExportCsv()` construit le CSV via `buildCsvContent()`, calcule le nom via `buildExportFilename()` puis déclenche le téléchargement.
+- `tests/applications/character-audit-log.test.mjs` couvre aujourd’hui surtout les helpers CSV (échappement, contenu, nom de fichier), mais pas encore le contrat applicatif d’appel à l’utilitaire Foundry d’export.
+- `tests/helpers/mock-foundry.mjs` est le point naturel si le mock Foundry doit exposer/stubber `foundry.utils.saveDataToFile` pour verrouiller la régression sans élargir le périmètre.
+
+## Plan d’implémentation
+
+### Étape 1 — Qualifier explicitement l’API Foundry utilisée pour l’export CSV
+
+**Fichiers** : `module/applications/character-audit-log.mjs`
+
+**What** :
+
+- Remplacer l’appel implicite à `saveDataToFile(...)` par `foundry.utils.saveDataToFile(...)` dans `#onExportCsv()`.
+- Garder inchangés le contrôle d’accès `canViewAuditLog()`, la génération du contenu CSV, la convention de nommage du fichier et la gestion d’erreur déjà en place.
+- Limiter le correctif à la migration d’API visée par l’issue, sans introduire de refactor plus large du module Audit Log.
+
+**Résultat attendu** : l’export CSV Audit Log dépend explicitement de l’API Foundry namespacée supportée par la cible v14, et non d’un global déprécié.
+
+### Étape 2 — Verrouiller le contrat d’export applicatif par des tests ciblés
+
+**Fichiers** : `tests/applications/character-audit-log.test.mjs`, `tests/helpers/mock-foundry.mjs` _(si nécessaire)_
+
+**What** :
+
+- Ajouter un test orienté application qui vérifie que l’action d’export appelle `foundry.utils.saveDataToFile` avec le contenu généré, le MIME `text/csv;charset=utf-8` et le nom calculé par `buildExportFilename()`.
+- Ajouter le cas d’échec miroir confirmant que si `foundry.utils.saveDataToFile` lève, l’application journalise l’erreur et affiche `SWERPG.AUDIT_LOG.EXPORT_FAILED` sans casser le flux utilisateur.
+- Étendre le mock Foundry uniquement au strict nécessaire pour rendre ce contrat testable de manière stable et explicite.
+
+**Résultat attendu** : la migration vers `foundry.utils.saveDataToFile` est protégée par un test applicatif explicite et ne peut plus régresser silencieusement.
+
+## Périmètre / hors périmètre
+
+### Inclus
+
+- Migration de l’appel d’export CSV Audit Log vers `foundry.utils.saveDataToFile`
+- Tests ciblés couvrant le chemin nominal et le chemin d’erreur de l’export
+
+### Exclus
+
+- Changement du format CSV, des colonnes exportées ou du nommage du fichier
+- Ajout du BOM UTF-8, durcissement anti-injection CSV ou autres améliorations backlog non demandées par l’issue
+- Refonte plus large de l’application Audit Log, du modèle métier ou du pipeline d’écriture d’audit

--- a/module/applications/character-audit-log.mjs
+++ b/module/applications/character-audit-log.mjs
@@ -1070,7 +1070,7 @@ export default class CharacterAuditLogApp extends api.HandlebarsApplicationMixin
       const csvContent = buildCsvContent(this.actor)
       const filename = buildExportFilename(this.actor)
 
-      saveDataToFile(csvContent, 'text/csv;charset=utf-8', filename)
+      foundry.utils.saveDataToFile(csvContent, 'text/csv;charset=utf-8', filename)
     } catch (err) {
       logger.error('[AuditLog] CSV export failed', err)
       ui.notifications.error(game.i18n.localize('SWERPG.AUDIT_LOG.EXPORT_FAILED'))

--- a/tests/applications/character-audit-log.test.mjs
+++ b/tests/applications/character-audit-log.test.mjs
@@ -2909,3 +2909,104 @@ describe('buildAuditLogEntries — hasDetails and details on entries', () => {
     expect(lines[0]).not.toContain('creditsBefore')
   })
 })
+
+/* ============================================ */
+/*  #onExportCsv applicative contract          */
+/* ============================================ */
+
+describe('#onExportCsv — foundry.utils.saveDataToFile applicative contract', () => {
+  let CharacterAuditLogApp
+
+  const baseTranslations = {
+    'SWERPG.AUDIT_LOG.NO_PERMISSION': 'No permission',
+    'SWERPG.AUDIT_LOG.EXPORT_FAILED': 'Export failed',
+    'SWERPG.AUDIT_LOG.FILTER.ALL': 'All',
+    'SWERPG.AUDIT_LOG.FILTER.SKILLS': 'Skills',
+    'SWERPG.AUDIT_LOG.FILTER.TALENTS': 'Talents',
+    'SWERPG.AUDIT_LOG.FILTER.XP': 'XP',
+    'SWERPG.AUDIT_LOG.FILTER.CHARACTERISTICS': 'Characteristics',
+    'SWERPG.AUDIT_LOG.FILTER.DETAILS': 'Core choices',
+    'SWERPG.AUDIT_LOG.FILTER.ADVANCEMENT': 'Advancement',
+    'SWERPG.AUDIT_LOG.FILTER.PURCHASES': 'Purchases',
+    'SWERPG.AUDIT_LOG.FILTER.SALES': 'Sales',
+    'SWERPG.AUDIT_LOG.EMPTY': 'No entries',
+    'SWERPG.AUDIT_LOG.TYPE.SKILL_TRAIN': 'Skill purchase',
+    'SWERPG.AUDIT_LOG.TYPE.UNKNOWN': 'Unknown event',
+    'SWERPG.AUDIT_LOG.NONE': 'None',
+    'SWERPG.AUDIT_LOG.UNKNOWN_VALUE': 'Unknown value',
+    'SWERPG.AUDIT_LOG.UNKNOWN_SKILL': 'Unknown skill',
+    'SWERPG.AUDIT_LOG.DESCRIPTION.SKILL_TRAIN': 'Skill {skill}: rank {oldRank} -> {newRank}',
+    'SWERPG.AUDIT_LOG.DESCRIPTION.UNKNOWN': 'Unknown event ({type})',
+    'SWERPG.AUDIT_LOG.VARIANT.ADD': 'Added',
+    'SWERPG.AUDIT_LOG.VARIANT.GAIN': 'Gained',
+    'SWERPG.AUDIT_LOG.VARIANT.REMOVE': 'Removed',
+    'SWERPG.AUDIT_LOG.VARIANT.CHANGE': 'Changed',
+    'SWERPG.AUDIT_LOG.VARIANT.FAIL': 'Failed',
+  }
+
+  beforeEach(async () => {
+    setupFoundryMock({ translations: baseTranslations })
+    globalThis.game.users = { get: vi.fn(() => undefined) }
+    ;({ default: CharacterAuditLogApp } = await import('../../module/applications/character-audit-log.mjs'))
+  })
+
+  afterEach(() => {
+    vi.resetModules()
+    vi.clearAllMocks()
+    teardownFoundryMock()
+  })
+
+  function makeActor(logs = []) {
+    return {
+      id: 'actor-export',
+      name: 'Vara Kesh',
+      type: 'character',
+      isOwner: true,
+      system: {},
+      flags: { swerpg: { logs } },
+      ownership: { 'owner-1': 3 },
+      testUserPermission: vi.fn(() => true),
+    }
+  }
+
+  it('nominal: calls foundry.utils.saveDataToFile with CSV content, text/csv MIME and the computed filename', async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-05-12T10:00:00Z'))
+
+    const actor = makeActor([{ id: 'e1', timestamp: 100, type: 'skill.train', xpDelta: -10, data: { skillName: 'Piloting', oldRank: 1, newRank: 2 } }])
+
+    const app = new CharacterAuditLogApp({ document: actor })
+    const fakeEvent = { preventDefault: vi.fn() }
+
+    await CharacterAuditLogApp.DEFAULT_OPTIONS.actions.exportCsv.call(app, fakeEvent, null)
+
+    expect(fakeEvent.preventDefault).toHaveBeenCalled()
+    expect(globalThis.foundry.utils.saveDataToFile).toHaveBeenCalledOnce()
+
+    const [csvContent, mime, filename] = globalThis.foundry.utils.saveDataToFile.mock.calls[0]
+
+    expect(typeof csvContent).toBe('string')
+    expect(csvContent).toContain('timestamp,date,userName,type,typeLabel,description,xpDelta,creditDelta,actorName,playerName')
+    expect(mime).toBe('text/csv;charset=utf-8')
+    expect(typeof filename).toBe('string')
+    expect(filename).toMatch(/^vara_kesh_.+_2026-05-12\.csv$/)
+
+    vi.useRealTimers()
+  })
+
+  it('error path: when foundry.utils.saveDataToFile throws, logs the error and shows EXPORT_FAILED notification', async () => {
+    const exportError = new Error('disk full')
+    globalThis.foundry.utils.saveDataToFile.mockImplementation(() => {
+      throw exportError
+    })
+
+    const actor = makeActor()
+    const app = new CharacterAuditLogApp({ document: actor })
+    const fakeEvent = { preventDefault: vi.fn() }
+
+    // Must not throw — the error is caught by #onExportCsv
+    await expect(CharacterAuditLogApp.DEFAULT_OPTIONS.actions.exportCsv.call(app, fakeEvent, null)).resolves.toBeUndefined()
+
+    expect(globalThis.ui.notifications.error).toHaveBeenCalledWith('Export failed')
+  })
+})

--- a/tests/helpers/mock-foundry.mjs
+++ b/tests/helpers/mock-foundry.mjs
@@ -482,6 +482,7 @@ export function setupFoundryMock(options = {}) {
       debounce: vi.fn((fn, _wait) => fn),
       randomID: vi.fn(() => Math.random().toString(36).slice(2, 10)),
       isEmpty: vi.fn((obj) => !obj || Object.keys(obj).length === 0),
+      saveDataToFile: vi.fn(),
     },
     ...foundryPatch,
   }


### PR DESCRIPTION
## Summary

- Switch the Audit Log CSV export to `foundry.utils.saveDataToFile` for explicit Foundry v14 compatibility.
- Add applicative coverage for the CSV export success path and the handled error path.
- Record the implementation plan for issue #561 under `documentation/plan/audit-log/`.

## Context

Closes #561

## Tests

- Not run (not requested).
