### PR TITLE
fix(audit-log): correct overwriting of commerce modifier in chat message

### DIFF
--- a/documentation/plan/audit-log/564-audit-log-corriger-l-ecrasement-du-modificateur-de-commerce-dans-le-message-chat.md
+++ b/documentation/plan/audit-log/564-audit-log-corriger-l-ecrasement-du-modificateur-de-commerce-dans-le-message-chat.md
@@ -1,0 +1,55 @@
+# Issue #564 — Audit Log : corriger l’écrasement du modificateur de commerce dans le message chat
+
+**Issue** : https://github.com/herveDarritchon/foundryvtt-swerpg/issues/564  
+**Domaine métier** : `audit-log`
+
+## Goal
+
+Rendre visible dans la carte chat d’achat le modificateur narratif de commerce (`AppliedModifier`) sans perdre l’information de solde restant (`creditsRemaining`), en corrigeant uniquement le contrat de rendu `item.purchase` et ses tests ciblés.
+
+## Contexte utile
+
+- `documentation/audit/audit-log/audit-feature-audit-log.md` référence explicitement ce défaut sous **AL6** et recommande de ne plus faire cohabiter `AppliedModifier` et `CREDITS_REMAINING` sur le même slot `metaRight`.
+- Dans `module/utils/audit-log.mjs`, la branche `item.purchase` renseigne aujourd’hui `context.metaRight` avec `MARKET.CommerceOutcome.AppliedModifier`, puis l’écrase systématiquement avec `SWERPG.AUDIT_LOG.META.CREDITS_REMAINING` dès que `snapshot.creditsAfter` existe.
+- Le template `templates/chat/audit-entry.hbs` expose déjà trois zones exploitables sans refonte structurelle : `description`, `metaLeft` et `metaRight`.
+- Les garde-fous naturels existent déjà dans `tests/utils/audit-log.test.mjs` et `tests/integration/market-audit-log.integration.test.mjs` pour verrouiller le view-model chat des achats.
+
+## Plan d’implémentation
+
+### Étape 1 — Corriger le contrat de rendu `item.purchase` pour préserver les deux informations
+
+**Fichiers** : `module/utils/audit-log.mjs`
+
+**What** :
+
+- Revoir la branche `_buildChatContext()['item.purchase']` pour que le modificateur narratif ne soit plus stocké dans un champ ensuite écrasé.
+- Conserver `creditsRemaining` dans `metaRight` comme information de solde final, et router `AppliedModifier` vers un emplacement stable non destructif (`metaLeft` enrichi, `description`, ou fusion explicite) sans masquer le prix de base.
+- Garder le correctif strictement local au rendu chat des achats, sans changer la persistance de l’entrée d’audit, le calcul métier du commerce, ni les autres types d’événements.
+
+**Résultat attendu** : un achat avec `outcome.priceModifier !== 0` affiche simultanément le prix/modificateur narratif et le solde restant dans la carte chat.
+
+### Étape 2 — Verrouiller le bug et la non-régression sur les achats
+
+**Fichiers** : `tests/utils/audit-log.test.mjs`, `tests/integration/market-audit-log.integration.test.mjs`
+
+**What** :
+
+- Ajouter un cas ciblé couvrant un `item.purchase` avec `outcome.priceModifier !== 0` et `snapshot.creditsAfter` défini.
+- Vérifier explicitement que le contexte template conserve le modificateur narratif visible et garde `SWERPG.AUDIT_LOG.META.CREDITS_REMAINING` visible en parallèle.
+- Mettre à jour les assertions existantes sur `item.purchase` pour refléter le nouvel emplacement du modificateur sans élargir le périmètre aux ventes, au résumé chat ou à l’application Audit Log.
+
+**Résultat attendu** : le bug d’écrasement est couvert par des tests unitaires/intégration ciblés et ne peut pas réapparaître silencieusement.
+
+## Périmètre / hors périmètre
+
+### Inclus
+
+- Correction du view-model chat pour `item.purchase`
+- Conservation simultanée du modificateur narratif et du solde restant
+- Mise à jour ciblée des tests Audit Log / Market liés à ce rendu
+
+### Exclus
+
+- Refonte du template chat ou des styles sans besoin prouvé
+- Changement du calcul de `priceModifier`, des règles Market ou du stockage `flags.swerpg.logs`
+- Élargissement aux autres branches du switch chat (`item.sale`, `xp.*`, talents, etc.)

--- a/module/utils/audit-log.mjs
+++ b/module/utils/audit-log.mjs
@@ -834,17 +834,22 @@ const CHAT_HANDLERS = {
     context.variant = 'add'
     context.metaLeft = game.i18n.format('SWERPG.AUDIT_LOG.META.PRICE', { price: data.price ?? 0 })
 
-    // Enrich with commerce outcome narrative when present (from availability check narrative dice)
+    // Enrich with commerce outcome narrative when present (from availability check narrative dice).
+    // AppliedModifier is routed to description to avoid overwriting the credits-remaining slot (metaRight).
     const outcome = entry.outcome ?? null
     if (outcome) {
+      const descriptionParts = []
       if (outcome.priceModifier !== 0) {
         const modifierPct = Math.round(outcome.priceModifier * 100)
         const modifierStr = modifierPct > 0 ? `+${modifierPct}%` : `${modifierPct}%`
-        context.metaRight = game.i18n.format('MARKET.CommerceOutcome.AppliedModifier', { modifier: modifierStr })
+        descriptionParts.push(game.i18n.format('MARKET.CommerceOutcome.AppliedModifier', { modifier: modifierStr }))
       }
       if (outcome.narrativeKeys?.length > 0) {
         const narratives = outcome.narrativeKeys.map((k) => game.i18n.localize(k)).join('; ')
-        context.description = narratives
+        descriptionParts.push(narratives)
+      }
+      if (descriptionParts.length > 0) {
+        context.description = descriptionParts.join(' — ')
       }
     }
 

--- a/tests/integration/market-audit-log.integration.test.mjs
+++ b/tests/integration/market-audit-log.integration.test.mjs
@@ -275,6 +275,128 @@ describe('Scénario 1 — happy path complet', () => {
 })
 
 /* ============================================================= */
+/*  Scénario 1b : AL6 — priceModifier ne doit pas écraser        */
+/*  creditsRemaining dans le view-model chat                     */
+/* ============================================================= */
+
+describe("Scénario 1b — AL6 : AppliedModifier n'écrase pas creditsRemaining", () => {
+  it('item.purchase avec priceModifier et creditsAfter : description porte le modificateur et metaRight porte CREDITS_REMAINING', async () => {
+    const { sendChatForAuditEntries } = await import('../../module/utils/audit-log.mjs')
+
+    const actor = makeActor()
+    const entry = {
+      id: 'purchase-xyz',
+      schemaVersion: 1,
+      type: 'item.purchase',
+      timestamp: 1234567890,
+      userId: 'user-123',
+      userName: 'GameMaster',
+      data: {
+        itemName: 'Blaster Pistol',
+        itemType: 'weapon',
+        price: 120,
+        quantity: 1,
+        itemId: 'item-uuid-abc',
+      },
+      xpDelta: 0,
+      creditDelta: -120,
+      snapshot: {
+        creditsBefore: 400,
+        creditsAfter: 280,
+        creditsDelta: 120,
+      },
+      outcome: {
+        priceModifier: 0.2,
+        narrativeKeys: [],
+      },
+    }
+
+    await sendChatForAuditEntries(actor, [entry])
+
+    const ctx = globalThis.foundry.applications.handlebars.renderTemplate.mock.calls[0][1]
+    // metaRight must remain CREDITS_REMAINING — not overwritten by AppliedModifier
+    expect(ctx.metaRight).toBe('SWERPG.AUDIT_LOG.META.CREDITS_REMAINING')
+    // AppliedModifier appears in description, not in metaRight
+    expect(ctx.description).toBe('MARKET.CommerceOutcome.AppliedModifier')
+    expect(ctx.metaLeft).toBe('SWERPG.AUDIT_LOG.META.PRICE')
+    expect(ctx.hasMeta).toBe(true)
+  })
+
+  it('item.purchase avec priceModifier et narrativeKeys : les deux apparaissent dans description', async () => {
+    const { sendChatForAuditEntries } = await import('../../module/utils/audit-log.mjs')
+
+    const actor = makeActor()
+    const entry = {
+      id: 'purchase-yyy',
+      schemaVersion: 1,
+      type: 'item.purchase',
+      timestamp: 1234567890,
+      userId: 'user-123',
+      userName: 'GameMaster',
+      data: {
+        itemName: 'Thermal Detonator',
+        itemType: 'gear',
+        price: 200,
+        quantity: 1,
+        itemId: 'item-thermo-001',
+      },
+      xpDelta: 0,
+      creditDelta: -180,
+      snapshot: {
+        creditsBefore: 500,
+        creditsAfter: 320,
+        creditsDelta: 180,
+      },
+      outcome: {
+        priceModifier: -0.1,
+        narrativeKeys: ['MARKET.Narrative.StreetContacts'],
+      },
+    }
+
+    await sendChatForAuditEntries(actor, [entry])
+
+    const ctx = globalThis.foundry.applications.handlebars.renderTemplate.mock.calls[0][1]
+    expect(ctx.metaRight).toBe('SWERPG.AUDIT_LOG.META.CREDITS_REMAINING')
+    expect(ctx.description).toContain('MARKET.CommerceOutcome.AppliedModifier')
+    expect(ctx.description).toContain('MARKET.Narrative.StreetContacts')
+    expect(ctx.metaLeft).toBe('SWERPG.AUDIT_LOG.META.PRICE')
+  })
+
+  it('item.purchase sans outcome : description reste null et metaRight porte CREDITS_REMAINING', async () => {
+    const { sendChatForAuditEntries } = await import('../../module/utils/audit-log.mjs')
+
+    const actor = makeActor()
+    const entry = {
+      id: 'purchase-no-outcome',
+      schemaVersion: 1,
+      type: 'item.purchase',
+      timestamp: 1234567890,
+      userId: 'user-123',
+      userName: 'GameMaster',
+      data: {
+        itemName: 'Blaster Pistol',
+        itemType: 'weapon',
+        price: 100,
+        quantity: 1,
+      },
+      xpDelta: 0,
+      creditDelta: -100,
+      snapshot: {
+        creditsBefore: 400,
+        creditsAfter: 300,
+        creditsDelta: 100,
+      },
+    }
+
+    await sendChatForAuditEntries(actor, [entry])
+
+    const ctx = globalThis.foundry.applications.handlebars.renderTemplate.mock.calls[0][1]
+    expect(ctx.metaRight).toBe('SWERPG.AUDIT_LOG.META.CREDITS_REMAINING')
+    expect(ctx.description).toBeNull()
+  })
+})
+
+/* ============================================================= */
 /*  Scénario 2 : Résilience audit                                */
 /*  recordItemPurchase non-blocking si actor.update rejette      */
 /* ============================================================= */

--- a/tests/utils/audit-log.test.mjs
+++ b/tests/utils/audit-log.test.mjs
@@ -1608,6 +1608,83 @@ describe('sendChatForAuditEntries', () => {
     expect(ctx.metaRight).toBeNull()
     expect(ctx.hasMeta).toBe(true)
   })
+
+  test('item.purchase with priceModifier: description carries the modifier and metaRight still shows CREDITS_REMAINING', async () => {
+    // Regression test for AL6 — AppliedModifier must not overwrite creditsRemaining slot (metaRight)
+    const { sendChatForAuditEntries } = await import('../../module/utils/audit-log.mjs')
+    const actor = makeActor()
+    const entry = makeEntry({
+      type: 'item.purchase',
+      data: { itemName: 'Blaster Pistol', itemType: 'weapon', price: 120, quantity: 1 },
+      xpDelta: 0,
+      snapshot: { creditsBefore: 500, creditsAfter: 380 },
+      outcome: { priceModifier: 0.2, narrativeKeys: [] },
+    })
+
+    await sendChatForAuditEntries(actor, [entry])
+
+    const ctx = globalThis.foundry.applications.handlebars.renderTemplate.mock.calls[0][1]
+    expect(ctx.metaRight).toBe('SWERPG.AUDIT_LOG.META.CREDITS_REMAINING')
+    expect(ctx.description).toBe('MARKET.CommerceOutcome.AppliedModifier')
+    expect(ctx.metaLeft).toBe('SWERPG.AUDIT_LOG.META.PRICE')
+    expect(ctx.hasMeta).toBe(true)
+  })
+
+  test('item.purchase with priceModifier and narrativeKeys: both appear in description', async () => {
+    const { sendChatForAuditEntries } = await import('../../module/utils/audit-log.mjs')
+    const actor = makeActor()
+    const entry = makeEntry({
+      type: 'item.purchase',
+      data: { itemName: 'Thermal Detonator', itemType: 'gear', price: 200, quantity: 1 },
+      xpDelta: 0,
+      snapshot: { creditsBefore: 600, creditsAfter: 400 },
+      outcome: { priceModifier: -0.1, narrativeKeys: ['MARKET.Narrative.StreetContacts'] },
+    })
+
+    await sendChatForAuditEntries(actor, [entry])
+
+    const ctx = globalThis.foundry.applications.handlebars.renderTemplate.mock.calls[0][1]
+    expect(ctx.metaRight).toBe('SWERPG.AUDIT_LOG.META.CREDITS_REMAINING')
+    expect(ctx.description).toContain('MARKET.CommerceOutcome.AppliedModifier')
+    expect(ctx.description).toContain('MARKET.Narrative.StreetContacts')
+    expect(ctx.metaLeft).toBe('SWERPG.AUDIT_LOG.META.PRICE')
+  })
+
+  test('item.purchase with zero priceModifier: description stays null when no narrativeKeys', async () => {
+    const { sendChatForAuditEntries } = await import('../../module/utils/audit-log.mjs')
+    const actor = makeActor()
+    const entry = makeEntry({
+      type: 'item.purchase',
+      data: { itemName: 'Blaster Pistol', itemType: 'weapon', price: 100, quantity: 1 },
+      xpDelta: 0,
+      snapshot: { creditsBefore: 400, creditsAfter: 300 },
+      outcome: { priceModifier: 0, narrativeKeys: [] },
+    })
+
+    await sendChatForAuditEntries(actor, [entry])
+
+    const ctx = globalThis.foundry.applications.handlebars.renderTemplate.mock.calls[0][1]
+    expect(ctx.description).toBeNull()
+    expect(ctx.metaRight).toBe('SWERPG.AUDIT_LOG.META.CREDITS_REMAINING')
+  })
+
+  test('item.purchase with null outcome: description stays null, metaRight shows CREDITS_REMAINING', async () => {
+    const { sendChatForAuditEntries } = await import('../../module/utils/audit-log.mjs')
+    const actor = makeActor()
+    const entry = makeEntry({
+      type: 'item.purchase',
+      data: { itemName: 'Blaster Pistol', itemType: 'weapon', price: 100, quantity: 1 },
+      xpDelta: 0,
+      snapshot: { creditsBefore: 400, creditsAfter: 300 },
+      outcome: null,
+    })
+
+    await sendChatForAuditEntries(actor, [entry])
+
+    const ctx = globalThis.foundry.applications.handlebars.renderTemplate.mock.calls[0][1]
+    expect(ctx.description).toBeNull()
+    expect(ctx.metaRight).toBe('SWERPG.AUDIT_LOG.META.CREDITS_REMAINING')
+  })
 })
 
 /* ============================================ */


### PR DESCRIPTION
## Summary

- Preserve the commerce modifier in `item.purchase` chat entries instead of overwriting it with the credits-remaining meta slot.
- Keep the credits remaining value visible in `metaRight` while moving modifier and narrative text into the chat description.
- Add targeted unit and integration coverage for the audit-log purchase rendering regression from issue #564.

## Context

Closes #564

## Tests

- Not run (not requested).

## Notes

- Includes the implementation plan under `documentation/plan/audit-log/564-audit-log-corriger-l-ecrasement-du-modificateur-de-commerce-dans-le-message-chat.md`.
