### PR TITLE
feat(audit-log): consolidate audit log taxonomy into a shared registry

### DIFF
--- a/documentation/plan/audit-log/563-audit-log-registre-unique-de-taxonomie-extraction-hors-de-applications.md
+++ b/documentation/plan/audit-log/563-audit-log-registre-unique-de-taxonomie-extraction-hors-de-applications.md
@@ -1,0 +1,68 @@
+# Issue #563 — Audit Log : registre unique de taxonomie + extraction hors de `applications/`
+
+**Issue** : https://github.com/herveDarritchon/foundryvtt-swerpg/issues/563  
+**Domaine métier** : `audit-log`
+
+## Goal
+
+Consolider la taxonomie Audit Log dans un registre métier unique pour supprimer les duplications labels/familles/descriptions/chat, lever l’inversion de couche entre `utils/` et `applications/`, et réduire le coût d’ajout d’un nouveau type d’événement à une seule édition.
+
+## Contexte utile
+
+- `documentation/audit/audit-log/audit-feature-audit-log.md` cadre précisément le besoin via **AL4**, **AL5** et **AL10** : taxonomie dupliquée, description métier logée dans `applications/`, et `switch` chat monolithique.
+- `module/applications/character-audit-log.mjs` concentre aujourd’hui plusieurs sources de vérité : `AUDIT_LOG_TYPE_LABELS`, `getAuditLogFamily()`, `buildAuditLogDescription()` et une partie du rendu de variantes.
+- `module/utils/audit-log.mjs` dépend actuellement de `../applications/character-audit-log.mjs` pour `buildAuditLogDescription()`, puis porte `_buildChatContext()` avec un `switch` long et coûteux à maintenir.
+- `tests/applications/character-audit-log.test.mjs` couvre déjà la description, les familles et une partie du rendu ; c’est le point naturel pour verrouiller le nouveau contrat partagé sans élargir le périmètre.
+
+## Plan d’implémentation
+
+### Étape 1 — Introduire un registre métier partagé de taxonomie Audit Log
+
+**Fichiers** : `module/lib/audit/taxonomy.mjs` _(nouveau)_, `module/applications/character-audit-log.mjs`, `module/utils/audit-log.mjs`
+
+**What** :
+
+- Créer un module métier dédié exportant un registre unique `type -> { label, family, describe(), chatVariant }` pour tous les types d’événements Audit Log connus.
+- Y déplacer la logique aujourd’hui dispersée entre `AUDIT_LOG_TYPE_LABELS`, `getAuditLogFamily()` et `buildAuditLogDescription()`, avec des fallbacks explicites pour les types inconnus.
+- Faire de ce module la seule source de vérité consommable aussi bien par l’application Audit Log que par le pipeline d’écriture/chat.
+
+**Résultat attendu** : tout ajout ou modification d’un type d’événement se fait dans un seul registre métier, sans duplication silencieuse entre UI, utilitaires et chat.
+
+### Étape 2 — Rebrancher les consommateurs et lever l’inversion de couche
+
+**Fichiers** : `module/applications/character-audit-log.mjs`, `module/utils/audit-log.mjs`
+
+**What** :
+
+- Remplacer dans l’application les accès directs aux mappings locaux par des helpers basés sur le registre partagé, en conservant le contrat public nécessaire au rendu existant.
+- Déplacer `buildAuditLogDescription()` hors de `applications/` et supprimer l’import `utils/ -> applications/` dans `module/utils/audit-log.mjs`.
+- Limiter le refactor aux responsabilités de taxonomie/description afin de ne pas modifier le stockage, l’export CSV ni le flux d’écriture des entrées.
+
+**Résultat attendu** : `module/utils/audit-log.mjs` ne dépend plus de la couche Application, et la description métier est réutilisable depuis une couche domaine neutre.
+
+### Étape 3 — Remplacer le `switch` chat par une map de handlers adossée au registre et verrouiller les tests
+
+**Fichiers** : `module/utils/audit-log.mjs`, `tests/applications/character-audit-log.test.mjs`, `tests/utils/audit-log.test.mjs` _(si couverture chat existante ou à compléter)_
+
+**What** :
+
+- Refactorer `_buildChatContext()` en map de handlers indexée par type, avec lecture des métadonnées (`label`, `family`, `chatVariant`) depuis le registre unique.
+- Conserver à l’identique le rendu fonctionnel attendu des cartes de chat pour éviter tout changement de comportement hors périmètre.
+- Mettre à jour/ajouter des tests ciblés pour garantir : source de vérité unique, description extraite hors de `applications/`, et couverture de plusieurs branches chat représentatives sans retomber dans un `switch` monolithique.
+
+**Résultat attendu** : le rendu chat devient extensible type par type, et le contrat métier de taxonomie est protégé par des tests explicites côté application et côté utilitaires.
+
+## Périmètre / hors périmètre
+
+### Inclus
+
+- Registre unique de taxonomie Audit Log
+- Extraction de la description métier hors de `applications/`
+- Refactor ciblé du rendu chat vers une map de handlers
+- Mise à jour ciblée des tests liés à la taxonomie et au chat
+
+### Exclus
+
+- Refonte du stockage `flags.swerpg.logs`, de l’export CSV ou des règles d’intégrité du journal
+- Changement fonctionnel des textes, filtres ou variantes chat au-delà de la consolidation demandée
+- Ajout de nouveaux types d’événements non requis par l’issue

--- a/module/applications/character-audit-log.mjs
+++ b/module/applications/character-audit-log.mjs
@@ -1,23 +1,11 @@
 import { logger } from '../utils/logger.mjs'
+import { AUDIT_LOG_FAMILIES, getAuditLogFamilyFromType, getAuditLogTypeLabelKey, buildAuditLogDescriptionFromRegistry } from '../lib/audit/taxonomy.mjs'
 
 const { api } = foundry.applications
 
 const AUDIT_LOG_PATH = 'flags.swerpg.logs'
 
 const CSV_COLUMNS = Object.freeze(['timestamp', 'date', 'userName', 'type', 'typeLabel', 'description', 'xpDelta', 'creditDelta', 'actorName', 'playerName'])
-
-const AUDIT_LOG_FAMILIES = Object.freeze({
-  all: 'all',
-  skills: 'skills',
-  talents: 'talents',
-  xp: 'xp',
-  characteristics: 'characteristics',
-  details: 'details',
-  advancement: 'advancement',
-  purchases: 'purchases',
-  sales: 'sales',
-  other: 'other',
-})
 
 const AUDIT_LOG_FILTER_ORDER = Object.freeze([
   AUDIT_LOG_FAMILIES.all,
@@ -145,29 +133,6 @@ export function getAuditLogVariantGlyph(variant) {
   return AUDIT_LOG_VARIANT_GLYPHS[variant] ?? AUDIT_LOG_VARIANT_GLYPHS.change
 }
 
-const AUDIT_LOG_TYPE_LABELS = Object.freeze({
-  'skill.train': 'SWERPG.AUDIT_LOG.TYPE.SKILL_TRAIN',
-  'skill.forget': 'SWERPG.AUDIT_LOG.TYPE.SKILL_FORGET',
-  'characteristic.increase': 'SWERPG.AUDIT_LOG.TYPE.CHARACTERISTIC_INCREASE',
-  'xp.spend': 'SWERPG.AUDIT_LOG.TYPE.XP_SPEND',
-  'xp.refund': 'SWERPG.AUDIT_LOG.TYPE.XP_REFUND',
-  'xp.grant': 'SWERPG.AUDIT_LOG.TYPE.XP_GRANT',
-  'xp.remove': 'SWERPG.AUDIT_LOG.TYPE.XP_REMOVE',
-  'species.set': 'SWERPG.AUDIT_LOG.TYPE.SPECIES_SET',
-  'career.set': 'SWERPG.AUDIT_LOG.TYPE.CAREER_SET',
-  'specialization.add': 'SWERPG.AUDIT_LOG.TYPE.SPECIALIZATION_ADD',
-  'specialization.remove': 'SWERPG.AUDIT_LOG.TYPE.SPECIALIZATION_REMOVE',
-  'talent.purchase': 'SWERPG.AUDIT_LOG.TYPE.TALENT_PURCHASE',
-  'talent-node-purchase': 'SWERPG.AUDIT_LOG.TYPE.TALENT_NODE_PURCHASE',
-  'talent-node-purchase-succeeded': 'SWERPG.AUDIT_LOG.TYPE.TALENT_NODE_PURCHASE_SUCCEEDED',
-  'talent-node-purchase-failed': 'SWERPG.AUDIT_LOG.TYPE.TALENT_NODE_PURCHASE_FAILED',
-  'talent-node-forget-succeeded': 'SWERPG.AUDIT_LOG.TYPE.TALENT_NODE_FORGET_SUCCEEDED',
-  'talent-node-forget-failed': 'SWERPG.AUDIT_LOG.TYPE.TALENT_NODE_FORGET_FAILED',
-  'advancement.level': 'SWERPG.AUDIT_LOG.TYPE.ADVANCEMENT_LEVEL',
-  'item.purchase': 'SWERPG.AUDIT_LOG.TYPE.ITEM_PURCHASE',
-  'item.sale': 'SWERPG.AUDIT_LOG.TYPE.ITEM_SALE',
-})
-
 /**
  * Determine whether the current user may view a character audit log.
  * @param {Actor|object|null} actor
@@ -182,42 +147,12 @@ export function canViewAuditLog(actor, user = game.user) {
 
 /**
  * Map a technical audit entry type to a business filter family.
+ * Delegates to the shared taxonomy registry.
  * @param {string} type
  * @returns {string}
  */
 export function getAuditLogFamily(type) {
-  switch (type) {
-    case 'skill.train':
-    case 'skill.forget':
-      return AUDIT_LOG_FAMILIES.skills
-    case 'talent.purchase':
-    case 'talent-node-purchase':
-    case 'talent-node-purchase-succeeded':
-    case 'talent-node-purchase-failed':
-    case 'talent-node-forget-succeeded':
-    case 'talent-node-forget-failed':
-      return AUDIT_LOG_FAMILIES.talents
-    case 'xp.spend':
-    case 'xp.refund':
-    case 'xp.grant':
-    case 'xp.remove':
-      return AUDIT_LOG_FAMILIES.xp
-    case 'characteristic.increase':
-      return AUDIT_LOG_FAMILIES.characteristics
-    case 'species.set':
-    case 'career.set':
-    case 'specialization.add':
-    case 'specialization.remove':
-      return AUDIT_LOG_FAMILIES.details
-    case 'advancement.level':
-      return AUDIT_LOG_FAMILIES.advancement
-    case 'item.purchase':
-      return AUDIT_LOG_FAMILIES.purchases
-    case 'item.sale':
-      return AUDIT_LOG_FAMILIES.sales
-    default:
-      return AUDIT_LOG_FAMILIES.other
-  }
+  return getAuditLogFamilyFromType(type)
 }
 
 /**
@@ -393,149 +328,25 @@ function formatAuditLogCreditDelta(creditDelta) {
 
 /**
  * Return the localized label for the given audit entry type, falling back to the UNKNOWN key.
+ * Delegates to the shared taxonomy registry.
  * @param {string} type
  */
 function getAuditLogTypeLabel(type) {
-  const key = AUDIT_LOG_TYPE_LABELS[type] ?? 'SWERPG.AUDIT_LOG.TYPE.UNKNOWN'
-  return game.i18n.localize(key)
-}
-
-/**
- * Return the display name for a value, localizing the fallback key when the value is absent or empty.
- * @param {*} value
- * @param {string} fallbackKey
- */
-function getAuditLogName(value, fallbackKey = 'SWERPG.AUDIT_LOG.UNKNOWN_VALUE') {
-  if (value === null || value === undefined || value === '') return game.i18n.localize(fallbackKey)
-  return value
-}
-
-/**
- * Resolve a localized characteristic label from its technical identifier.
- * Falls back to the localized UNKNOWN_VALUE key when the id is absent or unrecognized.
- * @param {string|null|undefined} characteristicId
- * @returns {string}
- */
-function getCharacteristicLabel(characteristicId) {
-  if (!characteristicId) return game.i18n.localize('SWERPG.AUDIT_LOG.UNKNOWN_VALUE')
-  const characteristic = game.system.config?.CHARACTERISTICS?.[characteristicId]
-  if (!characteristic?.label) return game.i18n.localize('SWERPG.AUDIT_LOG.UNKNOWN_VALUE')
-  return game.i18n.localize(characteristic.label)
+  return game.i18n.localize(getAuditLogTypeLabelKey(type))
 }
 
 /**
  * Build a localized description for a single audit log entry.
+ * Delegates to the shared taxonomy registry for all known types.
  * @param {object} entry
  * @returns {string}
  */
 export function buildAuditLogDescription(entry) {
-  const data = entry?.data ?? {}
-
-  switch (entry?.type) {
-    case 'skill.train':
-      return game.i18n.format('SWERPG.AUDIT_LOG.DESCRIPTION.SKILL_TRAIN', {
-        skill: getAuditLogName(data.skillName, 'SWERPG.AUDIT_LOG.UNKNOWN_SKILL'),
-        oldRank: data.oldRank ?? 0,
-        newRank: data.newRank ?? 0,
-      })
-    case 'skill.forget':
-      return game.i18n.format('SWERPG.AUDIT_LOG.DESCRIPTION.SKILL_FORGET', {
-        skill: getAuditLogName(data.skillName, 'SWERPG.AUDIT_LOG.UNKNOWN_SKILL'),
-        oldRank: data.oldRank ?? 0,
-        newRank: data.newRank ?? 0,
-      })
-    case 'characteristic.increase':
-      return game.i18n.format('SWERPG.AUDIT_LOG.DESCRIPTION.CHARACTERISTIC_INCREASE', {
-        characteristic: getCharacteristicLabel(data.characteristicId),
-        oldValue: data.oldValue ?? 0,
-        newValue: data.newValue ?? 0,
-      })
-    case 'xp.spend':
-      return game.i18n.format('SWERPG.AUDIT_LOG.DESCRIPTION.XP_SPEND', {
-        amount: data.amount ?? Math.abs(entry.xpDelta ?? 0),
-      })
-    case 'xp.refund':
-      return game.i18n.format('SWERPG.AUDIT_LOG.DESCRIPTION.XP_REFUND', {
-        amount: data.amount ?? Math.abs(entry.xpDelta ?? 0),
-      })
-    case 'xp.grant':
-      return game.i18n.format('SWERPG.AUDIT_LOG.DESCRIPTION.XP_GRANT', {
-        amount: data.amount ?? entry.xpDelta ?? 0,
-      })
-    case 'xp.remove':
-      return game.i18n.format('SWERPG.AUDIT_LOG.DESCRIPTION.XP_REMOVE', {
-        amount: data.amount ?? Math.abs(entry.xpDelta ?? 0),
-      })
-    case 'species.set':
-      return game.i18n.format('SWERPG.AUDIT_LOG.DESCRIPTION.SPECIES_SET', {
-        oldSpecies: getAuditLogName(data.oldSpecies, 'SWERPG.AUDIT_LOG.NONE'),
-        newSpecies: getAuditLogName(data.newSpecies, 'SWERPG.AUDIT_LOG.NONE'),
-      })
-    case 'career.set':
-      return game.i18n.format('SWERPG.AUDIT_LOG.DESCRIPTION.CAREER_SET', {
-        oldCareer: getAuditLogName(data.oldCareer, 'SWERPG.AUDIT_LOG.NONE'),
-        newCareer: getAuditLogName(data.newCareer, 'SWERPG.AUDIT_LOG.NONE'),
-      })
-    case 'specialization.add':
-      return game.i18n.format('SWERPG.AUDIT_LOG.DESCRIPTION.SPECIALIZATION_ADD', {
-        specialization: getAuditLogName(data.specializationName ?? data.specializationId, 'SWERPG.AUDIT_LOG.UNKNOWN_SPECIALIZATION'),
-      })
-    case 'specialization.remove':
-      return game.i18n.format('SWERPG.AUDIT_LOG.DESCRIPTION.SPECIALIZATION_REMOVE', {
-        specialization: getAuditLogName(data.specializationName ?? data.specializationId, 'SWERPG.AUDIT_LOG.UNKNOWN_SPECIALIZATION'),
-      })
-    case 'talent.purchase':
-      return game.i18n.format('SWERPG.AUDIT_LOG.DESCRIPTION.TALENT_PURCHASE', {
-        talent: getAuditLogName(data.talentName, 'SWERPG.AUDIT_LOG.UNKNOWN_TALENT'),
-        ranks: data.ranks ?? 1,
-      })
-    case 'talent-node-purchase':
-    case 'talent-node-purchase-succeeded':
-      return game.i18n.format('SWERPG.AUDIT_LOG.DESCRIPTION.TALENT_NODE_PURCHASE', {
-        talentId: getAuditLogName(data.talentId, 'SWERPG.AUDIT_LOG.UNKNOWN_VALUE'),
-        specializationId: getAuditLogName(data.specializationId, 'SWERPG.AUDIT_LOG.UNKNOWN_VALUE'),
-        cost: data.cost ?? 0,
-      })
-    case 'talent-node-purchase-failed':
-      return game.i18n.format('SWERPG.AUDIT_LOG.DESCRIPTION.TALENT_NODE_PURCHASE_FAILED', {
-        nodeId: getAuditLogName(data.nodeId, 'SWERPG.AUDIT_LOG.UNKNOWN_VALUE'),
-        reasonCode: getAuditLogName(data.reasonCode, 'SWERPG.AUDIT_LOG.UNKNOWN_VALUE'),
-      })
-    case 'talent-node-forget-succeeded':
-      return game.i18n.format('SWERPG.AUDIT_LOG.DESCRIPTION.TALENT_NODE_FORGET', {
-        talentId: getAuditLogName(data.talentId, 'SWERPG.AUDIT_LOG.UNKNOWN_VALUE'),
-        specializationId: getAuditLogName(data.specializationId, 'SWERPG.AUDIT_LOG.UNKNOWN_VALUE'),
-        cost: data.cost ?? 0,
-      })
-    case 'talent-node-forget-failed':
-      return game.i18n.format('SWERPG.AUDIT_LOG.DESCRIPTION.TALENT_NODE_FORGET_FAILED', {
-        nodeId: getAuditLogName(data.nodeId, 'SWERPG.AUDIT_LOG.UNKNOWN_VALUE'),
-        reasonCode: getAuditLogName(data.reasonCode, 'SWERPG.AUDIT_LOG.UNKNOWN_VALUE'),
-      })
-    case 'advancement.level':
-      return game.i18n.format('SWERPG.AUDIT_LOG.DESCRIPTION.ADVANCEMENT_LEVEL', {
-        oldLevel: data.oldLevel ?? 0,
-        newLevel: data.newLevel ?? 0,
-      })
-    case 'item.purchase':
-      return game.i18n.format('SWERPG.AUDIT_LOG.DESCRIPTION.ITEM_PURCHASE', {
-        itemName: getAuditLogName(data.itemName, 'SWERPG.AUDIT_LOG.UNKNOWN_ITEM'),
-        itemType: data.itemType ?? '',
-        price: data.price ?? 0,
-        quantity: data.quantity ?? 1,
-      })
-    case 'item.sale':
-      return game.i18n.format('SWERPG.AUDIT_LOG.DESCRIPTION.ITEM_SALE', {
-        itemName: getAuditLogName(data.itemName, 'SWERPG.AUDIT_LOG.UNKNOWN_ITEM'),
-        itemType: data.itemType ?? '',
-        resalePrice: data.resalePrice ?? 0,
-        fraction: Math.round((data.fraction ?? 0) * 100),
-      })
-    default:
-      return game.i18n.format('SWERPG.AUDIT_LOG.DESCRIPTION.UNKNOWN', {
-        type: getAuditLogName(entry?.type, 'SWERPG.AUDIT_LOG.UNKNOWN_VALUE'),
-      })
-  }
+  return buildAuditLogDescriptionFromRegistry(entry, {
+    localize: (key) => game.i18n.localize(key),
+    format: (key, data) => game.i18n.format(key, data),
+    characteristics: game.system?.config?.CHARACTERISTICS ?? null,
+  })
 }
 
 /**

--- a/module/lib/audit/taxonomy.mjs
+++ b/module/lib/audit/taxonomy.mjs
@@ -1,0 +1,411 @@
+/**
+ * @file module/lib/audit/taxonomy.mjs
+ *
+ * Pure-domain taxonomy registry for Audit Log event types.
+ *
+ * Each entry maps a technical type key to its business metadata:
+ *   - label:       i18n key for the human-readable event name
+ *   - family:      filter group the event belongs to
+ *   - describe():  builds the localized description for an audit entry
+ *   - chatVariant: default CSS variant for chat card rendering
+ *
+ * This module MUST NOT import Foundry globals (game, ui, Hooks, etc.).
+ * Consumers are responsible for providing the i18n helpers as parameters.
+ */
+
+/* -------------------------------------------- */
+/*  Canonical families                          */
+/* -------------------------------------------- */
+
+export const AUDIT_LOG_FAMILIES = Object.freeze({
+  all: 'all',
+  skills: 'skills',
+  talents: 'talents',
+  xp: 'xp',
+  characteristics: 'characteristics',
+  details: 'details',
+  advancement: 'advancement',
+  purchases: 'purchases',
+  sales: 'sales',
+  other: 'other',
+})
+
+/* -------------------------------------------- */
+/*  Helper: resolve a localized name            */
+/* -------------------------------------------- */
+
+/**
+ * Return a display-ready value or the localized fallback when value is absent/empty.
+ * @param {*} value
+ * @param {string} fallbackKey
+ * @param {Function} localize  i18n.localize from callers
+ * @returns {string}
+ */
+function resolveNameOr(value, fallbackKey, localize) {
+  if (value === null || value === undefined || value === '') return localize(fallbackKey)
+  return value
+}
+
+/**
+ * Resolve a localized characteristic label from its technical identifier.
+ * @param {string|null|undefined} characteristicId
+ * @param {Function} localize   i18n.localize
+ * @param {Function} format     i18n.format
+ * @param {object|null} characteristics  game.system.config.CHARACTERISTICS map, or null
+ * @returns {string}
+ */
+function resolveCharacteristicLabel(characteristicId, localize, characteristics) {
+  if (!characteristicId) return localize('SWERPG.AUDIT_LOG.UNKNOWN_VALUE')
+  const characteristic = characteristics?.[characteristicId]
+  if (!characteristic?.label) return localize('SWERPG.AUDIT_LOG.UNKNOWN_VALUE')
+  return localize(characteristic.label)
+}
+
+/* -------------------------------------------- */
+/*  Registry type definition                    */
+/* -------------------------------------------- */
+
+/**
+ * @typedef {object} AuditTaxonomyEntry
+ * @property {string}   label        i18n key for the event type label
+ * @property {string}   family       Canonical family identifier
+ * @property {Function} describe     (entry, i18nHelpers) => string — builds the localized description
+ * @property {string}   chatVariant  Default CSS variant for chat card ('add'|'remove'|'gain'|'change'|'fail')
+ */
+
+/**
+ * @typedef {object} I18nHelpers
+ * @property {Function} localize     game.i18n.localize
+ * @property {Function} format       game.i18n.format
+ * @property {object}   [characteristics]  game.system.config.CHARACTERISTICS
+ */
+
+/* -------------------------------------------- */
+/*  Registry                                    */
+/* -------------------------------------------- */
+
+/**
+ * Canonical taxonomy registry: maps each audit event type to its business metadata.
+ * Add a new type here — nowhere else — to extend the audit log.
+ *
+ * @type {Record<string, AuditTaxonomyEntry>}
+ */
+export const AUDIT_TAXONOMY = Object.freeze({
+  'skill.train': {
+    label: 'SWERPG.AUDIT_LOG.TYPE.SKILL_TRAIN',
+    family: AUDIT_LOG_FAMILIES.skills,
+    chatVariant: 'add',
+    describe(entry, { localize, format }) {
+      const data = entry?.data ?? {}
+      return format('SWERPG.AUDIT_LOG.DESCRIPTION.SKILL_TRAIN', {
+        skill: resolveNameOr(data.skillName, 'SWERPG.AUDIT_LOG.UNKNOWN_SKILL', localize),
+        oldRank: data.oldRank ?? 0,
+        newRank: data.newRank ?? 0,
+      })
+    },
+  },
+
+  'skill.forget': {
+    label: 'SWERPG.AUDIT_LOG.TYPE.SKILL_FORGET',
+    family: AUDIT_LOG_FAMILIES.skills,
+    chatVariant: 'remove',
+    describe(entry, { localize, format }) {
+      const data = entry?.data ?? {}
+      return format('SWERPG.AUDIT_LOG.DESCRIPTION.SKILL_FORGET', {
+        skill: resolveNameOr(data.skillName, 'SWERPG.AUDIT_LOG.UNKNOWN_SKILL', localize),
+        oldRank: data.oldRank ?? 0,
+        newRank: data.newRank ?? 0,
+      })
+    },
+  },
+
+  'characteristic.increase': {
+    label: 'SWERPG.AUDIT_LOG.TYPE.CHARACTERISTIC_INCREASE',
+    family: AUDIT_LOG_FAMILIES.characteristics,
+    chatVariant: 'add',
+    describe(entry, { localize, format, characteristics }) {
+      const data = entry?.data ?? {}
+      return format('SWERPG.AUDIT_LOG.DESCRIPTION.CHARACTERISTIC_INCREASE', {
+        characteristic: resolveCharacteristicLabel(data.characteristicId, localize, characteristics),
+        oldValue: data.oldValue ?? 0,
+        newValue: data.newValue ?? 0,
+      })
+    },
+  },
+
+  'xp.spend': {
+    label: 'SWERPG.AUDIT_LOG.TYPE.XP_SPEND',
+    family: AUDIT_LOG_FAMILIES.xp,
+    chatVariant: 'remove',
+    describe(entry, { format }) {
+      const data = entry?.data ?? {}
+      return format('SWERPG.AUDIT_LOG.DESCRIPTION.XP_SPEND', {
+        amount: data.amount ?? Math.abs(entry?.xpDelta ?? 0),
+      })
+    },
+  },
+
+  'xp.refund': {
+    label: 'SWERPG.AUDIT_LOG.TYPE.XP_REFUND',
+    family: AUDIT_LOG_FAMILIES.xp,
+    chatVariant: 'gain',
+    describe(entry, { format }) {
+      const data = entry?.data ?? {}
+      return format('SWERPG.AUDIT_LOG.DESCRIPTION.XP_REFUND', {
+        amount: data.amount ?? Math.abs(entry?.xpDelta ?? 0),
+      })
+    },
+  },
+
+  'xp.grant': {
+    label: 'SWERPG.AUDIT_LOG.TYPE.XP_GRANT',
+    family: AUDIT_LOG_FAMILIES.xp,
+    chatVariant: 'gain',
+    describe(entry, { format }) {
+      const data = entry?.data ?? {}
+      return format('SWERPG.AUDIT_LOG.DESCRIPTION.XP_GRANT', {
+        amount: data.amount ?? entry?.xpDelta ?? 0,
+      })
+    },
+  },
+
+  'xp.remove': {
+    label: 'SWERPG.AUDIT_LOG.TYPE.XP_REMOVE',
+    family: AUDIT_LOG_FAMILIES.xp,
+    chatVariant: 'remove',
+    describe(entry, { format }) {
+      const data = entry?.data ?? {}
+      return format('SWERPG.AUDIT_LOG.DESCRIPTION.XP_REMOVE', {
+        amount: data.amount ?? Math.abs(entry?.xpDelta ?? 0),
+      })
+    },
+  },
+
+  'species.set': {
+    label: 'SWERPG.AUDIT_LOG.TYPE.SPECIES_SET',
+    family: AUDIT_LOG_FAMILIES.details,
+    chatVariant: 'change',
+    describe(entry, { localize, format }) {
+      const data = entry?.data ?? {}
+      return format('SWERPG.AUDIT_LOG.DESCRIPTION.SPECIES_SET', {
+        oldSpecies: resolveNameOr(data.oldSpecies, 'SWERPG.AUDIT_LOG.NONE', localize),
+        newSpecies: resolveNameOr(data.newSpecies, 'SWERPG.AUDIT_LOG.NONE', localize),
+      })
+    },
+  },
+
+  'career.set': {
+    label: 'SWERPG.AUDIT_LOG.TYPE.CAREER_SET',
+    family: AUDIT_LOG_FAMILIES.details,
+    chatVariant: 'change',
+    describe(entry, { localize, format }) {
+      const data = entry?.data ?? {}
+      return format('SWERPG.AUDIT_LOG.DESCRIPTION.CAREER_SET', {
+        oldCareer: resolveNameOr(data.oldCareer, 'SWERPG.AUDIT_LOG.NONE', localize),
+        newCareer: resolveNameOr(data.newCareer, 'SWERPG.AUDIT_LOG.NONE', localize),
+      })
+    },
+  },
+
+  'specialization.add': {
+    label: 'SWERPG.AUDIT_LOG.TYPE.SPECIALIZATION_ADD',
+    family: AUDIT_LOG_FAMILIES.details,
+    chatVariant: 'add',
+    describe(entry, { localize, format }) {
+      const data = entry?.data ?? {}
+      return format('SWERPG.AUDIT_LOG.DESCRIPTION.SPECIALIZATION_ADD', {
+        specialization: resolveNameOr(data.specializationName ?? data.specializationId, 'SWERPG.AUDIT_LOG.UNKNOWN_SPECIALIZATION', localize),
+      })
+    },
+  },
+
+  'specialization.remove': {
+    label: 'SWERPG.AUDIT_LOG.TYPE.SPECIALIZATION_REMOVE',
+    family: AUDIT_LOG_FAMILIES.details,
+    chatVariant: 'remove',
+    describe(entry, { localize, format }) {
+      const data = entry?.data ?? {}
+      return format('SWERPG.AUDIT_LOG.DESCRIPTION.SPECIALIZATION_REMOVE', {
+        specialization: resolveNameOr(data.specializationName ?? data.specializationId, 'SWERPG.AUDIT_LOG.UNKNOWN_SPECIALIZATION', localize),
+      })
+    },
+  },
+
+  'talent.purchase': {
+    label: 'SWERPG.AUDIT_LOG.TYPE.TALENT_PURCHASE',
+    family: AUDIT_LOG_FAMILIES.talents,
+    chatVariant: 'add',
+    describe(entry, { localize, format }) {
+      const data = entry?.data ?? {}
+      return format('SWERPG.AUDIT_LOG.DESCRIPTION.TALENT_PURCHASE', {
+        talent: resolveNameOr(data.talentName, 'SWERPG.AUDIT_LOG.UNKNOWN_TALENT', localize),
+        ranks: data.ranks ?? 1,
+      })
+    },
+  },
+
+  'talent-node-purchase': {
+    label: 'SWERPG.AUDIT_LOG.TYPE.TALENT_NODE_PURCHASE',
+    family: AUDIT_LOG_FAMILIES.talents,
+    chatVariant: 'add',
+    describe(entry, { localize, format }) {
+      const data = entry?.data ?? {}
+      return format('SWERPG.AUDIT_LOG.DESCRIPTION.TALENT_NODE_PURCHASE', {
+        talentId: resolveNameOr(data.talentId, 'SWERPG.AUDIT_LOG.UNKNOWN_VALUE', localize),
+        specializationId: resolveNameOr(data.specializationId, 'SWERPG.AUDIT_LOG.UNKNOWN_VALUE', localize),
+        cost: data.cost ?? 0,
+      })
+    },
+  },
+
+  'talent-node-purchase-succeeded': {
+    label: 'SWERPG.AUDIT_LOG.TYPE.TALENT_NODE_PURCHASE_SUCCEEDED',
+    family: AUDIT_LOG_FAMILIES.talents,
+    chatVariant: 'add',
+    describe(entry, { localize, format }) {
+      const data = entry?.data ?? {}
+      return format('SWERPG.AUDIT_LOG.DESCRIPTION.TALENT_NODE_PURCHASE', {
+        talentId: resolveNameOr(data.talentId, 'SWERPG.AUDIT_LOG.UNKNOWN_VALUE', localize),
+        specializationId: resolveNameOr(data.specializationId, 'SWERPG.AUDIT_LOG.UNKNOWN_VALUE', localize),
+        cost: data.cost ?? 0,
+      })
+    },
+  },
+
+  'talent-node-purchase-failed': {
+    label: 'SWERPG.AUDIT_LOG.TYPE.TALENT_NODE_PURCHASE_FAILED',
+    family: AUDIT_LOG_FAMILIES.talents,
+    chatVariant: 'fail',
+    describe(entry, { localize, format }) {
+      const data = entry?.data ?? {}
+      return format('SWERPG.AUDIT_LOG.DESCRIPTION.TALENT_NODE_PURCHASE_FAILED', {
+        nodeId: resolveNameOr(data.nodeId, 'SWERPG.AUDIT_LOG.UNKNOWN_VALUE', localize),
+        reasonCode: resolveNameOr(data.reasonCode, 'SWERPG.AUDIT_LOG.UNKNOWN_VALUE', localize),
+      })
+    },
+  },
+
+  'talent-node-forget-succeeded': {
+    label: 'SWERPG.AUDIT_LOG.TYPE.TALENT_NODE_FORGET_SUCCEEDED',
+    family: AUDIT_LOG_FAMILIES.talents,
+    chatVariant: 'remove',
+    describe(entry, { localize, format }) {
+      const data = entry?.data ?? {}
+      return format('SWERPG.AUDIT_LOG.DESCRIPTION.TALENT_NODE_FORGET', {
+        talentId: resolveNameOr(data.talentId, 'SWERPG.AUDIT_LOG.UNKNOWN_VALUE', localize),
+        specializationId: resolveNameOr(data.specializationId, 'SWERPG.AUDIT_LOG.UNKNOWN_VALUE', localize),
+        cost: data.cost ?? 0,
+      })
+    },
+  },
+
+  'talent-node-forget-failed': {
+    label: 'SWERPG.AUDIT_LOG.TYPE.TALENT_NODE_FORGET_FAILED',
+    family: AUDIT_LOG_FAMILIES.talents,
+    chatVariant: 'fail',
+    describe(entry, { localize, format }) {
+      const data = entry?.data ?? {}
+      return format('SWERPG.AUDIT_LOG.DESCRIPTION.TALENT_NODE_FORGET_FAILED', {
+        nodeId: resolveNameOr(data.nodeId, 'SWERPG.AUDIT_LOG.UNKNOWN_VALUE', localize),
+        reasonCode: resolveNameOr(data.reasonCode, 'SWERPG.AUDIT_LOG.UNKNOWN_VALUE', localize),
+      })
+    },
+  },
+
+  'advancement.level': {
+    label: 'SWERPG.AUDIT_LOG.TYPE.ADVANCEMENT_LEVEL',
+    family: AUDIT_LOG_FAMILIES.advancement,
+    chatVariant: 'change',
+    describe(entry, { format }) {
+      const data = entry?.data ?? {}
+      return format('SWERPG.AUDIT_LOG.DESCRIPTION.ADVANCEMENT_LEVEL', {
+        oldLevel: data.oldLevel ?? 0,
+        newLevel: data.newLevel ?? 0,
+      })
+    },
+  },
+
+  'item.purchase': {
+    label: 'SWERPG.AUDIT_LOG.TYPE.ITEM_PURCHASE',
+    family: AUDIT_LOG_FAMILIES.purchases,
+    chatVariant: 'add',
+    describe(entry, { localize, format }) {
+      const data = entry?.data ?? {}
+      return format('SWERPG.AUDIT_LOG.DESCRIPTION.ITEM_PURCHASE', {
+        itemName: resolveNameOr(data.itemName, 'SWERPG.AUDIT_LOG.UNKNOWN_ITEM', localize),
+        itemType: data.itemType ?? '',
+        price: data.price ?? 0,
+        quantity: data.quantity ?? 1,
+      })
+    },
+  },
+
+  'item.sale': {
+    label: 'SWERPG.AUDIT_LOG.TYPE.ITEM_SALE',
+    family: AUDIT_LOG_FAMILIES.sales,
+    chatVariant: 'gain',
+    describe(entry, { localize, format }) {
+      const data = entry?.data ?? {}
+      return format('SWERPG.AUDIT_LOG.DESCRIPTION.ITEM_SALE', {
+        itemName: resolveNameOr(data.itemName, 'SWERPG.AUDIT_LOG.UNKNOWN_ITEM', localize),
+        itemType: data.itemType ?? '',
+        resalePrice: data.resalePrice ?? 0,
+        fraction: Math.round((data.fraction ?? 0) * 100),
+      })
+    },
+  },
+})
+
+/* -------------------------------------------- */
+/*  Public lookup helpers                       */
+/* -------------------------------------------- */
+
+/**
+ * Return the taxonomy entry for the given type, or undefined when the type is unknown.
+ * @param {string} type
+ * @returns {AuditTaxonomyEntry|undefined}
+ */
+export function getTaxonomyEntry(type) {
+  return AUDIT_TAXONOMY[type]
+}
+
+/**
+ * Map a technical audit entry type to its business filter family.
+ * Falls back to 'other' for unknown types.
+ * @param {string} type
+ * @returns {string}
+ */
+export function getAuditLogFamilyFromType(type) {
+  return AUDIT_TAXONOMY[type]?.family ?? AUDIT_LOG_FAMILIES.other
+}
+
+/**
+ * Return the i18n label key for the given audit event type.
+ * Falls back to the UNKNOWN key for unrecognized types.
+ * @param {string} type
+ * @returns {string}
+ */
+export function getAuditLogTypeLabelKey(type) {
+  return AUDIT_TAXONOMY[type]?.label ?? 'SWERPG.AUDIT_LOG.TYPE.UNKNOWN'
+}
+
+/**
+ * Build a localized description for a single audit log entry using the registry.
+ * Falls back to a generic description for unknown types.
+ *
+ * @param {object} entry  A raw audit log entry with at least { type, data? }
+ * @param {I18nHelpers} i18nHelpers
+ * @returns {string}
+ */
+export function buildAuditLogDescriptionFromRegistry(entry, i18nHelpers) {
+  const { localize, format } = i18nHelpers
+  const taxonomyEntry = AUDIT_TAXONOMY[entry?.type]
+
+  if (!taxonomyEntry) {
+    return format('SWERPG.AUDIT_LOG.DESCRIPTION.UNKNOWN', {
+      type: entry?.type ?? localize('SWERPG.AUDIT_LOG.UNKNOWN_VALUE'),
+    })
+  }
+
+  return taxonomyEntry.describe(entry, i18nHelpers)
+}

--- a/module/utils/audit-log.mjs
+++ b/module/utils/audit-log.mjs
@@ -1,6 +1,6 @@
 import { logger } from './logger.mjs'
 import { composeEntries, makeEntry, captureSnapshot } from './audit-diff.mjs'
-import { buildAuditLogDescription, getAuditLogVariantGlyph } from '../applications/character-audit-log.mjs'
+import { buildAuditLogDescriptionFromRegistry, getAuditLogTypeLabelKey } from '../lib/audit/taxonomy.mjs'
 
 /* -------------------------------------------- */
 /*  Constantes                                  */
@@ -616,6 +616,256 @@ async function recordItemSale(
 /*  Émission de messages chat depuis l'audit    */
 /* -------------------------------------------- */
 
+/* -------------------------------------------- */
+/*  Chat context helpers                        */
+/* -------------------------------------------- */
+
+/**
+ * Canonical glyph (FontAwesome) for each audit log variant.
+ * Local copy so `utils/audit-log.mjs` has no dependency on `applications/`.
+ */
+const CHAT_VARIANT_GLYPHS = Object.freeze({
+  add: 'fa-solid fa-plus',
+  remove: 'fa-solid fa-minus',
+  gain: 'fa-solid fa-arrow-down',
+  change: 'fa-solid fa-arrows-rotate',
+  fail: 'fa-solid fa-xmark',
+})
+
+/**
+ * Return the glyph CSS class for a given audit log variant.
+ * @param {string} variant
+ * @returns {string}
+ */
+function getChatVariantGlyph(variant) {
+  return CHAT_VARIANT_GLYPHS[variant] ?? CHAT_VARIANT_GLYPHS.change
+}
+
+/**
+ * Build the i18n helpers object for the taxonomy registry using game globals.
+ * @returns {import('../lib/audit/taxonomy.mjs').I18nHelpers}
+ */
+function buildI18nHelpers() {
+  return {
+    localize: (key) => game.i18n.localize(key),
+    format: (key, data) => game.i18n.format(key, data),
+    characteristics: game.system?.config?.CHARACTERISTICS ?? null,
+  }
+}
+
+/* -------------------------------------------- */
+/*  Chat context handlers per type              */
+/* -------------------------------------------- */
+
+/**
+ * @typedef {object} ChatContext
+ * @property {string}      actorImg
+ * @property {string}      actorName
+ * @property {string}      eventLabel
+ * @property {string|null} previousValue
+ * @property {string}      nextValue
+ * @property {string|null} description
+ * @property {string|null} metaLeft
+ * @property {string|null} metaRight
+ * @property {boolean}     hasMeta
+ * @property {string}      variant
+ * @property {string}      variantGlyph
+ */
+
+/**
+ * Map of per-type chat context handlers.
+ * Each handler receives (context, entry, data, snapshot) and mutates context in place.
+ * All type-specific logic lives here — no fallback switch required.
+ *
+ * @type {Record<string, (context: ChatContext, entry: object, data: object, snapshot: object) => void>}
+ */
+const CHAT_HANDLERS = {
+  'skill.train'(context, entry, data) {
+    const isFree = data.isFree === true
+    context.eventLabel = game.i18n.localize('SWERPG.AUDIT_LOG.TYPE.SKILL_TRAIN')
+    context.previousValue = String(data.oldRank)
+    context.nextValue = String(data.newRank)
+    context.variant = isFree ? 'gain' : 'add'
+    context.metaLeft = isFree ? game.i18n.localize('SKILL.CHAT.FREE_COST') : game.i18n.format('SKILL.CHAT.COST', { cost: data.cost })
+  },
+
+  'skill.forget'(context, entry, data) {
+    context.eventLabel = game.i18n.localize('SWERPG.AUDIT_LOG.TYPE.SKILL_FORGET')
+    context.previousValue = String(data.oldRank)
+    context.nextValue = String(data.newRank)
+    context.variant = 'remove'
+    context.metaLeft = game.i18n.format('SKILL.CHAT.REFUND', { cost: data.cost })
+  },
+
+  'characteristic.increase'(context, entry, data) {
+    context.eventLabel = game.i18n.localize('SWERPG.AUDIT_LOG.TYPE.CHARACTERISTIC_INCREASE')
+    context.previousValue = String(data.oldValue)
+    context.nextValue = String(data.newValue)
+    context.variant = 'add'
+    context.metaLeft = game.i18n.format('SKILL.CHAT.COST', { cost: data.cost })
+  },
+
+  'xp.spend'(context, entry, data) {
+    context.eventLabel = game.i18n.localize('SWERPG.AUDIT_LOG.TYPE.XP_SPEND')
+    context.nextValue = `-${data.amount} XP`
+    context.variant = 'remove'
+    context.metaLeft = game.i18n.format('SKILL.CHAT.COST', { cost: data.amount })
+  },
+
+  'xp.refund'(context, entry, data) {
+    context.eventLabel = game.i18n.localize('SWERPG.AUDIT_LOG.TYPE.XP_REFUND')
+    context.nextValue = `+${data.amount} XP`
+    context.variant = 'gain'
+    context.metaLeft = game.i18n.format('SKILL.CHAT.REFUND', { cost: data.amount })
+  },
+
+  'xp.grant'(context, entry, data) {
+    context.eventLabel = game.i18n.localize('SWERPG.AUDIT_LOG.TYPE.XP_GRANT')
+    context.nextValue = `+${data.amount} XP`
+    context.variant = 'gain'
+    context.metaLeft = game.i18n.format('SKILL.CHAT.REFUND', { cost: data.amount })
+  },
+
+  'xp.remove'(context, entry, data) {
+    context.eventLabel = game.i18n.localize('SWERPG.AUDIT_LOG.TYPE.XP_REMOVE')
+    context.nextValue = `-${data.amount} XP`
+    context.variant = 'remove'
+    context.metaLeft = game.i18n.format('SKILL.CHAT.COST', { cost: data.amount })
+  },
+
+  'species.set'(context, entry, data) {
+    context.eventLabel = game.i18n.localize('SWERPG.AUDIT_LOG.TYPE.SPECIES_SET')
+    const noneLabel = game.i18n.localize('SWERPG.AUDIT_LOG.NONE')
+    context.previousValue = data.oldSpecies ?? noneLabel
+    context.nextValue = data.newSpecies ?? noneLabel
+    context.variant = 'change'
+  },
+
+  'career.set'(context, entry, data) {
+    context.eventLabel = game.i18n.localize('SWERPG.AUDIT_LOG.TYPE.CAREER_SET')
+    const noneLabel = game.i18n.localize('SWERPG.AUDIT_LOG.NONE')
+    context.previousValue = data.oldCareer ?? noneLabel
+    context.nextValue = data.newCareer ?? noneLabel
+    context.variant = 'change'
+  },
+
+  'specialization.add'(context, entry, data) {
+    context.eventLabel = game.i18n.localize('SWERPG.AUDIT_LOG.TYPE.SPECIALIZATION_ADD')
+    context.nextValue = data.specializationName ?? data.specializationId ?? ''
+    context.variant = 'add'
+    if (data.cost) {
+      context.metaLeft = game.i18n.format('SKILL.CHAT.COST', { cost: data.cost })
+    }
+  },
+
+  'specialization.remove'(context, entry, data) {
+    context.eventLabel = game.i18n.localize('SWERPG.AUDIT_LOG.TYPE.SPECIALIZATION_REMOVE')
+    context.nextValue = data.specializationName ?? data.specializationId ?? ''
+    context.variant = 'remove'
+    if (data.cost) {
+      context.metaLeft = game.i18n.format('SKILL.CHAT.COST', { cost: data.cost })
+    }
+  },
+
+  'talent.purchase'(context, entry, data) {
+    context.eventLabel = game.i18n.localize('SWERPG.AUDIT_LOG.TYPE.TALENT_PURCHASE')
+    context.nextValue = data.talentName ?? data.talentId ?? ''
+    context.variant = 'add'
+    context.metaLeft = game.i18n.format('SKILL.CHAT.COST', { cost: data.cost })
+  },
+
+  'talent-node-purchase'(context, entry, data) {
+    context.eventLabel = game.i18n.localize('SWERPG.AUDIT_LOG.TYPE.TALENT_NODE_PURCHASE')
+    context.nextValue = data.talentId ?? data.nodeId ?? ''
+    context.variant = 'add'
+    if (data.cost) {
+      context.metaLeft = game.i18n.format('SKILL.CHAT.COST', { cost: data.cost })
+    }
+  },
+
+  'talent-node-purchase-succeeded'(context, entry, data) {
+    context.eventLabel = game.i18n.localize('SWERPG.AUDIT_LOG.TYPE.TALENT_NODE_PURCHASE_SUCCEEDED')
+    context.nextValue = data.talentId ?? data.nodeId ?? ''
+    context.variant = 'add'
+    if (data.cost) {
+      context.metaLeft = game.i18n.format('SKILL.CHAT.COST', { cost: data.cost })
+    }
+  },
+
+  'talent-node-purchase-failed'(context, entry, data) {
+    context.eventLabel = game.i18n.localize('SWERPG.AUDIT_LOG.TYPE.TALENT_NODE_PURCHASE_FAILED')
+    context.nextValue = data.nodeId ?? ''
+    context.description = game.i18n.format('SWERPG.AUDIT_LOG.DESCRIPTION.TALENT_NODE_PURCHASE_FAILED', {
+      reasonCode: data.reasonCode ?? '',
+      nodeId: data.nodeId ?? '',
+    })
+    context.variant = 'fail'
+  },
+
+  'talent-node-forget-succeeded'(context, entry, data) {
+    context.eventLabel = game.i18n.localize('SWERPG.AUDIT_LOG.TYPE.TALENT_NODE_FORGET_SUCCEEDED')
+    context.nextValue = data.talentId ?? data.nodeId ?? ''
+    context.variant = 'remove'
+    if (data.cost) {
+      context.metaLeft = game.i18n.format('SKILL.CHAT.REFUND', { cost: data.cost })
+    }
+  },
+
+  'talent-node-forget-failed'(context, entry, data) {
+    context.eventLabel = game.i18n.localize('SWERPG.AUDIT_LOG.TYPE.TALENT_NODE_FORGET_FAILED')
+    context.nextValue = data.nodeId ?? ''
+    context.description = game.i18n.format('SWERPG.AUDIT_LOG.DESCRIPTION.TALENT_NODE_FORGET_FAILED', {
+      reasonCode: data.reasonCode ?? '',
+      nodeId: data.nodeId ?? '',
+    })
+    context.variant = 'fail'
+  },
+
+  'advancement.level'(context, entry, data) {
+    context.eventLabel = game.i18n.localize('SWERPG.AUDIT_LOG.TYPE.ADVANCEMENT_LEVEL')
+    context.previousValue = String(data.oldLevel)
+    context.nextValue = String(data.newLevel)
+    context.variant = 'change'
+  },
+
+  'item.purchase'(context, entry, data, snapshot) {
+    context.eventLabel = game.i18n.localize('SWERPG.AUDIT_LOG.TYPE.ITEM_PURCHASE')
+    context.nextValue = `${data.itemName ?? ''} (${data.itemType ?? ''})`
+    context.variant = 'add'
+    context.metaLeft = game.i18n.format('SWERPG.AUDIT_LOG.META.PRICE', { price: data.price ?? 0 })
+
+    // Enrich with commerce outcome narrative when present (from availability check narrative dice)
+    const outcome = entry.outcome ?? null
+    if (outcome) {
+      if (outcome.priceModifier !== 0) {
+        const modifierPct = Math.round(outcome.priceModifier * 100)
+        const modifierStr = modifierPct > 0 ? `+${modifierPct}%` : `${modifierPct}%`
+        context.metaRight = game.i18n.format('MARKET.CommerceOutcome.AppliedModifier', { modifier: modifierStr })
+      }
+      if (outcome.narrativeKeys?.length > 0) {
+        const narratives = outcome.narrativeKeys.map((k) => game.i18n.localize(k)).join('; ')
+        context.description = narratives
+      }
+    }
+
+    if (snapshot.creditsAfter !== undefined && snapshot.creditsAfter !== null) {
+      context.metaRight = game.i18n.format('SWERPG.AUDIT_LOG.META.CREDITS_REMAINING', { credits: snapshot.creditsAfter })
+    }
+    context.hasMeta = true
+  },
+
+  'item.sale'(context, entry, data, snapshot) {
+    context.eventLabel = game.i18n.localize('SWERPG.AUDIT_LOG.TYPE.ITEM_SALE')
+    context.nextValue = `${data.itemName ?? ''} (${data.itemType ?? ''})`
+    context.variant = 'gain'
+    context.metaLeft = game.i18n.format('SWERPG.AUDIT_LOG.META.SOLD_FOR', { price: data.resalePrice ?? 0 })
+    if (snapshot.creditsAfter !== undefined && snapshot.creditsAfter !== null) {
+      context.metaRight = game.i18n.format('SWERPG.AUDIT_LOG.META.CREDITS_REMAINING', { credits: snapshot.creditsAfter })
+    }
+    context.hasMeta = true
+  },
+}
+
 /**
  * Build the template context for a chat message from a single audit entry.
  *
@@ -631,7 +881,7 @@ async function recordItemSale(
  *
  * @param {object} actor The actor document
  * @param {object} entry A single audit log entry
- * @returns {object} Context for audit-entry.hbs
+ * @returns {ChatContext} Context for audit-entry.hbs
  */
 function _buildChatContext(actor, entry) {
   const type = entry.type
@@ -652,162 +902,19 @@ function _buildChatContext(actor, entry) {
     variant: 'change',
   }
 
-  switch (type) {
-    case 'skill.train': {
-      const isFree = data.isFree === true
-      context.eventLabel = game.i18n.localize('SWERPG.AUDIT_LOG.TYPE.SKILL_TRAIN')
-      context.previousValue = String(data.oldRank)
-      context.nextValue = String(data.newRank)
-      context.variant = isFree ? 'gain' : 'add'
-      context.metaLeft = isFree ? game.i18n.localize('SKILL.CHAT.FREE_COST') : game.i18n.format('SKILL.CHAT.COST', { cost: data.cost })
-      break
-    }
-
-    case 'skill.forget': {
-      context.eventLabel = game.i18n.localize('SWERPG.AUDIT_LOG.TYPE.SKILL_FORGET')
-      context.previousValue = String(data.oldRank)
-      context.nextValue = String(data.newRank)
-      context.variant = 'remove'
-      context.metaLeft = game.i18n.format('SKILL.CHAT.REFUND', { cost: data.cost })
-      break
-    }
-
-    case 'characteristic.increase': {
-      context.eventLabel = game.i18n.localize('SWERPG.AUDIT_LOG.TYPE.CHARACTERISTIC_INCREASE')
-      context.previousValue = String(data.oldValue)
-      context.nextValue = String(data.newValue)
-      context.variant = 'add'
-      context.metaLeft = game.i18n.format('SKILL.CHAT.COST', { cost: data.cost })
-      break
-    }
-
-    case 'xp.spend':
-    case 'xp.refund':
-    case 'xp.grant':
-    case 'xp.remove': {
-      const isGain = type === 'xp.grant' || type === 'xp.refund'
-      context.eventLabel = game.i18n.localize(
-        `SWERPG.AUDIT_LOG.TYPE.${type === 'xp.spend' ? 'XP_SPEND' : type === 'xp.refund' ? 'XP_REFUND' : type === 'xp.grant' ? 'XP_GRANT' : 'XP_REMOVE'}`,
-      )
-      context.nextValue = isGain ? `+${data.amount} XP` : `-${data.amount} XP`
-      context.variant = isGain ? 'gain' : 'remove'
-      context.metaLeft = isGain ? game.i18n.format('SKILL.CHAT.REFUND', { cost: data.amount }) : game.i18n.format('SKILL.CHAT.COST', { cost: data.amount })
-      break
-    }
-
-    case 'species.set':
-    case 'career.set': {
-      const isSpecies = type === 'species.set'
-      context.eventLabel = game.i18n.localize(isSpecies ? 'SWERPG.AUDIT_LOG.TYPE.SPECIES_SET' : 'SWERPG.AUDIT_LOG.TYPE.CAREER_SET')
-      const noneLabel = game.i18n.localize('SWERPG.AUDIT_LOG.NONE')
-      const oldV = data.oldSpecies ?? data.oldCareer ?? null
-      const newV = data.newSpecies ?? data.newCareer ?? null
-      context.previousValue = oldV ?? noneLabel
-      context.nextValue = newV ?? noneLabel
-      context.variant = 'change'
-      break
-    }
-
-    case 'specialization.add':
-    case 'specialization.remove': {
-      const isAdd = type === 'specialization.add'
-      context.eventLabel = game.i18n.localize(isAdd ? 'SWERPG.AUDIT_LOG.TYPE.SPECIALIZATION_ADD' : 'SWERPG.AUDIT_LOG.TYPE.SPECIALIZATION_REMOVE')
-      context.nextValue = data.specializationName ?? data.specializationId ?? ''
-      context.variant = isAdd ? 'add' : 'remove'
-      if (data.cost) {
-        context.metaLeft = game.i18n.format('SKILL.CHAT.COST', { cost: data.cost })
-      }
-      break
-    }
-
-    case 'talent.purchase': {
-      context.eventLabel = game.i18n.localize('SWERPG.AUDIT_LOG.TYPE.TALENT_PURCHASE')
-      context.nextValue = data.talentName ?? data.talentId ?? ''
-      context.variant = 'add'
-      context.metaLeft = game.i18n.format('SKILL.CHAT.COST', { cost: data.cost })
-      break
-    }
-
-    case 'talent-node-purchase-succeeded':
-    case 'talent-node-purchase-failed':
-    case 'talent-node-forget-succeeded':
-    case 'talent-node-forget-failed': {
-      const isSuccess = type.endsWith('succeeded')
-      const isPurchase = type.includes('purchase')
-      context.eventLabel = game.i18n.localize(`SWERPG.AUDIT_LOG.TYPE.${type.replace(/[-.]/g, '_').toUpperCase()}`)
-      if (isSuccess) {
-        context.nextValue = data.talentId ?? data.nodeId ?? ''
-        context.variant = isPurchase ? 'add' : 'remove'
-        if (data.cost) {
-          context.metaLeft = isPurchase ? game.i18n.format('SKILL.CHAT.COST', { cost: data.cost }) : game.i18n.format('SKILL.CHAT.REFUND', { cost: data.cost })
-        }
-      } else {
-        context.nextValue = data.nodeId ?? ''
-        context.description = game.i18n.format('SWERPG.AUDIT_LOG.DESCRIPTION.TALENT_NODE_PURCHASE_FAILED', {
-          reasonCode: data.reasonCode ?? '',
-          nodeId: data.nodeId ?? '',
-        })
-        context.variant = 'fail'
-      }
-      break
-    }
-
-    case 'advancement.level': {
-      context.eventLabel = game.i18n.localize('SWERPG.AUDIT_LOG.TYPE.ADVANCEMENT_LEVEL')
-      context.previousValue = String(data.oldLevel)
-      context.nextValue = String(data.newLevel)
-      context.variant = 'change'
-      break
-    }
-
-    case 'item.purchase': {
-      context.eventLabel = game.i18n.localize('SWERPG.AUDIT_LOG.TYPE.ITEM_PURCHASE')
-      context.nextValue = `${data.itemName ?? ''} (${data.itemType ?? ''})`
-      context.variant = 'add'
-      context.metaLeft = game.i18n.format('SWERPG.AUDIT_LOG.META.PRICE', { price: data.price ?? 0 })
-
-      // Enrich with commerce outcome narrative when present (from availability check narrative dice)
-      const outcome = entry.outcome ?? null
-      if (outcome) {
-        if (outcome.priceModifier !== 0) {
-          const modifierPct = Math.round(outcome.priceModifier * 100)
-          const modifierStr = modifierPct > 0 ? `+${modifierPct}%` : `${modifierPct}%`
-          context.metaRight = game.i18n.format('MARKET.CommerceOutcome.AppliedModifier', { modifier: modifierStr })
-        }
-        if (outcome.narrativeKeys?.length > 0) {
-          const narratives = outcome.narrativeKeys.map((k) => game.i18n.localize(k)).join('; ')
-          context.description = narratives
-        }
-      }
-
-      if (snapshot.creditsAfter !== undefined && snapshot.creditsAfter !== null) {
-        context.metaRight = game.i18n.format('SWERPG.AUDIT_LOG.META.CREDITS_REMAINING', { credits: snapshot.creditsAfter })
-      }
-      context.hasMeta = true
-      break
-    }
-
-    case 'item.sale': {
-      context.eventLabel = game.i18n.localize('SWERPG.AUDIT_LOG.TYPE.ITEM_SALE')
-      context.nextValue = `${data.itemName ?? ''} (${data.itemType ?? ''})`
-      context.variant = 'gain'
-      context.metaLeft = game.i18n.format('SWERPG.AUDIT_LOG.META.SOLD_FOR', { price: data.resalePrice ?? 0 })
-      if (snapshot.creditsAfter !== undefined && snapshot.creditsAfter !== null) {
-        context.metaRight = game.i18n.format('SWERPG.AUDIT_LOG.META.CREDITS_REMAINING', { credits: snapshot.creditsAfter })
-      }
-      context.hasMeta = true
-      break
-    }
-
-    default: {
-      const desc = buildAuditLogDescription(entry)
-      context.eventLabel = game.i18n.localize('SWERPG.AUDIT_LOG.TYPE.UNKNOWN')
-      context.nextValue = desc
-      context.variant = xpDelta > 0 ? 'gain' : xpDelta < 0 ? 'remove' : 'change'
-      if (xpDelta !== 0) {
-        context.metaLeft =
-          xpDelta > 0 ? game.i18n.format('SKILL.CHAT.REFUND', { cost: xpDelta }) : game.i18n.format('SKILL.CHAT.COST', { cost: Math.abs(xpDelta) })
-      }
+  const handler = CHAT_HANDLERS[type]
+  if (handler) {
+    handler(context, entry, data, snapshot)
+  } else {
+    // Unknown type: fall back to registry description
+    const i18nHelpers = buildI18nHelpers()
+    const desc = buildAuditLogDescriptionFromRegistry(entry, i18nHelpers)
+    context.eventLabel = game.i18n.localize(getAuditLogTypeLabelKey(type))
+    context.nextValue = desc
+    context.variant = xpDelta > 0 ? 'gain' : xpDelta < 0 ? 'remove' : 'change'
+    if (xpDelta !== 0) {
+      context.metaLeft =
+        xpDelta > 0 ? game.i18n.format('SKILL.CHAT.REFUND', { cost: xpDelta }) : game.i18n.format('SKILL.CHAT.COST', { cost: Math.abs(xpDelta) })
     }
   }
 
@@ -816,7 +923,7 @@ function _buildChatContext(actor, entry) {
   }
 
   context.hasMeta = context.metaLeft !== null || context.metaRight !== null
-  context.variantGlyph = getAuditLogVariantGlyph(context.variant)
+  context.variantGlyph = getChatVariantGlyph(context.variant)
 
   return context
 }

--- a/tests/lib/audit/taxonomy.test.mjs
+++ b/tests/lib/audit/taxonomy.test.mjs
@@ -1,0 +1,376 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  AUDIT_LOG_FAMILIES,
+  AUDIT_TAXONOMY,
+  buildAuditLogDescriptionFromRegistry,
+  getAuditLogFamilyFromType,
+  getAuditLogTypeLabelKey,
+  getTaxonomyEntry,
+} from '../../../module/lib/audit/taxonomy.mjs'
+
+/**
+ * Minimal i18n helpers for pure-domain tests.
+ * Avoids any Foundry globals.
+ *
+ * - localize(key) returns the key as-is (no actual translation table).
+ * - format(key, data) returns a string that includes all data values,
+ *   so tests can assert on the presence of business values without needing
+ *   a real i18n translation table.
+ */
+const i18n = {
+  localize: (key) => key,
+  format: (key, data = {}) => {
+    // Build output as "KEY:value1:value2:..." so tests can check for data presence.
+    const values = Object.values(data).map(String).join(':')
+    return values ? `${key}:${values}` : key
+  },
+  characteristics: {
+    brawn: { label: 'CHARACTERISTICS.Brawn' },
+    agility: { label: 'CHARACTERISTICS.Agility' },
+  },
+}
+
+/* -------------------------------------------- */
+/*  AUDIT_LOG_FAMILIES                          */
+/* -------------------------------------------- */
+
+describe('AUDIT_LOG_FAMILIES', () => {
+  it('exports all expected family keys', () => {
+    expect(AUDIT_LOG_FAMILIES.all).toBe('all')
+    expect(AUDIT_LOG_FAMILIES.skills).toBe('skills')
+    expect(AUDIT_LOG_FAMILIES.talents).toBe('talents')
+    expect(AUDIT_LOG_FAMILIES.xp).toBe('xp')
+    expect(AUDIT_LOG_FAMILIES.characteristics).toBe('characteristics')
+    expect(AUDIT_LOG_FAMILIES.details).toBe('details')
+    expect(AUDIT_LOG_FAMILIES.advancement).toBe('advancement')
+    expect(AUDIT_LOG_FAMILIES.purchases).toBe('purchases')
+    expect(AUDIT_LOG_FAMILIES.sales).toBe('sales')
+    expect(AUDIT_LOG_FAMILIES.other).toBe('other')
+  })
+
+  it('is frozen', () => {
+    expect(Object.isFrozen(AUDIT_LOG_FAMILIES)).toBe(true)
+  })
+})
+
+/* -------------------------------------------- */
+/*  AUDIT_TAXONOMY registry integrity           */
+/* -------------------------------------------- */
+
+describe('AUDIT_TAXONOMY registry', () => {
+  it('is frozen', () => {
+    expect(Object.isFrozen(AUDIT_TAXONOMY)).toBe(true)
+  })
+
+  it('every entry has required shape: label, family, describe, chatVariant', () => {
+    for (const [type, entry] of Object.entries(AUDIT_TAXONOMY)) {
+      expect(typeof entry.label, `${type}.label must be a string`).toBe('string')
+      expect(typeof entry.family, `${type}.family must be a string`).toBe('string')
+      expect(typeof entry.describe, `${type}.describe must be a function`).toBe('function')
+      expect(typeof entry.chatVariant, `${type}.chatVariant must be a string`).toBe('string')
+    }
+  })
+
+  it('covers all expected canonical types', () => {
+    const expectedTypes = [
+      'skill.train',
+      'skill.forget',
+      'characteristic.increase',
+      'xp.spend',
+      'xp.refund',
+      'xp.grant',
+      'xp.remove',
+      'species.set',
+      'career.set',
+      'specialization.add',
+      'specialization.remove',
+      'talent.purchase',
+      'talent-node-purchase',
+      'talent-node-purchase-succeeded',
+      'talent-node-purchase-failed',
+      'talent-node-forget-succeeded',
+      'talent-node-forget-failed',
+      'advancement.level',
+      'item.purchase',
+      'item.sale',
+    ]
+    for (const type of expectedTypes) {
+      expect(AUDIT_TAXONOMY[type], `Type '${type}' should be in AUDIT_TAXONOMY`).toBeDefined()
+    }
+  })
+
+  it('each entry family is a known AUDIT_LOG_FAMILIES value', () => {
+    const validFamilies = new Set(Object.values(AUDIT_LOG_FAMILIES))
+    for (const [type, entry] of Object.entries(AUDIT_TAXONOMY)) {
+      expect(validFamilies.has(entry.family), `${type}.family '${entry.family}' must be a known family`).toBe(true)
+    }
+  })
+})
+
+/* -------------------------------------------- */
+/*  getTaxonomyEntry                            */
+/* -------------------------------------------- */
+
+describe('getTaxonomyEntry', () => {
+  it('returns the entry for a known type', () => {
+    const entry = getTaxonomyEntry('skill.train')
+    expect(entry).toBeDefined()
+    expect(entry.family).toBe(AUDIT_LOG_FAMILIES.skills)
+  })
+
+  it('returns undefined for an unknown type', () => {
+    expect(getTaxonomyEntry('mystery.event')).toBeUndefined()
+  })
+})
+
+/* -------------------------------------------- */
+/*  getAuditLogFamilyFromType                   */
+/* -------------------------------------------- */
+
+describe('getAuditLogFamilyFromType', () => {
+  const familyMap = [
+    ['skill.train', 'skills'],
+    ['skill.forget', 'skills'],
+    ['characteristic.increase', 'characteristics'],
+    ['xp.spend', 'xp'],
+    ['xp.refund', 'xp'],
+    ['xp.grant', 'xp'],
+    ['xp.remove', 'xp'],
+    ['species.set', 'details'],
+    ['career.set', 'details'],
+    ['specialization.add', 'details'],
+    ['specialization.remove', 'details'],
+    ['talent.purchase', 'talents'],
+    ['talent-node-purchase', 'talents'],
+    ['talent-node-purchase-succeeded', 'talents'],
+    ['talent-node-purchase-failed', 'talents'],
+    ['talent-node-forget-succeeded', 'talents'],
+    ['talent-node-forget-failed', 'talents'],
+    ['advancement.level', 'advancement'],
+    ['item.purchase', 'purchases'],
+    ['item.sale', 'sales'],
+  ]
+
+  for (const [type, expectedFamily] of familyMap) {
+    it(`maps '${type}' to family '${expectedFamily}'`, () => {
+      expect(getAuditLogFamilyFromType(type)).toBe(expectedFamily)
+    })
+  }
+
+  it('falls back to "other" for unknown types', () => {
+    expect(getAuditLogFamilyFromType('mystery.event')).toBe('other')
+    expect(getAuditLogFamilyFromType('')).toBe('other')
+    expect(getAuditLogFamilyFromType(undefined)).toBe('other')
+  })
+})
+
+/* -------------------------------------------- */
+/*  getAuditLogTypeLabelKey                     */
+/* -------------------------------------------- */
+
+describe('getAuditLogTypeLabelKey', () => {
+  it('returns the correct i18n key for skill.train', () => {
+    expect(getAuditLogTypeLabelKey('skill.train')).toBe('SWERPG.AUDIT_LOG.TYPE.SKILL_TRAIN')
+  })
+
+  it('returns the UNKNOWN fallback key for unknown types', () => {
+    expect(getAuditLogTypeLabelKey('mystery.event')).toBe('SWERPG.AUDIT_LOG.TYPE.UNKNOWN')
+    expect(getAuditLogTypeLabelKey(undefined)).toBe('SWERPG.AUDIT_LOG.TYPE.UNKNOWN')
+  })
+
+  it('returns unique keys for each known type', () => {
+    const keys = Object.keys(AUDIT_TAXONOMY).map(getAuditLogTypeLabelKey)
+    const unique = new Set(keys)
+    expect(unique.size).toBe(keys.length)
+  })
+})
+
+/* -------------------------------------------- */
+/*  buildAuditLogDescriptionFromRegistry        */
+/* -------------------------------------------- */
+
+describe('buildAuditLogDescriptionFromRegistry', () => {
+  it('skill.train — uses skillName, oldRank, newRank', () => {
+    const result = buildAuditLogDescriptionFromRegistry({ type: 'skill.train', data: { skillName: 'Piloting', oldRank: 1, newRank: 2 } }, i18n)
+    expect(result).toContain('Piloting')
+    expect(result).toContain('1')
+    expect(result).toContain('2')
+  })
+
+  it('skill.train — falls back to UNKNOWN_SKILL when skillName is absent', () => {
+    const result = buildAuditLogDescriptionFromRegistry({ type: 'skill.train', data: {} }, i18n)
+    expect(result).toContain('SWERPG.AUDIT_LOG.UNKNOWN_SKILL')
+  })
+
+  it('skill.forget — uses skillName, oldRank, newRank', () => {
+    const result = buildAuditLogDescriptionFromRegistry({ type: 'skill.forget', data: { skillName: 'Athletics', oldRank: 3, newRank: 2 } }, i18n)
+    expect(result).toContain('Athletics')
+  })
+
+  it('characteristic.increase — resolves label from characteristics map', () => {
+    const result = buildAuditLogDescriptionFromRegistry(
+      { type: 'characteristic.increase', data: { characteristicId: 'brawn', oldValue: 2, newValue: 3 } },
+      i18n,
+    )
+    expect(result).toContain('CHARACTERISTICS.Brawn')
+    expect(result).not.toContain('brawn')
+  })
+
+  it('characteristic.increase — falls back to UNKNOWN_VALUE for unknown characteristicId', () => {
+    const result = buildAuditLogDescriptionFromRegistry(
+      { type: 'characteristic.increase', data: { characteristicId: 'unknownStat', oldValue: 1, newValue: 2 } },
+      i18n,
+    )
+    expect(result).toContain('SWERPG.AUDIT_LOG.UNKNOWN_VALUE')
+  })
+
+  it('characteristic.increase — falls back to UNKNOWN_VALUE when characteristicId is absent', () => {
+    const result = buildAuditLogDescriptionFromRegistry({ type: 'characteristic.increase', data: {} }, i18n)
+    expect(result).toContain('SWERPG.AUDIT_LOG.UNKNOWN_VALUE')
+  })
+
+  it('xp.spend — uses amount from data, falls back to xpDelta', () => {
+    const result = buildAuditLogDescriptionFromRegistry({ type: 'xp.spend', data: { amount: 15 }, xpDelta: -15 }, i18n)
+    expect(result).toContain('15')
+  })
+
+  it('xp.grant — uses amount from data', () => {
+    const result = buildAuditLogDescriptionFromRegistry({ type: 'xp.grant', data: { amount: 20 }, xpDelta: 20 }, i18n)
+    expect(result).toContain('20')
+  })
+
+  it('talent-node-purchase — uses talentId, specializationId, cost', () => {
+    const result = buildAuditLogDescriptionFromRegistry(
+      { type: 'talent-node-purchase', data: { talentId: 'grit', specializationId: 'spec-bodyguard', cost: 10 } },
+      i18n,
+    )
+    expect(result).toContain('grit')
+    expect(result).toContain('spec-bodyguard')
+    expect(result).toContain('10')
+  })
+
+  it('talent-node-purchase-succeeded — same description format as talent-node-purchase', () => {
+    const result = buildAuditLogDescriptionFromRegistry(
+      { type: 'talent-node-purchase-succeeded', data: { talentId: 'parry', specializationId: 'spec-bodyguard', cost: 5 } },
+      i18n,
+    )
+    expect(result).toContain('parry')
+    expect(result).toContain('spec-bodyguard')
+  })
+
+  it('talent-node-purchase-failed — uses nodeId and reasonCode', () => {
+    const result = buildAuditLogDescriptionFromRegistry({ type: 'talent-node-purchase-failed', data: { nodeId: 'r1c1', reasonCode: 'not-enough-xp' } }, i18n)
+    expect(result).toContain('r1c1')
+    expect(result).toContain('not-enough-xp')
+  })
+
+  it('talent-node-forget-succeeded — uses talentId, specializationId, cost', () => {
+    const result = buildAuditLogDescriptionFromRegistry(
+      { type: 'talent-node-forget-succeeded', data: { talentId: 'grit', specializationId: 'spec-bodyguard', cost: 5 } },
+      i18n,
+    )
+    expect(result).toContain('grit')
+  })
+
+  it('talent-node-forget-failed — uses nodeId and reasonCode', () => {
+    const result = buildAuditLogDescriptionFromRegistry(
+      { type: 'talent-node-forget-failed', data: { nodeId: 'r1c1', reasonCode: 'node-has-dependents' } },
+      i18n,
+    )
+    expect(result).toContain('r1c1')
+    expect(result).toContain('node-has-dependents')
+  })
+
+  it('species.set — uses oldSpecies and newSpecies', () => {
+    const result = buildAuditLogDescriptionFromRegistry({ type: 'species.set', data: { oldSpecies: 'Human', newSpecies: 'Bothan' } }, i18n)
+    expect(result).toContain('Human')
+    expect(result).toContain('Bothan')
+  })
+
+  it('species.set — falls back to NONE key when oldSpecies is absent', () => {
+    const result = buildAuditLogDescriptionFromRegistry({ type: 'species.set', data: { newSpecies: "Twi'lek" } }, i18n)
+    expect(result).toContain('SWERPG.AUDIT_LOG.NONE')
+  })
+
+  it('item.purchase — uses itemName, itemType, price, quantity', () => {
+    const result = buildAuditLogDescriptionFromRegistry(
+      { type: 'item.purchase', data: { itemName: 'Blaster Pistol', itemType: 'weapon', price: 100, quantity: 1 } },
+      i18n,
+    )
+    expect(result).toContain('Blaster Pistol')
+    expect(result).toContain('100')
+  })
+
+  it('item.purchase — falls back to UNKNOWN_ITEM when itemName is absent', () => {
+    const result = buildAuditLogDescriptionFromRegistry({ type: 'item.purchase', data: { itemType: 'weapon', price: 100, quantity: 1 } }, i18n)
+    expect(result).toContain('SWERPG.AUDIT_LOG.UNKNOWN_ITEM')
+  })
+
+  it('item.sale — uses itemName, resalePrice, fraction', () => {
+    const result = buildAuditLogDescriptionFromRegistry(
+      { type: 'item.sale', data: { itemName: 'Old Blaster', itemType: 'weapon', resalePrice: 75, fraction: 0.75 } },
+      i18n,
+    )
+    expect(result).toContain('Old Blaster')
+    expect(result).toContain('75')
+  })
+
+  it('advancement.level — uses oldLevel and newLevel', () => {
+    const result = buildAuditLogDescriptionFromRegistry({ type: 'advancement.level', data: { oldLevel: 2, newLevel: 3 } }, i18n)
+    expect(result).toContain('2')
+    expect(result).toContain('3')
+  })
+
+  it('unknown type — falls back to DESCRIPTION.UNKNOWN with type included', () => {
+    const result = buildAuditLogDescriptionFromRegistry({ type: 'mystery.event', data: {} }, i18n)
+    expect(result).toContain('mystery.event')
+    expect(result).not.toContain('{type}')
+  })
+
+  it('null entry — returns fallback unknown description', () => {
+    const result = buildAuditLogDescriptionFromRegistry(null, i18n)
+    expect(typeof result).toBe('string')
+  })
+
+  it('no type on entry — returns fallback unknown description', () => {
+    const result = buildAuditLogDescriptionFromRegistry({ data: {} }, i18n)
+    expect(typeof result).toBe('string')
+  })
+})
+
+/* -------------------------------------------- */
+/*  Taxonomy completeness: each describe() runs */
+/* -------------------------------------------- */
+
+describe('AUDIT_TAXONOMY describe() functions run without throwing', () => {
+  const minimalEntries = {
+    'skill.train': { type: 'skill.train', data: {} },
+    'skill.forget': { type: 'skill.forget', data: {} },
+    'characteristic.increase': { type: 'characteristic.increase', data: {} },
+    'xp.spend': { type: 'xp.spend', data: {}, xpDelta: -10 },
+    'xp.refund': { type: 'xp.refund', data: {}, xpDelta: 10 },
+    'xp.grant': { type: 'xp.grant', data: {}, xpDelta: 10 },
+    'xp.remove': { type: 'xp.remove', data: {}, xpDelta: -10 },
+    'species.set': { type: 'species.set', data: {} },
+    'career.set': { type: 'career.set', data: {} },
+    'specialization.add': { type: 'specialization.add', data: {} },
+    'specialization.remove': { type: 'specialization.remove', data: {} },
+    'talent.purchase': { type: 'talent.purchase', data: {} },
+    'talent-node-purchase': { type: 'talent-node-purchase', data: {} },
+    'talent-node-purchase-succeeded': { type: 'talent-node-purchase-succeeded', data: {} },
+    'talent-node-purchase-failed': { type: 'talent-node-purchase-failed', data: {} },
+    'talent-node-forget-succeeded': { type: 'talent-node-forget-succeeded', data: {} },
+    'talent-node-forget-failed': { type: 'talent-node-forget-failed', data: {} },
+    'advancement.level': { type: 'advancement.level', data: {} },
+    'item.purchase': { type: 'item.purchase', data: {} },
+    'item.sale': { type: 'item.sale', data: {} },
+  }
+
+  for (const [type, entry] of Object.entries(minimalEntries)) {
+    it(`describe() for '${type}' does not throw and returns a string`, () => {
+      const result = buildAuditLogDescriptionFromRegistry(entry, i18n)
+      expect(typeof result).toBe('string')
+    })
+  }
+})


### PR DESCRIPTION
## Summary

- Centralise la taxonomie des entrees d'audit dans un registre partage.
- Ajoute module/lib/audit/taxonomy.mjs et adapte les utilitaires et l'application character-audit-log pour l'utiliser.
- Ajoute la documentation de plan liee a l'issue et un test unitaire dedie a la taxonomie.

## Context

Closes #563

## Tests

- Not run (not requested).

## Notes

- Diff develop...HEAD : 1 plan document, 2 modules modifies, 1 module ajoute, 1 test ajoute.
- La branche source est deja publiee sur origin ; aucun push supplementaire n'etait necessaire.
