### PR TITLE
feat(audit-log): correlate old/new state by operation ID for updates

### DIFF
--- a/documentation/plan/audit-log/565-audit-log-correler-old-new-par-identifiant-d-operation-ou-purge-sur-update-echouee.md
+++ b/documentation/plan/audit-log/565-audit-log-correler-old-new-par-identifiant-d-operation-ou-purge-sur-update-echouee.md
@@ -1,0 +1,55 @@
+# Issue #565 — Audit Log : corréler old/new par identifiant d’opération (ou purge sur update échouée)
+
+**Issue** : https://github.com/herveDarritchon/foundryvtt-swerpg/issues/565  
+**Domaine métier** : `audit-log`
+
+## Goal
+
+Éviter qu’un `oldState` capturé par `preUpdateActor()` soit réutilisé par la mauvaise mise à jour quand une update précédente échoue, afin de garantir que chaque entrée Audit Log compare bien le bon couple old/new.
+
+## Contexte utile
+
+- `documentation/audit/audit-log/audit-feature-audit-log.md` documente explicitement ce défaut sous **AL7** : la file pending est aujourd’hui FIFO par `actor:userId`, ce qui devient faux dès qu’une update rejetée laisse un `oldState` orphelin.
+- `module/utils/audit-log.mjs` pousse actuellement les snapshots via `pushPendingEntry()` dans `onPreUpdateActor()`, puis consomme le plus ancien via `shiftPendingEntry()` dans `onUpdateActor()`.
+- Le mono-writer (`game.userId === userId`), le TTL (`PENDING_TTL_MS`) et l’éviction (`evictOldestIfNeeded`) existent déjà ; le correctif doit préserver ces garde-fous tout en supprimant l’appariement FIFO fragile.
+- `tests/utils/audit-log.test.mjs` couvre déjà la queue pending et les handlers `onPreUpdateActor()` / `onUpdateActor()` ; c’est le point naturel pour verrouiller la régression sans élargir le périmètre.
+
+## Plan d’implémentation
+
+### Étape 1 — Remplacer l’appariement FIFO par un appariement par opération
+
+**Fichiers** : `module/utils/audit-log.mjs`
+
+**What** :
+
+- Introduire un identifiant d’opération interne partagé entre `preUpdateActor` et `updateActor` pour une même update, idéalement porté par `options`, puis stocké avec l’entrée pending.
+- Remplacer la consommation “plus ancien snapshot de la file” par une récupération ciblée de l’entrée pending correspondant à cet identifiant d’opération.
+- Conserver le TTL, l’éviction mémoire et le garde mono-écrivain ; utiliser la purge expirée comme filet de sécurité pour les updates rejetées qui ne déclenchent jamais `updateActor`.
+
+**Résultat attendu** : une update réussie ne peut plus consommer le `oldState` d’une update précédente rejetée ou abandonnée.
+
+### Étape 2 — Verrouiller la régression sur update rejetée puis update réussie
+
+**Fichiers** : `tests/utils/audit-log.test.mjs`
+
+**What** :
+
+- Ajouter un test ciblé reproduisant la séquence métier problématique : un `preUpdateActor()` capture un snapshot, l’update associée échoue donc `onUpdateActor()` n’est jamais appelée, puis une seconde update valide survient rapidement.
+- Vérifier que la seconde update corrèle son diff avec son propre `oldState`, et non avec le snapshot orphelin de la première tentative.
+- Mettre à jour les tests de la pending queue pour refléter le nouveau contrat de corrélation par identifiant plutôt que le FIFO implicite actuel.
+
+**Résultat attendu** : l’intégrité old/new de l’Audit Log reste correcte même en cas d’update rejetée suivie d’une nouvelle tentative immédiate.
+
+## Périmètre / hors périmètre
+
+### Inclus
+
+- Corrélation fiable des snapshots pending pour `preUpdateActor` / `updateActor`
+- Purge défensive des entrées pending orphelines via les mécanismes déjà en place
+- Tests unitaires ciblés sur cette séquence d’échec puis retry
+
+### Exclus
+
+- Refonte du stockage `flags.swerpg.logs` ou de la structure des entrées d’audit
+- Refonte UI de l’application Audit Log ou des cartes de chat
+- Chantiers Audit Log non liés à l’appariement old/new (CSV, taxonomie, styling, etc.)

--- a/module/utils/audit-log.mjs
+++ b/module/utils/audit-log.mjs
@@ -157,6 +157,7 @@ function pushPendingEntry(actor, userId, entry) {
 
 /**
  * Remove and return the oldest pending entry for the given actor and user, or undefined when the queue is empty.
+ * Used as a fallback when no operation ID is available.
  * @param {object} actor
  * @param {string} userId
  */
@@ -165,6 +166,25 @@ function shiftPendingEntry(actor, userId) {
   const queue = pendingOldStates.get(key)
   if (!queue?.length) return undefined
   const entry = queue.shift()
+  if (queue.length === 0) pendingOldStates.delete(key)
+  return entry
+}
+
+/**
+ * Remove and return the pending entry matching the given operation ID for the given actor and user.
+ * Returns undefined when no matching entry is found.
+ * Entries that do not match are left in the queue so they can be claimed by their own update or expired by the TTL.
+ * @param {object} actor
+ * @param {string} userId
+ * @param {string} opId
+ */
+function popPendingEntryByOpId(actor, userId, opId) {
+  const key = getPendingKey(actor, userId)
+  const queue = pendingOldStates.get(key)
+  if (!queue?.length) return undefined
+  const idx = queue.findIndex((e) => e.opId === opId)
+  if (idx === -1) return undefined
+  const [entry] = queue.splice(idx, 1)
   if (queue.length === 0) pendingOldStates.delete(key)
   return entry
 }
@@ -329,6 +349,7 @@ export {
   getPendingKey,
   shiftPendingEntry,
   pushPendingEntry,
+  popPendingEntryByOpId,
   isDeletionPath,
   writeLogEntries,
   handleWriteError,
@@ -349,6 +370,9 @@ export {
 
 /**
  * Capture the old actor state before an update and push it to the pending queue.
+ * Stamps a unique operation ID onto `options._swerpgOpId` so the matching `onUpdateActor`
+ * call can retrieve this specific snapshot, even when a preceding update was rejected and
+ * left an orphaned entry in the queue.
  * @param {object} actor
  * @param {object} changes
  * @param {object} options
@@ -363,9 +387,15 @@ export function onPreUpdateActor(actor, changes, options, userId) {
   pruneExpiredPending()
   evictOldestIfNeeded(1)
 
+  const opId = _generateOpId()
+  // Stamp the operation ID onto the shared options object so Foundry forwards it
+  // to the companion updateActor hook call for this same operation.
+  options._swerpgOpId = opId
+
   const oldState = snapshotOldState(actor._source, changes)
 
   pushPendingEntry(actor, userId, {
+    opId,
     oldState,
     changes: cloneValue(changes),
     userId,
@@ -375,6 +405,8 @@ export function onPreUpdateActor(actor, changes, options, userId) {
 
 /**
  * Compare the applied changes against the previously captured state and write the resulting audit entries.
+ * Uses the operation ID stamped by `onPreUpdateActor` to retrieve the correct pending snapshot,
+ * preventing a successful update from consuming the oldState of a previously rejected update.
  * @param {object} actor
  * @param {object} changes
  * @param {object} options
@@ -386,7 +418,8 @@ export function onUpdateActor(actor, changes, options, userId) {
   if (!isCharacterActor(actor)) return
   if (isOnlyAuditChange(changes)) return
 
-  const pending = shiftPendingEntry(actor, userId)
+  const opId = options?._swerpgOpId
+  const pending = opId ? popPendingEntryByOpId(actor, userId, opId) : shiftPendingEntry(actor, userId)
   if (!pending) return
   if (Date.now() - pending.timestamp > PENDING_TTL_MS) return
 
@@ -1084,4 +1117,21 @@ function _setProperty(object, path, value) {
  */
 function flushPending() {
   pendingOldStates.clear()
+}
+
+/* -------------------------------------------- */
+/*  Génération d'identifiant d'opération        */
+/* -------------------------------------------- */
+
+/**
+ * Generate a unique operation identifier for correlating pre/post update hooks.
+ * Uses crypto.randomUUID when available (modern browsers and Node 19+), otherwise
+ * falls back to a high-resolution timestamp combined with a random suffix.
+ * @returns {string}
+ */
+function _generateOpId() {
+  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+    return crypto.randomUUID()
+  }
+  return `${Date.now()}-${Math.random().toString(36).slice(2)}`
 }

--- a/tests/utils/audit-log.test.mjs
+++ b/tests/utils/audit-log.test.mjs
@@ -246,7 +246,7 @@ describe('isDeletionPath', () => {
 
 describe('pending queue', () => {
   test('pushPendingEntry and shiftPendingEntry work as FIFO', async () => {
-    const { pushPendingEntry, shiftPendingEntry, getPendingKey, flushPending } = await import('../../module/utils/audit-log.mjs')
+    const { pushPendingEntry, shiftPendingEntry, flushPending } = await import('../../module/utils/audit-log.mjs')
     flushPending()
 
     const actor = makeCharacterActor()
@@ -259,6 +259,51 @@ describe('pending queue', () => {
     const second = shiftPendingEntry(actor, userId)
     expect(second.changes).toEqual({ x: 2 })
     expect(shiftPendingEntry(actor, userId)).toBeUndefined()
+    flushPending()
+  })
+
+  test('popPendingEntryByOpId retrieves entry by opId regardless of insertion order', async () => {
+    const { pushPendingEntry, popPendingEntryByOpId, countPendingEntries, flushPending } = await import('../../module/utils/audit-log.mjs')
+    flushPending()
+
+    const actor = makeCharacterActor()
+    const userId = 'user-1'
+    pushPendingEntry(actor, userId, { opId: 'op-A', changes: { x: 1 }, timestamp: 100 })
+    pushPendingEntry(actor, userId, { opId: 'op-B', changes: { x: 2 }, timestamp: 200 })
+    pushPendingEntry(actor, userId, { opId: 'op-C', changes: { x: 3 }, timestamp: 300 })
+
+    // Retrieve the middle entry by opId — simulates op-A being orphaned (rejected update)
+    const retrieved = popPendingEntryByOpId(actor, userId, 'op-B')
+    expect(retrieved.changes).toEqual({ x: 2 })
+    expect(retrieved.opId).toBe('op-B')
+
+    // op-A and op-C must remain in the queue
+    expect(countPendingEntries()).toBe(2)
+    flushPending()
+  })
+
+  test('popPendingEntryByOpId returns undefined when opId does not match any entry', async () => {
+    const { pushPendingEntry, popPendingEntryByOpId, flushPending } = await import('../../module/utils/audit-log.mjs')
+    flushPending()
+
+    const actor = makeCharacterActor()
+    const userId = 'user-1'
+    pushPendingEntry(actor, userId, { opId: 'op-A', changes: { x: 1 }, timestamp: 100 })
+
+    expect(popPendingEntryByOpId(actor, userId, 'op-MISSING')).toBeUndefined()
+    flushPending()
+  })
+
+  test('popPendingEntryByOpId removes the queue key when the last entry is consumed', async () => {
+    const { pushPendingEntry, popPendingEntryByOpId, countPendingEntries, flushPending } = await import('../../module/utils/audit-log.mjs')
+    flushPending()
+
+    const actor = makeCharacterActor()
+    const userId = 'user-1'
+    pushPendingEntry(actor, userId, { opId: 'op-solo', changes: { x: 1 }, timestamp: 100 })
+
+    popPendingEntryByOpId(actor, userId, 'op-solo')
+    expect(countPendingEntries()).toBe(0)
     flushPending()
   })
 })
@@ -2404,6 +2449,114 @@ describe('onUpdateActor — mono-writer guard', () => {
 
     // The pending entry must be consumed regardless of whether composeEntries produces audit entries
     expect(countPendingEntries()).toBe(0)
+    flushPending()
+  })
+})
+
+/* ============================================ */
+/*  Corrélation old/new par opId               */
+/*  Régression AL7 — update rejetée + retry    */
+/* ============================================ */
+
+describe('opId correlation — rejected update followed by successful retry', () => {
+  test('second update uses its own oldState, not the orphaned snapshot from the first attempt', async () => {
+    const { onPreUpdateActor, onUpdateActor, flushPending, countPendingEntries } = await import('../../module/utils/audit-log.mjs')
+    flushPending()
+
+    globalThis.game.userId = 'gm-1'
+    globalThis.foundry.utils.deepClone = vi.fn((o) => structuredClone(o))
+
+    const actor = makeCharacterActor({
+      _source: {
+        system: {
+          skills: { Athletics: { rank: 2 }, Lore: { rank: 1 } },
+          characteristics: {},
+          progression: {},
+          details: {},
+          advancement: {},
+        },
+        flags: {},
+      },
+    })
+
+    // First attempt: preUpdate captures oldState with Athletics rank 2
+    const options1 = {}
+    onPreUpdateActor(actor, { system: { skills: { Athletics: { rank: 3 } } } }, options1, 'gm-1')
+    expect(countPendingEntries()).toBe(1)
+
+    // The first update is rejected — onUpdateActor is never called for options1.
+    // The orphaned entry stays in the queue with opId from options1.
+
+    // Actor source is not actually modified (update was rejected).
+    // Second attempt: preUpdate captures oldState again (still rank 2)
+    const options2 = {}
+    onPreUpdateActor(actor, { system: { skills: { Athletics: { rank: 3 } } } }, options2, 'gm-1')
+    expect(countPendingEntries()).toBe(2)
+
+    // The second update succeeds — onUpdateActor is called with options2
+    onUpdateActor(actor, { system: { skills: { Athletics: { rank: 3 } } } }, options2, 'gm-1')
+
+    // The orphaned entry from options1 must remain; only the matched entry was consumed.
+    expect(countPendingEntries()).toBe(1)
+
+    // Verify the options1 opId is different from options2 opId (both were stamped)
+    expect(options1._swerpgOpId).toBeDefined()
+    expect(options2._swerpgOpId).toBeDefined()
+    expect(options1._swerpgOpId).not.toBe(options2._swerpgOpId)
+
+    flushPending()
+  })
+
+  test('onPreUpdateActor stamps a unique _swerpgOpId onto options', async () => {
+    const { onPreUpdateActor, flushPending } = await import('../../module/utils/audit-log.mjs')
+    flushPending()
+
+    globalThis.game.userId = 'gm-1'
+
+    const actor = makeCharacterActor({
+      _source: {
+        system: { skills: { Athletics: { rank: 2 } }, characteristics: {}, progression: {}, details: {}, advancement: {} },
+        flags: {},
+      },
+    })
+
+    const optA = {}
+    const optB = {}
+    onPreUpdateActor(actor, { system: { skills: { Athletics: { rank: 3 } } } }, optA, 'gm-1')
+    onPreUpdateActor(actor, { system: { skills: { Athletics: { rank: 4 } } } }, optB, 'gm-1')
+
+    expect(typeof optA._swerpgOpId).toBe('string')
+    expect(typeof optB._swerpgOpId).toBe('string')
+    expect(optA._swerpgOpId).not.toBe(optB._swerpgOpId)
+
+    flushPending()
+  })
+
+  test('onUpdateActor without opId on options falls back to FIFO (backward-compat)', async () => {
+    const { onPreUpdateActor, onUpdateActor, countPendingEntries, flushPending } = await import('../../module/utils/audit-log.mjs')
+    flushPending()
+
+    globalThis.game.userId = 'gm-1'
+    globalThis.foundry.utils.deepClone = vi.fn((o) => structuredClone(o))
+
+    const actor = makeCharacterActor({
+      _source: {
+        system: { skills: { Athletics: { rank: 2 } }, characteristics: {}, progression: {}, details: {}, advancement: {} },
+        flags: {},
+      },
+    })
+
+    const optPre = {}
+    onPreUpdateActor(actor, { system: { skills: { Athletics: { rank: 3 } } } }, optPre, 'gm-1')
+    expect(countPendingEntries()).toBe(1)
+
+    // Pass a fresh options object with no _swerpgOpId to simulate an external caller
+    const optPost = {}
+    onUpdateActor(actor, { system: { skills: { Athletics: { rank: 3 } } } }, optPost, 'gm-1')
+
+    // Entry consumed via FIFO fallback
+    expect(countPendingEntries()).toBe(0)
+
     flushPending()
   })
 })


### PR DESCRIPTION
## Summary

- Correlate old/new audit-log entries by operation identifier for update and purge flows.
- Update audit-log utility implementation accordingly.
- Add/adjust unit tests for audit-log correlation.

## Context

This change fixes incorrect correlation of previous/new states when update or purge operations use an operation identifier. It modifies the audit-log utility and adds tests to cover the corrected behavior.

## Tests

- Not run (not requested).

## Notes

- Files changed: module/utils/audit-log.mjs, tests/utils/audit-log.test.mjs, documentation (see diff).
- Worktree was clean; no additional commit created by this action.
