### PR TITLE
refactor(dice): replace hardcoded colors with design tokens

### DIFF
--- a/documentation/plan/core/refactor/575-dice-less-remplacer-les-couleurs-brutes-par-des-design-tokens-adr-0022.md
+++ b/documentation/plan/core/refactor/575-dice-less-remplacer-les-couleurs-brutes-par-des-design-tokens-adr-0022.md
@@ -1,0 +1,67 @@
+# Issue #575 — `dice.less` : remplacer les couleurs brutes par des design tokens (ADR-0022)
+
+**Issue** : https://github.com/herveDarritchon/foundryvtt-swerpg/issues/575  
+**Domaine métier** : `core/refactor`
+
+## Goal
+
+Mettre `styles/dice.less` en conformité avec ADR-0022 en remplaçant les couleurs codées en dur par des design tokens, sans changer le comportement ni la structure des rendus de jets de dés.
+
+## Contexte utile
+
+- ADR-0022 cite explicitement `dice.less` parmi les feuilles encore en dette, avec **8 occurrences** de couleurs brutes.
+- Les occurrences relevées dans `styles/dice.less` sont concentrées sur les états visuels des résultats (`success`, `failure`, `glance`, `critical`) et sur l’ombre portée des dés dans la visualisation du pool.
+- `styles/variables.less` expose déjà une base réutilisable pour ce chantier : `--color-success-*`, `--color-danger-*`, `--color-warning-*`, `--color-success-text`, `--color-danger-text`, `--color-shadow`, `--color-result-good`, `--color-result-bad`, `--color-result-warn`.
+- Le périmètre de l’issue est strictement CSS : ne pas mélanger cette remédiation avec le moteur de dés, les templates de chat ou les dialogues de jet.
+
+## Plan d’implémentation
+
+### Étape 1 — Cartographier les 8 littéraux couleur et définir leur mapping cible
+
+**Fichiers** : `styles/dice.less`, `styles/variables.less`
+
+**What** :
+
+- relever les 8 occurrences brutes (`rgb(...)`, `#hex`) dans `dice.less` et les regrouper par rôle visuel ;
+- décider pour chaque occurrence si un token existant suffit ou si un token sémantique minimal doit être ajouté dans `variables.less` ;
+- qualifier explicitement le cas du `drop-shadow(... #000)` : remplacement par token si la sémantique existe, sinon exception ADR documentée.
+
+**Résultat attendu** : un mapping complet couvre les fonds d’état, les couleurs critiques de texte et l’ombre des dés avant toute modification de style.
+
+### Étape 2 — Tokeniser les états visuels des résultats de jet
+
+**Fichiers** : `styles/dice.less`, `styles/variables.less` _(uniquement si des tokens manquent réellement)_
+
+**What** :
+
+- remplacer les fonds `--check-bg-color` codés en dur pour `success`, `failure` et `glance` par des tokens cohérents avec les sémantiques succès / danger / warning ;
+- remplacer les couleurs critiques de texte (`failure.critical`, `success.critical`) par des tokens réels du design system, en privilégiant les familles `danger` / `success` existantes ;
+- conserver inchangés les sélecteurs, variables locales CSS et états fonctionnels déjà utilisés par le rendu des jets.
+
+**Résultat attendu** : les variantes de résultat n’embarquent plus de couleurs de marque en dur et restent lisibles dans les thèmes Jedi/Sith.
+
+### Étape 3 — Finaliser la conformité ADR-0022 de `dice.less`
+
+**Fichiers** : `styles/dice.less`
+
+**What** :
+
+- traiter l’ombre portée des dés selon la décision de mapping retenue à l’étape 1 ;
+- vérifier qu’aucun nouveau littéral couleur n’est introduit dans `dice.less` hors exception ADR justifiée ;
+- préparer la validation ciblée prévue à l’implémentation : `pnpm run style:tokens`, `pnpm run style:tokens:strict` et revue visuelle des états `success`, `failure`, `glance`, `critical` dans les cartes de jet.
+
+**Résultat attendu** : `styles/dice.less` devient vérifiable contre ADR-0022 sans élargir le chantier à d’autres feuilles de style.
+
+## Périmètre / hors périmètre
+
+### Inclus
+
+- Remédiation couleur de `styles/dice.less`
+- Ajout minimal de tokens partagés dans `styles/variables.less` si nécessaire
+- Qualification explicite des exceptions ADR éventuelles
+
+### Exclus
+
+- Modifications JS, Handlebars ou logique du moteur de dés
+- Refonte UX du rendu de jet
+- Remédiation d’autres feuilles (`actor.less`, `applications.less`, `chat.less`, etc.)

--- a/styles/dice.less
+++ b/styles/dice.less
@@ -133,34 +133,34 @@
 
   // Success
   &.success .check-result {
-    --check-bg-color: rgb(0 8 0);
+    --check-bg-color: var(--color-result-good-bg);
     --check-border-color: var(--color-result-good);
   }
 
   // Failure
   &.failure .check-result {
-    --check-bg-color: rgb(8 0 0);
+    --check-bg-color: var(--color-result-bad-bg);
     --check-border-color: var(--color-result-bad);
   }
 
   // Deflection
   &.glance .check-result {
-    --check-bg-color: rgb(8 8 0);
+    --check-bg-color: var(--color-result-warn-bg);
     --check-border-color: var(--color-result-warn);
   }
 
   // Critical Failure
   &.failure.critical .check-result {
-    --check-bg-color: rgb(8 0 0);
+    --check-bg-color: var(--color-result-bad-bg);
     --check-border-color: var(--color-result-bad);
-    color: #ff3724;
+    color: var(--color-danger);
   }
 
   // Critical Success
   &.success.critical .check-result {
-    --check-bg-color: rgb(0 8 0);
+    --check-bg-color: var(--color-result-good-bg);
     --check-border-color: var(--color-result-good);
-    color: #12cb3f;
+    color: var(--color-success);
   }
 
   // Hex labels
@@ -233,7 +233,7 @@
       color: var(--color-primary);
       text-align: center;
       font-size: 24px;
-      filter: drop-shadow(0px 0px 6px #000);
+      filter: drop-shadow(0px 0px 6px var(--color-shadow-black));
 
       &::before {
         display: block;

--- a/styles/swerpg.css
+++ b/styles/swerpg.css
@@ -92,6 +92,16 @@
   /* Bleu profond pour les bons résultats */
   --color-result-warn: #a98d0b;
   /* Doré vieilli pour les avertissements */
+  /* Result state background colors (dice check card backgrounds) */
+  --color-result-good-bg: #000800;
+  /* Quasi-noir teinté vert — fond succès */
+  --color-result-bad-bg: #080000;
+  /* Quasi-noir teinté rouge — fond échec */
+  --color-result-warn-bg: #080800;
+  /* Quasi-noir teinté jaune — fond déflexion */
+  /* Pure black shadow token (drop-shadow filter on dice pool) */
+  --color-shadow-black: #000;
+  /* tokens-allow-raw */
   --color-active: #1ab82a;
   /* Vert pour les éléments actifs */
   --color-border-active: #0e5915;
@@ -4956,26 +4966,26 @@ input[type='range'] {
   opacity: 0.2;
 }
 .swerpg.dice-roll.success .check-result {
-  --check-bg-color: #000800;
+  --check-bg-color: var(--color-result-good-bg);
   --check-border-color: var(--color-result-good);
 }
 .swerpg.dice-roll.failure .check-result {
-  --check-bg-color: #080000;
+  --check-bg-color: var(--color-result-bad-bg);
   --check-border-color: var(--color-result-bad);
 }
 .swerpg.dice-roll.glance .check-result {
-  --check-bg-color: #080800;
+  --check-bg-color: var(--color-result-warn-bg);
   --check-border-color: var(--color-result-warn);
 }
 .swerpg.dice-roll.failure.critical .check-result {
-  --check-bg-color: #080000;
+  --check-bg-color: var(--color-result-bad-bg);
   --check-border-color: var(--color-result-bad);
-  color: #ff3724;
+  color: var(--color-danger);
 }
 .swerpg.dice-roll.success.critical .check-result {
-  --check-bg-color: #000800;
+  --check-bg-color: var(--color-result-good-bg);
   --check-border-color: var(--color-result-good);
-  color: #12cb3f;
+  color: var(--color-success);
 }
 .swerpg.dice-roll .hex .label {
   position: absolute;
@@ -5038,7 +5048,7 @@ input[type='range'] {
   color: var(--color-primary);
   text-align: center;
   font-size: 24px;
-  filter: drop-shadow(0px 0px 6px #000);
+  filter: drop-shadow(0px 0px 6px var(--color-shadow-black));
 }
 .swerpg.dice-roll .pool .die::before {
   display: block;

--- a/styles/variables.less
+++ b/styles/variables.less
@@ -85,6 +85,14 @@
   --color-result-good: #0f4c75; /* Bleu profond pour les bons résultats */
   --color-result-warn: #a98d0b; /* Doré vieilli pour les avertissements */
 
+  /* Result state background colors (dice check card backgrounds) */
+  --color-result-good-bg: rgb(0 8 0); /* Quasi-noir teinté vert — fond succès */
+  --color-result-bad-bg: rgb(8 0 0); /* Quasi-noir teinté rouge — fond échec */
+  --color-result-warn-bg: rgb(8 8 0); /* Quasi-noir teinté jaune — fond déflexion */
+
+  /* Pure black shadow token (drop-shadow filter on dice pool) */
+  --color-shadow-black: #000; /* tokens-allow-raw */
+
   --color-active: #1ab82a; /* Vert pour les éléments actifs */
   --color-border-active: #0e5915; /* Vert sombre pour les borders des éléments actifs */
 


### PR DESCRIPTION
## Summary

- Replace hardcoded dice roll result colors in `styles/dice.less` with design tokens for success, failure, warning, and critical states.
- Add dedicated result background and shadow tokens in `styles/variables.less` and update generated `styles/swerpg.css` accordingly.
- Add the implementation plan document for issue #575 under `documentation/plan/core/refactor/`.

## Context

Closes #575

## Tests

- Not run (not requested).

## Notes

- Includes the generated stylesheet update in `styles/swerpg.css` to keep the compiled CSS aligned with the LESS source.
