### PR TITLE
feat(obligation): implement campaign evolution for obligations

### DIFF
--- a/documentation/plan/character-sheet/obligation/649-permettre-la-reduction-l-aggravation-et-la-transformation-d-une-obligation-en-campagne.md
+++ b/documentation/plan/character-sheet/obligation/649-permettre-la-reduction-l-aggravation-et-la-transformation-d-une-obligation-en-campagne.md
@@ -1,0 +1,67 @@
+# Character Sheet — Permettre la réduction, l'aggravation et la transformation d'une Obligation en campagne
+
+**Issue** : [#649 — Permettre la réduction, l'aggravation et la transformation d'une Obligation en campagne](https://github.com/herveDarritchon/foundryvtt-swerpg/issues/649)
+**Domaine métier** : `character-sheet/obligation`
+
+## Objectif
+
+Structurer l'évolution d'une Obligation en cours de campagne pour que le MJ et le joueur puissent la diminuer, l'aggraver ou la transformer sans détourner les champs de création ni perdre le contexte narratif.
+
+## Contexte utile
+
+- `module/models/obligation.mjs` ne porte aujourd'hui que `description`, `value`, `isExtra`, `extraXp` et `extraCredits` ; rien ne distingue une évolution de campagne d'un bonus de création.
+- `templates/sheets/partials/obligation-config.hbs` expose surtout les champs liés à la création du personnage, pas un workflow d'évolution en campagne.
+- `templates/sheets/actor/character-commitments.hbs` affiche la liste et le total d'Obligation, mais n'offre aucun résumé explicite des évolutions subies par une Obligation.
+- Le cadrage `documentation/cadrage/character-sheet/obligations/cadrage-obligations-star-wars-edge-aux-confins-empire.md` fixe déjà le contrat métier attendu : réduction progressive, aggravation par nouvelles dettes ou pressions, et transformation quand le problème change de nature plutôt que de disparaître.
+
+## Plan d'implémentation
+
+### Étape 1 — Canoniser le contrat d'évolution de campagne dans le domaine Obligation
+
+**Fichiers** : `module/models/obligation.mjs`, `module/lib/obligations/obligation-evolution.mjs`, `tests/models/obligation.test.mjs`, `tests/lib/obligations/obligation-evolution.test.mjs`
+
+**What** :
+
+- introduire dans le domaine Obligation une structure minimale dédiée aux évolutions de campagne (état courant, raison ou notes, transformation éventuelle, traçabilité compacte) séparée des bonus de création ;
+- centraliser dans un helper pur les trois opérations supportées — réduction, aggravation, transformation — avec garde-fous métier (pas de valeur négative, transformation incomplète refusée, conservation du contexte utile) ;
+- verrouiller par tests les cas typiques : réduction partielle, aggravation, transformation d'un type narratif vers un autre et tentative invalide.
+
+**Résultat attendu** : le runtime possède une source unique de vérité pour faire évoluer une Obligation en campagne sans surcharger `isExtra`, `extraXp` ou `extraCredits`.
+
+### Étape 2 — Ajouter un parcours d'édition explicite pour les évolutions de campagne
+
+**Fichiers** : `module/applications/sheets/obligation.mjs`, `templates/sheets/partials/obligation-config.hbs`, `lang/en.json`, `lang/fr.json`, `tests/applications/sheets/obligation-sheet.test.mjs`
+
+**What** :
+
+- faire apparaître dans la fiche d'Obligation une section dédiée à la campagne, distincte des bonus de création, pour saisir une réduction, une aggravation ou une transformation ;
+- guider l'utilisateur avec des libellés et aides explicites sur ce qui change réellement (valeur, nature de l'Obligation, justification narrative) ;
+- localiser en EN et FR l'ensemble des nouveaux champs, états et messages associés.
+
+**Résultat attendu** : la fiche item permet de faire évoluer une Obligation de manière explicite, compréhensible et localisée.
+
+### Étape 3 — Rendre l'évolution visible et lisible sur la fiche personnage
+
+**Fichiers** : `module/models/character.mjs`, `module/applications/sheets/character-sheet.mjs`, `templates/sheets/actor/character-commitments.hbs`, `tests/applications/sheets/character-sheet-commitments.test.mjs`
+
+**What** :
+
+- enrichir les données dérivées de la fiche personnage pour exposer un résumé de l'état courant d'une Obligation (valeur ajustée, transformation éventuelle, dernière évolution utile à afficher) ;
+- afficher ces informations dans l'onglet `Commitments` sans obliger le MJ à ouvrir chaque item pour comprendre ce qui a changé ;
+- garantir par tests que les totaux d'Obligation et les indicateurs visibles restent cohérents après réduction, aggravation et transformation.
+
+**Résultat attendu** : le suivi campagne devient immédiatement lisible depuis la fiche personnage, avec des totaux et un contexte d'évolution cohérents.
+
+## Périmètre / hors périmètre
+
+### Inclus
+
+- contrat métier d'évolution de campagne des Obligations
+- parcours d'édition dédié sur la fiche item
+- restitution synthétique sur la fiche personnage
+
+### Exclus
+
+- refonte complète du tirage d'Obligation avant session
+- automatisation du stress / strain lié au déclenchement d'Obligation
+- migration des Obligations individuelles vers des Obligations de groupe au-delà du minimum nécessaire pour la transformation

--- a/e2e/regression/specs/02a-oggdude-import-world.spec.ts
+++ b/e2e/regression/specs/02a-oggdude-import-world.spec.ts
@@ -27,6 +27,7 @@ import { verifyOggDudeWorldItems } from '../utils/oggdude-importer'
  */
 test.describe('[regression] 02a — OggDude import (world)', () => {
   test('import world crée les sentinelles dans game.items [ci]', async ({ page, oggdude }) => {
+    test.setTimeout(240_000)
     await expect(page).toHaveURL(/.*\/game/)
 
     // Cleanup + import complet via la fixture (mode world = sans interaction checkbox)

--- a/e2e/regression/utils/oggdude-importer.ts
+++ b/e2e/regression/utils/oggdude-importer.ts
@@ -113,7 +113,15 @@ export async function triggerOggDudeImport(page: Page): Promise<void> {
  * @param timeout en ms (défaut: 120s — l'import complet peut être long)
  */
 export async function waitForOggDudeImportComplete(page: Page, timeout = 120_000): Promise<void> {
-  await page.waitForFunction(() => (window as unknown as Record<string, unknown>).__oggdudeImportDone === true, undefined, { timeout })
+  try {
+    await page.waitForFunction(() => (window as unknown as Record<string, unknown>).__oggdudeImportDone === true, undefined, { timeout })
+  } catch (e) {
+    const currentUrl = page.url()
+    if (!currentUrl.includes('/game')) {
+      throw new Error(`[oggdude-import] Import timed out — page is at ${currentUrl} (expected /game). Foundry session lost or crashed during import.`)
+    }
+    throw e
+  }
   await page.evaluate(() => {
     delete (window as unknown as Record<string, unknown>).__oggdudeImportDone
   })

--- a/lang/en.json
+++ b/lang/en.json
@@ -965,6 +965,18 @@
       "extraXp": {
         "label": "Extra Experience",
         "hint": "The amount of extra experience which the character receives for taking on this obligation."
+      },
+      "campaignDelta": {
+        "label": "Campaign Adjustment",
+        "hint": "Net change applied during the campaign (negative = reduction, positive = aggravation). Does not overwrite the creation value."
+      },
+      "campaignNote": {
+        "label": "Evolution Note",
+        "hint": "Narrative context for the latest evolution: reason, in-game event, GM decision."
+      },
+      "transformedTo": {
+        "label": "Transformed To",
+        "hint": "When the obligation changes nature rather than disappearing, record the new narrative type here."
       }
     },
     "UI": {
@@ -983,7 +995,13 @@
       "CREATION_BONUS_OBLIGATION_LABEL": "extra Obligation",
       "CREATION_BONUS_OBLIGATION_TOOLTIP": "Extra Obligation consumed / allowed (based on starting obligation value)",
       "CREATION_ERRORS_LABEL": "Obligation conformance issues",
-      "CREATION_CONFORMANT_LABEL": "All extra obligations follow official rules."
+      "CREATION_CONFORMANT_LABEL": "All extra obligations follow official rules.",
+      "CAMPAIGN_EVOLUTION_LEGEND": "Campaign Evolution",
+      "CAMPAIGN_EVOLUTION_HINT": "Track reductions, aggravations, or transformations that happen during the campaign. These are separate from the character-creation bonus.",
+      "CAMPAIGN_CURRENT_VALUE_LABEL": "Current value (adjusted)",
+      "CAMPAIGN_CURRENT_VALUE_TOOLTIP": "Base creation value + campaign adjustments",
+      "CAMPAIGN_TRANSFORMED_LABEL": "Transformed into:",
+      "CAMPAIGN_NO_EVOLUTION": "No campaign evolution recorded yet."
     }
   },
   "RESOURCES": {

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -1068,6 +1068,18 @@
       "extraXp": {
         "label": "Expérience Supplémentaire",
         "hint": "Le montant d'expérience supplémentaire que le personnage reçoit pour avoir contracté cette obligation."
+      },
+      "campaignDelta": {
+        "label": "Ajustement Campagne",
+        "hint": "Variation nette appliquée pendant la campagne (négatif = réduction, positif = aggravation). Ne remplace pas la valeur de création."
+      },
+      "campaignNote": {
+        "label": "Note d'évolution",
+        "hint": "Contexte narratif de la dernière évolution : raison, événement en jeu, décision du MJ."
+      },
+      "transformedTo": {
+        "label": "Transformée en",
+        "hint": "Quand l'obligation change de nature plutôt que de disparaître, consignez ici le nouveau type narratif."
       }
     },
     "UI": {
@@ -1086,7 +1098,13 @@
       "CREATION_BONUS_OBLIGATION_LABEL": "Obligation supplémentaire",
       "CREATION_BONUS_OBLIGATION_TOOLTIP": "Obligation supplémentaire consommée / autorisée (basée sur la valeur d'obligation de départ)",
       "CREATION_ERRORS_LABEL": "Problèmes de conformité des Obligations",
-      "CREATION_CONFORMANT_LABEL": "Toutes les obligations supplémentaires respectent les règles officielles."
+      "CREATION_CONFORMANT_LABEL": "Toutes les obligations supplémentaires respectent les règles officielles.",
+      "CAMPAIGN_EVOLUTION_LEGEND": "Évolution en Campagne",
+      "CAMPAIGN_EVOLUTION_HINT": "Suivez les réductions, aggravations ou transformations survenues pendant la campagne. Ces données sont séparées du bonus de création.",
+      "CAMPAIGN_CURRENT_VALUE_LABEL": "Valeur actuelle (ajustée)",
+      "CAMPAIGN_CURRENT_VALUE_TOOLTIP": "Valeur de création de base + ajustements de campagne",
+      "CAMPAIGN_TRANSFORMED_LABEL": "Transformée en :",
+      "CAMPAIGN_NO_EVOLUTION": "Aucune évolution de campagne enregistrée pour l'instant."
     }
   },
   "RESOURCES": {

--- a/module/applications/sheets/character-sheet.mjs
+++ b/module/applications/sheets/character-sheet.mjs
@@ -11,6 +11,7 @@ import { logger } from '../../utils/logger.mjs'
 import { getPositiveDicePoolPreview } from '../../utils/skill-costs.mjs'
 import SkillCostCalculator from '../../lib/skills/skill-cost-calculator.mjs'
 import { evaluateSpecializationPurchase } from '../../lib/specializations/specialization-purchase-flow.mjs'
+import { computeEffectiveValue } from '../../lib/obligations/obligation-evolution.mjs'
 
 /**
  * @typedef {Object} DefenseDisplayData
@@ -29,11 +30,16 @@ import { evaluateSpecializationPurchase } from '../../lib/specializations/specia
  * @property {string} id - Unique ID of the Obligation Item.
  * @property {string} name - Name of the Obligation.
  * @property {string} img - Image path used for the Obligation icon.
- * @property {number} value - A value representing the Obligation.
+ * @property {number} value - Base creation value of the Obligation.
+ * @property {number} currentValue - Effective campaign value (base + campaignDelta, clamped to 0).
  * @property {string} [cssClass] - Optional CSS class applied to the container (e.g., "highlighted", "disabled").
  * @property {boolean} isExtra - Indicates if the Obligation is an extra obligation by any mean.
  * @property {number} extraXp - Optional extra experience points associated with the Obligation.
  * @property {number} extraCredits - Optional extra credits associated with the Obligation.
+ * @property {number} campaignDelta - Net campaign adjustment (negative = reduced, positive = aggravated).
+ * @property {string|null} campaignNote - Narrative note for the last campaign evolution.
+ * @property {string|null} transformedTo - Narrative type label when the obligation was transformed.
+ * @property {boolean} hasCampaignEvolution - True when at least one campaign evolution field is set.
  */
 
 /**
@@ -1161,24 +1167,38 @@ export default class CharacterSheet extends SwerpgBaseActorSheet {
   }
 
   #buildObligationDisplayData(obligation) {
+    const sys = obligation.system
+    const campaignDelta = sys.campaignDelta ?? 0
+    const campaignNote = sys.campaignNote ?? null
+    const transformedTo = sys.transformedTo ?? null
+    const currentValue = computeEffectiveValue({ value: sys.value, campaignDelta })
+    const hasCampaignEvolution = campaignDelta !== 0 || campaignNote !== null || transformedTo !== null
+
     return {
       id: obligation.id,
       name: obligation.name,
       img: obligation.img,
-      cssClass: obligation.system.isExtra ? 'extra' : '',
-      value: obligation.system.value,
-      isExtra: obligation.system.isExtra,
-      extraXp: obligation.system.extraXp || 0,
-      extraCredits: obligation.system.extraCredits || 0,
+      cssClass: sys.isExtra ? 'extra' : '',
+      value: sys.value,
+      currentValue,
+      isExtra: sys.isExtra,
+      extraXp: sys.extraXp || 0,
+      extraCredits: sys.extraCredits || 0,
+      campaignDelta,
+      campaignNote,
+      transformedTo,
+      hasCampaignEvolution,
     }
   }
 
   /**
    * Compute obligation points for the character sheet.
-   * @param obligations {MotivationDisplayData[]}
-   * @returns {number} The total obligation points.
+   * Uses the effective campaign value (base + delta, clamped to 0) so that
+   * reductions/aggravations applied during the campaign are reflected in the total.
+   * @param {ObligationDisplayData[]} obligations
+   * @returns {number} The total effective obligation points.
    */
   #computeObligationPoints(obligations) {
-    return obligations.reduce((total, obligation) => total + obligation.value, 0)
+    return obligations.reduce((total, obligation) => total + obligation.currentValue, 0)
   }
 }

--- a/module/lib/obligations/obligation-evolution.mjs
+++ b/module/lib/obligations/obligation-evolution.mjs
@@ -1,0 +1,112 @@
+/**
+ * @typedef {Object} ObligationEvolutionInput
+ * Plain-object snapshot of the obligation fields required for evolution operations.
+ * No Foundry dependency — callers must map the document before passing it here.
+ *
+ * @property {number}      value         - The base creation value (≥ 0).
+ * @property {number}      campaignDelta - Net campaign adjustment accumulated so far.
+ * @property {string|null} campaignNote  - Last recorded narrative note (may be null).
+ * @property {string|null} transformedTo - Narrative type the obligation was transformed into (null if not transformed).
+ */
+
+/**
+ * @typedef {Object} ObligationEvolutionResult
+ * Proposed new values for the obligation after an evolution operation.
+ * Callers should persist these via `document.update({ 'system.campaignDelta': …, … })`.
+ *
+ * @property {number}      campaignDelta - Updated net adjustment.
+ * @property {string|null} campaignNote  - Updated narrative note.
+ * @property {string|null} transformedTo - Updated transformation label (null when not transformed).
+ */
+
+/**
+ * Compute the effective current value of an obligation, clamped to 0.
+ * The effective value is the sum of the base creation value and the campaign delta.
+ *
+ * @param {ObligationEvolutionInput} obligation Plain obligation snapshot.
+ * @returns {number} Non-negative effective value.
+ */
+export function computeEffectiveValue(obligation) {
+  return Math.max(0, obligation.value + obligation.campaignDelta)
+}
+
+/**
+ * Reduce an obligation value by the given amount.
+ *
+ * Guards:
+ * - `amount` must be a strictly positive integer.
+ * - The resulting effective value cannot go below 0; the delta is clamped accordingly.
+ *
+ * @param {ObligationEvolutionInput} obligation Plain obligation snapshot.
+ * @param {number} amount Positive integer reduction amount.
+ * @param {string|null} [note=null] Optional narrative note to record with this reduction.
+ * @returns {ObligationEvolutionResult} Proposed new field values.
+ * @throws {RangeError} If `amount` is not a strictly positive integer.
+ */
+export function reduceObligation(obligation, amount, note = null) {
+  if (!Number.isInteger(amount) || amount <= 0) {
+    throw new RangeError(`reduceObligation: amount must be a strictly positive integer, got ${amount}`)
+  }
+
+  const currentEffective = computeEffectiveValue(obligation)
+  // Clamp so the effective value never goes below 0.
+  const actualReduction = Math.min(amount, currentEffective)
+  const newDelta = obligation.campaignDelta - actualReduction
+
+  return {
+    campaignDelta: newDelta,
+    campaignNote: note ?? obligation.campaignNote,
+    transformedTo: obligation.transformedTo,
+  }
+}
+
+/**
+ * Aggravate (increase) an obligation value by the given amount.
+ *
+ * Guards:
+ * - `amount` must be a strictly positive integer.
+ *
+ * @param {ObligationEvolutionInput} obligation Plain obligation snapshot.
+ * @param {number} amount Positive integer aggravation amount.
+ * @param {string|null} [note=null] Optional narrative note to record with this aggravation.
+ * @returns {ObligationEvolutionResult} Proposed new field values.
+ * @throws {RangeError} If `amount` is not a strictly positive integer.
+ */
+export function aggravateObligation(obligation, amount, note = null) {
+  if (!Number.isInteger(amount) || amount <= 0) {
+    throw new RangeError(`aggravateObligation: amount must be a strictly positive integer, got ${amount}`)
+  }
+
+  return {
+    campaignDelta: obligation.campaignDelta + amount,
+    campaignNote: note ?? obligation.campaignNote,
+    transformedTo: obligation.transformedTo,
+  }
+}
+
+/**
+ * Transform an obligation into a different narrative type.
+ *
+ * A transformation records that the problem has changed nature rather than
+ * disappearing. The `transformedTo` label must be a non-empty string.
+ *
+ * Guards:
+ * - `transformedTo` must be a non-empty, non-blank string.
+ *
+ * @param {ObligationEvolutionInput} obligation Plain obligation snapshot.
+ * @param {string} transformedTo Non-empty narrative type label for the new obligation nature.
+ * @param {string|null} [note=null] Optional narrative note to record with this transformation.
+ * @returns {ObligationEvolutionResult} Proposed new field values.
+ * @throws {TypeError} If `transformedTo` is not a non-empty string.
+ */
+export function transformObligation(obligation, transformedTo, note = null) {
+  if (typeof transformedTo !== 'string' || transformedTo.trim() === '') {
+    throw new TypeError(`transformObligation: transformedTo must be a non-empty string, got ${JSON.stringify(transformedTo)}`)
+  }
+
+  return {
+    campaignDelta: obligation.campaignDelta,
+    campaignNote: note ?? obligation.campaignNote,
+    transformedTo: transformedTo.trim(),
+  }
+}

--- a/module/models/obligation.mjs
+++ b/module/models/obligation.mjs
@@ -54,6 +54,33 @@ export default class SwerpgObligation extends foundry.abstract.TypeDataModel {
       step: 500,
     })
 
+    // Campaign evolution fields — distinct from character-creation bonuses.
+    // campaignDelta: net change applied in campaign (negative = reduction, positive = aggravation).
+    schema.campaignDelta = new fields.NumberField({
+      required: true,
+      integer: true,
+      nullable: false,
+      min: -50,
+      max: 50,
+      initial: 0,
+    })
+
+    // campaignNote: narrative justification for the latest evolution (GM/player note).
+    schema.campaignNote = new fields.StringField({
+      required: false,
+      nullable: true,
+      initial: null,
+      blank: false,
+    })
+
+    // transformedTo: when an Obligation changes nature, this stores the new narrative type.
+    schema.transformedTo = new fields.StringField({
+      required: false,
+      nullable: true,
+      initial: null,
+      blank: false,
+    })
+
     return schema
   }
 

--- a/templates/sheets/actor/character-commitments.hbs
+++ b/templates/sheets/actor/character-commitments.hbs
@@ -56,6 +56,23 @@
                        data-tooltip="{{localize "ACTOR.LABELS.OBLIGATIONS_EDIT_TOOLTIP"}}"></a>
                 </div>
             </div>
+
+            {{#if obligation.hasCampaignEvolution}}
+            <div class="obligation-campaign-summary" data-item-id="{{obligation.id}}">
+                <span class="obligation-campaign-summary__current"
+                      title="{{localize "OBLIGATION.UI.CAMPAIGN_CURRENT_VALUE_TOOLTIP"}}">
+                    {{localize "OBLIGATION.UI.CAMPAIGN_CURRENT_VALUE_LABEL"}}: <strong>{{obligation.currentValue}}</strong>
+                </span>
+                {{#if obligation.transformedTo}}
+                <span class="obligation-campaign-summary__transformed">
+                    {{localize "OBLIGATION.UI.CAMPAIGN_TRANSFORMED_LABEL"}} <em>{{obligation.transformedTo}}</em>
+                </span>
+                {{/if}}
+                {{#if obligation.campaignNote}}
+                <span class="obligation-campaign-summary__note">{{obligation.campaignNote}}</span>
+                {{/if}}
+            </div>
+            {{/if}}
         {{/each}}
 
         {{#if obligationCreationState}}

--- a/templates/sheets/partials/obligation-config.hbs
+++ b/templates/sheets/partials/obligation-config.hbs
@@ -23,4 +23,13 @@
   </fieldset>
   {{/if}}
 
+  <fieldset class="obligation-campaign-evolution">
+    <legend>{{localize "OBLIGATION.UI.CAMPAIGN_EVOLUTION_LEGEND"}}</legend>
+    <p class="obligation-campaign-evolution__hint">{{localize "OBLIGATION.UI.CAMPAIGN_EVOLUTION_HINT"}}</p>
+
+    {{formField @root.fields.campaignDelta value=source.system.campaignDelta localize=true rootId=partId}}
+    {{formField @root.fields.campaignNote value=source.system.campaignNote localize=true rootId=partId}}
+    {{formField @root.fields.transformedTo value=source.system.transformedTo localize=true rootId=partId}}
+  </fieldset>
+
 </section>

--- a/tests/applications/sheets/obligation-sheet.test.mjs
+++ b/tests/applications/sheets/obligation-sheet.test.mjs
@@ -66,3 +66,29 @@ describe('ObligationSheet — isExtra rendering contract', () => {
     expect(schema.isExtra.config.initial).toBe(false)
   })
 })
+
+describe('ObligationSheet — campaign evolution schema contract', () => {
+  it('schema exposes campaignDelta field', async () => {
+    const SwerpgObligation = (await import('../../../module/models/obligation.mjs')).default
+    const schema = SwerpgObligation.defineSchema()
+    expect(schema).toHaveProperty('campaignDelta')
+  })
+
+  it('schema exposes campaignNote field', async () => {
+    const SwerpgObligation = (await import('../../../module/models/obligation.mjs')).default
+    const schema = SwerpgObligation.defineSchema()
+    expect(schema).toHaveProperty('campaignNote')
+  })
+
+  it('schema exposes transformedTo field', async () => {
+    const SwerpgObligation = (await import('../../../module/models/obligation.mjs')).default
+    const schema = SwerpgObligation.defineSchema()
+    expect(schema).toHaveProperty('transformedTo')
+  })
+
+  it('campaignDelta has initial value of 0', async () => {
+    const SwerpgObligation = (await import('../../../module/models/obligation.mjs')).default
+    const schema = SwerpgObligation.defineSchema()
+    expect(schema.campaignDelta.config.initial).toBe(0)
+  })
+})

--- a/tests/lib/obligations/obligation-evolution.test.mjs
+++ b/tests/lib/obligations/obligation-evolution.test.mjs
@@ -1,0 +1,183 @@
+import { describe, expect, it } from 'vitest'
+
+import { aggravateObligation, computeEffectiveValue, reduceObligation, transformObligation } from '../../../module/lib/obligations/obligation-evolution.mjs'
+
+/**
+ * Helpers for building minimal plain-object obligation snapshots for tests.
+ */
+function makeObligation({ value = 10, campaignDelta = 0, campaignNote = null, transformedTo = null } = {}) {
+  return { value, campaignDelta, campaignNote, transformedTo }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// computeEffectiveValue
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('computeEffectiveValue', () => {
+  it('returns the base value when no campaign delta is set', () => {
+    expect(computeEffectiveValue(makeObligation({ value: 10 }))).toBe(10)
+  })
+
+  it('adds a positive campaign delta to the base value', () => {
+    expect(computeEffectiveValue(makeObligation({ value: 10, campaignDelta: 5 }))).toBe(15)
+  })
+
+  it('subtracts a negative campaign delta from the base value', () => {
+    expect(computeEffectiveValue(makeObligation({ value: 10, campaignDelta: -5 }))).toBe(5)
+  })
+
+  it('clamps to 0 when the delta exceeds the base value', () => {
+    expect(computeEffectiveValue(makeObligation({ value: 10, campaignDelta: -15 }))).toBe(0)
+  })
+
+  it('returns 0 for a fully cancelled obligation', () => {
+    expect(computeEffectiveValue(makeObligation({ value: 10, campaignDelta: -10 }))).toBe(0)
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// reduceObligation
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('reduceObligation', () => {
+  it('returns a new delta reduced by the given amount', () => {
+    const result = reduceObligation(makeObligation({ value: 10 }), 3)
+    expect(result.campaignDelta).toBe(-3)
+  })
+
+  it('accumulates reductions on top of an existing delta', () => {
+    const result = reduceObligation(makeObligation({ value: 10, campaignDelta: -3 }), 2)
+    expect(result.campaignDelta).toBe(-5)
+  })
+
+  it('clamps the delta so the effective value never falls below 0', () => {
+    const result = reduceObligation(makeObligation({ value: 10 }), 20)
+    expect(result.campaignDelta).toBe(-10)
+    expect(computeEffectiveValue({ value: 10, campaignDelta: result.campaignDelta })).toBe(0)
+  })
+
+  it('records the supplied note', () => {
+    const result = reduceObligation(makeObligation(), 5, 'Debt repaid after rescue mission')
+    expect(result.campaignNote).toBe('Debt repaid after rescue mission')
+  })
+
+  it('preserves the existing note when none is supplied', () => {
+    const obl = makeObligation({ campaignNote: 'previous note' })
+    const result = reduceObligation(obl, 2)
+    expect(result.campaignNote).toBe('previous note')
+  })
+
+  it('preserves the existing transformedTo value', () => {
+    const obl = makeObligation({ transformedTo: 'Family Debt' })
+    const result = reduceObligation(obl, 2)
+    expect(result.transformedTo).toBe('Family Debt')
+  })
+
+  it('throws RangeError for amount = 0', () => {
+    expect(() => reduceObligation(makeObligation(), 0)).toThrow(RangeError)
+  })
+
+  it('throws RangeError for a negative amount', () => {
+    expect(() => reduceObligation(makeObligation(), -5)).toThrow(RangeError)
+  })
+
+  it('throws RangeError for a non-integer amount', () => {
+    expect(() => reduceObligation(makeObligation(), 2.5)).toThrow(RangeError)
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// aggravateObligation
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('aggravateObligation', () => {
+  it('increases the delta by the given amount', () => {
+    const result = aggravateObligation(makeObligation({ value: 10 }), 5)
+    expect(result.campaignDelta).toBe(5)
+  })
+
+  it('accumulates aggravations on top of an existing delta', () => {
+    const result = aggravateObligation(makeObligation({ value: 10, campaignDelta: 5 }), 3)
+    expect(result.campaignDelta).toBe(8)
+  })
+
+  it('can aggravate an already-reduced obligation', () => {
+    const result = aggravateObligation(makeObligation({ value: 10, campaignDelta: -5 }), 2)
+    expect(result.campaignDelta).toBe(-3)
+  })
+
+  it('records the supplied note', () => {
+    const result = aggravateObligation(makeObligation(), 5, 'New debt contracted after Imperial raid')
+    expect(result.campaignNote).toBe('New debt contracted after Imperial raid')
+  })
+
+  it('preserves the existing note when none is supplied', () => {
+    const obl = makeObligation({ campaignNote: 'old note' })
+    const result = aggravateObligation(obl, 3)
+    expect(result.campaignNote).toBe('old note')
+  })
+
+  it('preserves the existing transformedTo value', () => {
+    const obl = makeObligation({ transformedTo: 'Gang Debt' })
+    const result = aggravateObligation(obl, 3)
+    expect(result.transformedTo).toBe('Gang Debt')
+  })
+
+  it('throws RangeError for amount = 0', () => {
+    expect(() => aggravateObligation(makeObligation(), 0)).toThrow(RangeError)
+  })
+
+  it('throws RangeError for a negative amount', () => {
+    expect(() => aggravateObligation(makeObligation(), -3)).toThrow(RangeError)
+  })
+
+  it('throws RangeError for a non-integer amount', () => {
+    expect(() => aggravateObligation(makeObligation(), 1.5)).toThrow(RangeError)
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// transformObligation
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('transformObligation', () => {
+  it('sets transformedTo to the given non-empty label', () => {
+    const result = transformObligation(makeObligation(), 'Imperial Bounty')
+    expect(result.transformedTo).toBe('Imperial Bounty')
+  })
+
+  it('trims whitespace from the label', () => {
+    const result = transformObligation(makeObligation(), '  Debt  ')
+    expect(result.transformedTo).toBe('Debt')
+  })
+
+  it('does not change the campaignDelta', () => {
+    const obl = makeObligation({ campaignDelta: -3 })
+    const result = transformObligation(obl, 'New Nature')
+    expect(result.campaignDelta).toBe(-3)
+  })
+
+  it('records the supplied note', () => {
+    const result = transformObligation(makeObligation(), 'Smuggler Debt', 'Original crime lord defeated; debt passed to the Pykes')
+    expect(result.campaignNote).toBe('Original crime lord defeated; debt passed to the Pykes')
+  })
+
+  it('preserves the existing note when none is supplied', () => {
+    const obl = makeObligation({ campaignNote: 'prior note' })
+    const result = transformObligation(obl, 'New Nature')
+    expect(result.campaignNote).toBe('prior note')
+  })
+
+  it('throws TypeError for an empty string', () => {
+    expect(() => transformObligation(makeObligation(), '')).toThrow(TypeError)
+  })
+
+  it('throws TypeError for a blank string', () => {
+    expect(() => transformObligation(makeObligation(), '   ')).toThrow(TypeError)
+  })
+
+  it('throws TypeError for a non-string value', () => {
+    expect(() => transformObligation(makeObligation(), null)).toThrow(TypeError)
+    expect(() => transformObligation(makeObligation(), 42)).toThrow(TypeError)
+  })
+})

--- a/tests/models/obligation.test.mjs
+++ b/tests/models/obligation.test.mjs
@@ -18,11 +18,30 @@ describe('SwerpgObligation — schema contract', () => {
     expect(schema).toHaveProperty('isExtra')
     expect(schema).toHaveProperty('extraXp')
     expect(schema).toHaveProperty('extraCredits')
+    // Campaign evolution fields
+    expect(schema).toHaveProperty('campaignDelta')
+    expect(schema).toHaveProperty('campaignNote')
+    expect(schema).toHaveProperty('transformedTo')
   })
 
-  it('defines exactly five fields — no accidental field added or removed', () => {
+  it('defines exactly eight fields — no accidental field added or removed', () => {
     const schema = SwerpgObligation.defineSchema()
-    expect(Object.keys(schema)).toHaveLength(5)
+    expect(Object.keys(schema)).toHaveLength(8)
+  })
+
+  it('campaignDelta defaults to 0', () => {
+    const schema = SwerpgObligation.defineSchema()
+    expect(schema.campaignDelta.config.initial).toBe(0)
+  })
+
+  it('campaignNote defaults to null', () => {
+    const schema = SwerpgObligation.defineSchema()
+    expect(schema.campaignNote.config.initial).toBeNull()
+  })
+
+  it('transformedTo defaults to null', () => {
+    const schema = SwerpgObligation.defineSchema()
+    expect(schema.transformedTo.config.initial).toBeNull()
   })
 
   it('LOCALIZATION_PREFIXES includes OBLIGATION', () => {


### PR DESCRIPTION
## Summary

- Implement campaign evolution for obligations: add obligation-evolution logic and update obligation model and character sheet integration.
- Update templates and i18n (en/fr) and add documentation plan.
- Add unit tests covering obligation evolution and obligation sheet behavior.

## Context

Closes #649

## Tests

- Not run (not requested).

## Notes

- See tests under tests/lib and tests/applications for coverage details.
