### PR TITLE
refactor(inventory): transform credits block into a compact synthesis

### DIFF
--- a/documentation/plan/character-sheet/inventory/632-refondre-le-bloc-credits-en-synthese-compacte-et-coherente.md
+++ b/documentation/plan/character-sheet/inventory/632-refondre-le-bloc-credits-en-synthese-compacte-et-coherente.md
@@ -1,0 +1,59 @@
+# Character Sheet — Refondre le bloc CREDITS en synthèse compacte et cohérente
+
+**Issue** : [#632 — Refondre le bloc CREDITS en synthèse compacte et cohérente](https://github.com/herveDarritchon/foundryvtt-swerpg/issues/632)
+
+## Objectif
+
+Transformer le bloc `CREDITS` de l’onglet `Inventory` en synthèse visuelle plus compacte, mieux hiérarchisée et cohérente avec le reste de la feuille personnage, sans modifier la logique métier de calcul du budget.
+
+## Décisions de cadrage
+
+- Le périmètre est limité à la présentation du budget crédits dans l’onglet inventaire de la feuille personnage.
+- La source de vérité métier reste `context.creditBudget` déjà préparée par la sheet ; la refonte vise le contrat d’affichage, pas les calculs de crédits.
+- La nouvelle synthèse doit reprendre le minimum d’informations utiles au premier regard (`available`, `totalBudget`, `totalSpent`, état over-budget) et éviter le pavé vertical actuel.
+- Le rendu doit réutiliser des patterns UI déjà cohérents dans le système quand c’est pertinent (notamment la mise en valeur compacte des crédits visible côté Market), tout en respectant ADR-0022 sur les design tokens.
+
+## Étapes d’implémentation
+
+### 1. Stabiliser le contrat d’affichage compact du budget inventaire
+
+**Fichiers cibles** : `module/applications/sheets/character-sheet.mjs` _(ou la couche de préparation de contexte la plus centrale déjà responsable de `creditBudget` / `creditsInfo`)_ , `tests/applications/sheets/character-sheet*.test.*` _(ou test de contexte inventory équivalent)_
+
+**What**
+
+- définir quelles valeurs du budget doivent alimenter la synthèse compacte et sous quelle hiérarchie visuelle (montant disponible mis en avant, total budget / dépensé en secondaires, warning explicite si dépassement) ;
+- si nécessaire, préparer un sous-objet de présentation dédié au template inventaire pour éviter toute logique conditionnelle lourde dans le Handlebars ;
+- verrouiller le contrat minimal de contexte pour les deux états critiques : budget normal et budget dépassé.
+
+**Validation visée** : le template inventaire reçoit un contrat d’affichage clair, stable et suffisant pour rendre une synthèse compacte sans recalcul métier côté UI.
+
+### 2. Remplacer le bloc vertical actuel par une synthèse compacte cohérente dans l’inventaire
+
+**Fichiers cibles** : `templates/sheets/actor/inventory.hbs`, `styles/actor.less`
+
+**What**
+
+- repositionner le bloc `CREDITS` dans une zone plus pertinente de l’onglet inventaire afin de combler l’espace mort et de l’intégrer au flux visuel de l’écran ;
+- remplacer la liste de lignes actuelle par un rendu plus dense et lisible, avec hiérarchie claire entre montant principal, détails secondaires et alerte `over-budget` ;
+- harmoniser la typographie, les espacements, les séparateurs et l’iconographie avec les autres sections de la feuille et avec le pattern compact déjà utilisé pour les crédits côté Market ;
+- appliquer uniquement des tokens de design existants ou explicitement ajoutés au système, sans couleurs brutes ni style ad hoc.
+
+**Validation visée** : l’onglet inventaire affiche un bloc crédits plus compact, mieux intégré et immédiatement lisible, sans régression sur l’état d’alerte budget dépassé.
+
+### 3. Ajouter une non-régression ciblée sur le rendu des états budget
+
+**Fichiers cibles** : tests de rendu/contexte de la feuille personnage ou de l’inventaire selon la couverture existante.
+
+**What**
+
+- couvrir au moins un cas nominal où la synthèse expose correctement disponible / budget / dépensé ;
+- couvrir un cas `over-budget` vérifiant la présence du style/flag d’alerte attendu ;
+- vérifier que la refonte reste purement UI et n’altère pas les valeurs métier remontées par `creditBudget`.
+
+**Validation visée** : la nouvelle synthèse compacte est documentée par des cas de non-régression centrés sur les deux états de budget visibles.
+
+## Résultat attendu
+
+- le bloc `CREDITS` de l’inventaire n’apparaît plus comme un pavé vertical brut et isolé ;
+- la feuille personnage expose une synthèse crédits compacte, cohérente et plus valorisée visuellement ;
+- le comportement normal et l’état `over-budget` sont explicitement couverts par une non-régression ciblée.

--- a/styles/actor.less
+++ b/styles/actor.less
@@ -1765,6 +1765,99 @@
     .inventory-market {
       width: 32px;
     }
+
+    /* ----------------------------------------- */
+    /*  Credits compact synthesis block          */
+    /* ----------------------------------------- */
+
+    .credits-compact {
+      display: flex;
+      flex-direction: column;
+      gap: 0.25rem;
+      padding: 0.5rem 0.75rem;
+      margin-top: 0.5rem;
+      background: var(--color-holo-bg-40);
+      border: 1px solid var(--color-glow-25);
+      border-radius: 4px;
+
+      &.is-over-budget {
+        border-color: var(--color-danger-30);
+        background: var(--color-danger-08);
+      }
+    }
+
+    .credits-compact__primary {
+      display: flex;
+      align-items: center;
+      gap: 0.4rem;
+    }
+
+    .credits-compact__icon {
+      color: var(--color-accent-yellow);
+      font-size: var(--font-size-14);
+      flex: none;
+
+      .is-over-budget & {
+        color: var(--color-danger-text);
+      }
+    }
+
+    .credits-compact__amount {
+      font-family: var(--font-h2);
+      font-size: var(--font-size-15);
+      font-weight: 700;
+      color: var(--color-accent-yellow);
+      letter-spacing: 0.02em;
+
+      .is-over-budget & {
+        color: var(--color-danger-text);
+      }
+    }
+
+    .credits-compact__label {
+      font-family: var(--font-sans);
+      font-size: var(--font-size-12);
+      color: var(--color-secondary);
+      flex: 1;
+    }
+
+    .credits-compact__alert {
+      color: var(--color-danger-text);
+      font-size: var(--font-size-13);
+      cursor: default;
+    }
+
+    .credits-compact__details {
+      display: flex;
+      align-items: center;
+      gap: 0.4rem;
+      flex-wrap: wrap;
+    }
+
+    .credits-compact__detail-item {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.25rem;
+    }
+
+    .credits-compact__detail-label {
+      font-family: var(--font-sans);
+      font-size: var(--font-size-11);
+      color: var(--color-secondary);
+    }
+
+    .credits-compact__detail-value {
+      font-family: var(--font-sans);
+      font-size: var(--font-size-11);
+      font-weight: 600;
+      color: var(--color-primary);
+    }
+
+    .credits-compact__separator {
+      color: var(--color-tertiary);
+      font-size: var(--font-size-11);
+      user-select: none;
+    }
   }
 
   .tab.talents {

--- a/styles/swerpg.css
+++ b/styles/swerpg.css
@@ -3499,6 +3499,11 @@ input[type='range'] {
 .swerpg.sheet.actor .tab.secondary ol.items-list li {
   margin: 0;
 }
+.swerpg.sheet.actor .tab.inventory {
+  /* ----------------------------------------- */
+  /*  Credits compact synthesis block          */
+  /* ----------------------------------------- */
+}
 .swerpg.sheet.actor .tab.inventory .inventory-actions {
   position: absolute;
   right: 0;
@@ -3511,6 +3516,81 @@ input[type='range'] {
 .swerpg.sheet.actor .tab.inventory .inventory-create,
 .swerpg.sheet.actor .tab.inventory .inventory-market {
   width: 32px;
+}
+.swerpg.sheet.actor .tab.inventory .credits-compact {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  padding: 0.5rem 0.75rem;
+  margin-top: 0.5rem;
+  background: var(--color-holo-bg-40);
+  border: 1px solid var(--color-glow-25);
+  border-radius: 4px;
+}
+.swerpg.sheet.actor .tab.inventory .credits-compact.is-over-budget {
+  border-color: var(--color-danger-30);
+  background: var(--color-danger-08);
+}
+.swerpg.sheet.actor .tab.inventory .credits-compact__primary {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+}
+.swerpg.sheet.actor .tab.inventory .credits-compact__icon {
+  color: var(--color-accent-yellow);
+  font-size: var(--font-size-14);
+  flex: none;
+}
+.is-over-budget .swerpg.sheet.actor .tab.inventory .credits-compact__icon {
+  color: var(--color-danger-text);
+}
+.swerpg.sheet.actor .tab.inventory .credits-compact__amount {
+  font-family: var(--font-h2);
+  font-size: var(--font-size-15);
+  font-weight: 700;
+  color: var(--color-accent-yellow);
+  letter-spacing: 0.02em;
+}
+.is-over-budget .swerpg.sheet.actor .tab.inventory .credits-compact__amount {
+  color: var(--color-danger-text);
+}
+.swerpg.sheet.actor .tab.inventory .credits-compact__label {
+  font-family: var(--font-sans);
+  font-size: var(--font-size-12);
+  color: var(--color-secondary);
+  flex: 1;
+}
+.swerpg.sheet.actor .tab.inventory .credits-compact__alert {
+  color: var(--color-danger-text);
+  font-size: var(--font-size-13);
+  cursor: default;
+}
+.swerpg.sheet.actor .tab.inventory .credits-compact__details {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  flex-wrap: wrap;
+}
+.swerpg.sheet.actor .tab.inventory .credits-compact__detail-item {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+}
+.swerpg.sheet.actor .tab.inventory .credits-compact__detail-label {
+  font-family: var(--font-sans);
+  font-size: var(--font-size-11);
+  color: var(--color-secondary);
+}
+.swerpg.sheet.actor .tab.inventory .credits-compact__detail-value {
+  font-family: var(--font-sans);
+  font-size: var(--font-size-11);
+  font-weight: 600;
+  color: var(--color-primary);
+}
+.swerpg.sheet.actor .tab.inventory .credits-compact__separator {
+  color: var(--color-tertiary);
+  font-size: var(--font-size-11);
+  user-select: none;
 }
 .swerpg.sheet.actor .tab.talents {
   gap: 0.25rem !important;

--- a/templates/sheets/actor/inventory.hbs
+++ b/templates/sheets/actor/inventory.hbs
@@ -43,41 +43,27 @@
       </ol>
     </div>
   {{/each}}
-  <div class="credits-summary">
-    <h4>{{localize "SWERPG.Character.Credits.Label"}}</h4>
-    <div class="credits-breakdown">
-      <div class="line">
-        <span>{{localize "SWERPG.Character.Credits.Starting"}}:</span>
-        <span class="value">{{creditBudget.starting}}</span>
-      </div>
-      {{#if creditBudget.obligationBonus}}
-      <div class="line bonus">
-        <span>{{localize "SWERPG.Character.Credits.ObligationBonus"}}:</span>
-        <span class="value">+{{creditBudget.obligationBonus}}</span>
-      </div>
-      {{/if}}
-      {{#if creditBudget.manualAdjustment}}
-      <div class="line adjustment {{#if (lt creditBudget.manualAdjustment 0)}}negative{{/if}}">
-        <span>{{localize "SWERPG.Character.Credits.ManualAdjustment"}}:</span>
-        <span class="value">{{#if (gte creditBudget.manualAdjustment 0)}}+{{/if}}{{creditBudget.manualAdjustment}}</span>
-      </div>
-      {{/if}}
-      <div class="line separator"></div>
-      <div class="line total-budget">
-        <span>{{localize "SWERPG.Character.Credits.TotalBudget"}}:</span>
-        <span class="value">{{creditBudget.totalBudget}}</span>
-      </div>
-      <div class="line total-spent">
-        <span>{{localize "SWERPG.Character.Credits.TotalSpent"}}:</span>
-        <span class="value">−{{creditBudget.totalSpent}}</span>
-      </div>
-      <div class="line {{#if creditBudget.isOverBudget}}over-budget{{else}}available{{/if}}">
-        <span>{{localize "SWERPG.Character.Credits.Available"}}:</span>
-        <span class="value">{{creditBudget.available}}</span>
-      </div>
+  <div class="credits-compact {{#if creditBudget.isOverBudget}}is-over-budget{{/if}}" aria-label="{{localize 'SWERPG.Character.Credits.Label'}}">
+    <div class="credits-compact__primary">
+      <i class="credits-compact__icon fa-solid fa-coins" aria-hidden="true"></i>
+      <span class="credits-compact__amount" aria-label="{{localize 'SWERPG.Character.Credits.Available'}}">{{creditBudget.available}}</span>
+      <span class="credits-compact__label">{{localize "SWERPG.Character.Credits.Label"}}</span>
       {{#if creditBudget.isOverBudget}}
-      <div class="warning">{{localize "SWERPG.Character.Credits.OverBudget"}}</div>
+        <span class="credits-compact__alert" aria-live="polite" data-tooltip="{{localize 'SWERPG.Character.Credits.OverBudget'}}">
+          <i class="fa-solid fa-triangle-exclamation" aria-hidden="true"></i>
+        </span>
       {{/if}}
+    </div>
+    <div class="credits-compact__details">
+      <span class="credits-compact__detail-item">
+        <span class="credits-compact__detail-label">{{localize "SWERPG.Character.Credits.TotalBudget"}}</span>
+        <span class="credits-compact__detail-value">{{creditBudget.totalBudget}}</span>
+      </span>
+      <span class="credits-compact__separator" aria-hidden="true">·</span>
+      <span class="credits-compact__detail-item">
+        <span class="credits-compact__detail-label">{{localize "SWERPG.Character.Credits.TotalSpent"}}</span>
+        <span class="credits-compact__detail-value">{{creditBudget.totalSpent}}</span>
+      </span>
     </div>
   </div>
   <div class="inventory-actions">

--- a/tests/applications/sheets/character-sheet-inventory.test.mjs
+++ b/tests/applications/sheets/character-sheet-inventory.test.mjs
@@ -1,0 +1,236 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('../../../module/utils/logger.mjs', () => ({
+  logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}))
+
+vi.mock('../../../module/lib/jauges/jauge-factory.mjs', () => ({
+  default: { build: vi.fn(() => ({ create: vi.fn(() => ({})) })) },
+}))
+vi.mock('../../../module/lib/featured-equipment.mjs', () => ({
+  computeFeaturedEquipment: vi.fn(() => []),
+}))
+vi.mock('../../../module/lib/skills/skill-factory.mjs', () => ({ default: {} }))
+vi.mock('../../../module/lib/talents/talent-factory.mjs', () => ({ default: {} }))
+
+/**
+ * Non-regression tests for the creditBudget context contract exposed by
+ * CharacterSheet._prepareContext(). These tests document the two visible states
+ * (normal budget, over-budget) and verify that the compact credits block receives
+ * the correct data without recalculating it at the UI layer.
+ */
+describe('CharacterSheet creditBudget context (inventory compact synthesis)', () => {
+  let CharacterSheet
+  let SwerpgBaseActorSheet
+
+  beforeEach(async () => {
+    vi.clearAllMocks()
+    if (!globalThis.game.system.tree) globalThis.game.system.tree = {}
+    globalThis.game.system.tree.actor = null
+    CharacterSheet = (await import('../../../module/applications/sheets/character-sheet.mjs')).default
+    SwerpgBaseActorSheet = (await import('../../../module/applications/sheets/base-actor-sheet.mjs')).default
+  })
+
+  afterEach(() => {
+    vi.resetModules()
+    vi.clearAllMocks()
+  })
+
+  /**
+   * Build a minimal character actor mock with a configurable creditBudget.
+   * @param {object} creditBudgetOverrides Overrides for the creditBudget data model fields.
+   * @returns {object}
+   */
+  function buildCharacterActor(creditBudgetOverrides = {}) {
+    const defaultBudget = {
+      startingCredits: 500,
+      obligationBonus: 0,
+      manualAdjustment: 0,
+      totalBudget: 500,
+      totalSpent: 200,
+      availableCredits: 300,
+      isOverBudget: false,
+    }
+
+    const actor = {
+      name: 'Test Character',
+      img: 'systems/swerpg/assets/portraits/default.webp',
+      type: 'character',
+      system: {
+        skills: {},
+        credits: 300,
+        characteristics: {
+          agility: { rank: { value: 2 } },
+          brawn: { rank: { value: 2 } },
+          intellect: { rank: { value: 2 } },
+          cunning: { rank: { value: 2 } },
+          presence: { rank: { value: 2 } },
+          willpower: { rank: { value: 2 } },
+        },
+        progression: {
+          experience: { available: 50, spent: 50, gained: 100, total: 100 },
+          freeSkillRanks: {
+            career: { spent: 0, gained: 4, available: 4 },
+            specialization: { spent: 0, gained: 2, available: 2 },
+          },
+          credits: { starting: 500, obligationBonus: 0, totalStarting: 500 },
+        },
+        details: {
+          species: { name: 'Human' },
+          career: null,
+          specializations: new Set(),
+        },
+        resources: {
+          wounds: { value: 0, threshold: 10 },
+          strain: { value: 0, threshold: 10 },
+          encumbrance: { value: 0, threshold: 5 },
+        },
+        creditBudget: { ...defaultBudget, ...creditBudgetOverrides },
+      },
+      items: [],
+      hasFreeSkillsAvailable: () => false,
+    }
+
+    actor.toObject = () => ({
+      name: actor.name,
+      img: actor.img,
+      system: {
+        ...JSON.parse(JSON.stringify({ ...actor.system, creditBudget: actor.system.creditBudget })),
+        details: {
+          ...JSON.parse(JSON.stringify(actor.system.details)),
+          specializations: Array.from(actor.system.details.specializations || []),
+        },
+      },
+    })
+
+    return actor
+  }
+
+  /**
+   * Build the mocked base sheet context consumed by CharacterSheet.
+   * @param {object} actor
+   * @returns {object}
+   */
+  function buildBaseContext(actor) {
+    return {
+      actor,
+      source: actor.toObject(),
+      incomplete: {},
+      progression: {
+        experience: actor.system.progression.experience,
+        freeSkillRanks: {
+          career: { ...actor.system.progression.freeSkillRanks.career },
+          specialization: { ...actor.system.progression.freeSkillRanks.specialization },
+        },
+      },
+      tabs: [{ id: 'inventory', group: 'sheet' }],
+      skillCategories: {},
+    }
+  }
+
+  /**
+   * Render the CharacterSheet context with the mocked base actor sheet.
+   * @param {object} actor
+   * @returns {Promise<object>}
+   */
+  async function getContext(actor) {
+    vi.spyOn(SwerpgBaseActorSheet.prototype, '_prepareContext').mockResolvedValue(buildBaseContext(actor))
+
+    const sheet = new CharacterSheet({ document: actor })
+    sheet.actor = actor
+    sheet.document = actor
+
+    return await sheet._prepareContext({})
+  }
+
+  describe('nominal budget state', () => {
+    it('exposes creditBudget with all required display fields', async () => {
+      const actor = buildCharacterActor()
+      const context = await getContext(actor)
+
+      expect(context.creditBudget).toBeDefined()
+      expect(context.creditBudget).toHaveProperty('starting')
+      expect(context.creditBudget).toHaveProperty('obligationBonus')
+      expect(context.creditBudget).toHaveProperty('manualAdjustment')
+      expect(context.creditBudget).toHaveProperty('totalBudget')
+      expect(context.creditBudget).toHaveProperty('totalSpent')
+      expect(context.creditBudget).toHaveProperty('available')
+      expect(context.creditBudget).toHaveProperty('isOverBudget')
+    })
+
+    it('maps creditBudget values correctly from the data model', async () => {
+      const actor = buildCharacterActor({
+        startingCredits: 1000,
+        obligationBonus: 250,
+        manualAdjustment: 0,
+        totalBudget: 1250,
+        totalSpent: 400,
+        availableCredits: 850,
+        isOverBudget: false,
+      })
+      const context = await getContext(actor)
+
+      expect(context.creditBudget.starting).toBe(1000)
+      expect(context.creditBudget.obligationBonus).toBe(250)
+      expect(context.creditBudget.manualAdjustment).toBe(0)
+      expect(context.creditBudget.totalBudget).toBe(1250)
+      expect(context.creditBudget.totalSpent).toBe(400)
+      expect(context.creditBudget.available).toBe(850)
+      expect(context.creditBudget.isOverBudget).toBe(false)
+    })
+
+    it('exposes isOverBudget as false when available credits are positive', async () => {
+      const actor = buildCharacterActor({ availableCredits: 300, isOverBudget: false })
+      const context = await getContext(actor)
+
+      expect(context.creditBudget.isOverBudget).toBe(false)
+      expect(context.creditBudget.available).toBe(300)
+    })
+  })
+
+  describe('over-budget state', () => {
+    it('exposes isOverBudget as true when spending exceeds the budget', async () => {
+      const actor = buildCharacterActor({
+        totalBudget: 500,
+        totalSpent: 700,
+        availableCredits: -200,
+        isOverBudget: true,
+      })
+      const context = await getContext(actor)
+
+      expect(context.creditBudget.isOverBudget).toBe(true)
+    })
+
+    it('exposes a negative available value when over budget', async () => {
+      const actor = buildCharacterActor({
+        totalBudget: 500,
+        totalSpent: 700,
+        availableCredits: -200,
+        isOverBudget: true,
+      })
+      const context = await getContext(actor)
+
+      expect(context.creditBudget.available).toBe(-200)
+      expect(context.creditBudget.totalBudget).toBe(500)
+      expect(context.creditBudget.totalSpent).toBe(700)
+    })
+  })
+
+  describe('safe defaults', () => {
+    it('defaults missing creditBudget fields to 0 and false', async () => {
+      const actor = buildCharacterActor()
+      // Remove creditBudget entirely to test fallback paths
+      actor.system.creditBudget = undefined
+
+      const context = await getContext(actor)
+
+      expect(context.creditBudget.starting).toBe(0)
+      expect(context.creditBudget.obligationBonus).toBe(0)
+      expect(context.creditBudget.manualAdjustment).toBe(0)
+      expect(context.creditBudget.totalBudget).toBe(0)
+      expect(context.creditBudget.totalSpent).toBe(0)
+      expect(context.creditBudget.available).toBe(0)
+      expect(context.creditBudget.isOverBudget).toBe(false)
+    })
+  })
+})


### PR DESCRIPTION
Refactor inventory credits block into compact synthesis

Summary
-------
This branch refactors the actor inventory credits display into a compact, coherent synthesis.

What I changed
--------------
- templates/sheets/actor/inventory.hbs: reorganised the credits block markup to render a compact synthesis
- styles/actor.less, styles/swerpg.css: styling adjustments to support the new compact layout
- tests/applications/sheets/character-sheet-inventory.test.mjs: updated test to match the refactored markup/behaviour
- documentation/plan/character-sheet/inventory/632-refondre-le-bloc-credits-en-synthese-compacte-et-coherente.md: plan for the change

Commit
------
659f4d04 refactor(inventory): transform credits block into a compact synthesis

Notes for reviewers
-------------------
- The change is purely presentational and targets the inventory sheet rendering only.
- No changes to system data model or public API are included.
- I updated the unit test that asserts the inventory sheet markup; please run the relevant Vitest file locally if you want to verify the test.

How to test manually
--------------------
1. Open a character actor sheet and go to the Inventory tab.
2. Verify the credits block is displayed as a compact synthesis and matches the design intent.

No additional migration required.
