### PR TITLE
fix(tags): prevent NaN values in equipment tags

### DIFF
--- a/documentation/plan/character-sheet/inventory/629-correction-des-valeurs-nan-dans-les-tags-d-equipement.md
+++ b/documentation/plan/character-sheet/inventory/629-correction-des-valeurs-nan-dans-les-tags-d-equipement.md
@@ -1,0 +1,45 @@
+# Character Sheet — Corriger les valeurs `NaN` dans les tags d’équipement
+
+**Issue** : [#629 — Correction des valeurs NaN dans les tags d'équipement](https://github.com/herveDarritchon/foundryvtt-swerpg/issues/629)
+
+## Objectif
+
+Empêcher l’affichage de `NaN` dans les tags courts des équipements affichés sur la feuille personnage en garantissant qu’aucune valeur numérique invalide n’est interpolée telle quelle dans le rendu.
+
+## Décisions de cadrage
+
+- Le correctif vise le flux de préparation des tags d’équipement affichés sur la feuille personnage, sans refonte UI ni changement de périmètre fonctionnel.
+- Toute valeur numérique absente, invalide ou non finie utilisée dans un tag doit produire un fallback lisible ou un tag omis, jamais la chaîne `NaN`.
+- Si plusieurs types d’équipement partagent le même helper de tags (`item.getTags('short')` ou équivalent), le guard doit être posé au niveau partagé pour éviter les divergences entre armes, armures et gear.
+
+## Étapes d’implémentation
+
+### 1. Localiser la source du `NaN` et centraliser la normalisation des tags
+
+**Fichiers cibles** : flux de préparation des équipements affichés sur la feuille personnage (notamment la préparation du featured equipment et/ou le helper partagé de tags courts appelé pour les items concernés).
+
+**What**
+
+- identifier quel champ numérique dérivé utilisé dans les tags (par exemple dégâts, soak, encumbrance ou équivalent) peut devenir `NaN` ;
+- corriger la source la plus centrale du problème pour transformer toute valeur non finie en fallback métier avant composition du tag ;
+- conserver les tags valides existants et limiter le correctif au défaut prouvé par l’issue.
+
+**Validation visée** : un équipement avec donnée partielle ou invalide n’affiche plus `NaN` dans ses tags et les autres tags restent cohérents.
+
+### 2. Verrouiller le rendu par des cas de non-régression ciblés
+
+**Fichiers cibles** : tests couvrant la préparation des tags d’équipement ou le helper partagé concerné.
+
+**What**
+
+- ajouter un cas reproduisant l’issue avec une valeur numérique absente ou non finie ;
+- couvrir au moins un cas nominal et un cas dégradé sur le helper corrigé ;
+- vérifier explicitement que le rendu final contient un fallback lisible ou omet le tag invalide, mais ne contient jamais `NaN`.
+
+**Validation visée** : le contrat de rendu des tags d’équipement interdit explicitement `NaN` pour le cas historique et ses variantes proches.
+
+## Résultat attendu
+
+- les tags d’équipement affichés sur la feuille ne montrent plus `NaN` ;
+- la normalisation est placée au niveau partagé le plus pertinent ;
+- une non-régression documente le comportement attendu sur données partielles ou invalides.

--- a/module/lib/featured-equipment.mjs
+++ b/module/lib/featured-equipment.mjs
@@ -36,7 +36,7 @@ export function computeFeaturedEquipment({ armor = null, weapons = [] } = {}) {
       // Défensif: ne jamais casser l'affichage
       tagsObj = {}
     }
-    let tags = Object.values(tagsObj).filter((t) => typeof t === 'string' && t.trim())
+    let tags = Object.values(tagsObj).filter((t) => typeof t === 'string' && t.trim() && !t.includes('NaN'))
     // Fallbacks si absence
     if (!tags.length) {
       tags = type === 'armor' ? ['Armor', 'Soak'] : ['Dmg', 'Range']

--- a/module/models/armor.mjs
+++ b/module/models/armor.mjs
@@ -120,13 +120,22 @@ export default class SwerpgArmor extends SwerpgCombatItem {
       const prop = SYSTEM.ARMOR.PROPERTIES[q.key]
       if (prop) tags[q.key] = prop.label
     }
-    tags.defense = `${this.defense.base + this.defense.bonus} Armor`
-    const actor = this.parent.parent
-    if (!actor) tags.soak = `${this.soak.base}+ Dodge`
-    else {
-      const soakBonus = Math.max(actor.system.characteristics.agility.value - this.soak.start, 0)
-      tags.soak = `${this.soak.base + soakBonus} Dodge`
-      tags.total = `${this.defense.base + this.defense.bonus + this.soak.base + soakBonus} Defense`
+    // Defense — guard against NaN from uninitialized or partially-prepared armor data
+    const defenseValue = (this.defense?.base ?? 0) + (this.defense?.bonus ?? 0)
+    if (Number.isFinite(defenseValue)) tags.defense = `${defenseValue} Armor`
+
+    const actor = this.parent?.parent
+    const soakBase = this.soak?.base ?? 0
+    if (!actor) {
+      if (Number.isFinite(soakBase)) tags.soak = `${soakBase}+ Dodge`
+    } else {
+      const agilityValue = actor.system?.characteristics?.agility?.value ?? 0
+      const soakStart = this.soak?.start ?? 0
+      const soakBonus = Math.max(agilityValue - soakStart, 0)
+      const soakTotal = soakBase + soakBonus
+      const total = defenseValue + soakTotal
+      if (Number.isFinite(soakTotal)) tags.soak = `${soakTotal} Dodge`
+      if (Number.isFinite(total)) tags.total = `${total} Defense`
     }
     return tags
   }

--- a/module/models/weapon.mjs
+++ b/module/models/weapon.mjs
@@ -289,8 +289,9 @@ export default class SwerpgWeapon extends SwerpgCombatItem {
   getTags(scope = 'full') {
     const tags = {}
 
-    // Damage
-    tags.damage = `${this.damage.weapon} Damage`
+    // Damage — guard against NaN from uninitialized or partially-prepared damage object
+    const weaponDamage = this.damage?.weapon
+    if (Number.isFinite(weaponDamage)) tags.damage = `${weaponDamage} Damage`
 
     // Canonical category (mechanical family)
     if (this.config?.category?.label) tags.category = game.i18n.localize(this.config.category.label)

--- a/tests/applications/actor/featuredEquipment.test.js
+++ b/tests/applications/actor/featuredEquipment.test.js
@@ -91,6 +91,64 @@ describe('computeFeaturedEquipment', () => {
     expect(dt).toBeLessThan(50)
   })
 
+  it('tags contenant NaN sont filtrés (régression #629)', () => {
+    // Simule un item dont getTags retourne une valeur NaN interpolée (ex: damage non initialisé)
+    const weapon = mockItem({
+      id: 'w-nan',
+      name: 'Blaster NaN',
+      type: 'weapon',
+      system: { equipped: true, slot: 'mainhand' },
+      tags: { damage: 'NaN Damage', category: 'Blaster' },
+    })
+    const out = computeFeaturedEquipment({ weapons: [weapon] })
+    expect(out).toHaveLength(1)
+    const tags = out[0].tags
+    const hasNaN = tags.some((t) => t.includes('NaN'))
+    expect(hasNaN).toBe(false)
+  })
+
+  it('tags partiellement invalides: les tags valides restent présents (régression #629)', () => {
+    // Seul le tag "NaN Damage" est filtré — "Blaster" doit rester
+    const weapon = mockItem({
+      id: 'w-partial',
+      name: 'Blaster Partiel',
+      type: 'weapon',
+      system: { equipped: true, slot: 'mainhand' },
+      tags: { damage: 'NaN Damage', category: 'Blaster', range: 'NaN Range' },
+    })
+    const out = computeFeaturedEquipment({ weapons: [weapon] })
+    expect(out[0].tags).toContain('Blaster')
+    expect(out[0].tags).not.toContain('NaN Damage')
+    expect(out[0].tags).not.toContain('NaN Range')
+  })
+
+  it('tous les tags sont NaN: fallback appliqué (régression #629)', () => {
+    // Quand tous les tags sont invalides, le fallback ['Dmg','Range'] est utilisé
+    const weapon = mockItem({
+      id: 'w-allnan',
+      name: 'Blaster Tout NaN',
+      type: 'weapon',
+      system: { equipped: true, slot: 'mainhand' },
+      tags: { damage: 'NaN Damage', range: 'NaN Range' },
+    })
+    const out = computeFeaturedEquipment({ weapons: [weapon] })
+    expect(out[0].tags).toEqual(['Dmg', 'Range'])
+  })
+
+  it('armure avec tags NaN: tag invalide filtré (régression #629)', () => {
+    const armor = mockItem({
+      id: 'a-nan',
+      name: 'Armure NaN',
+      type: 'armor',
+      system: { equipped: true },
+      tags: { defense: 'NaN Armor', category: 'Légère' },
+    })
+    const out = computeFeaturedEquipment({ armor, weapons: [] })
+    expect(out).toHaveLength(1)
+    expect(out[0].tags).not.toContain('NaN Armor')
+    expect(out[0].tags).toContain('Légère')
+  })
+
   it('immutabilité: sources non modifiés', () => {
     const armor = mockItem({ id: 'a1', name: 'Armure', type: 'armor', system: { equipped: true, soak: 2 } })
     const weapons = [mockItem({ id: 'w1', name: 'Blaster', type: 'weapon', system: { equipped: true, slot: 'mainhand', damage: 5 } })]


### PR DESCRIPTION
## Summary

- Prevent NaN values in equipment tags by sanitizing tag numeric parsing in featured-equipment and model code.
- Add unit test covering featured equipment behavior and update armor/weapon models accordingly.
- Add documentation plan for the inventory/featured-equipment change.

## Context

The changes include a fix to module/lib/featured-equipment.mjs and model adjustments (module/models/armor.mjs, module/models/weapon.mjs), a new test (tests/applications/actor/featuredEquipment.test.js) and a documentation plan file under documentation/plan/character-sheet/inventory/.

## Tests

- Not run (not requested).

## Notes

- No files were left uncommitted in the worktree at PR creation.
