### PR TITLE
feat(audit-log): prevent CSV formula injection and add UTF-8 BOM

### DIFF
--- a/documentation/plan/audit-log/566-audit-log-durcir-lexport-csv-contre-linjection-de-formules-bom-utf-8.md
+++ b/documentation/plan/audit-log/566-audit-log-durcir-lexport-csv-contre-linjection-de-formules-bom-utf-8.md
@@ -1,0 +1,55 @@
+# Issue #566 — Audit Log : durcir l’export CSV contre l’injection de formules + BOM UTF-8
+
+**Issue** : https://github.com/herveDarritchon/foundryvtt-swerpg/issues/566  
+**Domaine métier** : `audit-log`
+
+## Goal
+
+Sécuriser l’export CSV Audit Log contre l’exécution de formules dans Excel/Sheets et améliorer l’ouverture UTF-8 dans Excel FR, sans changer les colonnes exportées, le nom du fichier ni les permissions d’accès.
+
+## Contexte utile
+
+- `documentation/audit/audit-log/audit-feature-audit-log.md` référence explicitement ces deux écarts sous **AL8** (formula injection) et **AL13** (BOM UTF-8).
+- `module/applications/character-audit-log.mjs` concentre déjà tout le pipeline d’export : `#onExportCsv()` appelle `buildCsvContent(this.actor)` puis télécharge le résultat via `foundry.utils.saveDataToFile(...)`.
+- `escapeCsvCell()` protège aujourd’hui les virgules, guillemets et retours à la ligne, mais pas les préfixes dangereux `=`, `+`, `-`, `@`.
+- `buildCsvContent()` renvoie actuellement un CSV UTF-8 sans BOM ; `tests/applications/character-audit-log.test.mjs` est déjà le garde-fou naturel pour verrouiller helpers et contrat applicatif d’export.
+
+## Plan d’implémentation
+
+### Étape 1 — Durcir la sérialisation CSV et préfixer le fichier avec un BOM UTF-8
+
+**Fichiers** : `module/applications/character-audit-log.mjs`
+
+**What** :
+
+- Faire évoluer le chemin de sérialisation CSV pour neutraliser les cellules commençant par `=`, `+`, `-` ou `@`, en les préfixant d’une apostrophe avant l’échappement CSV final.
+- Ajouter un préfixe BOM UTF-8 au payload exporté, au niveau du fichier complet, pour que le téléchargement commence bien par `\uFEFF` sans dupliquer ce marqueur dans chaque cellule.
+- Garder le correctif strictement local au pipeline d’export Audit Log, sans toucher au stockage `flags.swerpg.logs`, au nommage du fichier, au MIME ni au contrôle d’accès existant.
+
+**Résultat attendu** : un export CSV Audit Log ne déclenche plus de formule à l’ouverture et s’affiche correctement avec accents dans Excel FR.
+
+### Étape 2 — Verrouiller la non-régression sur les helpers CSV et le contrat d’export
+
+**Fichiers** : `tests/applications/character-audit-log.test.mjs`
+
+**What** :
+
+- Ajouter des tests ciblés sur `escapeCsvCell()` et/ou `buildCsvContent()` pour couvrir des valeurs représentatives commençant par `=`, `+`, `-` et `@`, tout en conservant le comportement existant sur virgules, guillemets et retours à la ligne.
+- Étendre le test applicatif `#onExportCsv` pour vérifier que le contenu transmis à `foundry.utils.saveDataToFile` commence par le BOM UTF-8 et contient des cellules neutralisées quand les données source portent un préfixe dangereux.
+- Garder les assertions focalisées sur le contenu exporté, sans élargir le périmètre aux filtres, au rendu UI Audit Log ou aux autres familles d’événements.
+
+**Résultat attendu** : les deux durcissements demandés par l’issue sont couverts par des tests explicites et ne peuvent plus régresser silencieusement.
+
+## Périmètre / hors périmètre
+
+### Inclus
+
+- Neutralisation des préfixes de formule dans l’export CSV Audit Log
+- Ajout du BOM UTF-8 en tête du fichier exporté
+- Mise à jour ciblée des tests Audit Log liés à l’export CSV
+
+### Exclus
+
+- Changement des colonnes, de leur ordre ou du format métier des lignes d’audit
+- Refonte plus large de l’application Audit Log ou de ses helpers hors export CSV
+- Durcissements supplémentaires non demandés (nouveau format de fichier, options d’export, sandbox tableur, etc.)

--- a/module/applications/character-audit-log.mjs
+++ b/module/applications/character-audit-log.mjs
@@ -881,7 +881,8 @@ export default class CharacterAuditLogApp extends api.HandlebarsApplicationMixin
       const csvContent = buildCsvContent(this.actor)
       const filename = buildExportFilename(this.actor)
 
-      foundry.utils.saveDataToFile(csvContent, 'text/csv;charset=utf-8', filename)
+      // Prepend a UTF-8 BOM (﻿) so that Excel (FR) opens the file with correct encoding.
+      foundry.utils.saveDataToFile('﻿' + csvContent, 'text/csv;charset=utf-8', filename)
     } catch (err) {
       logger.error('[AuditLog] CSV export failed', err)
       ui.notifications.error(game.i18n.localize('SWERPG.AUDIT_LOG.EXPORT_FAILED'))
@@ -894,12 +895,30 @@ export default class CharacterAuditLogApp extends api.HandlebarsApplicationMixin
 /* -------------------------------------------- */
 
 /**
- * Escape a value for inclusion in a CSV cell, wrapping in double-quotes when the string contains commas, quotes, or line breaks.
+ * Neutralize a string that starts with a formula-injection prefix character
+ * by prepending a single-quote, following the OWASP CSV injection mitigation.
+ *
+ * Dangerous prefixes: =, +, -, @
+ *
+ * @param {string} str  Already-stringified cell value (never null / undefined)
+ * @returns {string}
+ */
+function neutralizeFormulaPrefixes(str) {
+  if (str.length > 0 && (str[0] === '=' || str[0] === '+' || str[0] === '-' || str[0] === '@')) {
+    return `'${str}`
+  }
+  return str
+}
+
+/**
+ * Escape a value for inclusion in a CSV cell.
+ * - Neutralizes formula-injection prefixes (=, +, -, @) by prepending a single-quote.
+ * - Wraps in double-quotes when the resulting string contains commas, double-quotes, or line breaks.
  * @param {*} value
  */
 export function escapeCsvCell(value) {
   if (value === null || value === undefined) return ''
-  const str = String(value)
+  const str = neutralizeFormulaPrefixes(String(value))
   if (str.includes(',') || str.includes('"') || str.includes('\n') || str.includes('\r')) {
     return `"${str.replace(/"/g, '""')}"`
   }

--- a/tests/applications/character-audit-log.test.mjs
+++ b/tests/applications/character-audit-log.test.mjs
@@ -430,6 +430,32 @@ describe('audit log CSV export', () => {
     it('wraps in quotes when the value contains a newline', () => {
       expect(escapeCsvCell('line1\nline2')).toBe('"line1\nline2"')
     })
+
+    it('prefixes with a single-quote when the value starts with =', () => {
+      expect(escapeCsvCell('=SUM(A1:A10)')).toBe("'=SUM(A1:A10)")
+    })
+
+    it('prefixes with a single-quote when the value starts with +', () => {
+      expect(escapeCsvCell('+1234')).toBe("'+1234")
+    })
+
+    it('prefixes with a single-quote when the value starts with -', () => {
+      expect(escapeCsvCell('-1234')).toBe("'-1234")
+    })
+
+    it('prefixes with a single-quote when the value starts with @', () => {
+      expect(escapeCsvCell('@SUM(1+1)')).toBe("'@SUM(1+1)")
+    })
+
+    it('does not alter values that do not start with a dangerous prefix', () => {
+      expect(escapeCsvCell('normal text')).toBe('normal text')
+      expect(escapeCsvCell('100')).toBe('100')
+      expect(escapeCsvCell('')).toBe('')
+    })
+
+    it('wraps in quotes and prefixes when the cell starts with = and contains a comma', () => {
+      expect(escapeCsvCell('=A1,B1')).toBe('"\'=A1,B1"')
+    })
   })
 
   describe('getPrimaryOwnerName', () => {
@@ -3008,5 +3034,72 @@ describe('#onExportCsv — foundry.utils.saveDataToFile applicative contract', (
     await expect(CharacterAuditLogApp.DEFAULT_OPTIONS.actions.exportCsv.call(app, fakeEvent, null)).resolves.toBeUndefined()
 
     expect(globalThis.ui.notifications.error).toHaveBeenCalledWith('Export failed')
+  })
+
+  it('BOM: the content passed to saveDataToFile starts with a UTF-8 BOM (﻿)', async () => {
+    const actor = makeActor([{ id: 'e1', timestamp: 100, type: 'skill.train', xpDelta: -10, data: { skillName: 'Piloting', oldRank: 1, newRank: 2 } }])
+
+    const app = new CharacterAuditLogApp({ document: actor })
+    const fakeEvent = { preventDefault: vi.fn() }
+
+    await CharacterAuditLogApp.DEFAULT_OPTIONS.actions.exportCsv.call(app, fakeEvent, null)
+
+    const [csvContent] = globalThis.foundry.utils.saveDataToFile.mock.calls[0]
+    expect(csvContent.charCodeAt(0)).toBe(0xfeff)
+  })
+
+  it('BOM: the content after the BOM starts with the CSV header', async () => {
+    const actor = makeActor([])
+
+    const app = new CharacterAuditLogApp({ document: actor })
+    const fakeEvent = { preventDefault: vi.fn() }
+
+    await CharacterAuditLogApp.DEFAULT_OPTIONS.actions.exportCsv.call(app, fakeEvent, null)
+
+    const [csvContent] = globalThis.foundry.utils.saveDataToFile.mock.calls[0]
+    // First character is BOM; the rest starts with the header
+    expect(csvContent.slice(1)).toContain('timestamp,date,userName,type,typeLabel,description,xpDelta,creditDelta,actorName,playerName')
+  })
+
+  it('formula injection: a cell starting with = is neutralized with a leading single-quote in the export', async () => {
+    const actor = makeActor([
+      {
+        id: 'e1',
+        timestamp: 100,
+        type: 'skill.train',
+        userName: '=MALICIOUS()',
+        xpDelta: -10,
+        data: { skillName: 'Piloting', oldRank: 1, newRank: 2 },
+      },
+    ])
+
+    const app = new CharacterAuditLogApp({ document: actor })
+    const fakeEvent = { preventDefault: vi.fn() }
+
+    await CharacterAuditLogApp.DEFAULT_OPTIONS.actions.exportCsv.call(app, fakeEvent, null)
+
+    const [csvContent] = globalThis.foundry.utils.saveDataToFile.mock.calls[0]
+    // The neutralized form must be present (leading single-quote before =)
+    expect(csvContent).toContain("'=MALICIOUS()")
+    // The raw unescaped form (comma immediately before =) must NOT appear anywhere
+    expect(csvContent).not.toMatch(/,=MALICIOUS/)
+  })
+
+  it('formula injection: cells starting with +, -, @ are also neutralized', async () => {
+    const actor = makeActor([
+      { id: 'e1', timestamp: 100, type: 'skill.train', userName: '+cmd', xpDelta: -10, data: { skillName: 'Piloting', oldRank: 1, newRank: 2 } },
+      { id: 'e2', timestamp: 200, type: 'skill.train', userName: '-cmd', xpDelta: -5, data: { skillName: 'Gunnery', oldRank: 0, newRank: 1 } },
+      { id: 'e3', timestamp: 300, type: 'skill.train', userName: '@SUM', xpDelta: -5, data: { skillName: 'Gunnery', oldRank: 1, newRank: 2 } },
+    ])
+
+    const app = new CharacterAuditLogApp({ document: actor })
+    const fakeEvent = { preventDefault: vi.fn() }
+
+    await CharacterAuditLogApp.DEFAULT_OPTIONS.actions.exportCsv.call(app, fakeEvent, null)
+
+    const [csvContent] = globalThis.foundry.utils.saveDataToFile.mock.calls[0]
+    expect(csvContent).toContain("'+cmd")
+    expect(csvContent).toContain("'-cmd")
+    expect(csvContent).toContain("'@SUM")
   })
 })


### PR DESCRIPTION
## Summary

- Prevent CSV formula injection in the audit log CSV export and add a UTF-8 BOM to improve editor compatibility.
- Update module/applications/character-audit-log.mjs to sanitize exported fields and emit a BOM.
- Add unit tests covering the CSV export behavior and a documentation note describing the change.

## Tests

- Not run (not requested).

## Notes

- Files changed in this PR:
  - documentation/notes/566-audit-log-durcir-lexport-csv-contre-linjection-de-formules-bom-utf-8.md
  - module/applications/character-audit-log.mjs
  - tests/applications/character-audit-log.test.mjs
