### PR TITLE
refactor(audit-log): replace magic numbers with named constants for cost and ranks

### DIFF
--- a/documentation/plan/audit-log/568-audit-log-nommer-les-constantes-metier-cout-caracteristique-defauts-cost-ranks.md
+++ b/documentation/plan/audit-log/568-audit-log-nommer-les-constantes-metier-cout-caracteristique-defauts-cost-ranks.md
@@ -1,0 +1,57 @@
+# Issue #568 — Audit Log : nommer les constantes métier (coût caractéristique, défauts `cost` / `ranks`)
+
+**Issue** : https://github.com/herveDarritchon/foundryvtt-swerpg/issues/568  
+**Domaine métier** : `audit-log`
+
+## Goal
+
+Aligner le flux Audit Log sur l’ADR-0018 en supprimant les derniers littéraux métier ciblés (`10`, `5`, `1`) sans changer le comportement fonctionnel des entrées d’audit déjà produites.
+
+## Contexte utile
+
+- `documentation/audit/audit-log/audit-feature-audit-log.md` identifie ce défaut via **AL12**.
+- `module/utils/audit-diff.mjs` calcule encore le coût de caractéristique via `newValue * 10`.
+- `module/config/progression.mjs` expose déjà la constante canonique `CHARACTERISTIC_RANK_COST_MULTIPLIER = 10`, ainsi que le namespace `SYSTEM.PROGRESSION` destiné à ce type de règle métier.
+- `module/utils/audit-log.mjs` utilise encore des fallbacks inline dans `onCreateItem()` : `item.system?.cost ?? 5` et `item.system?.ranks ?? 1`.
+- `tests/utils/audit-diff.test.mjs`, `tests/utils/audit-log.test.mjs` et `tests/config/progression.test.mjs` constituent les points naturels pour verrouiller le contrat sans élargir le périmètre.
+
+## Plan d’implémentation
+
+### Étape 1 — Centraliser les règles métier ciblées dans la configuration canonique
+
+**Fichiers** : `module/config/progression.mjs`, `module/config/system.mjs`, `tests/config/progression.test.mjs`
+
+**What** :
+
+- Réutiliser la constante existante `CHARACTERISTIC_RANK_COST_MULTIPLIER` comme source de vérité du coût de caractéristique au lieu de conserver un `10` inline dans l’audit.
+- Ajouter dans `module/config/progression.mjs` les constantes nommées manquantes pour les fallbacks de talent purchase audit (coût par défaut et rangs par défaut), puis les exposer via `SYSTEM.PROGRESSION` conformément à l’ADR-0018.
+- Étendre les tests de configuration pour verrouiller les valeurs exportées et leur exposition via `SYSTEM`, sans introduire de doublon sémantique avec une constante déjà existante.
+
+**Résultat attendu** : chaque valeur métier visée par l’issue possède une source de vérité explicite dans `module/config/`.
+
+### Étape 2 — Rebrancher l’audit sur ces constantes et préserver le comportement actuel
+
+**Fichiers** : `module/utils/audit-diff.mjs`, `module/utils/audit-log.mjs`, `tests/utils/audit-diff.test.mjs`, `tests/utils/audit-log.test.mjs`
+
+**What** :
+
+- Remplacer dans `computeCharacteristicCost()` le littéral `10` par la constante canonique de progression.
+- Remplacer dans `onCreateItem()` les fallbacks inline `5` / `1` par les nouvelles constantes nommées, tout en conservant à l’identique `cost`, `ranks` et `xpDelta` dans les entrées `talent.purchase`.
+- Mettre à jour les tests ciblés pour démontrer que le comportement reste inchangé (coût caractéristique 30/40, fallback talent purchase 5/1) tout en supprimant la dépendance aux magic numbers dans l’implémentation.
+
+**Résultat attendu** : l’audit reste fonctionnellement identique, mais les règles métier ciblées sont désormais lisibles, centralisées et protégées par des tests.
+
+## Périmètre / hors périmètre
+
+### Inclus
+
+- Remplacement des littéraux métier ciblés par l’issue
+- Réutilisation de la constante de progression déjà existante pour le coût de caractéristique
+- Ajout ciblé des constantes manquantes pour les fallbacks `cost` / `ranks`
+- Mise à jour ciblée des tests de configuration et d’audit concernés
+
+### Exclus
+
+- Changement des valeurs métier elles-mêmes
+- Refactor large d’Audit Log, du stockage, du chat ou des hooks
+- Revue exhaustive d’autres seuils déjà nommés (`MAX_PENDING`, TTL, etc.) au-delà de la vérification de non-régression demandée

--- a/module/config/progression.mjs
+++ b/module/config/progression.mjs
@@ -159,6 +159,30 @@ export const CAREER_MIN_FREE_SKILL_RANK = 0
 export const CAREER_MAX_FREE_SKILL_RANK = 8
 
 /* -------------------------------------------- */
+/*  Talent purchase audit defaults              */
+/* -------------------------------------------- */
+
+/**
+ * Default XP cost recorded in a `talent.purchase` audit entry when the talent
+ * item does not expose a `system.cost` value.
+ *
+ * This fallback matches the canonical career-skill rank-1 base cost and is
+ * intentionally a named constant so the audit trail remains readable and
+ * testable (ADR-0018).
+ *
+ * @type {number}
+ */
+export const TALENT_PURCHASE_DEFAULT_COST = 5
+
+/**
+ * Default rank count recorded in a `talent.purchase` audit entry when the
+ * talent item does not expose a `system.ranks` value.
+ *
+ * @type {number}
+ */
+export const TALENT_PURCHASE_DEFAULT_RANKS = 1
+
+/* -------------------------------------------- */
 /*  Starting Resources                          */
 /* -------------------------------------------- */
 

--- a/module/utils/audit-diff.mjs
+++ b/module/utils/audit-diff.mjs
@@ -1,6 +1,7 @@
 import { logger } from './logger.mjs'
 import SkillCostCalculator from '../lib/skills/skill-cost-calculator.mjs'
 import { getCanonicalSpecializationKey } from '../lib/specializations/owned-specializations.mjs'
+import { CHARACTERISTIC_RANK_COST_MULTIPLIER } from '../config/progression.mjs'
 
 /* -------------------------------------------- */
 /*  Capture instantané de l'état XP après update */
@@ -27,7 +28,7 @@ function captureSnapshot(actor) {
  * @param {number} newValue
  */
 function computeCharacteristicCost(newValue) {
-  return newValue * 10
+  return CHARACTERISTIC_RANK_COST_MULTIPLIER * newValue
 }
 
 /**

--- a/module/utils/audit-log.mjs
+++ b/module/utils/audit-log.mjs
@@ -2,6 +2,7 @@ import { logger } from './logger.mjs'
 import { composeEntries, makeEntry, captureSnapshot } from './audit-diff.mjs'
 import { buildAuditLogDescriptionFromRegistry, getAuditLogTypeLabelKey } from '../lib/audit/taxonomy.mjs'
 import { buildNextSegmentedState, computeAuditLogMetrics } from '../lib/audit/storage.mjs'
+import { TALENT_PURCHASE_DEFAULT_COST, TALENT_PURCHASE_DEFAULT_RANKS } from '../config/progression.mjs'
 
 /* -------------------------------------------- */
 /*  Constantes                                  */
@@ -472,8 +473,8 @@ function onCreateItem(item, data, options, userId) {
   const ts = Date.now()
   const snapshot = captureSnapshot(item.parent)
   const user = game.users?.get(userId) ?? null
-  const cost = item.system?.cost ?? 5
-  const ranks = item.system?.ranks ?? 1
+  const cost = item.system?.cost ?? TALENT_PURCHASE_DEFAULT_COST
+  const ranks = item.system?.ranks ?? TALENT_PURCHASE_DEFAULT_RANKS
 
   const entry = makeEntry({
     type: 'talent.purchase',

--- a/tests/config/progression.test.mjs
+++ b/tests/config/progression.test.mjs
@@ -18,6 +18,8 @@ import {
   STARTING_CREDITS,
   OBLIGATION_EXTRA_CREDITS_5,
   OBLIGATION_EXTRA_CREDITS_10,
+  TALENT_PURCHASE_DEFAULT_COST,
+  TALENT_PURCHASE_DEFAULT_RANKS,
 } from '../../module/config/progression.mjs'
 import { MAX_RANK_AT_CREATION, MAX_RANK } from '../../module/config/skills.mjs'
 import { SYSTEM } from '../../module/config/system.mjs'
@@ -228,6 +230,30 @@ describe('Progression config — contractual constants (ADR-0018)', () => {
   })
 
   /* -------------------------------------------- */
+  /*  Talent purchase audit defaults              */
+  /* -------------------------------------------- */
+
+  describe('Talent purchase audit default constants', () => {
+    test('TALENT_PURCHASE_DEFAULT_COST is 5 (fallback XP cost when talent has no system.cost)', () => {
+      expect(TALENT_PURCHASE_DEFAULT_COST).toBe(5)
+    })
+
+    test('TALENT_PURCHASE_DEFAULT_RANKS is 1 (fallback rank count when talent has no system.ranks)', () => {
+      expect(TALENT_PURCHASE_DEFAULT_RANKS).toBe(1)
+    })
+
+    test('TALENT_PURCHASE_DEFAULT_COST is a positive integer', () => {
+      expect(Number.isInteger(TALENT_PURCHASE_DEFAULT_COST)).toBe(true)
+      expect(TALENT_PURCHASE_DEFAULT_COST).toBeGreaterThan(0)
+    })
+
+    test('TALENT_PURCHASE_DEFAULT_RANKS is a positive integer', () => {
+      expect(Number.isInteger(TALENT_PURCHASE_DEFAULT_RANKS)).toBe(true)
+      expect(TALENT_PURCHASE_DEFAULT_RANKS).toBeGreaterThan(0)
+    })
+  })
+
+  /* -------------------------------------------- */
   /*  SYSTEM.PROGRESSION exposure (ADR-0018)      */
   /* -------------------------------------------- */
 
@@ -302,6 +328,14 @@ describe('Progression config — contractual constants (ADR-0018)', () => {
 
     test('SYSTEM.PROGRESSION.OBLIGATION_EXTRA_CREDITS_10 equals OBLIGATION_EXTRA_CREDITS_10', () => {
       expect(SYSTEM.PROGRESSION.OBLIGATION_EXTRA_CREDITS_10).toBe(OBLIGATION_EXTRA_CREDITS_10)
+    })
+
+    test('SYSTEM.PROGRESSION.TALENT_PURCHASE_DEFAULT_COST equals TALENT_PURCHASE_DEFAULT_COST', () => {
+      expect(SYSTEM.PROGRESSION.TALENT_PURCHASE_DEFAULT_COST).toBe(TALENT_PURCHASE_DEFAULT_COST)
+    })
+
+    test('SYSTEM.PROGRESSION.TALENT_PURCHASE_DEFAULT_RANKS equals TALENT_PURCHASE_DEFAULT_RANKS', () => {
+      expect(SYSTEM.PROGRESSION.TALENT_PURCHASE_DEFAULT_RANKS).toBe(TALENT_PURCHASE_DEFAULT_RANKS)
     })
   })
 })

--- a/tests/utils/audit-diff.test.mjs
+++ b/tests/utils/audit-diff.test.mjs
@@ -420,10 +420,19 @@ describe('makeEntry', () => {
 /* ============================================ */
 
 describe('computeCharacteristicCost', () => {
-  test('computeCharacteristicCost', async () => {
+  test('returns CHARACTERISTIC_RANK_COST_MULTIPLIER * newValue (value 3 → 30)', async () => {
     const { computeCharacteristicCost } = await import('../../module/utils/audit-diff.mjs')
+    const { CHARACTERISTIC_RANK_COST_MULTIPLIER } = await import('../../module/config/progression.mjs')
 
+    expect(computeCharacteristicCost(3)).toBe(CHARACTERISTIC_RANK_COST_MULTIPLIER * 3)
     expect(computeCharacteristicCost(3)).toBe(30)
+  })
+
+  test('returns CHARACTERISTIC_RANK_COST_MULTIPLIER * newValue (value 4 → 40)', async () => {
+    const { computeCharacteristicCost } = await import('../../module/utils/audit-diff.mjs')
+    const { CHARACTERISTIC_RANK_COST_MULTIPLIER } = await import('../../module/config/progression.mjs')
+
+    expect(computeCharacteristicCost(4)).toBe(CHARACTERISTIC_RANK_COST_MULTIPLIER * 4)
     expect(computeCharacteristicCost(4)).toBe(40)
   })
 })

--- a/tests/utils/audit-log.test.mjs
+++ b/tests/utils/audit-log.test.mjs
@@ -706,6 +706,7 @@ describe('onCreateItem', () => {
 
   test('uses default cost and ranks when system values are missing', async () => {
     const { onCreateItem } = await import('../../module/utils/audit-log.mjs')
+    const { TALENT_PURCHASE_DEFAULT_COST, TALENT_PURCHASE_DEFAULT_RANKS } = await import('../../module/config/progression.mjs')
     globalThis.foundry.utils.deepClone = vi.fn((o) => structuredClone(o))
 
     const actor = makeCharacterActor()
@@ -716,9 +717,9 @@ describe('onCreateItem', () => {
     expect(actor.update).toHaveBeenCalledTimes(1)
     const updateArg = actor.update.mock.calls[0][0]
     const logs = getWrittenLogs(updateArg)
-    expect(logs[0].data.cost).toBe(5)
-    expect(logs[0].data.ranks).toBe(1)
-    expect(logs[0].xpDelta).toBe(-5)
+    expect(logs[0].data.cost).toBe(TALENT_PURCHASE_DEFAULT_COST)
+    expect(logs[0].data.ranks).toBe(TALENT_PURCHASE_DEFAULT_RANKS)
+    expect(logs[0].xpDelta).toBe(-TALENT_PURCHASE_DEFAULT_COST)
   })
 
   test('ignores non-talent items', async () => {


### PR DESCRIPTION
## Summary

- Replace magic numeric literals in audit log and progression code with named constants for cost and ranks
- Add tests covering the new `module/config/progression.mjs` constants and audit-log utilities
- Add documentation draft explaining the business constants mapping

## Context

This branch factors business-magic numbers into named constants to improve readability and maintainability. Changes include updates to module/config, audit-log utilities, unit tests, and a documentation draft.

## Tests

- Not run (not requested).

## Notes

- No behavior/API contract intentionally changed; this is a refactor aimed at internal clarity and test coverage.
