### PR TITLE
docs(audit-log): clarify trust contract and journal integrity status

### DIFF
--- a/documentation/architecture/adr/adr-0011-stockage-journal-evolution-personnage-flags.md
+++ b/documentation/architecture/adr/adr-0011-stockage-journal-evolution-personnage-flags.md
@@ -2,7 +2,7 @@
 
 ## Statut
 
-Accepté
+Accepté — Contrat de confiance explicité (issue #562, 2026-06-06)
 
 ## Contexte
 
@@ -121,3 +121,34 @@ actor.flags.swerpg.logs
 ```
 
 Il s’agit d’une donnée secondaire, destinée au suivi, à l’audit et au debug, et non d’une donnée cœur du modèle personnage.
+
+---
+
+## Contrat de confiance — Niveau indicatif (décision issue #562, AUDIT-03)
+
+### Décision
+
+Le journal est **indicatif** : il est consultable et exportable, mais **non inviolable**.
+
+Un propriétaire d’acteur (rôle OWNER) peut techniquement modifier ou purger ses propres entrées via l’API Foundry (`actor.setFlag`, console développeur, voire désactivation du module). Le système ne met pas en place de stockage protégé côté serveur ou MJ dans ce cycle.
+
+### Critères retenus
+
+| Critère           | Valeur retenue                                           |
+| ----------------- | -------------------------------------------------------- |
+| Qui écrit         | L’utilisateur déclencheur de la modification (userId)    |
+| Où est stocké     | `flags.swerpg.logs` sur l’acteur (côté client/joueur)    |
+| Qui peut modifier | Le propriétaire OWNER (non bloqué par le système)        |
+| Niveau de preuve  | Indicatif — outil de suivi, pas une preuve infalsifiable |
+
+### Conséquences sur la surface utilisateur
+
+Toute formulation visible dans l’UI ou la documentation doit rester cohérente avec ce contrat :
+
+- Le journal est un **outil de suivi** et de **consultation** de l’évolution du personnage.
+- Il **ne constitue pas une preuve** de la conformité des dépenses d’expérience ou de crédits.
+- Le MJ peut s’appuyer sur ce journal à titre indicatif, mais ne doit pas en faire une source d’arbitrage définitive.
+
+### Voie future possible (hors périmètre de cette décision)
+
+Un durcissement ultérieur pourrait consister à stocker le journal dans un document de monde accessible uniquement au MJ, ou à implémenter un hash de chaînage anti-falsification. Ce travail est à inscrire explicitement en backlog (AUDIT-03 future) et ne doit pas être promis implicitement par l’interface actuelle.

--- a/documentation/audit/audit-log/audit-feature-audit-log.md
+++ b/documentation/audit/audit-log/audit-feature-audit-log.md
@@ -77,9 +77,16 @@ Idem pour `onCreateItem` (`game.userId !== userId`). Variante MJ-autoritaire : `
 
 #### AL3. Intégrité du journal compromise : il est éditable par l'audité
 
+> **Décision actée — issue #562, AUDIT-03 (2026-06-06) — Option A retenue**
+>
+> Le journal est **indicatif, consultable et exportable, mais non inviolable**.  
+> Un propriétaire OWNER peut techniquement modifier ou purger ses propres entrées. Aucun stockage protégé côté MJ/serveur n'est mis en place dans ce cycle.  
+> Le contrat de confiance complet est documenté dans [ADR-0011](../../architecture/adr/adr-0011-stockage-journal-evolution-personnage-flags.md) — section « Contrat de confiance ».  
+> Un durcissement futur (stockage journal de monde, hash de chaînage) reste possible en backlog.
+
 Le journal vit dans `flags.swerpg.logs` **sur l'acteur** que le joueur possède (`OWNER`). Un joueur peut donc **éditer ou purger son propre historique** (`actor.setFlag`, console, voire désactivation du module). Pour une feature d'**audit/responsabilité** (tracer les dépenses XP/crédits), l'audité ne devrait pas pouvoir altérer la preuve.
 
-**Décision à acter** : selon l'objectif (confort joueur vs contrôle MJ). Options : journal en _flag_ protégé écrit uniquement par le MJ/serveur, hash de chaînage anti-falsification, ou stockage côté MJ (journal de monde) répliqué. À défaut, documenter explicitement que le journal est **indicatif, non inviolable**.
+**Décision actée** : le journal est un outil de suivi indicatif, pas une preuve infalsifiable. Toute surface UI ou documentation doit éviter un vocabulaire de preuve ou d'inviolabilité.
 
 #### AL4. Taxonomie des types dupliquée en 4 endroits (risque de dérive)
 
@@ -160,20 +167,20 @@ Le contenu est annoncé `charset=utf-8` mais sans BOM ; Excel (FR) peut mal affi
 
 > **P0** = correctness/intégrité multijoueur ; **P1** = robustesse/architecture ; **P2** = polish/hardening.
 
-| ID       | Titre                                                                                   | Prio   | Type             | Effort | Réf.     |
-| -------- | --------------------------------------------------------------------------------------- | ------ | ---------------- | ------ | -------- |
-| AUDIT-01 | Garde mono-écrivain sur les hooks (`game.userId === userId`) + test multijoueur         | **P0** | bug              | S      | AL1      |
-| AUDIT-02 | Migrer l'export CSV vers `foundry.utils.saveDataToFile` (+ test)                        | **P1** | dette/API        | XS     | AL2      |
-| AUDIT-03 | Arbitrer l'inviolabilité du journal (écriture MJ/serveur ou doc de monde)               | **P1** | conception/sécu  | M      | AL3      |
-| AUDIT-04 | Registre unique de taxonomie type→{label,family,describe,chatVariant}                   | **P1** | refactor         | M      | AL4/AL10 |
-| AUDIT-05 | Sortir la taxonomie/descriptions de `applications/` vers le domaine (lever l'inversion) | **P1** | archi            | S      | AL5      |
-| AUDIT-06 | Corriger l'écrasement de `metaRight` (modificateur commerce visible) + test             | **P1** | bug              | XS     | AL6      |
-| AUDIT-07 | Corréler old/new par id d'opération (ou purge sur update échouée)                       | **P2** | robustesse       | M      | AL7      |
-| AUDIT-08 | Durcir `escapeCsvCell` contre l'injection de formules                                   | **P2** | sécu             | XS     | AL8      |
-| AUDIT-09 | Surveiller/segmenter la volumétrie du journal sur l'acteur                              | **P2** | perf             | M      | AL9      |
-| AUDIT-10 | Nommer les constantes métier (coût caractéristique, défauts cost/ranks)                 | **P2** | dette (ADR-0018) | S      | AL12     |
-| AUDIT-11 | Unifier la source du delta crédits (purchase)                                           | **P2** | qualité          | XS     | AL11     |
-| AUDIT-12 | BOM UTF-8 dans l'export CSV                                                             | **P2** | i18n             | XS     | AL13     |
+| ID       | Titre                                                                                   | Prio        | Type             | Effort | Réf.     |
+| -------- | --------------------------------------------------------------------------------------- | ----------- | ---------------- | ------ | -------- |
+| AUDIT-01 | Garde mono-écrivain sur les hooks (`game.userId === userId`) + test multijoueur         | **P0**      | bug              | S      | AL1      |
+| AUDIT-02 | Migrer l'export CSV vers `foundry.utils.saveDataToFile` (+ test)                        | **P1**      | dette/API        | XS     | AL2      |
+| AUDIT-03 | Arbitrer l'inviolabilité du journal (écriture MJ/serveur ou doc de monde)               | ✅ **done** | conception/sécu  | M      | AL3      |
+| AUDIT-04 | Registre unique de taxonomie type→{label,family,describe,chatVariant}                   | **P1**      | refactor         | M      | AL4/AL10 |
+| AUDIT-05 | Sortir la taxonomie/descriptions de `applications/` vers le domaine (lever l'inversion) | **P1**      | archi            | S      | AL5      |
+| AUDIT-06 | Corriger l'écrasement de `metaRight` (modificateur commerce visible) + test             | **P1**      | bug              | XS     | AL6      |
+| AUDIT-07 | Corréler old/new par id d'opération (ou purge sur update échouée)                       | **P2**      | robustesse       | M      | AL7      |
+| AUDIT-08 | Durcir `escapeCsvCell` contre l'injection de formules                                   | **P2**      | sécu             | XS     | AL8      |
+| AUDIT-09 | Surveiller/segmenter la volumétrie du journal sur l'acteur                              | **P2**      | perf             | M      | AL9      |
+| AUDIT-10 | Nommer les constantes métier (coût caractéristique, défauts cost/ranks)                 | **P2**      | dette (ADR-0018) | S      | AL12     |
+| AUDIT-11 | Unifier la source du delta crédits (purchase)                                           | **P2**      | qualité          | XS     | AL11     |
+| AUDIT-12 | BOM UTF-8 dans l'export CSV                                                             | **P2**      | i18n             | XS     | AL13     |
 
 ---
 

--- a/documentation/plan/audit-log/562-audit-log-arbitrer-l-inviolabilite-du-journal-ecriture-mj-serveur-ou-documentation.md
+++ b/documentation/plan/audit-log/562-audit-log-arbitrer-l-inviolabilite-du-journal-ecriture-mj-serveur-ou-documentation.md
@@ -1,0 +1,81 @@
+# Issue #562 — Audit Log : arbitrer l’inviolabilité du journal (écriture MJ/serveur ou documentation)
+
+**Issue** : https://github.com/herveDarritchon/foundryvtt-swerpg/issues/562  
+**Domaine métier** : `audit-log`
+
+## Goal
+
+Acter puis rendre explicite le niveau de confiance du journal Audit Log afin d’éviter une promesse implicite de traçabilité inviolable alors que le stockage actuel sur l’acteur reste modifiable par son propriétaire.
+
+## Contexte utile
+
+- `documentation/audit/audit-log/audit-feature-audit-log.md` identifie **AL3 / AUDIT-03** : le journal vit aujourd’hui dans `flags.swerpg.logs` sur l’acteur et l’audité peut donc altérer ou purger son propre historique.
+- Le correctif **#560** traite le doublonnage multijoueur via un garde mono-écrivain, mais ne change pas le niveau d’intégrité du stockage.
+- Les permissions de lecture/export sont déjà cadrées côté UI ; le point restant est bien l’**arbitrage du contrat d’inviolabilité**, pas une refonte générale de l’interface Audit Log.
+- L’issue ouvre explicitement deux sorties acceptables : **durcir l’écriture/stockage côté MJ/serveur** ou **documenter clairement que le journal est indicatif et non inviolable**.
+
+## Plan d’implémentation
+
+### Étape 1 — Acter le contrat de confiance cible
+
+**Fichiers** : `documentation/audit/audit-log/audit-feature-audit-log.md` ; ADR dédiée uniquement si l’option retenue modifie l’architecture de persistance
+
+**What** :
+
+- Décider explicitement si l’objectif produit est un journal **informatif** ou un journal **autoritaire**.
+- Formaliser les critères de décision : qui écrit, où le journal est stocké, qui peut le modifier, et quel niveau de preuve l’UI est autorisée à revendiquer.
+- Si aucune persistance protégée MJ/serveur n’est retenue dans ce cycle, acter sans ambiguïté la voie documentation plutôt qu’une promesse de sécurité partielle.
+
+**Résultat attendu** : un contrat de confiance unique, explicite et partageable, qui supprime l’ambiguïté fonctionnelle de l’issue.
+
+### Étape 2 — Appliquer la voie retenue sans mélange de promesses
+
+**Option A — Documentation assumée**
+
+**Fichiers** : documentation Audit Log et toute surface utilisateur décrivant la feature
+
+**What** :
+
+- Documenter que le journal actuel est **indicatif, consultable et exportable**, mais **non inviolable** tant qu’il reste stocké sur l’acteur.
+- Aligner le wording UI/doc pour éviter toute formulation laissant entendre une preuve infalsifiable.
+- Ajouter une note de limites connues reliant cette décision à la backlog d’un éventuel durcissement futur.
+
+**Résultat attendu** : plus aucune ambiguïté entre le comportement réel du système et la promesse faite aux MJ/joueurs.
+
+**Option B — Écriture/stocker autoritaires côté MJ/serveur**
+
+**Fichiers** : pipeline Audit Log d’écriture/lecture, emplacement de persistance retenu, tests ciblés, documentation d’architecture associée
+
+**What** :
+
+- Déplacer l’autorité d’écriture et le stockage vers un support que l’audité ne peut pas modifier directement.
+- Adapter la lecture/export pour conserver l’expérience actuelle de consultation sans reposer sur un flag acteur falsifiable.
+- Encadrer par des tests ciblés le fait qu’un propriétaire d’acteur ne peut plus altérer seul le journal autoritaire.
+
+**Résultat attendu** : le niveau d’intégrité promis par la feature devient techniquement cohérent avec son architecture de stockage.
+
+### Étape 3 — Verrouiller la clôture de l’issue par des critères ciblés
+
+**Fichiers** : documentation et/ou tests strictement alignés sur l’option retenue
+
+**What** :
+
+- Pour la voie documentation : vérifier que les docs et libellés exposés n’emploient plus un vocabulaire de preuve/inviolabilité.
+- Pour la voie autoritaire : vérifier que l’écriture protégée, la lecture MJ/OWNER et l’export continuent de fonctionner sans retour au flag acteur éditable.
+- Maintenir le périmètre strict de l’issue : ne pas embarquer la taxonomie Audit Log, le durcissement CSV ou d’autres refactors non requis.
+
+**Résultat attendu** : l’issue se ferme sur une définition claire, vérifiable et non trompeuse de la fiabilité du journal.
+
+## Périmètre / hors périmètre
+
+### Inclus
+
+- Arbitrage explicite du statut de confiance du journal Audit Log
+- Mise en cohérence de la documentation et/ou de l’architecture avec cet arbitrage
+- Validation ciblée du contrat retenu
+
+### Exclus
+
+- Refonte générale de l’application Audit Log
+- Consolidation de taxonomie, durcissement CSV, ou autres items backlog AUDIT-04+
+- Travaux hors sujet sur d’autres journaux, chats ou pipelines de progression

--- a/lang/en.json
+++ b/lang/en.json
@@ -277,7 +277,7 @@
   "SWERPG.AUDIT.ERROR": "Error",
   "SWERPG.AUDIT.CHECK_CONSOLE": "See the console (F12) for more details.",
   "SWERPG.AUDIT_LOG.TITLE": "Character evolution history: {actor}",
-  "SWERPG.AUDIT_LOG.SUBTITLE": "Read-only timeline of the character's evolution.",
+  "SWERPG.AUDIT_LOG.SUBTITLE": "Indicative timeline of the character's evolution (consultable, not tamper-proof).",
   "SWERPG.AUDIT_LOG.OPEN": "Open character evolution history",
   "SWERPG.AUDIT_LOG.NO_PERMISSION": "You may only view the history of characters you own.",
   "SWERPG.AUDIT_LOG.EMPTY": "No entries in the history yet.",

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -252,7 +252,7 @@
   "SWERPG.AUDIT.ERROR": "Erreur",
   "SWERPG.AUDIT.CHECK_CONSOLE": "Voir la console (F12) pour plus de détails.",
   "SWERPG.AUDIT_LOG.TITLE": "Historique d'évolution : {actor}",
-  "SWERPG.AUDIT_LOG.SUBTITLE": "Journal complet des évolutions du personnage, en lecture seule.",
+  "SWERPG.AUDIT_LOG.SUBTITLE": "Journal indicatif des évolutions du personnage (consultable, non inviolable).",
   "SWERPG.AUDIT_LOG.OPEN": "Consulter l'historique d'évolution",
   "SWERPG.AUDIT_LOG.NO_PERMISSION": "Vous ne pouvez consulter l'historique que de vos propres personnages.",
   "SWERPG.AUDIT_LOG.EMPTY": "Aucune entrée dans l'historique pour l'instant.",


### PR DESCRIPTION
## Summary

- Update documentation for the audit-log feature: clarify the trust contract and journal integrity status.
- Modify ADR-0011 (journal storage / flags) and audit feature docs; add a plan file for this work.
- Update en/fr language keys used by the documentation.

## Context

This change is documentation-only and adds a planning file under documentation/plan for the audit-log feature. It summarizes decisions about journal storage, the actor evolution flags and the guarantees expected from the MJ server vs local documentation.

## Tests

- Not run (not requested).

## Notes

- Files changed: documentation/architecture/adr/adr-0011-stockage-journal-evolution-personnage-flags.md, documentation/audit/audit-log/audit-feature-audit-log.md, documentation/plan/audit-log/562-audit-log-arbitrer-l-inviolabilite-du-journal-ecriture-mj-serveur-ou-documentation.md (added), lang/en.json, lang/fr.json
- No code changes; this PR is documentation and plan only.
