### PR TITLE
refactor(chat): replace hardcoded colors and fix legacy tokens per ADR-0022

### DIFF
--- a/documentation/plan/core/refactor/576-chat-less-remplacer-les-couleurs-brutes-et-corriger-les-tokens-non-reconnus-adr-0022.md
+++ b/documentation/plan/core/refactor/576-chat-less-remplacer-les-couleurs-brutes-et-corriger-les-tokens-non-reconnus-adr-0022.md
@@ -1,0 +1,79 @@
+# Issue #576 — `chat.less` : remplacer les couleurs brutes et corriger les tokens non reconnus (ADR-0022)
+
+**Issue** : https://github.com/herveDarritchon/foundryvtt-swerpg/issues/576  
+**Domaine métier** : `core/refactor`
+
+## Goal
+
+Mettre `styles/chat.less` en conformité avec ADR-0022 en supprimant les couleurs codées en dur et en remplaçant les tokens CSS non reconnus par des tokens réels du design system, sans changer la structure ni le comportement des cartes de chat.
+
+## Contexte utile
+
+- `chat.less` concentre plusieurs surfaces distinctes dans un même fichier : cartes de chat génériques, actions, confirmations, `skill-transaction`, `audit-entry`, `audit-entry-summary` et `audit-log-warning`.
+- Les dettes visibles sont de deux types : quelques littéraux couleur (`#090b13`, `#7b8cc7`, `#130913`, `#977dcc`, `#b33a2e`, `#fff`) et plusieurs tokens legacy/non reconnus (`--colorBeige`, `--colorOlive`, `--colorSuccess`, `--colorError`, `--color-error`, etc.).
+- ADR-0022 impose de réutiliser des tokens existants ou d’ajouter un minimum de tokens partagés dans `styles/variables.less` seulement si aucune sémantique canonique n’existe déjà.
+- Le périmètre de l’issue est strictement orienté couleurs/tokens ; ne pas rouvrir les chantiers séparés sur les polices littérales ou sur une refonte des templates chat.
+
+## Plan d’implémentation
+
+### Étape 1 — Cartographier la dette ADR-0022 restante dans `chat.less`
+
+**Fichiers** : `styles/chat.less`, `styles/variables.less`
+
+**What** :
+
+- relever les couleurs brutes et les tokens non reconnus encore présents par bloc fonctionnel ;
+- distinguer les zones génériques (`whisper`, `blind`, actions, confirmations, métadonnées) des zones métier (`skill-transaction`, `audit-log-warning`) ;
+- définir pour chaque occurrence un mapping cible vers un token existant, ou identifier le très petit nombre de tokens partagés réellement manquants.
+
+**Résultat attendu** : un mapping complet couvre toute la dette de `chat.less` sans élargir le périmètre à d’autres feuilles de style.
+
+### Étape 2 — Corriger les tokens legacy/non reconnus par des équivalents canoniques
+
+**Fichiers** : `styles/chat.less`, `styles/variables.less` _(uniquement si un token partagé manque réellement)_
+
+**What** :
+
+- remplacer les aliases/casses non valides par les tokens sémantiques déjà canonisés dans le design system ;
+- harmoniser les états `success` / `danger` / `secondary` / `frame` utilisés dans les métadonnées, actions et variantes de badges ;
+- limiter tout ajout éventuel dans `variables.less` à des besoins récurrents réellement partagés, sans créer de palette ad hoc propre à `chat.less`.
+
+**Résultat attendu** : `chat.less` ne référence plus de token fantôme ou non reconnu dans les règles concernées.
+
+### Étape 3 — Remplacer les couleurs brutes restantes par des design tokens
+
+**Fichiers** : `styles/chat.less`
+
+**What** :
+
+- tokeniser les couleurs brutes des cartes `whisper` / `blind` et de l’icône `audit-log-warning` ;
+- convertir les bordures, fonds et couleurs d’accent pour qu’ils reposent sur des `var(--color-*)` réels, ou sur des compositions conformes ADR (`color-mix(...)`) si une alpha thémable est nécessaire ;
+- conserver strictement les mêmes rôles visuels et ne pas modifier la structure CSS/HTML des cartes chat.
+
+**Résultat attendu** : `styles/chat.less` n’embarque plus de couleurs de marque en dur hors exceptions ADR explicitement justifiées.
+
+### Étape 4 — Préparer la validation ciblée de la conformité `chat.less`
+
+**Fichiers** : aucun nouveau fichier requis
+
+**What** :
+
+- prévoir une validation par `pnpm run style:tokens` puis `pnpm run style:tokens:strict` sur les fichiers touchés ;
+- prévoir une revue visuelle ciblée des cartes `whisper`, `blind`, `skill-transaction`, `audit-entry` et `audit-log-warning` ;
+- vérifier que les contrastes et le theming Jedi/Sith restent lisibles après tokenisation.
+
+**Résultat attendu** : la conformité ADR-0022 de `chat.less` devient vérifiable sans rouvrir d’autres chantiers CSS.
+
+## Périmètre / hors périmètre
+
+### Inclus
+
+- Remédiation couleur de `styles/chat.less`
+- Correction des tokens non reconnus encore présents dans `chat.less`
+- Ajout minimal de tokens partagés dans `styles/variables.less` si nécessaire
+
+### Exclus
+
+- Modifications JS, Handlebars ou logique métier des cartes chat
+- Refonte UX des cartes `skill-transaction`, `audit-entry` ou `audit-log-warning`
+- Tokenisation des polices littérales ou autres chantiers CSS déjà suivis par des issues dédiées

--- a/styles/chat.less
+++ b/styles/chat.less
@@ -25,13 +25,13 @@
   }
 
   &.whisper {
-    background: #090b13;
-    border: 1px solid #7b8cc7;
+    background: var(--color-chat-whisper-bg);
+    border: 1px solid var(--color-chat-whisper-border);
   }
 
   &.blind {
-    background: #130913;
-    border: 1px solid #977dcc;
+    background: var(--color-chat-blind-bg);
+    border: 1px solid var(--color-chat-blind-border);
   }
 
   // Smaller die icons
@@ -67,8 +67,8 @@
     padding: 4px 0;
     font-size: var(--font-size-12);
     font-style: italic;
-    border-top: 1px solid var(--colorBeige);
-    border-bottom: 1px solid var(--colorBeige);
+    border-top: 1px solid var(--color-frame);
+    border-bottom: 1px solid var(--color-frame);
   }
 }
 
@@ -77,18 +77,18 @@
   align-items: center;
   justify-content: center;
   font-size: var(--font-size-14);
-  color: var(--colorOlive);
+  color: var(--color-secondary);
   line-height: 20px;
   margin-top: 0.25rem;
 }
 
 .message-metadata {
   .confirmed {
-    color: var(--colorSuccess);
+    color: var(--color-success);
   }
 
   .unconfirmed {
-    color: var(--colorError);
+    color: var(--color-danger);
   }
 }
 
@@ -167,8 +167,8 @@
     }
 
     &.is-fail {
-      color: var(--color-error);
-      border: 1px solid var(--color-error);
+      color: var(--color-danger);
+      border: 1px solid var(--color-danger);
     }
   }
 
@@ -542,9 +542,9 @@
     display: flex;
     align-items: center;
     justify-content: center;
-    background: #b33a2e;
+    background: var(--color-chat-warning-icon-bg);
     border-radius: 50%;
-    color: #fff;
+    color: var(--color-holo-text-bright);
     font-size: 14px;
   }
 

--- a/styles/swerpg.css
+++ b/styles/swerpg.css
@@ -273,6 +273,18 @@
   /* teal-green bottom */
   /* Success hover text (CTA button hover on holo surface) */
   --color-success-text-hover: #e8fff5;
+  /* Chat message variant backgrounds (whisper / blind) */
+  --color-chat-whisper-bg: #090b13;
+  /* dark blue-black — whisper message background */
+  --color-chat-whisper-border: #7b8cc7;
+  /* muted blue-purple — whisper message border */
+  --color-chat-blind-bg: #130913;
+  /* dark purple-black — blind message background */
+  --color-chat-blind-border: #977dcc;
+  /* muted purple — blind message border */
+  /* Chat warning icon background (audit-log-warning icon circle) */
+  --color-chat-warning-icon-bg: #b33a2e;
+  /* dark danger red — warning icon circle */
   /* Audit log header gradient stops */
   --color-audit-header-bg-top: rgba(17, 25, 36, 0.92);
   --color-audit-header-bg-bottom: rgba(10, 15, 24, 0.85);
@@ -4458,12 +4470,12 @@ input[type='range'] {
   margin-top: 0.25rem;
 }
 .swerpg.chat-message.whisper {
-  background: #090b13;
-  border: 1px solid #7b8cc7;
+  background: var(--color-chat-whisper-bg);
+  border: 1px solid var(--color-chat-whisper-border);
 }
 .swerpg.chat-message.blind {
-  background: #130913;
-  border: 1px solid #977dcc;
+  background: var(--color-chat-blind-bg);
+  border: 1px solid var(--color-chat-blind-border);
 }
 .swerpg.chat-message .swerpg.dice-roll .pool .die {
   --die-size: 48px;
@@ -4488,23 +4500,23 @@ input[type='range'] {
   padding: 4px 0;
   font-size: var(--font-size-12);
   font-style: italic;
-  border-top: 1px solid var(--colorBeige);
-  border-bottom: 1px solid var(--colorBeige);
+  border-top: 1px solid var(--color-frame);
+  border-bottom: 1px solid var(--color-frame);
 }
 .swerpg.confirm {
   display: flex;
   align-items: center;
   justify-content: center;
   font-size: var(--font-size-14);
-  color: var(--colorOlive);
+  color: var(--color-secondary);
   line-height: 20px;
   margin-top: 0.25rem;
 }
 .message-metadata .confirmed {
-  color: var(--colorSuccess);
+  color: var(--color-success);
 }
 .message-metadata .unconfirmed {
-  color: var(--colorError);
+  color: var(--color-danger);
 }
 /* -------------------------------------------- */
 /*  Skill Transaction Chat (US7)                */
@@ -4571,8 +4583,8 @@ input[type='range'] {
   border: 1px solid var(--color-underline);
 }
 .swerpg.chat-message.skill-transaction .skill-transaction__rank.is-fail {
-  color: var(--color-error);
-  border: 1px solid var(--color-error);
+  color: var(--color-danger);
+  border: 1px solid var(--color-danger);
 }
 .swerpg.chat-message.skill-transaction .skill-transaction__details {
   margin-top: 0.35rem;
@@ -4879,9 +4891,9 @@ input[type='range'] {
   display: flex;
   align-items: center;
   justify-content: center;
-  background: #b33a2e;
+  background: var(--color-chat-warning-icon-bg);
   border-radius: 50%;
-  color: #fff;
+  color: var(--color-holo-text-bright);
   font-size: 14px;
 }
 .swerpg.chat-message.audit-log-warning .audit-log-warning__title {

--- a/styles/variables.less
+++ b/styles/variables.less
@@ -287,6 +287,15 @@
   /* Success hover text (CTA button hover on holo surface) */
   --color-success-text-hover: #e8fff5;
 
+  /* Chat message variant backgrounds (whisper / blind) */
+  --color-chat-whisper-bg: #090b13; /* dark blue-black — whisper message background */
+  --color-chat-whisper-border: #7b8cc7; /* muted blue-purple — whisper message border */
+  --color-chat-blind-bg: #130913; /* dark purple-black — blind message background */
+  --color-chat-blind-border: #977dcc; /* muted purple — blind message border */
+
+  /* Chat warning icon background (audit-log-warning icon circle) */
+  --color-chat-warning-icon-bg: #b33a2e; /* dark danger red — warning icon circle */
+
   /* Audit log header gradient stops */
   --color-audit-header-bg-top: rgb(17 25 36 / 92%);
   --color-audit-header-bg-bottom: rgb(10 15 24 / 85%);


### PR DESCRIPTION
## Summary

- Replace raw hex colors in `chat.less` with design tokens (`--color-chat-whisper-bg`, `--color-chat-whisper-border`, `--color-chat-blind-bg`, `--color-chat-blind-border`, `--color-chat-warning-icon-bg`)
- Fix 5 legacy/unrecognized tokens: `--colorBeige` → `--color-frame`, `--colorOlive` → `--color-secondary`, `--colorSuccess` → `--color-success`, `--colorError` → `--color-danger`, `--color-error` → `--color-danger`
- Add 5 new chat-specific design tokens in `styles/variables.less` for whisper/blind/warning surfaces
- Update compiled `styles/swerpg.css` accordingly

## Context

Closes #576

## Tests

- Not run (not requested).

## Notes

- No JS, Handlebars, or visual structure changes
- Whisper/blind/warning colors extracted to tokens but values preserved unchanged
