### PR TITLE
fix(inventory): use getTags("short") for equipment tags to avoid aggressive truncation

### DIFF
--- a/documentation/plan/character-sheet/inventory/631-rendre-les-tags-d-equipement-lisibles-sans-troncature-agressive.md
+++ b/documentation/plan/character-sheet/inventory/631-rendre-les-tags-d-equipement-lisibles-sans-troncature-agressive.md
@@ -1,0 +1,68 @@
+# Character Sheet — Rendre les tags d'équipement lisibles sans troncature agressive
+
+**Issue** : [#631 — Rendre les tags d'équipement lisibles sans troncature agressive](https://github.com/herveDarritchon/foundryvtt-swerpg/issues/631)
+**Domaine métier** : `character-sheet/inventory`
+**Tags** : `HITL` — validation humaine requise sur la stratégie unique de rendu avant gel du markup/CSS
+
+## Objectif
+
+Rendre les tags d'équipement de l'onglet `Inventory` lisibles sans troncature destructive, y compris pour les libellés à plusieurs mots et le badge de restriction avec icône, sans ajouter de colonne métier ni sortir du design system.
+
+## Contexte utile
+
+- `templates/sheets/actor/inventory.hbs` rend aujourd'hui les tags d'items et le badge `restricted`.
+- `module/applications/sheets/base-actor-sheet.mjs` prépare `item.tags` et `restrictionBadge` pour l'inventaire.
+- `styles/applications.less`, `styles/theme.less` et `styles/actor.less` portent les règles génériques et sheet-level susceptibles d'imposer nowrap, ellipsis, hauteur max ou espacement insuffisant.
+- L'issue ne demande pas de nouveau tag métier : elle impose une stratégie de présentation unique et compréhensible pour les tags déjà existants.
+
+## Plan d'implémentation
+
+### Étape 1 — Valider une stratégie unique de rendu des tags inventory (HITL)
+
+**Fichiers** : `templates/sheets/actor/inventory.hbs`, `styles/applications.less`, `styles/theme.less`, `styles/actor.less`, `module/applications/sheets/base-actor-sheet.mjs` _(zones à auditer)_
+
+**What** :
+
+- comparer les deux leviers compatibles avec le scope : assouplir le rendu CSS (wrap, multiline, spacing) ou densifier/normaliser les libellés à la source via un scope de tags dédié à l'inventaire ;
+- trancher explicitement le comportement cible pour trois cas : tag court, tag à plusieurs mots, badge de restriction avec icône ;
+- retenir une seule règle de lisibilité applicable à toute la liste inventory, sans solution ad hoc par type d'item.
+
+**Résultat attendu** : une direction de rendu validée humainement avant modification structurelle.
+
+### Étape 2 — Appliquer la stratégie retenue au pipeline inventory
+
+**Fichiers** : `templates/sheets/actor/inventory.hbs`, `styles/actor.less`, `styles/applications.less`, `styles/theme.less`, `module/applications/sheets/base-actor-sheet.mjs` _(et helper partagé de tags si la décision impose une normalisation côté données)_
+
+**What** :
+
+- ajuster le markup et les classes du template inventory uniquement si nécessaire pour supporter le rendu retenu ;
+- si la décision HITL exige des libellés plus compacts, déplacer la normalisation au niveau partagé le plus central plutôt que de masquer le problème par une ellipsis supplémentaire dans le template ;
+- garantir un espacement lisible entre l'icône et le texte du badge de restriction, en restant 100 % design tokens et sans ajouter de colonne métier.
+
+**Résultat attendu** : les tags inventory restent lisibles sur la feuille avec un comportement cohérent pour tous les équipements.
+
+### Étape 3 — Verrouiller la non-régression du contrat de tags inventory
+
+**Fichiers** : `tests/applications/sheets/base-actor-sheet.test.mjs` _(et test plus ciblé sur le helper/tag scope si un helper partagé est introduit)_
+
+**What** :
+
+- ajouter des cas couvrant au moins un tag court, un tag à plusieurs mots et un tag de restriction pour vérifier que le pipeline inventory expose encore les données attendues après normalisation éventuelle ;
+- si la stratégie retenue introduit un scope de tags dédié, le tester comme contrat explicite plutôt que via des assertions indirectes ;
+- documenter la validation visuelle manuelle attendue sur l'onglet `Inventory` pour confirmer l'absence de troncature agressive.
+
+**Résultat attendu** : le contrat de préparation des tags est stabilisé et la revue visuelle finale sait exactement quoi contrôler.
+
+## Périmètre / hors périmètre
+
+### Inclus
+
+- lisibilité des tags existants dans l'onglet `Inventory`
+- badge de restriction avec icône
+- ajustements ciblés de template/CSS et normalisation des labels si validée en HITL
+
+### Exclus
+
+- ajout de nouvelles colonnes d'inventaire
+- refonte générale de la feuille personnage
+- changement métier des équipements hors affichage des tags

--- a/module/applications/sheets/base-actor-sheet.mjs
+++ b/module/applications/sheets/base-actor-sheet.mjs
@@ -400,7 +400,7 @@ export default class SwerpgBaseActorSheet extends HBMixin(BaseActorSheetV2) {
 
     // Iterate over items and organize them
     for (let i of this.document.items) {
-      const d = { id: i.id, name: i.name, img: i.img, tags: i.getTags() }
+      const d = { id: i.id, name: i.name, img: i.img, tags: i.getTags('short') }
       // restriction badge for inventory lists
       const rl = i.system?.restrictionLevel
       if (rl && rl !== 'none') {

--- a/tests/applications/sheets/base-actor-sheet.test.mjs
+++ b/tests/applications/sheets/base-actor-sheet.test.mjs
@@ -604,3 +604,182 @@ describe('SwerpgBaseActorSheet #prepareItems — inventory section i18n labels',
     expect(ctx.inventory.backpack.label).toBe('ACTOR.LABELS.BACKPACK')
   })
 })
+
+// ---------------------------------------------------------------------------
+// Regression: inventory items must use getTags('short') — issue #631
+// ---------------------------------------------------------------------------
+
+import { computeFeaturedEquipment as computeFeaturedEquipmentForTagsTests } from '../../../module/lib/featured-equipment.mjs'
+
+describe('SwerpgBaseActorSheet #prepareItems — compact tags via getTags("short")', () => {
+  let SwerpgBaseActorSheetTags
+
+  function buildMockDocumentTags(itemsArray) {
+    return {
+      id: 'actor-tags',
+      name: 'Tags Actor',
+      system: {
+        characteristics: {
+          brawn: { rank: { base: 2, trained: 0 } },
+          agility: { rank: { base: 2, trained: 0 } },
+          intellect: { rank: { base: 2, trained: 0 } },
+          cunning: { rank: { base: 2, trained: 0 } },
+          willpower: { rank: { base: 2, trained: 0 } },
+          presence: { rank: { base: 2, trained: 0 } },
+        },
+        progression: {
+          experience: { gained: 0, spent: 0 },
+          freeSkillRanks: {
+            career: { gained: 0, spent: 0 },
+            specialization: { gained: 0, spent: 0 },
+          },
+        },
+        details: {
+          biography: { appearance: '', public: '', private: '' },
+          commitments: { motivation: '' },
+        },
+        schema: { fields: {} },
+      },
+      isOwner: true,
+      items: {
+        find: vi.fn((fn) => itemsArray.find(fn) || null),
+        filter: vi.fn((fn) => itemsArray.filter(fn)),
+        get: vi.fn((id) => itemsArray.find((i) => i.id === id) || null),
+        [Symbol.iterator]: function* () {
+          yield* itemsArray
+        },
+      },
+      effects: [],
+      actions: {},
+      canPurchaseCharacteristic: vi.fn(() => false),
+      toObject: vi.fn(() => ({})),
+    }
+  }
+
+  async function buildSheetTags(itemsArray) {
+    const Sheet = SwerpgBaseActorSheetTags
+    const actor = buildMockDocumentTags(itemsArray)
+
+    if (!globalThis.foundry.applications.ux) {
+      globalThis.foundry.applications.ux = {}
+    }
+    if (!globalThis.foundry.applications.ux.TextEditor) {
+      globalThis.foundry.applications.ux.TextEditor = { enrichHTML: vi.fn(async (s) => s || '') }
+    }
+    if (!globalThis.SYSTEM.RESTRICTION_LEVELS) {
+      globalThis.SYSTEM.RESTRICTION_LEVELS = {}
+    }
+
+    const instance = new Sheet({})
+    instance.document = actor
+    instance.actor = actor
+    instance.tabGroups = { sheet: 'attributes' }
+    instance.isEditable = true
+    return instance
+  }
+
+  beforeEach(async () => {
+    vi.clearAllMocks()
+    SwerpgBaseActorSheetTags = (await import('../../../module/applications/sheets/base-actor-sheet.mjs')).default
+    vi.mocked(computeFeaturedEquipmentForTagsTests).mockReturnValue([])
+  })
+
+  test('weapon item getTags is called with "short" scope for inventory', async () => {
+    const getTagsMock = vi.fn(() => ({ damage: '5 Damage', category: 'Ranged' }))
+    const weaponItem = {
+      id: 'weapon-short-1',
+      name: 'Blaster Pistol',
+      img: 'icons/weapon.webp',
+      type: 'weapon',
+      system: { equipped: false, quantity: 1 },
+      getTags: getTagsMock,
+      actions: { at: () => null },
+    }
+    const instance = await buildSheetTags([weaponItem])
+    await instance._prepareContext({})
+
+    expect(getTagsMock).toHaveBeenCalledWith('short')
+  })
+
+  test('armor item getTags is called with "short" scope for inventory', async () => {
+    const getTagsMock = vi.fn(() => ({ category: 'Light Armor', defense: '2 Armor' }))
+    const armorItem = {
+      id: 'armor-short-1',
+      name: 'Light Armor',
+      img: 'icons/armor.webp',
+      type: 'armor',
+      system: { equipped: false, quantity: 1 },
+      getTags: getTagsMock,
+      actions: { at: () => null },
+    }
+    const instance = await buildSheetTags([armorItem])
+    await instance._prepareContext({})
+
+    expect(getTagsMock).toHaveBeenCalledWith('short')
+  })
+
+  test('gear item getTags is called with "short" scope for inventory', async () => {
+    const getTagsMock = vi.fn(() => ({}))
+    const gearItem = {
+      id: 'gear-short-1',
+      name: 'Medpac',
+      img: 'icons/gear.webp',
+      type: 'gear',
+      system: { quantity: 2 },
+      getTags: getTagsMock,
+      actions: { at: () => null },
+    }
+    const instance = await buildSheetTags([gearItem])
+    await instance._prepareContext({})
+
+    expect(getTagsMock).toHaveBeenCalledWith('short')
+  })
+
+  test('inventory item tags object reflects short-scope tags returned by getTags', async () => {
+    // Short scope for weapon omits range, qualities, block, parry — only damage, category, type
+    const shortTags = { damage: '5 Damage', category: 'Ranged' }
+    const weaponItem = {
+      id: 'weapon-tags-1',
+      name: 'Blaster Pistol',
+      img: '',
+      type: 'weapon',
+      system: { equipped: false, quantity: 1 },
+      getTags: vi.fn(() => shortTags),
+      actions: { at: () => null },
+    }
+    const instance = await buildSheetTags([weaponItem])
+    const ctx = await instance._prepareContext({})
+
+    const item = ctx.inventory.backpack.items.find((i) => i.id === 'weapon-tags-1')
+    expect(item).toBeDefined()
+    expect(item.tags).toEqual(shortTags)
+    // Verify no full-scope-only tags leaked through
+    expect(item.tags).not.toHaveProperty('range')
+  })
+
+  test('restriction badge tag is preserved in short scope for weapon with restriction', async () => {
+    const shortTags = { damage: '5 Damage', restricted: 'Restricted' }
+    const weaponItem = {
+      id: 'weapon-restricted-1',
+      name: 'Heavy Repeating Blaster',
+      img: '',
+      type: 'weapon',
+      system: { equipped: false, quantity: 1, restrictionLevel: 'restricted' },
+      getTags: vi.fn(() => shortTags),
+      actions: { at: () => null },
+    }
+
+    globalThis.SYSTEM.RESTRICTION_LEVELS = {
+      restricted: { label: 'SWERPG.Restriction.Restricted' },
+    }
+    globalThis.game.i18n.localize = (key) => key
+
+    const instance = await buildSheetTags([weaponItem])
+    const ctx = await instance._prepareContext({})
+
+    const item = ctx.inventory.backpack.items.find((i) => i.id === 'weapon-restricted-1')
+    expect(item).toBeDefined()
+    expect(item.restrictionBadge).toBeDefined()
+    expect(item.restrictionBadge.level).toBe('restricted')
+  })
+})


### PR DESCRIPTION
## Description

Rend les tags d'équipement de l'onglet **Inventory** lisibles sans troncature agressive en utilisant le scope `'short'` de `getTags()` plutôt que le scope `'full'`.

## Problème

`i.getTags()` (scope `'full'`) produisait des libellés longs (range, qualities, block, parry…) tronqués par les contraintes CSS existantes (`white-space: nowrap`, `max-width: 45px`, `text-overflow: ellipsis` dans `styles/actor.less`).

## Solution

- `module/applications/sheets/base-actor-sheet.mjs` — passer de `i.getTags()` à `i.getTags('short')` pour les items d'inventaire. Les tags longs (range, qualities, défense…) ne sont plus inclus, seuls les tags essentiels (dégâts, catégorie, type d'arme, restriction…) restent affichés.
- Le badge de restriction (`restrictionBadge`) est conservé via le pipeline parallèle (non impacté par le scope).

## Tests

5 nouveaux cas dans `tests/applications/sheets/base-actor-sheet.test.mjs` :
- vérifie que `getTags` est appelé avec `'short'` pour chaque type d'item (weapon, armor, gear)
- vérifie que les tags reçus sont ceux du scope court
- vérifie qu'aucun tag full-scope-only ne fuit
- vérifie que le badge de restriction est préservé

## Issue

Closes #631

## Validation visuelle

Ouvrir l'onglet Inventory d'un personnage équipé (armes/armures/équipement) et vérifier que les tags ne sont plus tronqués (ellipsis). Vérifier le cas du badge de restriction avec icône.