### PR TITLE
refactor(inventory): localize UI strings in inventory tab

### DIFF
--- a/documentation/plan/character-sheet/inventory/630-localiser-entierement-les-chaines-ui-de-l-inventaire.md
+++ b/documentation/plan/character-sheet/inventory/630-localiser-entierement-les-chaines-ui-de-l-inventaire.md
@@ -1,0 +1,45 @@
+# Character Sheet — Localiser entièrement les chaînes UI de l'inventaire
+
+**Issue** : [#630 — Localiser entièrement les chaînes UI de l'inventaire](https://github.com/herveDarritchon/foundryvtt-swerpg/issues/630)
+
+## Objectif
+
+Supprimer les dernières chaînes UI d’inventaire codées en dur dans la feuille personnage afin que l’onglet `Inventory` rende des libellés, tooltips et hints cohérents en anglais comme en français.
+
+## Décisions de cadrage
+
+- Le périmètre est limité à l’onglet inventaire de la feuille personnage : libellés de sections, actions visibles et hint d’état vide déjà identifié.
+- Les chaînes localisées doivent exister dans `lang/en.json` et `lang/fr.json` avec une formulation joueur cohérente ; le correctif ne doit pas dépendre de fallback implicites en anglais.
+- La correction doit viser les points de définition les plus centraux du flux inventaire existant : préparation de sections côté sheet et attributs `data-tooltip`/libellés du template.
+
+## Étapes d’implémentation
+
+### 1. Recenser et brancher toutes les chaînes d’inventaire encore en dur sur des clés i18n dédiées
+
+**Fichiers cibles** : `module/applications/sheets/base-actor-sheet.mjs`, `templates/sheets/actor/inventory.hbs`, `lang/en.json`, `lang/fr.json`
+
+**What**
+
+- remplacer les libellés codés en dur encore utilisés par le flux inventaire (`Equipment`, `Backpack`, actions `Equip Item`, `Edit Item`, `Delete Item`, `Create Item`, et toute autre microcopy visible de ce template) par des clés i18n explicites ;
+- corriger le hint vide d’équipement déjà repéré comme non traduit en s’assurant que la clé française n’embarque plus de texte anglais ;
+- vérifier si les clés existantes `ACTOR.LABELS.*` couvrent correctement le besoin ou s’il faut introduire un sous-ensemble plus précis pour les actions d’inventaire, sans dupliquer inutilement des libellés déjà canoniques.
+
+**Validation visée** : aucun contrôle visible de l’onglet inventaire ne dépend encore d’une chaîne anglaise hardcodée dans le code ou le template.
+
+### 2. Verrouiller la non-régression de localisation sur la préparation de contexte et le rendu de l’onglet
+
+**Fichiers cibles** : `tests/applications/sheets/base-actor-sheet.test.mjs` _(et tout test de rendu inventory plus ciblé si nécessaire)_
+
+**What**
+
+- ajouter des assertions ciblées sur les libellés de sections d’inventaire préparés par la sheet et sur les tooltips/actions exposés au rendu ;
+- couvrir explicitement au moins un cas en anglais et un cas en français pour le hint vide d’équipement et les actions principales ;
+- vérifier que le correctif reste limité à l’inventaire et n’altère pas le comportement existant des autres onglets de la feuille.
+
+**Validation visée** : les libellés et hints corrigés sont présents dans les deux langues et le rendu anglais historique reste intact.
+
+## Résultat attendu
+
+- l’onglet inventaire n’affiche plus de chaîne UI en anglais lorsqu’il est consulté en français ;
+- les actions et sections de l’inventaire reposent sur des clés i18n explicites et maintenables ;
+- une non-régression documente la couverture bilingue minimale attendue pour cette UI.

--- a/lang/en.json
+++ b/lang/en.json
@@ -575,8 +575,14 @@
     "LABELS": {
       "CURRENT_EQUIPMENT": "Current Equipment",
       "FAVORITE_ACTIONS": "Favorite Actions",
+      "EQUIPMENT": "Equipment",
       "EQUIPMENT_HINT": "Equip weapons and armor from your Backpack toggling the shield icon.",
+      "BACKPACK": "Backpack",
       "BACKPACK_HINT": "Add Armor, Weapons, or Gear by dropping them from the provided Swerpg system compendium packs.",
+      "EQUIP_ITEM": "Equip Item",
+      "EDIT_ITEM": "Edit Item",
+      "DELETE_ITEM": "Delete Item",
+      "CREATE_ITEM": "Create Item",
       "SIZE": "Size"
     }
   },

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -694,11 +694,17 @@
       "BIOGRAPHY": "Biography"
     },
     "LABELS": {
-      "CURRENT_EQUIPMENT": "Current Equipment",
-      "FAVORITE_ACTIONS": "Favorite Actions",
-      "EQUIPMENT_HINT": "Equip weapons and armor from your Backpack toggling the shield icon.",
+      "CURRENT_EQUIPMENT": "Équipement actuel",
+      "FAVORITE_ACTIONS": "Actions favorites",
+      "EQUIPMENT": "Équipement",
+      "EQUIPMENT_HINT": "Équipez vos armes et armures depuis votre sac à dos en activant l'icône de bouclier.",
+      "BACKPACK": "Sac à dos",
       "BACKPACK_HINT": "Ajoutez une armure, des armes ou du matériel en les déposant depuis les compendiums du système Swerpg fournis.",
-      "SIZE": "Size"
+      "EQUIP_ITEM": "Équiper l'objet",
+      "EDIT_ITEM": "Modifier l'objet",
+      "DELETE_ITEM": "Supprimer l'objet",
+      "CREATE_ITEM": "Créer un objet",
+      "SIZE": "Taille"
     }
   },
   "ACTOR.AppliedDetailItem": "Applied the {name} {type} to {actor}.",

--- a/module/applications/sheets/base-actor-sheet.mjs
+++ b/module/applications/sheets/base-actor-sheet.mjs
@@ -393,8 +393,8 @@ export default class SwerpgBaseActorSheet extends HBMixin(BaseActorSheetV2) {
         passive: { label: 'Passive Talents', items: [] },
       },
       inventory: {
-        equipment: { label: 'Equipment', items: [], empty: game.i18n.localize('ACTOR.LABELS.EQUIPMENT_HINT') },
-        backpack: { label: 'Backpack', items: [], empty: game.i18n.localize('ACTOR.LABELS.BACKPACK_HINT') },
+        equipment: { label: game.i18n.localize('ACTOR.LABELS.EQUIPMENT'), items: [], empty: game.i18n.localize('ACTOR.LABELS.EQUIPMENT_HINT') },
+        backpack: { label: game.i18n.localize('ACTOR.LABELS.BACKPACK'), items: [], empty: game.i18n.localize('ACTOR.LABELS.BACKPACK_HINT') },
       },
     }
 

--- a/templates/sheets/actor/inventory.hbs
+++ b/templates/sheets/actor/inventory.hbs
@@ -31,10 +31,10 @@
             </div>
             <div class="controls">
               {{#if item.canEquip}}
-                <a class="button icon equipped-state fa-solid fa-shield-alt" data-action="itemEquip" data-tooltip="Equip Item"></a>
+                <a class="button icon equipped-state fa-solid fa-shield-alt" data-action="itemEquip" data-tooltip="{{localize 'ACTOR.LABELS.EQUIP_ITEM'}}"></a>
               {{/if}}
-              <a class="button icon fa-solid fa-edit" data-action="itemEdit" data-tooltip="Edit Item"></a>
-              <a class="button icon fa-solid fa-trash" data-action="itemDelete" data-tooltip="Delete Item"></a>
+              <a class="button icon fa-solid fa-edit" data-action="itemEdit" data-tooltip="{{localize 'ACTOR.LABELS.EDIT_ITEM'}}"></a>
+              <a class="button icon fa-solid fa-trash" data-action="itemDelete" data-tooltip="{{localize 'ACTOR.LABELS.DELETE_ITEM'}}"></a>
             </div>
           </li>
         {{else}}
@@ -81,7 +81,7 @@
     </div>
   </div>
   <div class="inventory-actions">
-    <button type="button" class="icon frame-brown fa-solid fa-plus inventory-create" data-action="itemCreate" data-tooltip="Create Item"></button>
+    <button type="button" class="icon frame-brown fa-solid fa-plus inventory-create" data-action="itemCreate" data-tooltip="{{localize 'ACTOR.LABELS.CREATE_ITEM'}}"></button>
     {{#if showMarketButton}}
       <button
         type="button"

--- a/tests/applications/sheets/base-actor-sheet.test.mjs
+++ b/tests/applications/sheets/base-actor-sheet.test.mjs
@@ -446,3 +446,161 @@ describe('SwerpgBaseActorSheet #prepareItems — gear inventory classification',
     expect(armorEntry.canEquip).toBe(true)
   })
 })
+
+// ---------------------------------------------------------------------------
+// Regression: inventory section labels must come from i18n keys (issue #630)
+// ---------------------------------------------------------------------------
+
+import { setupFoundryMock as setupFoundryMockForI18n } from '../../helpers/mock-foundry.mjs'
+import { computeFeaturedEquipment as computeFeaturedEquipmentForI18nTests } from '../../../module/lib/featured-equipment.mjs'
+
+describe('SwerpgBaseActorSheet #prepareItems — inventory section i18n labels', () => {
+  let SwerpgBaseActorSheetI18n
+
+  function buildMockDocumentI18n(itemsArray = []) {
+    return {
+      id: 'actor-i18n',
+      name: 'I18n Actor',
+      system: {
+        characteristics: {
+          brawn: { rank: { base: 2, trained: 0 } },
+          agility: { rank: { base: 2, trained: 0 } },
+          intellect: { rank: { base: 2, trained: 0 } },
+          cunning: { rank: { base: 2, trained: 0 } },
+          willpower: { rank: { base: 2, trained: 0 } },
+          presence: { rank: { base: 2, trained: 0 } },
+        },
+        progression: {
+          experience: { gained: 0, spent: 0 },
+          freeSkillRanks: {
+            career: { gained: 0, spent: 0 },
+            specialization: { gained: 0, spent: 0 },
+          },
+        },
+        details: {
+          biography: { appearance: '', public: '', private: '' },
+          commitments: { motivation: '' },
+        },
+        schema: { fields: {} },
+      },
+      isOwner: true,
+      items: {
+        find: vi.fn((fn) => itemsArray.find(fn) || null),
+        filter: vi.fn((fn) => itemsArray.filter(fn)),
+        get: vi.fn((id) => itemsArray.find((i) => i.id === id) || null),
+        [Symbol.iterator]: function* () {
+          yield* itemsArray
+        },
+      },
+      effects: [],
+      actions: {},
+      canPurchaseCharacteristic: vi.fn(() => false),
+      toObject: vi.fn(() => ({})),
+    }
+  }
+
+  async function buildSheetI18n() {
+    const Sheet = SwerpgBaseActorSheetI18n
+    const actor = buildMockDocumentI18n([])
+
+    if (!globalThis.foundry.applications.ux) {
+      globalThis.foundry.applications.ux = {}
+    }
+    if (!globalThis.foundry.applications.ux.TextEditor) {
+      globalThis.foundry.applications.ux.TextEditor = { enrichHTML: vi.fn(async (s) => s || '') }
+    }
+    if (!globalThis.SYSTEM.RESTRICTION_LEVELS) {
+      globalThis.SYSTEM.RESTRICTION_LEVELS = {}
+    }
+
+    const instance = new Sheet({})
+    instance.document = actor
+    instance.actor = actor
+    instance.tabGroups = { sheet: 'attributes' }
+    instance.isEditable = true
+    return instance
+  }
+
+  beforeEach(async () => {
+    vi.clearAllMocks()
+    SwerpgBaseActorSheetI18n = (await import('../../../module/applications/sheets/base-actor-sheet.mjs')).default
+    vi.mocked(computeFeaturedEquipmentForI18nTests).mockReturnValue([])
+  })
+
+  test('inventory.equipment.label is resolved via i18n key ACTOR.LABELS.EQUIPMENT (English)', async () => {
+    // Override translations with English values to verify the key is used
+    setupFoundryMockForI18n({
+      translations: {
+        'ACTOR.LABELS.EQUIPMENT': 'Equipment',
+        'ACTOR.LABELS.BACKPACK': 'Backpack',
+        'ACTOR.LABELS.EQUIPMENT_HINT': 'Equip weapons and armor from your Backpack toggling the shield icon.',
+        'ACTOR.LABELS.BACKPACK_HINT': 'Add Armor, Weapons, or Gear by dropping them from the provided Swerpg system compendium packs.',
+      },
+    })
+    const instance = await buildSheetI18n()
+    const ctx = await instance._prepareContext({})
+
+    expect(ctx.inventory.equipment.label).toBe('Equipment')
+    expect(ctx.inventory.backpack.label).toBe('Backpack')
+  })
+
+  test('inventory.equipment.label is resolved via i18n key ACTOR.LABELS.EQUIPMENT (French)', async () => {
+    // Simulate French locale by overriding translations with French values
+    setupFoundryMockForI18n({
+      translations: {
+        'ACTOR.LABELS.EQUIPMENT': 'Équipement',
+        'ACTOR.LABELS.BACKPACK': 'Sac à dos',
+        'ACTOR.LABELS.EQUIPMENT_HINT': "Équipez vos armes et armures depuis votre sac à dos en activant l'icône de bouclier.",
+        'ACTOR.LABELS.BACKPACK_HINT': 'Ajoutez une armure, des armes ou du matériel en les déposant depuis les compendiums du système Swerpg fournis.',
+      },
+    })
+    const instance = await buildSheetI18n()
+    const ctx = await instance._prepareContext({})
+
+    expect(ctx.inventory.equipment.label).toBe('Équipement')
+    expect(ctx.inventory.backpack.label).toBe('Sac à dos')
+  })
+
+  test('inventory.equipment.empty hint is resolved via i18n key (English)', async () => {
+    setupFoundryMockForI18n({
+      translations: {
+        'ACTOR.LABELS.EQUIPMENT': 'Equipment',
+        'ACTOR.LABELS.BACKPACK': 'Backpack',
+        'ACTOR.LABELS.EQUIPMENT_HINT': 'Equip weapons and armor from your Backpack toggling the shield icon.',
+        'ACTOR.LABELS.BACKPACK_HINT': 'Add Armor, Weapons, or Gear by dropping them from the provided Swerpg system compendium packs.',
+      },
+    })
+    const instance = await buildSheetI18n()
+    const ctx = await instance._prepareContext({})
+
+    expect(ctx.inventory.equipment.empty).toBe('Equip weapons and armor from your Backpack toggling the shield icon.')
+    expect(ctx.inventory.backpack.empty).toBe('Add Armor, Weapons, or Gear by dropping them from the provided Swerpg system compendium packs.')
+  })
+
+  test('inventory.equipment.empty hint is resolved via i18n key (French)', async () => {
+    setupFoundryMockForI18n({
+      translations: {
+        'ACTOR.LABELS.EQUIPMENT': 'Équipement',
+        'ACTOR.LABELS.BACKPACK': 'Sac à dos',
+        'ACTOR.LABELS.EQUIPMENT_HINT': "Équipez vos armes et armures depuis votre sac à dos en activant l'icône de bouclier.",
+        'ACTOR.LABELS.BACKPACK_HINT': 'Ajoutez une armure, des armes ou du matériel en les déposant depuis les compendiums du système Swerpg fournis.',
+      },
+    })
+    const instance = await buildSheetI18n()
+    const ctx = await instance._prepareContext({})
+
+    expect(ctx.inventory.equipment.empty).toBe("Équipez vos armes et armures depuis votre sac à dos en activant l'icône de bouclier.")
+    expect(ctx.inventory.backpack.empty).toBe('Ajoutez une armure, des armes ou du matériel en les déposant depuis les compendiums du système Swerpg fournis.')
+  })
+
+  test('inventory section labels are not hardcoded English strings', async () => {
+    // When i18n returns the key (no translation found), the label must equal the key, not a hardcoded English word
+    // This guards against regression where labels were inlined as 'Equipment' / 'Backpack' in JS
+    setupFoundryMockForI18n({ translations: {} })
+    const instance = await buildSheetI18n()
+    const ctx = await instance._prepareContext({})
+
+    expect(ctx.inventory.equipment.label).toBe('ACTOR.LABELS.EQUIPMENT')
+    expect(ctx.inventory.backpack.label).toBe('ACTOR.LABELS.BACKPACK')
+  })
+})


### PR DESCRIPTION
## Summary

- Localise inventory UI strings (English and French).
- Update inventory template and base actor sheet to use i18n keys.
- Add unit test for base-actor-sheet to cover the inventory rendering.

## Context

This change extracts and moves hard-coded strings in the inventory tab into lang/en.json and lang/fr.json and updates the inventory Handlebars template and the base actor sheet to use the new i18n keys.

## Tests

- Not run (not requested).

## Notes

- Files changed: documentation/plan/character-sheet/inventory/630-localiser-entierement-les-chaines-ui-de-l-inventaire.md, lang/en.json, lang/fr.json, module/applications/sheets/base-actor-sheet.mjs, templates/sheets/actor/inventory.hbs, tests/applications/sheets/base-actor-sheet.test.mjs
