### PR TITLE
refactor(audit-log): unify credit delta source in recordItemPurchase

### DIFF
--- a/documentation/plan/audit-log/569-audit-log-unifier-la-source-du-delta-credits-dans-record-item-purchase.md
+++ b/documentation/plan/audit-log/569-audit-log-unifier-la-source-du-delta-credits-dans-record-item-purchase.md
@@ -1,0 +1,55 @@
+# Issue #569 — Audit Log : unifier la source du delta crédits dans `recordItemPurchase`
+
+**Issue** : https://github.com/herveDarritchon/foundryvtt-swerpg/issues/569  
+**Domaine métier** : `audit-log`
+
+## Goal
+
+Supprimer la double source de vérité entre `creditDelta` et `snapshot.creditsDelta` lors d’un achat Market, afin que l’entrée d’audit reflète toujours le delta réel de crédits après modificateurs et arrondis.
+
+## Contexte utile
+
+- `documentation/audit/audit-log/audit-feature-audit-log.md` identifie ce défaut via **AL11**.
+- L’issue précise que `recordItemPurchase` calcule aujourd’hui `creditDelta = -(price * quantity)` indépendamment de `snapshot.creditsDelta = creditsBefore - creditsAfter`.
+- Cette divergence peut produire des écarts dès qu’un modificateur de commerce, un arrondi ou une variation de calcul intervient dans le flux d’achat.
+- Les garde-fous naturels se trouvent déjà dans `tests/utils/audit-log.test.mjs` et `tests/integration/market-audit-log.integration.test.mjs`.
+
+## Plan d’implémentation
+
+### Étape 1 — Rebrancher `recordItemPurchase` sur une source canonique unique du delta crédits
+
+**Fichiers** : `module/utils/audit-log.mjs`
+
+**What** :
+
+- Revoir `recordItemPurchase()` pour que `creditDelta` et `snapshot.creditsDelta` proviennent de la même valeur canonique au lieu d’être calculés séparément.
+- Privilégier le delta issu du snapshot (`creditsBefore - creditsAfter`) comme source de vérité métier, car il reflète le résultat réellement appliqué après modificateurs.
+- Conserver le contrat d’entrée `item.purchase` et sa convention de signe, sans élargir le changement au calcul Market lui-même, aux ventes ou au rendu chat.
+
+**Résultat attendu** : une entrée `item.purchase` ne peut plus exposer deux deltas crédits divergents pour une même opération.
+
+### Étape 2 — Verrouiller la non-régression sur les scénarios d’achat avec variation réelle du coût
+
+**Fichiers** : `tests/utils/audit-log.test.mjs`, `tests/integration/market-audit-log.integration.test.mjs`
+
+**What** :
+
+- Ajouter ou ajuster un cas ciblé couvrant un achat où le total effectivement payé diffère du simple `price * quantity` (modificateur, arrondi ou cas équivalent déjà reproductible dans le flux).
+- Vérifier explicitement que `creditDelta` et `snapshot.creditsDelta` restent alignés sur la même valeur dans l’entrée d’audit persistée.
+- Mettre à jour uniquement les assertions impactées par cette unification, sans ouvrir un refactor plus large du Market ou du modèle Audit Log.
+
+**Résultat attendu** : la divergence signalée par AL11 est couverte par des tests ciblés et ne peut plus réapparaître silencieusement.
+
+## Périmètre / hors périmètre
+
+### Inclus
+
+- Unification de la source du delta crédits dans `recordItemPurchase`
+- Préservation du contrat métier de l’entrée `item.purchase`
+- Mise à jour ciblée des tests Audit Log / Market concernés
+
+### Exclus
+
+- Refonte du calcul de prix du Market
+- Changement de sémantique des ventes ou d’autres types d’entrées d’audit
+- Refactor large du système Audit Log au-delà du défaut AL11

--- a/module/utils/audit-log.mjs
+++ b/module/utils/audit-log.mjs
@@ -594,7 +594,9 @@ async function recordItemPurchase(actor, { itemName, itemType, price, quantity =
   const creditsDelta = creditsBefore !== null && creditsAfter !== null ? creditsBefore - creditsAfter : null
   const snapshot = { creditsBefore, creditsAfter, creditsDelta }
   const user = game.users?.get(game.user?.id) ?? null
-  const creditDelta = -(price * quantity)
+  // Use the snapshot delta as the canonical source of truth so that price modifiers,
+  // rounding and any commerce adjustments are reflected consistently in the audit entry.
+  const creditDelta = creditsDelta !== null ? -creditsDelta : -(price * quantity)
 
   const entry = {
     ...makeEntry({

--- a/tests/integration/market-audit-log.integration.test.mjs
+++ b/tests/integration/market-audit-log.integration.test.mjs
@@ -412,6 +412,115 @@ describe("Scénario 1b — AL6 : AppliedModifier n'écrase pas creditsRemaining"
 })
 
 /* ============================================================= */
+/*  Scénario 1c : AL11 — source unique du delta crédits          */
+/*  creditDelta et snapshot.creditsDelta doivent être alignés    */
+/*  même quand un modificateur commercial altère le coût réel    */
+/* ============================================================= */
+
+describe('Scénario 1c — AL11 : creditDelta aligné sur snapshot.creditsDelta', () => {
+  it('achat sans modificateur : creditDelta et snapshot.creditsDelta sont cohérents', async () => {
+    const { recordItemPurchase } = await import('../../module/utils/audit-log.mjs')
+
+    const actor = makeActor({ system: { credits: 400 } })
+
+    await recordItemPurchase(actor, {
+      itemName: 'Blaster Pistol',
+      itemType: 'weapon',
+      price: 100,
+      quantity: 1,
+      creditsAfter: 300,
+    })
+
+    const updateArg = actor.update.mock.calls[0][0]
+    const entry = getWrittenLogs(updateArg)[0]
+
+    // Both must represent the same 100-credit debit
+    expect(entry.creditDelta).toBe(-100)
+    expect(entry.snapshot.creditsDelta).toBe(100)
+    expect(entry.creditDelta).toBe(-entry.snapshot.creditsDelta)
+  })
+
+  it('achat avec modificateur de prix (+20%) : creditDelta reflète le coût réellement payé', async () => {
+    // AL11 regression: before the fix, creditDelta = -(price * quantity) = -100
+    // while snapshot.creditsDelta = creditsBefore - creditsAfter = 500 - 380 = 120
+    // After the fix, creditDelta must equal -snapshot.creditsDelta = -120.
+    const { recordItemPurchase } = await import('../../module/utils/audit-log.mjs')
+
+    const actor = makeActor({ system: { credits: 500 } })
+
+    // Base price = 100, but +20% modifier means the actor actually pays 120 credits.
+    // The caller passes creditsAfter reflecting the real debit after the modifier.
+    await recordItemPurchase(actor, {
+      itemName: 'Blaster Pistol',
+      itemType: 'weapon',
+      price: 100,
+      quantity: 1,
+      creditsAfter: 380, // 500 - 120 (effective cost with +20% modifier)
+      outcome: { priceModifier: 0.2, narrativeKeys: [] },
+    })
+
+    const updateArg = actor.update.mock.calls[0][0]
+    const entry = getWrittenLogs(updateArg)[0]
+
+    // snapshot.creditsDelta reflects the real transaction
+    expect(entry.snapshot.creditsBefore).toBe(500)
+    expect(entry.snapshot.creditsAfter).toBe(380)
+    expect(entry.snapshot.creditsDelta).toBe(120)
+
+    // creditDelta must be derived from the same source — not from -(price * quantity)
+    expect(entry.creditDelta).toBe(-120)
+    expect(entry.creditDelta).toBe(-entry.snapshot.creditsDelta)
+  })
+
+  it('achat avec réduction (-10%) : creditDelta reflète le coût réduit réellement payé', async () => {
+    const { recordItemPurchase } = await import('../../module/utils/audit-log.mjs')
+
+    const actor = makeActor({ system: { credits: 300 } })
+
+    // Base price = 200, but -10% discount means the actor pays 180.
+    await recordItemPurchase(actor, {
+      itemName: 'Thermal Detonator',
+      itemType: 'gear',
+      price: 200,
+      quantity: 1,
+      creditsAfter: 120, // 300 - 180 (effective cost with -10% discount)
+      outcome: { priceModifier: -0.1, narrativeKeys: ['MARKET.Narrative.StreetContacts'] },
+    })
+
+    const updateArg = actor.update.mock.calls[0][0]
+    const entry = getWrittenLogs(updateArg)[0]
+
+    expect(entry.snapshot.creditsDelta).toBe(180)
+    expect(entry.creditDelta).toBe(-180)
+    expect(entry.creditDelta).toBe(-entry.snapshot.creditsDelta)
+  })
+
+  it('achat sans creditsAfter connu : creditDelta revient à -(price * quantity)', async () => {
+    // When creditsBefore or creditsAfter is null, the canonical delta is unavailable.
+    // The fallback -(price * quantity) is acceptable in that edge case.
+    const { recordItemPurchase } = await import('../../module/utils/audit-log.mjs')
+
+    // Actor with no credits field — creditsBefore resolves to null
+    const actor = makeActor({ system: {} })
+
+    await recordItemPurchase(actor, {
+      itemName: 'Blaster Pistol',
+      itemType: 'weapon',
+      price: 100,
+      quantity: 2,
+      creditsAfter: null,
+    })
+
+    const updateArg = actor.update.mock.calls[0][0]
+    const entry = getWrittenLogs(updateArg)[0]
+
+    expect(entry.snapshot.creditsDelta).toBeNull()
+    // Fallback: -(price * quantity) = -200
+    expect(entry.creditDelta).toBe(-200)
+  })
+})
+
+/* ============================================================= */
 /*  Scénario 2 : Résilience audit                                */
 /*  recordItemPurchase non-blocking si actor.update rejette      */
 /* ============================================================= */

--- a/tests/utils/audit-log.test.mjs
+++ b/tests/utils/audit-log.test.mjs
@@ -1998,22 +1998,28 @@ describe('recordItemPurchase', () => {
     expect(entry.xpDelta).toBe(0)
   })
 
-  test('calculates creditDelta as -price * quantity', async () => {
+  test('creditDelta is derived from snapshot.creditsDelta (canonical source), not from -(price * quantity)', async () => {
+    // AL11 regression guard: creditDelta must always equal -snapshot.creditsDelta so that
+    // price modifiers and rounding are reflected consistently in the audit entry.
     const { recordItemPurchase } = await import('../../module/utils/audit-log.mjs')
     globalThis.foundry.utils.deepClone = vi.fn((o) => structuredClone(o))
 
+    // actor.system.credits = 150 (from makeActor); price=25, quantity=3 → list cost = 75.
+    // creditsAfter reflects what the actor actually paid (75), so creditsBefore - creditsAfter = 75.
     const actor = makeActor()
     await recordItemPurchase(actor, {
       itemName: 'Stun Grenade',
       itemType: 'gear',
       price: 25,
       quantity: 3,
-      creditsAfter: 0,
+      creditsAfter: 75, // 150 - 75 (actual cost paid)
     })
 
     const updateArg = actor.update.mock.calls[0][0]
     const entry = getWrittenLogs(updateArg)[0]
+    expect(entry.snapshot.creditsDelta).toBe(75)
     expect(entry.creditDelta).toBe(-75)
+    expect(entry.creditDelta).toBe(-entry.snapshot.creditsDelta)
     expect(entry.data.quantity).toBe(3)
   })
 


### PR DESCRIPTION
## Summary

- Unify `recordItemPurchase` so `creditDelta` is derived from the same canonical snapshot credit delta.
- Add regression coverage for market purchases where the effective paid amount differs from `price * quantity`.
- Add the implementation plan file for issue #569 under `documentation/plan/audit-log/`.

## Context

Closes #569

## Tests

- Not run (not requested).
