### PR TITLE
refactor(applications): replace hardcoded colors with design tokens

### DIFF
--- a/documentation/plan/core/refactor/574-applications-less-remplacer-les-couleurs-brutes-par-des-design-tokens-adr-0022.md
+++ b/documentation/plan/core/refactor/574-applications-less-remplacer-les-couleurs-brutes-par-des-design-tokens-adr-0022.md
@@ -1,0 +1,79 @@
+# Issue #574 — `applications.less` : remplacer les couleurs brutes par des design tokens (ADR-0022)
+
+**Issue** : https://github.com/herveDarritchon/foundryvtt-swerpg/issues/574  
+**Domaine métier** : `core/refactor`
+
+## Goal
+
+Mettre `styles/applications.less` en conformité avec ADR-0022 en remplaçant les couleurs codées en dur par des design tokens, sans changer la structure ni le comportement des applications V2 concernées.
+
+## Contexte utile
+
+- ADR-0022 cite explicitement `applications.less` parmi les principaux foyers de dette, avec **~85 occurrences** de couleurs brutes.
+- Les occurrences restantes sont surtout concentrées dans deux zones : la jauge de progression de l’import OggDude et l’application `specialization-tree-app` (header, sidebar, cartes, viewport, légende, toolbar, panneau de détail).
+- La zone `character-audit-log` est déjà largement tokenisée ; les rares littéraux encore présents y sont documentés comme exceptions ponctuelles `// tokens-allow-raw`.
+- `styles/variables.less` expose déjà une base exploitable (`--color-frame-*`, `--color-glow-*`, `--color-success-*`, `--color-danger-*`, `--color-warning-*`, `--color-primary/secondary/tertiary`) ; n’ajouter de nouveaux tokens que s’ils sont réellement réutilisables.
+
+## Plan d’implémentation
+
+### Étape 1 — Cartographier les littéraux restants par surface applicative
+
+**Fichiers** : `styles/applications.less`, `styles/variables.less`
+
+**What** :
+
+- relever les couleurs brutes, gradients et fallbacks non conformes encore présents dans `applications.less` ;
+- regrouper les remplacements par rôle visuel : progression importeur, surfaces holo de la specialization tree, états success/danger, textes, bordures, overlays et ombres ;
+- distinguer explicitement les exceptions ADR déjà justifiées de la dette réellement à résorber.
+
+**Résultat attendu** : un mapping clair couvre toutes les occurrences à traiter sans rouvrir les blocs déjà conformes.
+
+### Étape 2 — Compléter la surface de tokens partagés strictement nécessaire
+
+**Fichiers** : `styles/variables.less` _(uniquement si des tokens manquent réellement)_
+
+**What** :
+
+- remplacer les fallbacks du type `var(..., rgba(...))` / `var(..., #hex)` par de vrais tokens existants ou nouvellement définis ;
+- ajouter seulement les tokens sémantiques ou alpha récurrents nécessaires aux surfaces holo, aux bordures actives et aux états success/danger de `applications.less` ;
+- conserver un nommage cohérent avec ADR-0022 (`--color-*-NN`, tokens de texte sémantiques, `color-mix(...)` si l’héritage de thème doit rester dynamique).
+
+**Résultat attendu** : `applications.less` dispose d’une surface de tokens suffisante sans introduire de palette ad hoc locale au fichier.
+
+### Étape 3 — Remplacer les couleurs brutes dans `applications.less`
+
+**Fichiers** : `styles/applications.less`
+
+**What** :
+
+- tokeniser la jauge de progression OggDude (fond, bordure, gradient de barre) ;
+- tokeniser les surfaces de la `specialization-tree-app` : header, meta pills, sidebar, summary cards, états `is-available` / `is-active`, viewport, detail panel, CTA, legend, toolbar et empty states ;
+- convertir textes, bordures, gradients, radial backgrounds, box-shadows et swatches d’état pour qu’ils reposent sur des `var(--color-*)` réels plutôt que sur des hex/rgb en dur.
+
+**Résultat attendu** : `styles/applications.less` n’embarque plus de couleurs de marque en dur hors exceptions ADR explicitement documentées.
+
+### Étape 4 — Préparer la validation ciblée ADR-0022
+
+**Fichiers** : aucun nouveau fichier requis
+
+**What** :
+
+- prévoir une validation par `pnpm run style:tokens` puis `pnpm run style:tokens:strict` sur les fichiers touchés ;
+- prévoir une revue visuelle des deux surfaces critiques : progression d’import OggDude et specialization tree app ;
+- vérifier que les contrastes et les thèmes Jedi/Sith restent cohérents après tokenisation.
+
+**Résultat attendu** : la conformité ADR-0022 de `applications.less` devient vérifiable sans élargir le chantier aux autres feuilles de style.
+
+## Périmètre / hors périmètre
+
+### Inclus
+
+- Remédiation couleur de `styles/applications.less`
+- Ajout minimal de tokens partagés dans `styles/variables.less` si nécessaire
+- Suppression des fallbacks couleur non conformes dans `applications.less`
+
+### Exclus
+
+- Modifications JS, templates Handlebars ou logique applicative
+- Refonte UX/fonctionnelle de l’importeur OggDude, de l’Audit Log ou de la specialization tree
+- Remédiation d’autres feuilles (`actor.less`, `dice.less`, `item.less`, `chat.less`, etc.)

--- a/styles/applications.less
+++ b/styles/applications.less
@@ -113,8 +113,8 @@
         display: block;
         width: 100%;
         height: 12px;
-        background: var(--color-cool-5-50, rgba(255, 255, 255, 0.1));
-        border: 2px solid var(--color-cool-2, #444);
+        background: var(--color-import-progress-bg);
+        border: 2px solid var(--color-import-progress-border);
         border-radius: 4px;
         margin: 0.5rem 0 0.75rem;
         overflow: hidden;
@@ -123,7 +123,7 @@
       .import-progress-global .bar {
         height: 100%;
         width: 0;
-        background: linear-gradient(90deg, #0b5e0b, #19a319);
+        background: linear-gradient(90deg, var(--color-import-progress-bar-start), var(--color-import-progress-bar-end));
         transition: width 0.25s ease;
       }
 
@@ -377,7 +377,7 @@
     gap: 0.75rem;
     padding: 1rem;
     border-bottom: 1px solid var(--color-frame);
-    background: linear-gradient(180deg, rgba(17, 25, 36, 0.92), rgba(10, 15, 24, 0.85));
+    background: linear-gradient(180deg, var(--color-audit-header-bg-top), var(--color-audit-header-bg-bottom));
   }
 
   .audit-log__title {
@@ -918,7 +918,7 @@
   display: flex;
   flex-direction: column;
   min-height: 100%;
-  background: linear-gradient(180deg, rgba(12, 18, 27, 0.96), rgba(7, 11, 18, 0.94));
+  background: linear-gradient(180deg, var(--color-spec-tree-bg-top), var(--color-spec-tree-bg-bottom));
 
   .specialization-tree-app__header {
     display: flex;
@@ -926,8 +926,8 @@
     justify-content: space-between;
     gap: 1rem;
     padding: 0.75rem 1rem;
-    border-bottom: 1px solid rgba(120, 169, 194, 0.22);
-    background: linear-gradient(180deg, rgba(16, 25, 37, 0.92), rgba(10, 16, 26, 0.88));
+    border-bottom: 1px solid var(--color-glow-22);
+    background: linear-gradient(180deg, var(--color-spec-header-bg-top), var(--color-spec-header-bg-bottom));
   }
 
   .specialization-tree-app__title-block {
@@ -936,14 +936,14 @@
 
   .specialization-tree-app__title {
     margin: 0;
-    color: #e8f3fb;
+    color: var(--color-text-bright);
     font-family: var(--font-h1);
     font-size: var(--font-size-20);
   }
 
   .specialization-tree-app__subtitle {
     margin: 0.15rem 0 0;
-    color: #9fc0d6;
+    color: var(--color-holo-text-label);
     font-size: var(--font-size-11);
   }
 
@@ -959,16 +959,16 @@
     gap: 0.1rem;
     min-width: 120px;
     padding: 0.45rem 0.65rem;
-    border: 1px solid rgba(120, 169, 194, 0.18);
+    border: 1px solid var(--color-glow-18);
     border-radius: 8px;
-    background: rgba(18, 28, 42, 0.6);
-    color: #eef8ff;
+    background: var(--color-holo-deep-60);
+    color: var(--color-holo-text-bright);
     text-align: right;
   }
 
   .specialization-tree-app__meta-label,
   .specialization-tree-app__section-label {
-    color: #9fc0d6;
+    color: var(--color-holo-text-label);
     font-size: var(--font-size-10);
     letter-spacing: 0.08em;
     text-transform: uppercase;
@@ -992,8 +992,8 @@
     gap: 1rem;
     min-height: 0;
     padding: 1rem;
-    border-right: 1px solid rgba(120, 169, 194, 0.18);
-    background: rgba(10, 17, 26, 0.72);
+    border-right: 1px solid var(--color-glow-18);
+    background: var(--color-holo-bg-72);
     overflow-y: auto;
   }
 
@@ -1010,9 +1010,9 @@
     display: grid;
     gap: 0.75rem;
     padding: 0.9rem;
-    border: 1px solid rgba(120, 169, 194, 0.18);
+    border: 1px solid var(--color-glow-18);
     border-radius: 10px;
-    background: rgba(18, 28, 42, 0.72);
+    background: var(--color-holo-deep-72);
   }
 
   .specialization-tree-app__summary-head {
@@ -1024,15 +1024,15 @@
 
   .specialization-tree-app__summary-title {
     margin: 0;
-    color: #eef8ff;
+    color: var(--color-holo-text-bright);
     font-size: var(--font-size-16);
   }
 
   .specialization-tree-app__summary-progress {
     padding: 0.2rem 0.45rem;
     border-radius: 999px;
-    background: rgba(99, 200, 166, 0.14);
-    color: #c9f3e2;
+    background: var(--color-success-15);
+    color: var(--color-success-text-light);
     font-size: var(--font-size-11);
     font-weight: 700;
   }
@@ -1050,11 +1050,11 @@
     margin: 0;
     padding: 0.5rem 0.6rem;
     border-radius: 8px;
-    background: rgba(8, 13, 21, 0.5);
+    background: var(--color-holo-dark-50);
 
     dt {
       margin: 0;
-      color: #9fc0d6;
+      color: var(--color-holo-text-label);
       font-size: var(--font-size-10);
       letter-spacing: 0.04em;
       text-transform: uppercase;
@@ -1062,7 +1062,7 @@
 
     dd {
       margin: 0;
-      color: #eef8ff;
+      color: var(--color-holo-text-bright);
       font-size: var(--font-size-14);
       font-weight: 600;
     }
@@ -1073,9 +1073,9 @@
     flex-direction: column;
     gap: 0.35rem;
     padding: 0.65rem 0.75rem;
-    border: 1px solid rgba(120, 169, 194, 0.18);
+    border: 1px solid var(--color-glow-18);
     border-radius: 8px;
-    background: rgba(18, 28, 42, 0.72);
+    background: var(--color-holo-deep-72);
     transition:
       border-color 0.15s ease,
       background 0.15s ease,
@@ -1083,17 +1083,17 @@
       transform 0.15s ease;
 
     &.is-available {
-      border-color: rgba(99, 200, 166, 0.38);
-      box-shadow: inset 0 0 0 1px rgba(99, 200, 166, 0.08);
+      border-color: var(--color-success-38);
+      box-shadow: inset 0 0 0 1px var(--color-success-10);
       cursor: pointer;
     }
 
     &.is-active {
-      border-color: rgba(120, 169, 194, 0.7);
-      background: rgba(28, 43, 62, 0.92);
+      border-color: var(--color-glow-70);
+      background: var(--color-holo-deep-92);
       box-shadow:
-        inset 0 0 0 1px rgba(120, 169, 194, 0.25),
-        0 0 0 1px rgba(120, 169, 194, 0.18);
+        inset 0 0 0 1px var(--color-glow-25),
+        0 0 0 1px var(--color-glow-18);
       transform: translateX(2px);
     }
 
@@ -1108,7 +1108,7 @@
         left: 0;
         width: 3px;
         border-radius: 999px;
-        background: linear-gradient(180deg, #7dc8e7, #63c8a6);
+        background: linear-gradient(180deg, var(--color-spec-selected-bar-start), var(--color-spec-selected-bar-end));
       }
     }
   }
@@ -1121,12 +1121,12 @@
   }
 
   .specialization-tree-app__specialization-name {
-    color: #eff8ff;
+    color: var(--color-holo-text-bright);
     font-weight: 600;
   }
 
   .specialization-tree-app__specialization-state {
-    color: #9fc0d6;
+    color: var(--color-holo-text-label);
     font-size: var(--font-size-11);
     text-transform: uppercase;
     letter-spacing: 0.04em;
@@ -1146,16 +1146,16 @@
     display: grid;
     width: 100%;
     min-height: 100%;
-    border: 1px solid rgba(120, 169, 194, 0.18);
+    border: 1px solid var(--color-glow-18);
     border-radius: 10px;
-    background: radial-gradient(circle at top, rgba(24, 39, 58, 0.72), rgba(8, 13, 21, 0.94));
-    box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.03);
+    background: radial-gradient(circle at top, var(--color-holo-layer-72), var(--color-holo-dark-94));
+    box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.03); // tokens-allow-raw
   }
 
   .specialization-tree-app__viewport {
     min-height: 420px;
     overflow: hidden;
-    background-image: radial-gradient(circle at 1px 1px, rgba(120, 169, 194, 0.06) 1px, transparent 0);
+    background-image: radial-gradient(circle at 1px 1px, var(--color-glow-07) 1px, transparent 0);
     background-size: 24px 24px;
   }
 
@@ -1173,15 +1173,15 @@
     max-width: 280px;
     padding: 0.6rem 0.7rem;
     padding-top: 1.2rem;
-    background: rgba(10, 17, 26, 0.95);
-    border: 1px solid rgba(120, 169, 194, 0.4);
+    background: var(--color-holo-bg-95);
+    border: 1px solid var(--color-glow-40);
     border-radius: 8px;
-    color: #d5e4f1;
+    color: var(--color-holo-text-soft);
     font-size: var(--font-size-12, 12px);
     line-height: 1.5;
     z-index: 10;
     pointer-events: auto;
-    box-shadow: 0 4px 16px rgba(0, 0, 0, 0.5);
+    box-shadow: 0 4px 16px rgba(0, 0, 0, 0.5); // tokens-allow-raw
 
     &[hidden] {
       display: none;
@@ -1200,7 +1200,7 @@
     justify-content: center;
     border: none;
     background: transparent;
-    color: #9fc0d6;
+    color: var(--color-holo-text-label);
     cursor: pointer;
     opacity: 0.55;
     font-size: 14px;
@@ -1210,8 +1210,8 @@
 
     &:hover {
       opacity: 1;
-      color: #eef8ff;
-      background: rgba(120, 169, 194, 0.12);
+      color: var(--color-holo-text-bright);
+      background: var(--color-glow-12);
     }
   }
 
@@ -1223,12 +1223,12 @@
     margin-bottom: 0.25rem;
     padding-bottom: 0.25rem;
     padding-right: 1.2rem;
-    border-bottom: 1px solid rgba(120, 169, 194, 0.18);
+    border-bottom: 1px solid var(--color-glow-18);
     min-width: 0;
   }
 
   .specialization-tree-app__detail-panel-talent-name {
-    color: #eef8ff;
+    color: var(--color-holo-text-bright);
     font-weight: 600;
     font-size: var(--font-size-13, 13px);
     flex: 0 1 auto;
@@ -1239,7 +1239,7 @@
   }
 
   .specialization-tree-app__detail-panel-cost {
-    color: #b9d9ff;
+    color: var(--color-holo-cost-text);
     font-size: var(--font-size-11, 11px);
     font-weight: 600;
     flex: none;
@@ -1247,26 +1247,26 @@
   }
 
   .specialization-tree-app__detail-panel-type {
-    color: #9fc0d6;
+    color: var(--color-holo-text-label);
     font-size: var(--font-size-10, 10px);
     flex: none;
     white-space: nowrap;
   }
 
   .specialization-tree-app__detail-panel-state {
-    color: #c8dcee;
+    color: var(--color-holo-text-mid);
     font-size: var(--font-size-11, 11px);
     margin-bottom: 0.2rem;
   }
 
   .specialization-tree-app__detail-panel-reason {
-    color: #f07a7a;
+    color: var(--color-danger-text);
     font-size: var(--font-size-11, 11px);
     margin-bottom: 0.2rem;
   }
 
   .specialization-tree-app__detail-panel-description {
-    color: #b8ccdf;
+    color: var(--color-holo-text-muted);
     font-size: var(--font-size-11, 11px);
     margin-bottom: 0.35rem;
     max-height: 80px;
@@ -1286,10 +1286,10 @@
     align-items: center;
     gap: 0.35rem;
     padding: 0.3rem 0.65rem;
-    background: rgba(99, 200, 166, 0.14);
-    border: 1px solid rgba(99, 200, 166, 0.4);
+    background: var(--color-success-15);
+    border: 1px solid var(--color-success-40);
     border-radius: 6px;
-    color: #c9f3e2;
+    color: var(--color-success-text-light);
     font-size: var(--font-size-11, 11px);
     font-weight: 600;
     cursor: pointer;
@@ -1298,9 +1298,9 @@
       border-color 0.15s;
 
     &:hover {
-      background: rgba(99, 200, 166, 0.25);
-      border-color: rgba(99, 200, 166, 0.7);
-      color: #e8fff5;
+      background: var(--color-success-25);
+      border-color: var(--color-success-70);
+      color: var(--color-success-text-hover);
     }
 
     &[hidden] {
@@ -1319,8 +1319,8 @@
     align-items: center;
     gap: 0.6rem;
     padding: 0.35rem 0.65rem;
-    background: rgba(10, 17, 26, 0.82);
-    border: 1px solid rgba(120, 169, 194, 0.14);
+    background: var(--color-holo-bg-82);
+    border: 1px solid var(--color-glow-14);
     border-radius: 6px;
     pointer-events: none;
     backdrop-filter: blur(2px);
@@ -1328,7 +1328,7 @@
   }
 
   .specialization-tree-app__legend-title {
-    color: #9fc0d6;
+    color: var(--color-holo-text-label);
     font-size: var(--font-size-10, 10px);
     font-weight: 600;
     letter-spacing: 0.06em;
@@ -1347,7 +1347,7 @@
     display: inline-flex;
     align-items: center;
     gap: 0.25rem;
-    color: #c8dcee;
+    color: var(--color-holo-text-mid);
     font-size: var(--font-size-10, 10px);
     line-height: 1;
     pointer-events: auto;
@@ -1368,23 +1368,23 @@
 
   /* Swatch colours matched to the PIXI node-state visual palette */
   .specialization-tree-app__legend-swatch[data-state='purchased'] {
-    background: #5f85ad;
-    box-shadow: 0 0 0 1px rgba(149, 201, 255, 0.45);
+    background: var(--color-legend-swatch-purchased);
+    box-shadow: 0 0 0 1px var(--color-legend-swatch-purchased-ring);
   }
 
   .specialization-tree-app__legend-swatch[data-state='available'] {
-    background: #355a84;
-    box-shadow: 0 0 0 1px rgba(140, 184, 232, 0.45);
+    background: var(--color-legend-swatch-available);
+    box-shadow: 0 0 0 1px var(--color-legend-swatch-available-ring);
   }
 
   .specialization-tree-app__legend-swatch[data-state='locked'] {
-    background: #4a4a4a;
-    box-shadow: 0 0 0 1px rgba(122, 122, 122, 0.3);
+    background: var(--color-legend-swatch-locked);
+    box-shadow: 0 0 0 1px var(--color-legend-swatch-locked-ring);
   }
 
   .specialization-tree-app__legend-swatch[data-state='invalid'] {
-    background: #7c4e5a;
-    box-shadow: 0 0 0 1px rgba(180, 111, 130, 0.35);
+    background: var(--color-legend-swatch-invalid);
+    box-shadow: 0 0 0 1px var(--color-legend-swatch-invalid-ring);
   }
 
   .specialization-tree-app__viewport-toolbar {
@@ -1406,10 +1406,10 @@
     align-items: center;
     gap: 0.35rem;
     padding: 0.35rem 0.65rem;
-    background: rgba(10, 17, 26, 0.85);
-    border: 1px solid rgba(120, 169, 194, 0.3);
+    background: var(--color-holo-bg-85);
+    border: 1px solid var(--color-glow-30);
     border-radius: 6px;
-    color: #c8dcee;
+    color: var(--color-holo-text-mid);
     font-size: var(--font-size-11, 11px);
     cursor: pointer;
     transition:
@@ -1417,9 +1417,9 @@
       border-color 0.15s;
 
     &:hover {
-      background: rgba(24, 39, 58, 0.9);
-      border-color: rgba(120, 169, 194, 0.6);
-      color: #eef8ff;
+      background: var(--color-holo-layer-90);
+      border-color: var(--color-glow-60);
+      color: var(--color-holo-text-bright);
     }
   }
 
@@ -1428,11 +1428,11 @@
     place-items: center;
     padding: 1.5rem;
     text-align: center;
-    color: #d5e4f1;
+    color: var(--color-holo-text-soft);
 
     h3 {
       margin: 0 0 0.4rem;
-      color: #eef8ff;
+      color: var(--color-holo-text-bright);
       font-family: var(--font-h1);
       font-size: var(--font-size-18);
     }
@@ -1440,7 +1440,7 @@
     p {
       max-width: 40rem;
       margin: 0;
-      color: #9fc0d6;
+      color: var(--color-holo-text-label);
     }
   }
 
@@ -1460,7 +1460,7 @@
 
     .specialization-tree-app__sidebar {
       border-right: 0;
-      border-bottom: 1px solid rgba(120, 169, 194, 0.18);
+      border-bottom: 1px solid var(--color-glow-18);
     }
 
     .specialization-tree-app__summary-stats {

--- a/styles/swerpg.css
+++ b/styles/swerpg.css
@@ -147,16 +147,25 @@
   --color-glow-20: color-mix(in srgb, var(--color-glow) 20%, transparent);
   --color-glow-22: color-mix(in srgb, var(--color-glow) 22%, transparent);
   --color-glow-25: color-mix(in srgb, var(--color-glow) 25%, transparent);
+  --color-glow-12: color-mix(in srgb, var(--color-glow) 12%, transparent);
+  --color-glow-14: color-mix(in srgb, var(--color-glow) 14%, transparent);
+  --color-glow-18: color-mix(in srgb, var(--color-glow) 18%, transparent);
+  --color-glow-30: color-mix(in srgb, var(--color-glow) 30%, transparent);
+  --color-glow-40: color-mix(in srgb, var(--color-glow) 40%, transparent);
   --color-glow-50: color-mix(in srgb, var(--color-glow) 50%, transparent);
   --color-glow-60: color-mix(in srgb, var(--color-glow) 60%, transparent);
+  --color-glow-70: color-mix(in srgb, var(--color-glow) 70%, transparent);
   /* Success alpha */
   --color-success-10: color-mix(in srgb, var(--color-success) 10%, transparent);
   --color-success-12: color-mix(in srgb, var(--color-success) 12%, transparent);
   --color-success-15: color-mix(in srgb, var(--color-success) 15%, transparent);
   --color-success-20: color-mix(in srgb, var(--color-success) 20%, transparent);
+  --color-success-25: color-mix(in srgb, var(--color-success) 25%, transparent);
   --color-success-30: color-mix(in srgb, var(--color-success) 30%, transparent);
   --color-success-35: color-mix(in srgb, var(--color-success) 35%, transparent);
+  --color-success-38: color-mix(in srgb, var(--color-success) 38%, transparent);
   --color-success-40: color-mix(in srgb, var(--color-success) 40%, transparent);
+  --color-success-70: color-mix(in srgb, var(--color-success) 70%, transparent);
   --color-success-text: color-mix(in srgb, var(--color-success) 80%, var(--color-text));
   --color-success-text-light: color-mix(in srgb, var(--color-success) 60%, var(--color-text));
   /* Danger alpha */
@@ -209,11 +218,70 @@
   /* base frame dark blue */
   --color-holo-bg-dark: #080c12;
   /* deeper dark blue */
+  --color-holo-bg-20: rgba(16, 23, 34, 0.2);
+  --color-holo-bg-34: rgba(16, 23, 34, 0.34);
   --color-holo-bg-40: rgba(16, 23, 34, 0.4);
   --color-holo-bg-60: rgba(16, 23, 34, 0.6);
-  --color-holo-bg-34: rgba(16, 23, 34, 0.34);
-  --color-holo-bg-20: rgba(16, 23, 34, 0.2);
+  --color-holo-bg-72: rgba(10, 17, 26, 0.72);
+  --color-holo-bg-82: rgba(10, 17, 26, 0.82);
+  --color-holo-bg-85: rgba(10, 17, 26, 0.85);
+  --color-holo-bg-95: rgba(10, 17, 26, 0.95);
   --color-holo-bg-inactive: rgba(12, 15, 23, 0.5);
+  /* Holo deep layer (specialization tree panels / summary cards) */
+  --color-holo-deep-60: rgba(18, 28, 42, 0.6);
+  --color-holo-deep-72: rgba(18, 28, 42, 0.72);
+  --color-holo-deep-92: rgba(28, 43, 62, 0.92);
+  /* active selected state */
+  /* Holo layer (specialization tree header / radial top) */
+  --color-holo-layer-72: rgba(24, 39, 58, 0.72);
+  --color-holo-layer-90: rgba(24, 39, 58, 0.9);
+  /* Holo dark sub-layer (specialization tree dark stat cells / radial bottom) */
+  --color-holo-dark-50: rgba(8, 13, 21, 0.5);
+  --color-holo-dark-94: rgba(8, 13, 21, 0.94);
+  /* Specialization tree text shades */
+  --color-holo-text-bright: #eef8ff;
+  /* near-white text on dark holo backgrounds */
+  --color-holo-text-mid: #c8dcee;
+  /* medium-blue grey text (state labels, legend items) */
+  --color-holo-text-soft: #d5e4f1;
+  /* soft blue text (panel body, empty states) */
+  --color-holo-text-muted: #b8ccdf;
+  /* muted blue text (description) */
+  --color-holo-text-label: #9fc0d6;
+  /* label / secondary text on holo surfaces */
+  --color-holo-cost-text: #b9d9ff;
+  /* XP cost label in detail panel */
+  /* Legend swatch colors (matched to PIXI node-state visual palette) */
+  --color-legend-swatch-purchased: #5f85ad;
+  --color-legend-swatch-purchased-ring: color-mix(in srgb, #5f85ad 45%, transparent);
+  --color-legend-swatch-available: #355a84;
+  --color-legend-swatch-available-ring: color-mix(in srgb, #355a84 45%, transparent);
+  --color-legend-swatch-locked: #4a4a4a;
+  --color-legend-swatch-locked-ring: color-mix(in srgb, #4a4a4a 30%, transparent);
+  --color-legend-swatch-invalid: #7c4e5a;
+  --color-legend-swatch-invalid-ring: color-mix(in srgb, #7c4e5a 35%, transparent);
+  /* OggDude import progress bar (success green gradient) */
+  --color-import-progress-bg: rgba(255, 255, 255, 0.1);
+  --color-import-progress-border: #444;
+  /* tokens-allow-raw */
+  --color-import-progress-bar-start: #0b5e0b;
+  --color-import-progress-bar-end: #19a319;
+  /* Specialization tree sidebar "selected" accent bar gradient */
+  --color-spec-selected-bar-start: #7dc8e7;
+  /* cyan-teal top */
+  --color-spec-selected-bar-end: #63c8a6;
+  /* teal-green bottom */
+  /* Success hover text (CTA button hover on holo surface) */
+  --color-success-text-hover: #e8fff5;
+  /* Audit log header gradient stops */
+  --color-audit-header-bg-top: rgba(17, 25, 36, 0.92);
+  --color-audit-header-bg-bottom: rgba(10, 15, 24, 0.85);
+  /* Specialization tree app root gradient stops */
+  --color-spec-tree-bg-top: rgba(12, 18, 27, 0.96);
+  --color-spec-tree-bg-bottom: rgba(7, 11, 18, 0.94);
+  /* Specialization tree header gradient stops */
+  --color-spec-header-bg-top: rgba(16, 25, 37, 0.92);
+  --color-spec-header-bg-bottom: rgba(10, 16, 26, 0.88);
   /* Specialization badge (gold badge on identity summary) */
   --color-badge-gold: #c9a84c;
   --color-badge-gold-40: color-mix(in srgb, #c9a84c 40%, transparent);
@@ -815,8 +883,8 @@ input[type='range'] {
   display: block;
   width: 100%;
   height: 12px;
-  background: var(--color-cool-5-50, rgba(255, 255, 255, 0.1));
-  border: 2px solid var(--color-cool-2, #444);
+  background: var(--color-import-progress-bg);
+  border: 2px solid var(--color-import-progress-border);
   border-radius: 4px;
   margin: 0.5rem 0 0.75rem;
   overflow: hidden;
@@ -824,7 +892,7 @@ input[type='range'] {
 #swerpgSettings-form .window-content .standard-form .import-progress-global .bar {
   height: 100%;
   width: 0;
-  background: linear-gradient(90deg, #0b5e0b, #19a319);
+  background: linear-gradient(90deg, var(--color-import-progress-bar-start), var(--color-import-progress-bar-end));
   transition: width 0.25s ease;
 }
 #swerpgSettings-form .window-content .standard-form .sr-only:not(:focus):not(:active) {
@@ -1021,7 +1089,7 @@ input[type='range'] {
   gap: 0.75rem;
   padding: 1rem;
   border-bottom: 1px solid var(--color-frame);
-  background: linear-gradient(180deg, rgba(17, 25, 36, 0.92), rgba(10, 15, 24, 0.85));
+  background: linear-gradient(180deg, var(--color-audit-header-bg-top), var(--color-audit-header-bg-bottom));
 }
 .swerpg.application.character-audit-log .audit-log__title {
   margin: 0;
@@ -1477,7 +1545,7 @@ input[type='range'] {
   display: flex;
   flex-direction: column;
   min-height: 100%;
-  background: linear-gradient(180deg, rgba(12, 18, 27, 0.96), rgba(7, 11, 18, 0.94));
+  background: linear-gradient(180deg, var(--color-spec-tree-bg-top), var(--color-spec-tree-bg-bottom));
   /* ── Legend: compact state reference at bottom of viewport ──── */
   /* Swatch colours matched to the PIXI node-state visual palette */
 }
@@ -1487,21 +1555,21 @@ input[type='range'] {
   justify-content: space-between;
   gap: 1rem;
   padding: 0.75rem 1rem;
-  border-bottom: 1px solid rgba(120, 169, 194, 0.22);
-  background: linear-gradient(180deg, rgba(16, 25, 37, 0.92), rgba(10, 16, 26, 0.88));
+  border-bottom: 1px solid var(--color-glow-22);
+  background: linear-gradient(180deg, var(--color-spec-header-bg-top), var(--color-spec-header-bg-bottom));
 }
 .swerpg.application.specialization-tree-app .specialization-tree-app__title-block {
   min-width: 0;
 }
 .swerpg.application.specialization-tree-app .specialization-tree-app__title {
   margin: 0;
-  color: #e8f3fb;
+  color: var(--color-text-bright);
   font-family: var(--font-h1);
   font-size: var(--font-size-20);
 }
 .swerpg.application.specialization-tree-app .specialization-tree-app__subtitle {
   margin: 0.15rem 0 0;
-  color: #9fc0d6;
+  color: var(--color-holo-text-label);
   font-size: var(--font-size-11);
 }
 .swerpg.application.specialization-tree-app .specialization-tree-app__header-meta {
@@ -1515,15 +1583,15 @@ input[type='range'] {
   gap: 0.1rem;
   min-width: 120px;
   padding: 0.45rem 0.65rem;
-  border: 1px solid rgba(120, 169, 194, 0.18);
+  border: 1px solid var(--color-glow-18);
   border-radius: 8px;
-  background: rgba(18, 28, 42, 0.6);
-  color: #eef8ff;
+  background: var(--color-holo-deep-60);
+  color: var(--color-holo-text-bright);
   text-align: right;
 }
 .swerpg.application.specialization-tree-app .specialization-tree-app__meta-label,
 .swerpg.application.specialization-tree-app .specialization-tree-app__section-label {
-  color: #9fc0d6;
+  color: var(--color-holo-text-label);
   font-size: var(--font-size-10);
   letter-spacing: 0.08em;
   text-transform: uppercase;
@@ -1544,8 +1612,8 @@ input[type='range'] {
   gap: 1rem;
   min-height: 0;
   padding: 1rem;
-  border-right: 1px solid rgba(120, 169, 194, 0.18);
-  background: rgba(10, 17, 26, 0.72);
+  border-right: 1px solid var(--color-glow-18);
+  background: var(--color-holo-bg-72);
   overflow-y: auto;
 }
 .swerpg.application.specialization-tree-app .specialization-tree-app__specializations {
@@ -1560,9 +1628,9 @@ input[type='range'] {
   display: grid;
   gap: 0.75rem;
   padding: 0.9rem;
-  border: 1px solid rgba(120, 169, 194, 0.18);
+  border: 1px solid var(--color-glow-18);
   border-radius: 10px;
-  background: rgba(18, 28, 42, 0.72);
+  background: var(--color-holo-deep-72);
 }
 .swerpg.application.specialization-tree-app .specialization-tree-app__summary-head {
   display: flex;
@@ -1572,14 +1640,14 @@ input[type='range'] {
 }
 .swerpg.application.specialization-tree-app .specialization-tree-app__summary-title {
   margin: 0;
-  color: #eef8ff;
+  color: var(--color-holo-text-bright);
   font-size: var(--font-size-16);
 }
 .swerpg.application.specialization-tree-app .specialization-tree-app__summary-progress {
   padding: 0.2rem 0.45rem;
   border-radius: 999px;
-  background: rgba(99, 200, 166, 0.14);
-  color: #c9f3e2;
+  background: var(--color-success-15);
+  color: var(--color-success-text-light);
   font-size: var(--font-size-11);
   font-weight: 700;
 }
@@ -1595,18 +1663,18 @@ input[type='range'] {
   margin: 0;
   padding: 0.5rem 0.6rem;
   border-radius: 8px;
-  background: rgba(8, 13, 21, 0.5);
+  background: var(--color-holo-dark-50);
 }
 .swerpg.application.specialization-tree-app .specialization-tree-app__summary-stat dt {
   margin: 0;
-  color: #9fc0d6;
+  color: var(--color-holo-text-label);
   font-size: var(--font-size-10);
   letter-spacing: 0.04em;
   text-transform: uppercase;
 }
 .swerpg.application.specialization-tree-app .specialization-tree-app__summary-stat dd {
   margin: 0;
-  color: #eef8ff;
+  color: var(--color-holo-text-bright);
   font-size: var(--font-size-14);
   font-weight: 600;
 }
@@ -1615,20 +1683,20 @@ input[type='range'] {
   flex-direction: column;
   gap: 0.35rem;
   padding: 0.65rem 0.75rem;
-  border: 1px solid rgba(120, 169, 194, 0.18);
+  border: 1px solid var(--color-glow-18);
   border-radius: 8px;
-  background: rgba(18, 28, 42, 0.72);
+  background: var(--color-holo-deep-72);
   transition: border-color 0.15s ease, background 0.15s ease, box-shadow 0.15s ease, transform 0.15s ease;
 }
 .swerpg.application.specialization-tree-app .specialization-tree-app__specialization.is-available {
-  border-color: rgba(99, 200, 166, 0.38);
-  box-shadow: inset 0 0 0 1px rgba(99, 200, 166, 0.08);
+  border-color: var(--color-success-38);
+  box-shadow: inset 0 0 0 1px var(--color-success-10);
   cursor: pointer;
 }
 .swerpg.application.specialization-tree-app .specialization-tree-app__specialization.is-active {
-  border-color: rgba(120, 169, 194, 0.7);
-  background: rgba(28, 43, 62, 0.92);
-  box-shadow: inset 0 0 0 1px rgba(120, 169, 194, 0.25), 0 0 0 1px rgba(120, 169, 194, 0.18);
+  border-color: var(--color-glow-70);
+  background: var(--color-holo-deep-92);
+  box-shadow: inset 0 0 0 1px var(--color-glow-25), 0 0 0 1px var(--color-glow-18);
   transform: translateX(2px);
 }
 .swerpg.application.specialization-tree-app .specialization-tree-app__specialization[data-selected='true'] {
@@ -1642,7 +1710,7 @@ input[type='range'] {
   left: 0;
   width: 3px;
   border-radius: 999px;
-  background: linear-gradient(180deg, #7dc8e7, #63c8a6);
+  background: linear-gradient(180deg, var(--color-spec-selected-bar-start), var(--color-spec-selected-bar-end));
 }
 .swerpg.application.specialization-tree-app .specialization-tree-app__specialization-main {
   display: flex;
@@ -1651,11 +1719,11 @@ input[type='range'] {
   gap: 0.75rem;
 }
 .swerpg.application.specialization-tree-app .specialization-tree-app__specialization-name {
-  color: #eff8ff;
+  color: var(--color-holo-text-bright);
   font-weight: 600;
 }
 .swerpg.application.specialization-tree-app .specialization-tree-app__specialization-state {
-  color: #9fc0d6;
+  color: var(--color-holo-text-label);
   font-size: var(--font-size-11);
   text-transform: uppercase;
   letter-spacing: 0.04em;
@@ -1673,15 +1741,15 @@ input[type='range'] {
   display: grid;
   width: 100%;
   min-height: 100%;
-  border: 1px solid rgba(120, 169, 194, 0.18);
+  border: 1px solid var(--color-glow-18);
   border-radius: 10px;
-  background: radial-gradient(circle at top, rgba(24, 39, 58, 0.72), rgba(8, 13, 21, 0.94));
+  background: radial-gradient(circle at top, var(--color-holo-layer-72), var(--color-holo-dark-94));
   box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.03);
 }
 .swerpg.application.specialization-tree-app .specialization-tree-app__viewport {
   min-height: 420px;
   overflow: hidden;
-  background-image: radial-gradient(circle at 1px 1px, rgba(120, 169, 194, 0.06) 1px, transparent 0);
+  background-image: radial-gradient(circle at 1px 1px, var(--color-glow-07) 1px, transparent 0);
   background-size: 24px 24px;
 }
 .swerpg.application.specialization-tree-app .specialization-tree-app__canvas {
@@ -1697,10 +1765,10 @@ input[type='range'] {
   max-width: 280px;
   padding: 0.6rem 0.7rem;
   padding-top: 1.2rem;
-  background: rgba(10, 17, 26, 0.95);
-  border: 1px solid rgba(120, 169, 194, 0.4);
+  background: var(--color-holo-bg-95);
+  border: 1px solid var(--color-glow-40);
   border-radius: 8px;
-  color: #d5e4f1;
+  color: var(--color-holo-text-soft);
   font-size: var(--font-size-12, 12px);
   line-height: 1.5;
   z-index: 10;
@@ -1722,7 +1790,7 @@ input[type='range'] {
   justify-content: center;
   border: none;
   background: transparent;
-  color: #9fc0d6;
+  color: var(--color-holo-text-label);
   cursor: pointer;
   opacity: 0.55;
   font-size: 14px;
@@ -1732,8 +1800,8 @@ input[type='range'] {
 }
 .swerpg.application.specialization-tree-app .specialization-tree-app__detail-panel-close:hover {
   opacity: 1;
-  color: #eef8ff;
-  background: rgba(120, 169, 194, 0.12);
+  color: var(--color-holo-text-bright);
+  background: var(--color-glow-12);
 }
 .swerpg.application.specialization-tree-app .specialization-tree-app__detail-panel-header {
   display: flex;
@@ -1743,11 +1811,11 @@ input[type='range'] {
   margin-bottom: 0.25rem;
   padding-bottom: 0.25rem;
   padding-right: 1.2rem;
-  border-bottom: 1px solid rgba(120, 169, 194, 0.18);
+  border-bottom: 1px solid var(--color-glow-18);
   min-width: 0;
 }
 .swerpg.application.specialization-tree-app .specialization-tree-app__detail-panel-talent-name {
-  color: #eef8ff;
+  color: var(--color-holo-text-bright);
   font-weight: 600;
   font-size: var(--font-size-13, 13px);
   flex: 0 1 auto;
@@ -1757,30 +1825,30 @@ input[type='range'] {
   min-width: 0;
 }
 .swerpg.application.specialization-tree-app .specialization-tree-app__detail-panel-cost {
-  color: #b9d9ff;
+  color: var(--color-holo-cost-text);
   font-size: var(--font-size-11, 11px);
   font-weight: 600;
   flex: none;
   white-space: nowrap;
 }
 .swerpg.application.specialization-tree-app .specialization-tree-app__detail-panel-type {
-  color: #9fc0d6;
+  color: var(--color-holo-text-label);
   font-size: var(--font-size-10, 10px);
   flex: none;
   white-space: nowrap;
 }
 .swerpg.application.specialization-tree-app .specialization-tree-app__detail-panel-state {
-  color: #c8dcee;
+  color: var(--color-holo-text-mid);
   font-size: var(--font-size-11, 11px);
   margin-bottom: 0.2rem;
 }
 .swerpg.application.specialization-tree-app .specialization-tree-app__detail-panel-reason {
-  color: #f07a7a;
+  color: var(--color-danger-text);
   font-size: var(--font-size-11, 11px);
   margin-bottom: 0.2rem;
 }
 .swerpg.application.specialization-tree-app .specialization-tree-app__detail-panel-description {
-  color: #b8ccdf;
+  color: var(--color-holo-text-muted);
   font-size: var(--font-size-11, 11px);
   margin-bottom: 0.35rem;
   max-height: 80px;
@@ -1797,19 +1865,19 @@ input[type='range'] {
   align-items: center;
   gap: 0.35rem;
   padding: 0.3rem 0.65rem;
-  background: rgba(99, 200, 166, 0.14);
-  border: 1px solid rgba(99, 200, 166, 0.4);
+  background: var(--color-success-15);
+  border: 1px solid var(--color-success-40);
   border-radius: 6px;
-  color: #c9f3e2;
+  color: var(--color-success-text-light);
   font-size: var(--font-size-11, 11px);
   font-weight: 600;
   cursor: pointer;
   transition: background 0.15s, border-color 0.15s;
 }
 .swerpg.application.specialization-tree-app .specialization-tree-app__detail-panel-cta:hover {
-  background: rgba(99, 200, 166, 0.25);
-  border-color: rgba(99, 200, 166, 0.7);
-  color: #e8fff5;
+  background: var(--color-success-25);
+  border-color: var(--color-success-70);
+  color: var(--color-success-text-hover);
 }
 .swerpg.application.specialization-tree-app .specialization-tree-app__detail-panel-cta[hidden] {
   display: none;
@@ -1823,15 +1891,15 @@ input[type='range'] {
   align-items: center;
   gap: 0.6rem;
   padding: 0.35rem 0.65rem;
-  background: rgba(10, 17, 26, 0.82);
-  border: 1px solid rgba(120, 169, 194, 0.14);
+  background: var(--color-holo-bg-82);
+  border: 1px solid var(--color-glow-14);
   border-radius: 6px;
   pointer-events: none;
   backdrop-filter: blur(2px);
   -webkit-backdrop-filter: blur(2px);
 }
 .swerpg.application.specialization-tree-app .specialization-tree-app__legend-title {
-  color: #9fc0d6;
+  color: var(--color-holo-text-label);
   font-size: var(--font-size-10, 10px);
   font-weight: 600;
   letter-spacing: 0.06em;
@@ -1848,7 +1916,7 @@ input[type='range'] {
   display: inline-flex;
   align-items: center;
   gap: 0.25rem;
-  color: #c8dcee;
+  color: var(--color-holo-text-mid);
   font-size: var(--font-size-10, 10px);
   line-height: 1;
   pointer-events: auto;
@@ -1865,20 +1933,20 @@ input[type='range'] {
   color: inherit;
 }
 .swerpg.application.specialization-tree-app .specialization-tree-app__legend-swatch[data-state='purchased'] {
-  background: #5f85ad;
-  box-shadow: 0 0 0 1px rgba(149, 201, 255, 0.45);
+  background: var(--color-legend-swatch-purchased);
+  box-shadow: 0 0 0 1px var(--color-legend-swatch-purchased-ring);
 }
 .swerpg.application.specialization-tree-app .specialization-tree-app__legend-swatch[data-state='available'] {
-  background: #355a84;
-  box-shadow: 0 0 0 1px rgba(140, 184, 232, 0.45);
+  background: var(--color-legend-swatch-available);
+  box-shadow: 0 0 0 1px var(--color-legend-swatch-available-ring);
 }
 .swerpg.application.specialization-tree-app .specialization-tree-app__legend-swatch[data-state='locked'] {
-  background: #4a4a4a;
-  box-shadow: 0 0 0 1px rgba(122, 122, 122, 0.3);
+  background: var(--color-legend-swatch-locked);
+  box-shadow: 0 0 0 1px var(--color-legend-swatch-locked-ring);
 }
 .swerpg.application.specialization-tree-app .specialization-tree-app__legend-swatch[data-state='invalid'] {
-  background: #7c4e5a;
-  box-shadow: 0 0 0 1px rgba(180, 111, 130, 0.35);
+  background: var(--color-legend-swatch-invalid);
+  box-shadow: 0 0 0 1px var(--color-legend-swatch-invalid-ring);
 }
 .swerpg.application.specialization-tree-app .specialization-tree-app__viewport-toolbar {
   position: absolute;
@@ -1897,30 +1965,30 @@ input[type='range'] {
   align-items: center;
   gap: 0.35rem;
   padding: 0.35rem 0.65rem;
-  background: rgba(10, 17, 26, 0.85);
-  border: 1px solid rgba(120, 169, 194, 0.3);
+  background: var(--color-holo-bg-85);
+  border: 1px solid var(--color-glow-30);
   border-radius: 6px;
-  color: #c8dcee;
+  color: var(--color-holo-text-mid);
   font-size: var(--font-size-11, 11px);
   cursor: pointer;
   transition: background 0.15s, border-color 0.15s;
 }
 .swerpg.application.specialization-tree-app .specialization-tree-app__toolbar-btn:hover {
-  background: rgba(24, 39, 58, 0.9);
-  border-color: rgba(120, 169, 194, 0.6);
-  color: #eef8ff;
+  background: var(--color-holo-layer-90);
+  border-color: var(--color-glow-60);
+  color: var(--color-holo-text-bright);
 }
 .swerpg.application.specialization-tree-app .specialization-tree-app__empty,
 .swerpg.application.specialization-tree-app .specialization-tree-app__sidebar-empty {
   place-items: center;
   padding: 1.5rem;
   text-align: center;
-  color: #d5e4f1;
+  color: var(--color-holo-text-soft);
 }
 .swerpg.application.specialization-tree-app .specialization-tree-app__empty h3,
 .swerpg.application.specialization-tree-app .specialization-tree-app__sidebar-empty h3 {
   margin: 0 0 0.4rem;
-  color: #eef8ff;
+  color: var(--color-holo-text-bright);
   font-family: var(--font-h1);
   font-size: var(--font-size-18);
 }
@@ -1928,7 +1996,7 @@ input[type='range'] {
 .swerpg.application.specialization-tree-app .specialization-tree-app__sidebar-empty p {
   max-width: 40rem;
   margin: 0;
-  color: #9fc0d6;
+  color: var(--color-holo-text-label);
 }
 @media (max-width: 768px) {
   .swerpg.application.specialization-tree-app .specialization-tree-app__header {
@@ -1943,7 +2011,7 @@ input[type='range'] {
   }
   .swerpg.application.specialization-tree-app .specialization-tree-app__sidebar {
     border-right: 0;
-    border-bottom: 1px solid rgba(120, 169, 194, 0.18);
+    border-bottom: 1px solid var(--color-glow-18);
   }
   .swerpg.application.specialization-tree-app .specialization-tree-app__summary-stats {
     grid-template-columns: 1fr;

--- a/styles/variables.less
+++ b/styles/variables.less
@@ -154,17 +154,26 @@
   --color-glow-20: color-mix(in srgb, var(--color-glow) 20%, transparent);
   --color-glow-22: color-mix(in srgb, var(--color-glow) 22%, transparent);
   --color-glow-25: color-mix(in srgb, var(--color-glow) 25%, transparent);
+  --color-glow-12: color-mix(in srgb, var(--color-glow) 12%, transparent);
+  --color-glow-14: color-mix(in srgb, var(--color-glow) 14%, transparent);
+  --color-glow-18: color-mix(in srgb, var(--color-glow) 18%, transparent);
+  --color-glow-30: color-mix(in srgb, var(--color-glow) 30%, transparent);
+  --color-glow-40: color-mix(in srgb, var(--color-glow) 40%, transparent);
   --color-glow-50: color-mix(in srgb, var(--color-glow) 50%, transparent);
   --color-glow-60: color-mix(in srgb, var(--color-glow) 60%, transparent);
+  --color-glow-70: color-mix(in srgb, var(--color-glow) 70%, transparent);
 
   /* Success alpha */
   --color-success-10: color-mix(in srgb, var(--color-success) 10%, transparent);
   --color-success-12: color-mix(in srgb, var(--color-success) 12%, transparent);
   --color-success-15: color-mix(in srgb, var(--color-success) 15%, transparent);
   --color-success-20: color-mix(in srgb, var(--color-success) 20%, transparent);
+  --color-success-25: color-mix(in srgb, var(--color-success) 25%, transparent);
   --color-success-30: color-mix(in srgb, var(--color-success) 30%, transparent);
   --color-success-35: color-mix(in srgb, var(--color-success) 35%, transparent);
+  --color-success-38: color-mix(in srgb, var(--color-success) 38%, transparent);
   --color-success-40: color-mix(in srgb, var(--color-success) 40%, transparent);
+  --color-success-70: color-mix(in srgb, var(--color-success) 70%, transparent);
   --color-success-text: color-mix(in srgb, var(--color-success) 80%, var(--color-text));
   --color-success-text-light: color-mix(in srgb, var(--color-success) 60%, var(--color-text));
 
@@ -224,11 +233,71 @@
   /* Holo / dark overlay backgrounds (actor sheet circles, steppers, console) */
   --color-holo-bg: rgb(16 23 34); /* base frame dark blue */
   --color-holo-bg-dark: rgb(8 12 18); /* deeper dark blue */
+  --color-holo-bg-20: rgb(16 23 34 / 20%);
+  --color-holo-bg-34: rgb(16 23 34 / 34%);
   --color-holo-bg-40: rgb(16 23 34 / 40%);
   --color-holo-bg-60: rgb(16 23 34 / 60%);
-  --color-holo-bg-34: rgb(16 23 34 / 34%);
-  --color-holo-bg-20: rgb(16 23 34 / 20%);
+  --color-holo-bg-72: rgb(10 17 26 / 72%);
+  --color-holo-bg-82: rgb(10 17 26 / 82%);
+  --color-holo-bg-85: rgb(10 17 26 / 85%);
+  --color-holo-bg-95: rgb(10 17 26 / 95%);
   --color-holo-bg-inactive: rgb(12 15 23 / 50%);
+
+  /* Holo deep layer (specialization tree panels / summary cards) */
+  --color-holo-deep-60: rgb(18 28 42 / 60%);
+  --color-holo-deep-72: rgb(18 28 42 / 72%);
+  --color-holo-deep-92: rgb(28 43 62 / 92%); /* active selected state */
+
+  /* Holo layer (specialization tree header / radial top) */
+  --color-holo-layer-72: rgb(24 39 58 / 72%);
+  --color-holo-layer-90: rgb(24 39 58 / 90%);
+
+  /* Holo dark sub-layer (specialization tree dark stat cells / radial bottom) */
+  --color-holo-dark-50: rgb(8 13 21 / 50%);
+  --color-holo-dark-94: rgb(8 13 21 / 94%);
+
+  /* Specialization tree text shades */
+  --color-holo-text-bright: #eef8ff; /* near-white text on dark holo backgrounds */
+  --color-holo-text-mid: #c8dcee; /* medium-blue grey text (state labels, legend items) */
+  --color-holo-text-soft: #d5e4f1; /* soft blue text (panel body, empty states) */
+  --color-holo-text-muted: #b8ccdf; /* muted blue text (description) */
+  --color-holo-text-label: #9fc0d6; /* label / secondary text on holo surfaces */
+  --color-holo-cost-text: #b9d9ff; /* XP cost label in detail panel */
+
+  /* Legend swatch colors (matched to PIXI node-state visual palette) */
+  --color-legend-swatch-purchased: #5f85ad;
+  --color-legend-swatch-purchased-ring: color-mix(in srgb, #5f85ad 45%, transparent);
+  --color-legend-swatch-available: #355a84;
+  --color-legend-swatch-available-ring: color-mix(in srgb, #355a84 45%, transparent);
+  --color-legend-swatch-locked: #4a4a4a;
+  --color-legend-swatch-locked-ring: color-mix(in srgb, #4a4a4a 30%, transparent);
+  --color-legend-swatch-invalid: #7c4e5a;
+  --color-legend-swatch-invalid-ring: color-mix(in srgb, #7c4e5a 35%, transparent);
+
+  /* OggDude import progress bar (success green gradient) */
+  --color-import-progress-bg: rgb(255 255 255 / 10%);
+  --color-import-progress-border: #444; /* tokens-allow-raw */
+  --color-import-progress-bar-start: #0b5e0b;
+  --color-import-progress-bar-end: #19a319;
+
+  /* Specialization tree sidebar "selected" accent bar gradient */
+  --color-spec-selected-bar-start: #7dc8e7; /* cyan-teal top */
+  --color-spec-selected-bar-end: #63c8a6; /* teal-green bottom */
+
+  /* Success hover text (CTA button hover on holo surface) */
+  --color-success-text-hover: #e8fff5;
+
+  /* Audit log header gradient stops */
+  --color-audit-header-bg-top: rgb(17 25 36 / 92%);
+  --color-audit-header-bg-bottom: rgb(10 15 24 / 85%);
+
+  /* Specialization tree app root gradient stops */
+  --color-spec-tree-bg-top: rgb(12 18 27 / 96%);
+  --color-spec-tree-bg-bottom: rgb(7 11 18 / 94%);
+
+  /* Specialization tree header gradient stops */
+  --color-spec-header-bg-top: rgb(16 25 37 / 92%);
+  --color-spec-header-bg-bottom: rgb(10 16 26 / 88%);
 
   /* Specialization badge (gold badge on identity summary) */
   --color-badge-gold: #c9a84c;


### PR DESCRIPTION
## Summary

- Replace hardcoded color values (`#hex`, `rgba()`) with design tokens (`var(--color-*)`) in application-specific LESS/CSS files (audit log, specialization tree, import progress)
- Add missing design tokens in `variables.less` and `swerpg.css` for holo backgrounds, text shades, legend swatches, import progress bars, and specialization tree accents

## Tests

- Not run (not requested).

## Notes

- Two raw `rgba()` calls remain with a `// tokens-allow-raw` comment: one for box-shadow inset on specialization tree canvas, one for box-shadow on detail panel tooltip
- This is the applications part of the ADR-0022 tokenization effort (sister PRs: #624 dice, #625 actor)
