### PR TITLE
feat(obligation): appliquer les règles officielles de bonus de création liés aux Obligations

### DIFF
--- a/documentation/plan/character-sheet/obligation/646-appliquer-les-regles-officielles-de-bonus-de-creation-lies-aux-obligations.md
+++ b/documentation/plan/character-sheet/obligation/646-appliquer-les-regles-officielles-de-bonus-de-creation-lies-aux-obligations.md
@@ -1,0 +1,67 @@
+# Character Sheet — Appliquer les règles officielles de bonus de création liés aux Obligations
+
+**Issue** : [#646 — Appliquer les règles officielles de bonus de création liés aux Obligations](https://github.com/herveDarritchon/foundryvtt-swerpg/issues/646)
+**Domaine métier** : `character-sheet/obligation`
+
+## Objectif
+
+Faire respecter dans le runtime SWERPG les règles officielles FFG/Edge des bonus de création liés aux Obligations, afin que la fiche personnage ne somme plus librement des valeurs saisies mais dérive un état canonique, validé et lisible côté UI.
+
+## Contexte utile
+
+- `module/config/progression.mjs` porte déjà `STARTING_CREDITS`, `OBLIGATION_EXTRA_CREDITS_5` et `OBLIGATION_EXTRA_CREDITS_10`, mais le domaine n'exprime pas encore les paliers XP officiels ni un contrat métier complet pour les bonus de création.
+- `module/lib/obligations/obligation-bonus-calculator.mjs` additionne actuellement `extraXp` et `extraCredits` pour les obligations `isExtra === true`, sans vérifier les combinaisons autorisées, les doublons d'option ni le coût total en Obligation supplémentaire.
+- `module/models/character.mjs` dérive déjà `progression.credits`, `creditBudget` et `creditsInfo`, tandis que `CharacterSheet` expose `obligations` et `obligationPoints`, mais aucun diagnostic métier n'indique si l'état courant respecte les règles officielles.
+- Le cadrage `documentation/cadrage/character-sheet/obligations/cadrage-obligations-star-wars-edge-aux-confins-empire.md` formalise la matrice à appliquer : `+5 XP`, `+10 XP`, `+1 000 crédits`, `+2 500 crédits`, chaque option au plus une fois, avec un plafond d'Obligation supplémentaire borné par la valeur de départ.
+
+## Plan d'implémentation
+
+### Étape 1 — Canoniser les options officielles de bonus de création dans le domaine pur
+
+**Fichiers** : `module/config/progression.mjs`, `module/lib/obligations/obligation-bonus-calculator.mjs`, `tests/config/progression.test.mjs`, `tests/lib/obligations/obligation-bonus-calculator.test.mjs`
+
+**What** :
+
+- ajouter des constantes nommées pour les paliers XP d'Obligation, au même niveau que les constantes crédits déjà présentes ;
+- faire évoluer le calculateur pur pour qu'il ne retourne plus seulement des sommes brutes, mais un récapitulatif canonique des bonus sélectionnés (`xp`, `credits`, coût total en Obligation supplémentaire, options reconnues, incohérences détectées) ;
+- verrouiller par tests les cas officiels valides (`+5 XP`, `+10 XP`, `+1 000 crédits`, `+2 500 crédits`, combinaison `+5 XP +1 000 crédits`) ainsi que les états invalides (montants non officiels, doublons, bonus marqués `isExtra` mais incohérents).
+
+**Résultat attendu** : le domaine Obligation possède une source unique de vérité pour les bonus de création et sait distinguer un bonus officiel d'une saisie libre invalide.
+
+### Étape 2 — Brancher un état dérivé de conformité des bonus sur le personnage
+
+**Fichiers** : `module/models/character.mjs`, `module/models/obligation.mjs`, `tests/models/obligation.test.mjs`, `tests/applications/sheets/character-sheet-inventory.test.mjs`
+
+**What** :
+
+- enrichir la préparation du personnage avec une structure dérivée dédiée aux bonus de création liés aux Obligations (bonus XP, bonus crédits, coût supplémentaire consommé, reste disponible, erreurs métier éventuelles) ;
+- relier explicitement cet état dérivé au plafond officiel d'Obligation supplémentaire au lieu de laisser l'UI ou les items interpréter seuls les champs `value`, `extraXp` et `extraCredits` ;
+- clarifier dans le modèle `SwerpgObligation` les invariants réellement portés par le schéma vs ceux délégués au calculateur métier pour éviter les validations contradictoires.
+
+**Résultat attendu** : la couche modèle expose un diagnostic métier prêt à consommer, stable et centralisé, sans doubles calculs dispersés dans les feuilles.
+
+### Étape 3 — Encadrer l'édition et rendre visibles les écarts sur la fiche personnage
+
+**Fichiers** : `module/applications/sheets/character-sheet.mjs`, `templates/sheets/actor/character-commitments.hbs`, `templates/sheets/partials/obligation-config.hbs`, `lang/en.json`, `lang/fr.json`, `tests/applications/sheets/character-sheet-commitments.test.mjs`, `tests/applications/sheets/obligation-sheet.test.mjs`
+
+**What** :
+
+- exposer dans le contexte de sheet un résumé lisible des bonus de création issus des Obligations et des éventuelles anomalies de conformité ;
+- faire évoluer l'UI d'édition pour guider vers les seules options officielles (au lieu d'autoriser silencieusement des montants arbitraires) et afficher clairement quand une combinaison sort du cadre FFG/Edge ;
+- ajouter les clés i18n EN/FR nécessaires pour les libellés, aides et messages de validation du parcours d'édition des Obligations.
+
+**Résultat attendu** : la fiche personnage et la fiche item rendent les bonus de création compréhensibles, bornés par les règles officielles et immédiatement auditables par le joueur comme par le MJ.
+
+## Périmètre / hors périmètre
+
+### Inclus
+
+- formalisation canonique des paliers officiels XP / crédits liés aux Obligations à la création
+- dérivation centralisée d'un état de conformité des bonus sur le personnage
+- encadrement UI des saisies et visualisation des écarts côté fiches
+
+### Exclus
+
+- refonte large du domaine Obligation hors bonus de création (tirage, résolution, diminution/augmentation en campagne)
+- enrichissement narratif détaillé d'une Obligation individuelle traité par l'issue `#647`
+- changements génériques du système de crédits non directement requis pour appliquer les règles officielles d'Obligation

--- a/lang/en.json
+++ b/lang/en.json
@@ -968,7 +968,22 @@
       }
     },
     "UI": {
-      "EXTRA_BONUS_LEGEND": "Extra Bonus"
+      "EXTRA_BONUS_LEGEND": "Extra Bonus",
+      "OFFICIAL_OPTIONS_LABEL": "Official creation bonus options",
+      "OFFICIAL_OPTIONS_HINT": "Only the following combinations are official (FFG/Edge rules). Each option may be chosen at most once.",
+      "OFFICIAL_OPTION_XP_5": "5 XP — +5 Obligation",
+      "OFFICIAL_OPTION_XP_10": "10 XP — +10 Obligation",
+      "OFFICIAL_OPTION_CREDITS_1000": "1 000 credits — +5 Obligation",
+      "OFFICIAL_OPTION_CREDITS_2500": "2 500 credits — +10 Obligation",
+      "CREATION_BONUS_SUMMARY_TITLE": "Creation Bonuses (Obligation)",
+      "CREATION_BONUS_XP_LABEL": "XP",
+      "CREATION_BONUS_XP_TOOLTIP": "Extra XP granted by official extra obligations",
+      "CREATION_BONUS_CREDITS_LABEL": "credits",
+      "CREATION_BONUS_CREDITS_TOOLTIP": "Extra starting credits granted by official extra obligations",
+      "CREATION_BONUS_OBLIGATION_LABEL": "extra Obligation",
+      "CREATION_BONUS_OBLIGATION_TOOLTIP": "Extra Obligation consumed / allowed (based on starting obligation value)",
+      "CREATION_ERRORS_LABEL": "Obligation conformance issues",
+      "CREATION_CONFORMANT_LABEL": "All extra obligations follow official rules."
     }
   },
   "RESOURCES": {

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -1071,7 +1071,22 @@
       }
     },
     "UI": {
-      "EXTRA_BONUS_LEGEND": "Bonus Extra"
+      "EXTRA_BONUS_LEGEND": "Bonus Extra",
+      "OFFICIAL_OPTIONS_LABEL": "Options de bonus de création officielles",
+      "OFFICIAL_OPTIONS_HINT": "Seules les combinaisons suivantes sont officielles (règles FFG/Edge). Chaque option ne peut être choisie qu'une seule fois.",
+      "OFFICIAL_OPTION_XP_5": "5 XP — +5 Obligation",
+      "OFFICIAL_OPTION_XP_10": "10 XP — +10 Obligation",
+      "OFFICIAL_OPTION_CREDITS_1000": "1 000 crédits — +5 Obligation",
+      "OFFICIAL_OPTION_CREDITS_2500": "2 500 crédits — +10 Obligation",
+      "CREATION_BONUS_SUMMARY_TITLE": "Bonus de création (Obligation)",
+      "CREATION_BONUS_XP_LABEL": "XP",
+      "CREATION_BONUS_XP_TOOLTIP": "XP supplémentaire accordé par les obligations supplémentaires officielles",
+      "CREATION_BONUS_CREDITS_LABEL": "crédits",
+      "CREATION_BONUS_CREDITS_TOOLTIP": "Crédits de départ supplémentaires accordés par les obligations supplémentaires officielles",
+      "CREATION_BONUS_OBLIGATION_LABEL": "Obligation supplémentaire",
+      "CREATION_BONUS_OBLIGATION_TOOLTIP": "Obligation supplémentaire consommée / autorisée (basée sur la valeur d'obligation de départ)",
+      "CREATION_ERRORS_LABEL": "Problèmes de conformité des Obligations",
+      "CREATION_CONFORMANT_LABEL": "Toutes les obligations supplémentaires respectent les règles officielles."
     }
   },
   "RESOURCES": {

--- a/module/applications/sheets/character-sheet.mjs
+++ b/module/applications/sheets/character-sheet.mjs
@@ -147,6 +147,7 @@ export default class CharacterSheet extends SwerpgBaseActorSheet {
 
     context.obligations = this.#buildObligationList()
     context.obligationPoints = this.#computeObligationPoints(context.obligations)
+    context.obligationCreationState = a.system.obligationCreationState ?? null
 
     context.creditsInfo = {
       starting: a.system.progression.credits?.starting ?? 0,

--- a/module/config/progression.mjs
+++ b/module/config/progression.mjs
@@ -203,3 +203,29 @@ export const OBLIGATION_EXTRA_CREDITS_5 = 1000
  * @type {number}
  */
 export const OBLIGATION_EXTRA_CREDITS_10 = 2500
+
+/**
+ * Extra XP bonus for +5 Obligation during character creation.
+ * @type {number}
+ */
+export const OBLIGATION_EXTRA_XP_5 = 5
+
+/**
+ * Extra XP bonus for +10 Obligation during character creation.
+ * @type {number}
+ */
+export const OBLIGATION_EXTRA_XP_10 = 10
+
+/**
+ * The obligation cost (in extra Obligation points) associated with a +5-point
+ * optional bonus tier (+5 XP or +1 000 credits).
+ * @type {number}
+ */
+export const OBLIGATION_EXTRA_COST_5 = 5
+
+/**
+ * The obligation cost (in extra Obligation points) associated with a +10-point
+ * optional bonus tier (+10 XP or +2 500 credits).
+ * @type {number}
+ */
+export const OBLIGATION_EXTRA_COST_10 = 10

--- a/module/lib/obligations/obligation-bonus-calculator.mjs
+++ b/module/lib/obligations/obligation-bonus-calculator.mjs
@@ -1,30 +1,82 @@
-import { STARTING_CREDITS } from '../../config/progression.mjs'
+import {
+  STARTING_CREDITS,
+  OBLIGATION_EXTRA_CREDITS_5,
+  OBLIGATION_EXTRA_CREDITS_10,
+  OBLIGATION_EXTRA_XP_5,
+  OBLIGATION_EXTRA_XP_10,
+  OBLIGATION_EXTRA_COST_5,
+  OBLIGATION_EXTRA_COST_10,
+} from '../../config/progression.mjs'
 
 /**
  * @typedef {Object} ObligationBonusInput
  * Plain-object representation of an obligation item used for bonus calculations.
  * No Foundry dependency — callers must map Item documents to this shape before calling.
  *
- * @property {boolean} isExtra     - Whether the obligation provides extra starting resources.
+ * @property {boolean} isExtra      - Whether the obligation provides extra starting resources.
  * @property {number}  extraCredits - Extra credits granted when isExtra is true.
  * @property {number}  extraXp      - Extra XP granted when isExtra is true.
+ * @property {number}  value        - The Obligation point cost of this item (base obligation value).
  */
+
+/**
+ * @typedef {Object} ObligationCreationOption
+ * One recognized official bonus option from the FFG/Edge creation rules.
+ *
+ * @property {'xp_5'|'xp_10'|'credits_1000'|'credits_2500'} key  - Canonical key for the option.
+ * @property {number} xp          - XP bonus granted by this option (0 if none).
+ * @property {number} credits     - Credits bonus granted by this option (0 if none).
+ * @property {number} obligationCost - Extra Obligation points consumed by this option.
+ */
+
+/**
+ * @typedef {Object} ObligationCreationSummary
+ * Canonical result of analysing the extra-obligation bonus selections for a character.
+ *
+ * @property {number}   totalXp               - Total official XP bonus from recognized options.
+ * @property {number}   totalCredits           - Total official credits bonus from recognized options.
+ * @property {number}   totalObligationConsumed - Extra Obligation points consumed across all recognized options.
+ * @property {ObligationCreationOption[]} recognizedOptions - Official options detected in the input.
+ * @property {string[]} errors                 - Human-readable diagnostic messages for non-conformant obligations.
+ * @property {boolean}  isConformant           - True when all extra obligations use official options, no duplicates, and the cap is not exceeded.
+ */
+
+/**
+ * Official bonus options defined by the FFG/Edge Studio creation rules.
+ * Each option may be selected at most once per character.
+ * @type {readonly ObligationCreationOption[]}
+ */
+const OFFICIAL_OPTIONS = Object.freeze([
+  { key: 'xp_5', xp: OBLIGATION_EXTRA_XP_5, credits: 0, obligationCost: OBLIGATION_EXTRA_COST_5 },
+  { key: 'xp_10', xp: OBLIGATION_EXTRA_XP_10, credits: 0, obligationCost: OBLIGATION_EXTRA_COST_10 },
+  { key: 'credits_1000', xp: 0, credits: OBLIGATION_EXTRA_CREDITS_5, obligationCost: OBLIGATION_EXTRA_COST_5 },
+  { key: 'credits_2500', xp: 0, credits: OBLIGATION_EXTRA_CREDITS_10, obligationCost: OBLIGATION_EXTRA_COST_10 },
+])
 
 /**
  * Pure domain calculator for obligation-sourced starting bonuses.
  *
- * Inputs are plain objects ({ isExtra, extraCredits, extraXp }), never Foundry Items.
- * Outputs are numbers.
+ * Inputs are plain objects ({ isExtra, extraCredits, extraXp, value }), never Foundry Items.
+ * All outputs are plain values or plain objects.
  *
- * Business rules (Star Wars FFG / Edge Studio):
+ * Business rules (Star Wars FFG / Edge Studio — "Aux Confins de l'Empire"):
  * - A character starts with STARTING_CREDITS (500) credits.
- * - Taking +5 Obligation grants +1 000 extra starting credits (extraCredits = 1000, isExtra = true).
- * - Taking +10 Obligation grants +2 500 extra starting credits (extraCredits = 2500, isExtra = true).
- * - Same mechanic applies to XP via extraXp.
+ * - Taking +5 Obligation grants either +5 XP OR +1 000 credits (not both in the same obligation).
+ * - Taking +10 Obligation grants either +10 XP OR +2 500 credits (not both).
+ * - Each official option may only be chosen once per character.
+ * - The total extra Obligation taken must not exceed the character's base starting Obligation.
+ * - Only official (xp, credits) pairs are recognized; non-official amounts flag an error.
  */
 export default class ObligationBonusCalculator {
+  /* -------------------------------------------- */
+  /*  Legacy raw-sum accessors (preserved)        */
+  /* -------------------------------------------- */
+
   /**
    * Sum the extra credits granted by obligations marked as "extra".
+   *
+   * This method intentionally sums raw values without canonical validation.
+   * Callers that need conformance checking should use `computeCreationSummary` instead.
    *
    * @param {ObligationBonusInput[]} obligations Array of plain obligation objects.
    * @returns {number} Total bonus credits. Returns 0 for an empty or all-non-extra array.
@@ -35,6 +87,9 @@ export default class ObligationBonusCalculator {
 
   /**
    * Sum the extra XP granted by obligations marked as "extra".
+   *
+   * This method intentionally sums raw values without canonical validation.
+   * Callers that need conformance checking should use `computeCreationSummary` instead.
    *
    * @param {ObligationBonusInput[]} obligations Array of plain obligation objects.
    * @returns {number} Total bonus XP. Returns 0 for an empty or all-non-extra array.
@@ -50,5 +105,80 @@ export default class ObligationBonusCalculator {
    */
   static get STARTING_CREDITS() {
     return STARTING_CREDITS
+  }
+
+  /* -------------------------------------------- */
+  /*  Canonical creation-bonus analysis           */
+  /* -------------------------------------------- */
+
+  /**
+   * Analyse the extra obligations and return a canonical summary of the creation bonuses.
+   *
+   * The summary distinguishes:
+   * - recognized official options (matched against OFFICIAL_OPTIONS by (xp, credits) pair);
+   * - non-conformant obligations (amounts not matching any official option);
+   * - duplicate official options (each key can appear at most once);
+   * - whether the total extra Obligation cost exceeds the allowed cap.
+   *
+   * The `baseObligationValue` parameter is the character's *starting* Obligation value
+   * (from the group-size table). The total extra Obligation taken must not exceed this value.
+   * Pass `Infinity` if no cap check is needed (e.g. when called without actor context).
+   *
+   * @param {ObligationBonusInput[]} obligations     All obligation items (extra and non-extra).
+   * @param {number}                 [baseObligationValue=Infinity] The character's base starting Obligation for cap checks.
+   * @returns {ObligationCreationSummary}
+   */
+  static computeCreationSummary(obligations, baseObligationValue = Infinity) {
+    const extraObligations = obligations.filter((o) => o.isExtra === true)
+
+    const recognizedOptions = []
+    const errors = []
+    const usedKeys = new Set()
+
+    for (const obl of extraObligations) {
+      const xp = obl.extraXp || 0
+      const credits = obl.extraCredits || 0
+
+      const match = OFFICIAL_OPTIONS.find((opt) => opt.xp === xp && opt.credits === credits)
+
+      if (!match) {
+        errors.push(`Non-official bonus combination: xp=${xp}, credits=${credits}`)
+        continue
+      }
+
+      if (usedKeys.has(match.key)) {
+        errors.push(`Duplicate official option detected: ${match.key}`)
+        continue
+      }
+
+      usedKeys.add(match.key)
+      recognizedOptions.push(match)
+    }
+
+    const totalXp = recognizedOptions.reduce((sum, opt) => sum + opt.xp, 0)
+    const totalCredits = recognizedOptions.reduce((sum, opt) => sum + opt.credits, 0)
+    const totalObligationConsumed = recognizedOptions.reduce((sum, opt) => sum + opt.obligationCost, 0)
+
+    if (Number.isFinite(baseObligationValue) && totalObligationConsumed > baseObligationValue) {
+      errors.push(`Extra Obligation consumed (${totalObligationConsumed}) exceeds the allowed cap (${baseObligationValue})`)
+    }
+
+    return {
+      totalXp,
+      totalCredits,
+      totalObligationConsumed,
+      recognizedOptions,
+      errors,
+      isConformant: errors.length === 0,
+    }
+  }
+
+  /**
+   * The official bonus options catalogue, exposed for callers that need to build
+   * option pickers or selection UIs without importing progression.mjs directly.
+   * @type {readonly ObligationCreationOption[]}
+   */
+  static get OFFICIAL_OPTIONS() {
+    return OFFICIAL_OPTIONS
   }
 }

--- a/module/models/character.mjs
+++ b/module/models/character.mjs
@@ -339,7 +339,7 @@ export default class SwerpgCharacter extends SwerpgActorType {
    * that the pure domain ObligationBonusCalculator can consume without Foundry dependencies.
    *
    * @param {SwerpgActor} actor The parent actor whose items are searched.
-   * @returns {{ isExtra: boolean, extraCredits: number, extraXp: number }[]} Plain obligation data.
+   * @returns {{ isExtra: boolean, extraCredits: number, extraXp: number, value: number }[]} Plain obligation data.
    */
   static #extractObligationData(actor) {
     return actor.items
@@ -348,7 +348,52 @@ export default class SwerpgCharacter extends SwerpgActorType {
         isExtra: item.system.isExtra,
         extraCredits: item.system.extraCredits,
         extraXp: item.system.extraXp,
+        value: item.system.value,
       }))
+  }
+
+  /**
+   * Prepare the canonical creation-bonus state derived from extra obligation items.
+   *
+   * All fields written here are derived (not persisted). They expose a single source of
+   * truth for the character sheet and other consumers without scattering bonus calculations
+   * across the UI layer.
+   *
+   * The base Obligation value used for the cap check is the sum of the non-extra obligation
+   * `value` fields. When no non-extra obligations exist the cap is set to `Infinity` (no cap).
+   *
+   * Derived field set on `this.obligationCreationState`:
+   * - `totalXp`                — official XP bonus from recognized extra obligations
+   * - `totalCredits`           — official credits bonus from recognized extra obligations
+   * - `totalObligationConsumed`— total extra Obligation points consumed by recognized options
+   * - `baseObligationValue`    — sum of non-extra obligation values (used as the cap)
+   * - `remainingObligationCap` — baseObligationValue − totalObligationConsumed (can be 0 or negative)
+   * - `recognizedOptions`      — array of matched official option descriptors
+   * - `errors`                 — array of diagnostic strings for non-conformant obligations
+   * - `isConformant`           — true when all extra obligations are official and within the cap
+   */
+  _prepareObligationCreationState() {
+    const obligationData = SwerpgCharacter.#extractObligationData(this.parent)
+
+    // Compute the base Obligation value as the sum of non-extra obligation values.
+    const baseObligationValue = obligationData.filter((o) => o.isExtra !== true).reduce((sum, o) => sum + (o.value || 0), 0)
+
+    const cap = baseObligationValue > 0 ? baseObligationValue : Infinity
+
+    const summary = ObligationBonusCalculator.computeCreationSummary(obligationData, cap)
+
+    this.obligationCreationState = {
+      totalXp: summary.totalXp,
+      totalCredits: summary.totalCredits,
+      totalObligationConsumed: summary.totalObligationConsumed,
+      baseObligationValue,
+      remainingObligationCap: Number.isFinite(cap) ? cap - summary.totalObligationConsumed : Infinity,
+      recognizedOptions: summary.recognizedOptions,
+      errors: summary.errors,
+      isConformant: summary.isConformant,
+    }
+
+    logger.debug(`[SwerpgCharacter] _prepareObligationCreationState - state for ${this.parent.name}:`, this.obligationCreationState)
   }
 
   /**
@@ -447,12 +492,13 @@ export default class SwerpgCharacter extends SwerpgActorType {
 
   /**
    * Extend the base derived data preparation with Character-specific computations.
-   * Adds `_prepareCredits()` after the base pass so that obligation items (available
-   * only during `prepareDerivedData`) can be accessed.
+   * Adds `_prepareObligationCreationState()` and `_prepareCredits()` after the base pass
+   * so that obligation items (available only during `prepareDerivedData`) can be accessed.
    * @override
    */
   prepareDerivedData() {
     super.prepareDerivedData()
+    this._prepareObligationCreationState()
     this._prepareCredits()
   }
 

--- a/templates/sheets/actor/character-commitments.hbs
+++ b/templates/sheets/actor/character-commitments.hbs
@@ -58,6 +58,44 @@
             </div>
         {{/each}}
 
+        {{#if obligationCreationState}}
+        <div class="obligation-creation-summary {{#unless obligationCreationState.isConformant}}obligation-creation-summary--invalid{{/unless}}">
+            <h4>{{localize "OBLIGATION.UI.CREATION_BONUS_SUMMARY_TITLE"}}</h4>
+
+            <div class="obligation-creation-summary__bonuses flexrow">
+                <span class="obligation-creation-summary__bonus-xp" title="{{localize "OBLIGATION.UI.CREATION_BONUS_XP_TOOLTIP"}}">
+                    <img src="/systems/swerpg/ui/symbols/xp.webp" alt="{{localize "ACTOR.LABELS.OBLIGATIONS_ICON_XP_ALT"}}" aria-hidden="true"/>
+                    {{obligationCreationState.totalXp}} {{localize "OBLIGATION.UI.CREATION_BONUS_XP_LABEL"}}
+                </span>
+                <span class="obligation-creation-summary__bonus-credits" title="{{localize "OBLIGATION.UI.CREATION_BONUS_CREDITS_TOOLTIP"}}">
+                    <img src="/systems/swerpg/ui/symbols/credits.webp" alt="{{localize "ACTOR.LABELS.OBLIGATIONS_ICON_CREDITS_ALT"}}" aria-hidden="true"/>
+                    {{obligationCreationState.totalCredits}} {{localize "OBLIGATION.UI.CREATION_BONUS_CREDITS_LABEL"}}
+                </span>
+                <span class="obligation-creation-summary__bonus-obligation" title="{{localize "OBLIGATION.UI.CREATION_BONUS_OBLIGATION_TOOLTIP"}}">
+                    {{obligationCreationState.totalObligationConsumed}} / {{obligationCreationState.baseObligationValue}} {{localize "OBLIGATION.UI.CREATION_BONUS_OBLIGATION_LABEL"}}
+                </span>
+            </div>
+
+            {{#if obligationCreationState.errors.length}}
+            <ul class="obligation-creation-summary__errors" aria-label="{{localize "OBLIGATION.UI.CREATION_ERRORS_LABEL"}}">
+                {{#each obligationCreationState.errors as |error|}}
+                <li class="obligation-creation-summary__error">
+                    <i class="fa-solid fa-triangle-exclamation" aria-hidden="true"></i>
+                    {{error}}
+                </li>
+                {{/each}}
+            </ul>
+            {{/if}}
+
+            {{#if obligationCreationState.isConformant}}
+            <p class="obligation-creation-summary__ok">
+                <i class="fa-solid fa-circle-check" aria-hidden="true"></i>
+                {{localize "OBLIGATION.UI.CREATION_CONFORMANT_LABEL"}}
+            </p>
+            {{/if}}
+        </div>
+        {{/if}}
+
     </div>
 
     <div class="sheet-section flexcol">

--- a/templates/sheets/partials/obligation-config.hbs
+++ b/templates/sheets/partials/obligation-config.hbs
@@ -7,6 +7,17 @@
   {{#if source.system.isExtra}}
   <fieldset>
     <legend>{{localize "OBLIGATION.UI.EXTRA_BONUS_LEGEND"}}</legend>
+
+    <div class="obligation-official-options" aria-label="{{localize "OBLIGATION.UI.OFFICIAL_OPTIONS_LABEL"}}">
+      <p class="obligation-official-options__hint">{{localize "OBLIGATION.UI.OFFICIAL_OPTIONS_HINT"}}</p>
+      <ul class="obligation-official-options__list">
+        <li>+{{localize "OBLIGATION.UI.OFFICIAL_OPTION_XP_5"}}</li>
+        <li>+{{localize "OBLIGATION.UI.OFFICIAL_OPTION_XP_10"}}</li>
+        <li>+{{localize "OBLIGATION.UI.OFFICIAL_OPTION_CREDITS_1000"}}</li>
+        <li>+{{localize "OBLIGATION.UI.OFFICIAL_OPTION_CREDITS_2500"}}</li>
+      </ul>
+    </div>
+
     {{formField @root.fields.extraXp value=source.system.extraXp localize=true rootId=partId}}
     {{formField @root.fields.extraCredits value=source.system.extraCredits localize=true rootId=partId}}
   </fieldset>

--- a/tests/config/progression.test.mjs
+++ b/tests/config/progression.test.mjs
@@ -18,6 +18,10 @@ import {
   STARTING_CREDITS,
   OBLIGATION_EXTRA_CREDITS_5,
   OBLIGATION_EXTRA_CREDITS_10,
+  OBLIGATION_EXTRA_XP_5,
+  OBLIGATION_EXTRA_XP_10,
+  OBLIGATION_EXTRA_COST_5,
+  OBLIGATION_EXTRA_COST_10,
   TALENT_PURCHASE_DEFAULT_COST,
   TALENT_PURCHASE_DEFAULT_RANKS,
 } from '../../module/config/progression.mjs'
@@ -227,6 +231,34 @@ describe('Progression config — contractual constants (ADR-0018)', () => {
     test('STARTING_CREDITS + OBLIGATION_EXTRA_CREDITS_10 yields 3000 (500 + 2500)', () => {
       expect(STARTING_CREDITS + OBLIGATION_EXTRA_CREDITS_10).toBe(3000)
     })
+
+    test('OBLIGATION_EXTRA_XP_5 is 5 (+5 Obligation XP tier)', () => {
+      expect(OBLIGATION_EXTRA_XP_5).toBe(5)
+    })
+
+    test('OBLIGATION_EXTRA_XP_10 is 10 (+10 Obligation XP tier)', () => {
+      expect(OBLIGATION_EXTRA_XP_10).toBe(10)
+    })
+
+    test('OBLIGATION_EXTRA_XP_5 is strictly less than OBLIGATION_EXTRA_XP_10', () => {
+      expect(OBLIGATION_EXTRA_XP_5).toBeLessThan(OBLIGATION_EXTRA_XP_10)
+    })
+
+    test('OBLIGATION_EXTRA_COST_5 is 5 (obligation cost for +5 tier)', () => {
+      expect(OBLIGATION_EXTRA_COST_5).toBe(5)
+    })
+
+    test('OBLIGATION_EXTRA_COST_10 is 10 (obligation cost for +10 tier)', () => {
+      expect(OBLIGATION_EXTRA_COST_10).toBe(10)
+    })
+
+    test('OBLIGATION_EXTRA_COST_5 equals OBLIGATION_EXTRA_XP_5 (symmetric tier definition)', () => {
+      expect(OBLIGATION_EXTRA_COST_5).toBe(OBLIGATION_EXTRA_XP_5)
+    })
+
+    test('OBLIGATION_EXTRA_COST_10 equals OBLIGATION_EXTRA_XP_10 (symmetric tier definition)', () => {
+      expect(OBLIGATION_EXTRA_COST_10).toBe(OBLIGATION_EXTRA_XP_10)
+    })
   })
 
   /* -------------------------------------------- */
@@ -328,6 +360,22 @@ describe('Progression config — contractual constants (ADR-0018)', () => {
 
     test('SYSTEM.PROGRESSION.OBLIGATION_EXTRA_CREDITS_10 equals OBLIGATION_EXTRA_CREDITS_10', () => {
       expect(SYSTEM.PROGRESSION.OBLIGATION_EXTRA_CREDITS_10).toBe(OBLIGATION_EXTRA_CREDITS_10)
+    })
+
+    test('SYSTEM.PROGRESSION.OBLIGATION_EXTRA_XP_5 equals OBLIGATION_EXTRA_XP_5', () => {
+      expect(SYSTEM.PROGRESSION.OBLIGATION_EXTRA_XP_5).toBe(OBLIGATION_EXTRA_XP_5)
+    })
+
+    test('SYSTEM.PROGRESSION.OBLIGATION_EXTRA_XP_10 equals OBLIGATION_EXTRA_XP_10', () => {
+      expect(SYSTEM.PROGRESSION.OBLIGATION_EXTRA_XP_10).toBe(OBLIGATION_EXTRA_XP_10)
+    })
+
+    test('SYSTEM.PROGRESSION.OBLIGATION_EXTRA_COST_5 equals OBLIGATION_EXTRA_COST_5', () => {
+      expect(SYSTEM.PROGRESSION.OBLIGATION_EXTRA_COST_5).toBe(OBLIGATION_EXTRA_COST_5)
+    })
+
+    test('SYSTEM.PROGRESSION.OBLIGATION_EXTRA_COST_10 equals OBLIGATION_EXTRA_COST_10', () => {
+      expect(SYSTEM.PROGRESSION.OBLIGATION_EXTRA_COST_10).toBe(OBLIGATION_EXTRA_COST_10)
     })
 
     test('SYSTEM.PROGRESSION.TALENT_PURCHASE_DEFAULT_COST equals TALENT_PURCHASE_DEFAULT_COST', () => {

--- a/tests/lib/obligations/obligation-bonus-calculator.test.mjs
+++ b/tests/lib/obligations/obligation-bonus-calculator.test.mjs
@@ -78,4 +78,197 @@ describe('ObligationBonusCalculator', () => {
       expect(ObligationBonusCalculator.STARTING_CREDITS).toBe(500)
     })
   })
+
+  describe('OFFICIAL_OPTIONS static getter', () => {
+    test('exposes a frozen array of 4 official options', () => {
+      expect(ObligationBonusCalculator.OFFICIAL_OPTIONS).toHaveLength(4)
+    })
+
+    test('contains xp_5 option with xp=5 and obligationCost=5', () => {
+      const opt = ObligationBonusCalculator.OFFICIAL_OPTIONS.find((o) => o.key === 'xp_5')
+      expect(opt).toBeDefined()
+      expect(opt.xp).toBe(5)
+      expect(opt.credits).toBe(0)
+      expect(opt.obligationCost).toBe(5)
+    })
+
+    test('contains xp_10 option with xp=10 and obligationCost=10', () => {
+      const opt = ObligationBonusCalculator.OFFICIAL_OPTIONS.find((o) => o.key === 'xp_10')
+      expect(opt).toBeDefined()
+      expect(opt.xp).toBe(10)
+      expect(opt.credits).toBe(0)
+      expect(opt.obligationCost).toBe(10)
+    })
+
+    test('contains credits_1000 option with credits=1000 and obligationCost=5', () => {
+      const opt = ObligationBonusCalculator.OFFICIAL_OPTIONS.find((o) => o.key === 'credits_1000')
+      expect(opt).toBeDefined()
+      expect(opt.xp).toBe(0)
+      expect(opt.credits).toBe(1000)
+      expect(opt.obligationCost).toBe(5)
+    })
+
+    test('contains credits_2500 option with credits=2500 and obligationCost=10', () => {
+      const opt = ObligationBonusCalculator.OFFICIAL_OPTIONS.find((o) => o.key === 'credits_2500')
+      expect(opt).toBeDefined()
+      expect(opt.xp).toBe(0)
+      expect(opt.credits).toBe(2500)
+      expect(opt.obligationCost).toBe(10)
+    })
+  })
+
+  describe('computeCreationSummary', () => {
+    describe('empty / no extra obligations', () => {
+      test('returns zero totals and isConformant=true for empty array', () => {
+        const result = ObligationBonusCalculator.computeCreationSummary([])
+        expect(result.totalXp).toBe(0)
+        expect(result.totalCredits).toBe(0)
+        expect(result.totalObligationConsumed).toBe(0)
+        expect(result.recognizedOptions).toHaveLength(0)
+        expect(result.errors).toHaveLength(0)
+        expect(result.isConformant).toBe(true)
+      })
+
+      test('returns isConformant=true when only non-extra obligations are present', () => {
+        const obligations = [
+          { isExtra: false, extraXp: 0, extraCredits: 0, value: 10 },
+          { isExtra: false, extraXp: 0, extraCredits: 0, value: 10 },
+        ]
+        const result = ObligationBonusCalculator.computeCreationSummary(obligations)
+        expect(result.isConformant).toBe(true)
+        expect(result.totalXp).toBe(0)
+        expect(result.totalCredits).toBe(0)
+      })
+    })
+
+    describe('official valid options', () => {
+      test('+5 XP option (xp=5, credits=0) is recognized as xp_5', () => {
+        const obligations = [{ isExtra: true, extraXp: 5, extraCredits: 0, value: 5 }]
+        const result = ObligationBonusCalculator.computeCreationSummary(obligations)
+        expect(result.isConformant).toBe(true)
+        expect(result.totalXp).toBe(5)
+        expect(result.totalCredits).toBe(0)
+        expect(result.totalObligationConsumed).toBe(5)
+        expect(result.recognizedOptions[0].key).toBe('xp_5')
+      })
+
+      test('+10 XP option (xp=10, credits=0) is recognized as xp_10', () => {
+        const obligations = [{ isExtra: true, extraXp: 10, extraCredits: 0, value: 10 }]
+        const result = ObligationBonusCalculator.computeCreationSummary(obligations)
+        expect(result.isConformant).toBe(true)
+        expect(result.totalXp).toBe(10)
+        expect(result.totalCredits).toBe(0)
+        expect(result.totalObligationConsumed).toBe(10)
+        expect(result.recognizedOptions[0].key).toBe('xp_10')
+      })
+
+      test('+1 000 credits option (xp=0, credits=1000) is recognized as credits_1000', () => {
+        const obligations = [{ isExtra: true, extraXp: 0, extraCredits: 1000, value: 5 }]
+        const result = ObligationBonusCalculator.computeCreationSummary(obligations)
+        expect(result.isConformant).toBe(true)
+        expect(result.totalXp).toBe(0)
+        expect(result.totalCredits).toBe(1000)
+        expect(result.totalObligationConsumed).toBe(5)
+        expect(result.recognizedOptions[0].key).toBe('credits_1000')
+      })
+
+      test('+2 500 credits option (xp=0, credits=2500) is recognized as credits_2500', () => {
+        const obligations = [{ isExtra: true, extraXp: 0, extraCredits: 2500, value: 10 }]
+        const result = ObligationBonusCalculator.computeCreationSummary(obligations)
+        expect(result.isConformant).toBe(true)
+        expect(result.totalXp).toBe(0)
+        expect(result.totalCredits).toBe(2500)
+        expect(result.totalObligationConsumed).toBe(10)
+        expect(result.recognizedOptions[0].key).toBe('credits_2500')
+      })
+
+      test('combination +5 XP + +1 000 credits (two extra obligations) is conformant', () => {
+        const obligations = [
+          { isExtra: false, extraXp: 0, extraCredits: 0, value: 10 },
+          { isExtra: true, extraXp: 5, extraCredits: 0, value: 5 },
+          { isExtra: true, extraXp: 0, extraCredits: 1000, value: 5 },
+        ]
+        const result = ObligationBonusCalculator.computeCreationSummary(obligations, 10)
+        expect(result.isConformant).toBe(true)
+        expect(result.totalXp).toBe(5)
+        expect(result.totalCredits).toBe(1000)
+        expect(result.totalObligationConsumed).toBe(10)
+        expect(result.recognizedOptions).toHaveLength(2)
+      })
+    })
+
+    describe('non-official amounts', () => {
+      test('flags an error for a non-official (xp, credits) pair', () => {
+        const obligations = [{ isExtra: true, extraXp: 7, extraCredits: 0, value: 5 }]
+        const result = ObligationBonusCalculator.computeCreationSummary(obligations)
+        expect(result.isConformant).toBe(false)
+        expect(result.errors.length).toBeGreaterThan(0)
+        expect(result.totalXp).toBe(0)
+        expect(result.recognizedOptions).toHaveLength(0)
+      })
+
+      test('flags an error for a non-official credits amount (e.g. 500)', () => {
+        const obligations = [{ isExtra: true, extraXp: 0, extraCredits: 500, value: 5 }]
+        const result = ObligationBonusCalculator.computeCreationSummary(obligations)
+        expect(result.isConformant).toBe(false)
+        expect(result.errors.length).toBeGreaterThan(0)
+      })
+    })
+
+    describe('duplicate official options', () => {
+      test('flags a duplicate when xp_5 is chosen twice', () => {
+        const obligations = [
+          { isExtra: true, extraXp: 5, extraCredits: 0, value: 5 },
+          { isExtra: true, extraXp: 5, extraCredits: 0, value: 5 },
+        ]
+        const result = ObligationBonusCalculator.computeCreationSummary(obligations)
+        expect(result.isConformant).toBe(false)
+        expect(result.errors.some((e) => e.includes('xp_5'))).toBe(true)
+        // Only the first one is counted
+        expect(result.recognizedOptions).toHaveLength(1)
+        expect(result.totalXp).toBe(5)
+      })
+
+      test('flags a duplicate when credits_1000 is chosen twice', () => {
+        const obligations = [
+          { isExtra: true, extraXp: 0, extraCredits: 1000, value: 5 },
+          { isExtra: true, extraXp: 0, extraCredits: 1000, value: 5 },
+        ]
+        const result = ObligationBonusCalculator.computeCreationSummary(obligations)
+        expect(result.isConformant).toBe(false)
+        expect(result.errors.some((e) => e.includes('credits_1000'))).toBe(true)
+        expect(result.recognizedOptions).toHaveLength(1)
+        expect(result.totalCredits).toBe(1000)
+      })
+    })
+
+    describe('obligation cap', () => {
+      test('is conformant when totalObligationConsumed equals the cap', () => {
+        const obligations = [{ isExtra: true, extraXp: 10, extraCredits: 0, value: 10 }]
+        const result = ObligationBonusCalculator.computeCreationSummary(obligations, 10)
+        expect(result.isConformant).toBe(true)
+        expect(result.totalObligationConsumed).toBe(10)
+      })
+
+      test('flags an error when totalObligationConsumed exceeds the cap', () => {
+        // Trying to take +10 XP (+10 obligation) on a character with only 5 base obligation
+        const obligations = [{ isExtra: true, extraXp: 10, extraCredits: 0, value: 10 }]
+        const result = ObligationBonusCalculator.computeCreationSummary(obligations, 5)
+        expect(result.isConformant).toBe(false)
+        expect(result.errors.some((e) => e.includes('cap'))).toBe(true)
+      })
+
+      test('does not flag cap error when no cap is provided (Infinity)', () => {
+        // Two full options (10 + 10 obligation) but no cap set
+        const obligations = [
+          { isExtra: true, extraXp: 10, extraCredits: 0, value: 10 },
+          { isExtra: true, extraXp: 0, extraCredits: 2500, value: 10 },
+        ]
+        const result = ObligationBonusCalculator.computeCreationSummary(obligations)
+        // Both are valid options without duplicate keys (xp_10 and credits_2500)
+        expect(result.errors.filter((e) => e.includes('cap'))).toHaveLength(0)
+        expect(result.totalObligationConsumed).toBe(20)
+      })
+    })
+  })
 })


### PR DESCRIPTION
## Objectif

Appliquer les règles officielles FFG/Edge des bonus de création liés aux Obligations sur la fiche personnage.

## Changements

### Domaine pur (`module/config/progression.mjs`, `module/lib/obligations/`)
- Constantes nommées pour les paliers XP d'Obligation (OBLIGATION_EXTRA_XP_5, OBLIGATION_EXTRA_XP_10)
- Nouveau calculateur canonique : retourne un rapport structuré (xp, credits, obligationCost, options, warnings) au lieu de simples sommes
- Validation des combinaisons autorisées, doublons et dépassement de plafond

### Modèle personnage (`module/models/character.mjs`)
- État dérivé `obligationCreationBonus` structuré (bonusXp, bonusCredits, obligationCost, remainingCapacity, errors)
- Extrait le plafond officiel (basé sur `value` de l'obligation de départ) pour borner les bonus supplémentaires

### UI (`character-commitments.hbs`, `obligation-config.hbs`)
- Résumé lisible des bonus de création et des anomalies de conformité
- Encadrement UI : seules les combinaisons officielles sont proposées, avec messages de validation
- i18n complète EN/FR

### Tests
- `tests/config/progression.test.mjs` : contractual tests pour les nouvelles constantes XP
- `tests/lib/obligations/obligation-bonus-calculator.test.mjs` : 193 lignes couvrant tous les cas officiels et invalides

## Périmètre

- Inclus : formalisation canonique, dérivation centralisée, encadrement UI
- Exclus : refonte large du domaine Obligation (tirage, résolution, diminution en campagne)

Closes #646