### PR TITLE
feat(obligation): rendre l'ajout d'Obligation narrative découvrable

### DIFF
--- a/documentation/plan/character-sheet/obligation/656-rendre-l-ajout-d-obligation-narrative-decouvrable.md
+++ b/documentation/plan/character-sheet/obligation/656-rendre-l-ajout-d-obligation-narrative-decouvrable.md
@@ -1,0 +1,67 @@
+# Character Sheet — Rendre l’ajout d’Obligation narrative découvrable
+
+**Issue** : [#656 — Rendre l’ajout d’Obligation narrative découvrable](https://github.com/herveDarritchon/foundryvtt-swerpg/issues/656)
+**Domaine métier** : `character-sheet/obligation`
+
+## Objectif
+
+Permettre au joueur ou au MJ d’identifier immédiatement, depuis l’onglet `Commitments`, comment ajouter une Obligation narrative sans devoir passer par un flux générique de création d’item orienté inventaire.
+
+## Contexte utile
+
+- `templates/sheets/actor/character-commitments.hbs` affiche aujourd’hui la liste des Obligations, leurs actions d’édition/suppression et les résumés associés, mais aucun point d’entrée explicite pour en créer une nouvelle.
+- `module/applications/sheets/base-actor-sheet.mjs` branche l’action générique `itemCreate` sur un `createDialog` préconfiguré avec `type: 'weapon'`, ce qui n’aide pas l’utilisateur à créer une Obligation depuis la fiche personnage.
+- `module/applications/sheets/character-sheet.mjs` prépare déjà tout le contexte du bloc Obligations et constitue le bon point d’entrée pour porter une action dédiée à ce parcours.
+- `module/models/obligation.mjs` et `templates/sheets/partials/obligation-config.hbs` distinguent déjà les bonus de création (`isExtra`) et les champs narratifs/campagne ; le déficit principal est donc la découvrabilité du flux d’ajout, pas l’absence de modèle.
+
+## Plan d'implémentation
+
+### Étape 1 — Ajouter un point d’entrée explicite de création dans le bloc Obligations
+
+**Fichiers** : `templates/sheets/actor/character-commitments.hbs`, `module/applications/sheets/character-sheet.mjs`, `module/applications/sheets/base-actor-sheet.mjs`, `tests/applications/sheets/character-sheet-commitments.test.mjs`, `tests/applications/sheets/base-actor-sheet.test.mjs`
+
+**What** :
+
+- ajouter un CTA visible dans l’en-tête ou l’état vide du bloc Obligations, formulé comme ajout d’Obligation narrative plutôt que création d’item générique ;
+- brancher ce CTA sur une action dédiée qui vise directement le type `obligation`, au lieu de réutiliser silencieusement le flux `itemCreate` par défaut centré sur `weapon` ;
+- garantir que ce parcours ouvre immédiatement la bonne fiche d’item pour éviter toute étape implicite de sélection de type.
+
+**Résultat attendu** : depuis l’onglet `Commitments`, l’utilisateur comprend immédiatement comment créer une Obligation narrative et arrive directement sur le bon formulaire.
+
+### Étape 2 — Clarifier le parcours de création pour distinguer Obligation narrative et bonus de création
+
+**Fichiers** : `templates/sheets/partials/obligation-config.hbs`, `lang/en.json`, `lang/fr.json`, `tests/applications/sheets/obligation-sheet.test.mjs`
+
+**What** :
+
+- expliciter dans la fiche d’Obligation qu’une nouvelle entrée créée via ce parcours correspond d’abord à une Obligation narrative standard ;
+- conserver `isExtra` comme option secondaire clairement séparée des bonus de création, avec une aide qui explique quand l’utiliser ;
+- ajouter les clés i18n EN/FR nécessaires pour le CTA, l’éventuel état vide et les aides contextuelles du formulaire.
+
+**Résultat attendu** : le flux de création ne laisse plus penser qu’une Obligation doit d’abord être manipulée comme un bonus XP/crédits ou comme un item générique.
+
+### Étape 3 — Verrouiller la découvrabilité et le routage du flux par des tests ciblés
+
+**Fichiers** : `tests/applications/sheets/character-sheet-commitments.test.mjs`, `tests/applications/sheets/obligation-sheet.test.mjs`, `tests/applications/sheets/base-actor-sheet.test.mjs`
+
+**What** :
+
+- couvrir la présence du CTA ou de l’état vide et le déclenchement de l’action dédiée ;
+- vérifier que l’action de création cible bien `obligation` et ne retombe pas sur le défaut `weapon` ;
+- valider que le premier rendu de la fiche d’Obligation reste compréhensible pour une Obligation narrative standard.
+
+**Résultat attendu** : une régression de découvrabilité ou un retour au flux générique inadapté est détecté automatiquement.
+
+## Périmètre / hors périmètre
+
+### Inclus
+
+- CTA explicite d’ajout d’Obligation dans l’onglet `Commitments`
+- routage du flux de création vers le type `obligation`
+- microcopy et i18n pour distinguer Obligation narrative et bonus de création
+
+### Exclus
+
+- refonte métier complète du domaine Obligation
+- nouvelles règles de calcul des bonus XP/crédits
+- automatisation de l’évolution de campagne au-delà du flux d’ajout

--- a/documentation/review/character/obligations/ux-review-obligation-purchase-workflow.md
+++ b/documentation/review/character/obligations/ux-review-obligation-purchase-workflow.md
@@ -1,0 +1,259 @@
+# UX Review — Workflow d'achat / bonus des Obligations
+
+- **Date** : 2026-06-08
+- **Périmètre** : experience utilisateur de l'acquisition et configuration des Obligations dans la feuille personnage, du drag-drop à l'activation du bonus de création
+- **Reviewer** : UX sénior
+- **Fichiers couverts** :
+  - `templates/sheets/actor/character-commitments.hbs`
+  - `module/applications/sheets/character-sheet.mjs` (préparation contexte, `#onToggleObligationExtraState`, `#buildObligationList`)
+  - `templates/sheets/partials/obligation-config.hbs`
+  - `module/applications/sheets/obligation.mjs`
+  - `module/models/obligation.mjs`
+  - `module/lib/obligations/obligation-bonus-calculator.mjs`
+  - `module/models/character.mjs` (`_prepareObligationCreationState`, `#extractObligationData`)
+  - `lang/en.json` + `lang/fr.json` (bloc `OBLIGATION.UI.*`)
+
+---
+
+## Forces
+
+- **Données temps réel** : le bloc `obligationCreationState` est dérivé et recalculé à chaque rendu — pas de désync.
+- **Transparence des erreurs** : les erreurs de conformité sont affichées en clair (combinaison non officielle, doublon, dépassement de plafond). L'information est là.
+- **Séparation domaine / UI respectée** : `ObligationBonusCalculator` est pur, sans dépendance Foundry. La logique de validation est testable et l'est.
+- **ADR-0025 respectée** : le data model reste minimal et narratif — aucun enrichissement structurel intempestif.
+
+---
+
+## Faiblesses
+
+### 🔴 Bloquantes — rupture de flux
+
+**1. Workflow dispersé sur deux sheets.**
+
+La configuration d'un bonus de création Obligation nécessite :
+
+1. drag-drop d'un item `obligation` sur la feuille personnage
+2. clic sur l'item pour ouvrir sa sheet dédiée
+3. toggler `isExtra` sur la sheet item
+4. remplir `extraXp` ET `extraCredits` à la main
+5. retour sur la feuille personnage pour vérifier le bloc `obligationCreationState`
+
+Le joueur doit jongler entre deux fenêtres pour une seule intention métier : "prendre un bonus de départ".  
+C'est le problème principal. Le reste en découle.
+
+**Impact** : taux d'abandon élevé, erreurs fréquentes, sentiment que le système "ne marche pas" alors que la règle est respectée.
+
+---
+
+**2. Le toggle `Extra` est un leurre.**
+
+`data-action="toggleObligationExtraState"` bascule `system.isExtra` sans guider la suite.  
+L'utilisateur active le mode "extra" mais ne voit aucun champ apparaître dans la feuille personnage — il faut savoir qu'il faut ouvrir la sheet item.
+
+Le toggle ne devrait pas exister sans être immédiatement accompagné du choix du bonus.
+
+---
+
+**3. Erreur affichée au lieu d'empêcher l'erreur.**
+
+Le bloc `obligationCreationState.errors` liste les problèmes après coup. L'utilisateur doit :
+
+1. commettre l'erreur
+2. retourner sur la sheet item
+3. corriger à l'aveugle (les valeurs autorisées ne sont pas signalées)
+4. revenir vérifier
+
+C'est un pattern **error-detection** pur, sans **error-prevention**. Les valeurs `extraXp` et `extraCredits` sont en input libre avec `step` et `min`/`max`, mais aucune contrainte sur la combinaison valide (xp, credits) n'est appliquée à la saisie.
+
+---
+
+### 🟠 Importantes — charge cognitive
+
+**4. Deux intentions métier mélangées dans la même liste.**
+
+La liste d'obligations mélange :
+
+- les obligations narratives de base (`isExtra = false`)
+- les obligations bonus de création (`isExtra = true`)
+
+Elles partagent la même ligne, le même toggle, les mêmes colonnes XP/crédits.  
+Un joueur qui pose une obligation narrative "Dette 10" voit apparaître un toggle et des colonnes XP/crédits qui n'ont aucun sens pour son cas.
+
+**5. Notion de "base Obligation" implicite.**
+
+Le plafond des bonus supplémentaires est calculé à partir de la somme des obligations non-extra.  
+Si le joueur n'a qu'une seule obligation de base `value: 10` et qu'il ajoute une extra, le plafond est 10.  
+Mais rien n'explique visuellement d'où vient ce plafond — il est juste affiché dans `obligationCreationState.totalObligationConsumed / baseObligationValue`.
+
+**6. Pas de CTA primaire pour ajouter une obligation.**
+
+L'onglet Commitments n'a aucun bouton "Ajouter une obligation". Le seul moyen est le drag-drop depuis un compendium.  
+L'inventaire, les talents, les jauges ont tous un bouton `+` — pas les obligations. L'utilisateur doit deviner le drag-drop.
+
+---
+
+### 🟡 Mineures — friction
+
+**7. Colonnes XP/Crédits visibles pour toutes les obligations.**
+
+Les colonnes `extraXp` / `extraCredits` s'affichent dans la liste même pour les obligations non-extra (tiret).  
+C'est du bruit visuel. Seules les obligations extra ont besoin de ces colonnes.
+
+**8. Aucun feedback positif après configuration réussie.**
+
+Quand l'utilisateur configure correctement un bonus, le bloc passe de `--invalid` à vert avec "Toutes les obligations supplémentaires respectent les règles officielles."  
+Mais aucun changement visible dans les métriques du personnage (XP, crédits) n'est immédiatement perceptible — il faut aller voir l'onglet "Progression" ou le budget crédits.
+
+**9. Pas de guidance sur les valeurs autorisées dans la sheet item.**
+
+`obligation-config.hbs` affiche une liste des options officielles en commentaire (`<ul class="obligation-official-options__list">`) mais c'est statique et les champs restent en input libre avec `step:5`.  
+Un utilisateur peut taper `extraXp: 7` sans que le champ ne le rejette — l'erreur n'apparaît que dans le bloc de la feuille personnage.
+
+---
+
+## Analyse par étape du flux actuel
+
+```
+Étape                     | Problème                          | Coût
+--------------------------|-----------------------------------|-----
+1. Drag-drop obligation   | Pas de CTA visible                | Élevé (découverte)
+2. Voir la ligne          | Colonnes inutiles pour le joueur  | Faible
+3. Toggle Extra           | Aucun guidage sur la suite        | Moyen
+4. Ouvrir sheet item      | Changement de fenêtre             | Élevé
+5. Saisir extraXp/credits | Input libre, pas de validation    | Élevé (erreur probable)
+6. Retour feuille perso   | Vérifier bloc erreurs             | Moyen
+7. Corriger si erreur     | Retour étape 4, boucle            | Très élevé
+```
+
+---
+
+## Recommandations UX
+
+### R1 — Séparer clairement "Obligations narratives" et "Bonus de création"
+
+Dans l'onglet Commitments :
+
+```
+┌─────────────────────────────────────────────────┐
+│  Obligations (20)                               │
+│  ┌───────────────────────────────────────────┐  │
+│  │ Dette envers Teemo (10)           ✎  🗑  │  │
+│  │ Prime sur ma tête (10)            ✎  🗑  │  │
+│  └───────────────────────────────────────────┘  │
+│  [+ Ajouter une obligation narrative]           │
+│                                                 │
+│  ── Bonus de départ ──────────────────────────  │
+│                                                   │
+│  Plafond disponible : 10 / 10                     │
+│  Bonus déjà pris :                                │
+│  ┌───────────────────────────────────────────┐  │
+│  │ +5 XP (5 Obligation)             ✎  🗑  │  │
+│  │ +1 000 crédits (5 Obligation)    ✎  🗑  │  │
+│  └───────────────────────────────────────────┘  │
+│  Total : +5 XP, +1 000 crédits                  │
+│  [Prendre un bonus]                         │
+└─────────────────────────────────────────────────┘
+```
+
+### R2 — Remplacer le toggle + inputs libres par un sélecteur guidé
+
+Au clic sur "Prendre un bonus" :
+
+```
+┌─ Choisir un bonus de départ ───────────────────┐
+│                                                 │
+│  Sélectionne une option parmi les suivantes :   │
+│                                                 │
+│  ┌──────────────────────────────────────────┐   │
+│  │ ◉ +5 XP          · Coût : +5 Obligation  │   │
+│  │   Obligation totale : 10 → 15            │   │
+│  ├──────────────────────────────────────────┤   │
+│  │ ○ +10 XP         · Coût : +10 Obligation │   │
+│  │   Obligation totale : 10 → 20            │   │
+│  ├──────────────────────────────────────────┤   │
+│  │ ○ +1 000 crédits · Coût : +5 Obligation  │   │
+│  │   Obligation totale : 10 → 15            │   │
+│  ├──────────────────────────────────────────┤   │
+│  │ ○ +2 500 crédits · Coût : +10 Obligation │   │
+│  │   Obligation totale : 10 → 20            │   │
+│  └──────────────────────────────────────────┘   │
+│                                                 │
+│       [Annuler]              [Confirmer]         │
+└─────────────────────────────────────────────────┘
+```
+
+- Les options déjà prises sont désactivées (disabled + tooltip "Déjà sélectionné")
+- Les options dépassant le plafond restant sont désactivées (disabled + tooltip "Dépasse le plafond disponible")
+- Chaque ligne montre l'impact immédiat sur la valeur d'obligation totale
+
+### R3 — Feedback immédiat des bonus sur la feuille
+
+Une fois configuré, le total XP et crédits dérivés doit apparaître directement dans l'onglet Commitments (pas besoin d'aller voir un autre onglet). Soit sous forme de métriques synthétiques en haut de section :
+
+```
+XP bonus : +5    Crédits bonus : +1 000    Obligation totale : 15 / 20 (plafond 10)
+```
+
+### R4 — CTA primaire "Ajouter une obligation"
+
+Ajouter un bouton `+` dans l'en-tête de la section Obligations, comme pour l'inventaire :
+
+```hbs
+<button
+  type='button'
+  class='icon frame-brown fa-solid fa-plus'
+  data-action='itemCreate'
+  data-tooltip='Ajouter une obligation'
+  data-item-type='obligation'
+></button>
+```
+
+(ou une action spécifique `createObligation` si `itemCreate` est trop générique)
+
+### R5 — Nettoyage des colonnes conditionnelles
+
+Les colonnes XP / Crédits ne devraient apparaître que dans la section des bonus de création, pas dans la liste des obligations narratives.
+
+---
+
+## Plan d'action suggéré
+
+| #   | Section        | Action                                                                 | Effort |
+| --- | -------------- | ---------------------------------------------------------------------- | ------ |
+| 1   | Template HBS   | Séparer le partial `character-commitments.hbs` en deux zones           | M      |
+| 2   | Sheet contr.   | Créer une action `createObligation` avec CTA visible                   | XS     |
+| 3   | Nouveau dialog | Créer une mini-ApplicationV2 `ObligationBonusPicker` avec les 4 cartes | M      |
+| 4   | Sheet contr.   | Remplacer `toggleObligationExtraState` par `openObligationBonusPicker` | M      |
+| 5   | Sheet contr.   | Ajouter les métriques synthétiques XP/crédits bonus en haut de section | S      |
+| 6   | Config partial | Remplacer les inputs libres par des radios/readonly en fallback expert | S      |
+| 7   | i18n           | Extraire toutes les chaînes résiduelles en clés `SWERPG.*`             | S      |
+| 8   | Tests          | Adapter les tests du toggle et ajouter des tests pour le picker dialog | M      |
+
+---
+
+## Vérification
+
+```bash
+pnpm vitest run tests/applications/sheets/character-sheet-commitments.test.mjs
+pnpm run lint && pnpm fmt:check
+```
+
+Smoke manuel :
+
+- ouvrir un Personnage, onglet Commitments
+- cliquer "Ajouter une obligation" → item créé
+- cliquer "Prendre un bonus" → dialog s'affiche avec options
+- sélectionner +5 XP → confirmer → section bonus mise à jour, métriques impactées
+- tenter de reprendre la même option → désactivée
+- tenter de dépasser le plafond → option désactivée
+- supprimer un bonus → compteurs recalculés
+- vérifier que la sheet item obligation reste éditable en fallback (GM mode)
+
+---
+
+## Verdict
+
+**L'implémentation actuelle est correcte du point de vue des règles mais pénalisante du point de vue UX.**  
+Le flux oblige l'utilisateur à connaître l'architecture du système (deux sheets, deux fenêtres, trois champs à remplir) pour accomplir une tâche simple : "je veux plus de XP / plus de crédits en échange d'une obligation plus lourde".
+
+La séparation claire des deux intentions métier (narrer une dette / acheter un bonus) combinée à un sélecteur guidé et contraint est le levier le plus fort pour transformer l'onglet Commitments d'un "éditeur d'items" en un vrai outil de création de personnage fluide.

--- a/lang/en.json
+++ b/lang/en.json
@@ -598,7 +598,10 @@
       "OBLIGATIONS_ICON_XP_ALT": "XP",
       "OBLIGATIONS_ICON_CREDITS_ALT": "Credits",
       "OBLIGATIONS_DELETE_TOOLTIP": "Delete Obligation",
-      "OBLIGATIONS_EDIT_TOOLTIP": "Edit Obligation"
+      "OBLIGATIONS_EDIT_TOOLTIP": "Edit Obligation",
+      "OBLIGATIONS_ADD_TOOLTIP": "Add a narrative Obligation",
+      "OBLIGATIONS_ADD_CTA": "Add a narrative Obligation",
+      "OBLIGATIONS_EMPTY_MESSAGE": "No obligations yet. Narrative obligations represent debts, secrets, or bonds that drive the story."
     }
   },
   "ACTOR.AppliedDetailItem": "Applied the {name} {type} to {actor}.",
@@ -1001,7 +1004,9 @@
       "CAMPAIGN_CURRENT_VALUE_LABEL": "Current value (adjusted)",
       "CAMPAIGN_CURRENT_VALUE_TOOLTIP": "Base creation value + campaign adjustments",
       "CAMPAIGN_TRANSFORMED_LABEL": "Transformed into:",
-      "CAMPAIGN_NO_EVOLUTION": "No campaign evolution recorded yet."
+      "CAMPAIGN_NO_EVOLUTION": "No campaign evolution recorded yet.",
+      "NARRATIVE_HINT": "A narrative Obligation represents a debt, secret, or bond that drives the story. Fill in the name and base value to get started.",
+      "EXTRA_SECONDARY_HINT": "The Extra Obligation option grants additional XP or credits at character creation. Enable it only if you took on a higher obligation than the base value during character creation."
     }
   },
   "RESOURCES": {

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -720,7 +720,10 @@
       "OBLIGATIONS_ICON_XP_ALT": "XP",
       "OBLIGATIONS_ICON_CREDITS_ALT": "Crédits",
       "OBLIGATIONS_DELETE_TOOLTIP": "Supprimer l'Obligation",
-      "OBLIGATIONS_EDIT_TOOLTIP": "Modifier l'Obligation"
+      "OBLIGATIONS_EDIT_TOOLTIP": "Modifier l'Obligation",
+      "OBLIGATIONS_ADD_TOOLTIP": "Ajouter une Obligation narrative",
+      "OBLIGATIONS_ADD_CTA": "Ajouter une Obligation narrative",
+      "OBLIGATIONS_EMPTY_MESSAGE": "Aucune obligation pour l'instant. Les Obligations narratives représentent des dettes, des secrets ou des liens qui font avancer l'histoire."
     }
   },
   "ACTOR.AppliedDetailItem": "Applied the {name} {type} to {actor}.",
@@ -1104,7 +1107,9 @@
       "CAMPAIGN_CURRENT_VALUE_LABEL": "Valeur actuelle (ajustée)",
       "CAMPAIGN_CURRENT_VALUE_TOOLTIP": "Valeur de création de base + ajustements de campagne",
       "CAMPAIGN_TRANSFORMED_LABEL": "Transformée en :",
-      "CAMPAIGN_NO_EVOLUTION": "Aucune évolution de campagne enregistrée pour l'instant."
+      "CAMPAIGN_NO_EVOLUTION": "Aucune évolution de campagne enregistrée pour l'instant.",
+      "NARRATIVE_HINT": "Une Obligation narrative représente une dette, un secret ou un lien qui fait avancer l'histoire. Renseignez le nom et la valeur de base pour commencer.",
+      "EXTRA_SECONDARY_HINT": "L'option Obligation Extra accorde des XP ou des crédits supplémentaires à la création du personnage. Activez-la uniquement si vous avez accepté une obligation plus élevée que la valeur de base lors de la création."
     }
   },
   "RESOURCES": {

--- a/module/applications/sheets/character-sheet.mjs
+++ b/module/applications/sheets/character-sheet.mjs
@@ -80,6 +80,7 @@ export default class CharacterSheet extends SwerpgBaseActorSheet {
       skillRefund: CharacterSheet.#onSkillRefund,
       skillSelect: CharacterSheet.#onSkillSelect,
       toggleObligationExtraState: CharacterSheet.#onToggleObligationExtraState,
+      obligationCreate: CharacterSheet.#onObligationCreate,
     },
     form: {
       submitOnChange: true,
@@ -424,6 +425,20 @@ export default class CharacterSheet extends SwerpgBaseActorSheet {
   }
 
   /* -------------------------------------------- */
+
+  /**
+   * Handle click action to create a new narrative Obligation directly on the actor.
+   * Bypasses the generic item-creation dialog and targets the obligation type so the
+   * user lands on the correct form without any intermediate type-selection step.
+   * @this {CharacterSheet}
+   * @param {PointerEvent} event
+   * @returns {Promise<void>}
+   */
+  static async #onObligationCreate(event) {
+    logger.debug('[CharacterSheet] obligationCreate — opening obligation creation dialog')
+    const cls = getDocumentClass('Item')
+    await cls.createDialog({ type: 'obligation' }, { parent: this.document, pack: this.document.pack })
+  }
 
   /* -------------------------------------------- */
 

--- a/styles/actor.less
+++ b/styles/actor.less
@@ -1787,6 +1787,62 @@
       background: var(--color-frame-bg);
       font-style: italic;
     }
+
+    /* ----------------------------------------- */
+    /*  Obligation — add button in header         */
+    /* ----------------------------------------- */
+
+    .obligation-add-btn {
+      background: transparent;
+      border: none;
+      color: var(--color-primary);
+      cursor: pointer;
+      font-size: var(--font-size-14);
+      line-height: 1;
+      padding: 0.15rem 0.35rem;
+
+      &:hover {
+        color: var(--color-glow);
+      }
+    }
+
+    /* ----------------------------------------- */
+    /*  Obligation — empty state                  */
+    /* ----------------------------------------- */
+
+    .obligation-empty-state {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      gap: 0.5rem;
+      padding: 1rem 0.75rem;
+      color: var(--color-secondary);
+      font-size: var(--font-size-12);
+      text-align: center;
+    }
+
+    .obligation-empty-state__message {
+      margin: 0;
+    }
+
+    .obligation-empty-state__cta {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.35rem;
+      padding: 0.35rem 0.75rem;
+      border: 1px solid var(--color-primary);
+      border-radius: 4px;
+      background: transparent;
+      color: var(--color-primary);
+      cursor: pointer;
+      font-size: var(--font-size-12);
+
+      &:hover {
+        background: var(--color-frame-bg-25);
+        color: var(--color-glow);
+        border-color: var(--color-glow);
+      }
+    }
   }
 
   /* ----------------------------------------- */

--- a/styles/item.less
+++ b/styles/item.less
@@ -290,3 +290,33 @@
     }
   }
 }
+
+/* ----------------------------------------- */
+/*  Obligation item sheet                    */
+/* ----------------------------------------- */
+
+.swerpg.item.obligation {
+  .obligation-narrative-hint {
+    margin: 0 0 0.75rem;
+    padding: 0.5rem 0.75rem;
+    border-left: 3px solid var(--color-primary);
+    background: var(--color-frame-bg-25);
+    border-radius: 0 4px 4px 0;
+    font-size: var(--font-size-12);
+    color: var(--color-secondary);
+  }
+
+  .obligation-extra-section {
+    margin-top: 0.5rem;
+
+    &__hint {
+      margin: 0.25rem 0 0;
+      padding: 0.3rem 0.5rem;
+      border-radius: 3px;
+      background: var(--color-frame-bg);
+      font-size: var(--font-size-11);
+      color: var(--color-secondary);
+      font-style: italic;
+    }
+  }
+}

--- a/styles/swerpg.css
+++ b/styles/swerpg.css
@@ -3408,6 +3408,12 @@ input[type='range'] {
   /* ----------------------------------------- */
   /*  Obligation — campaign evolution summary   */
   /* ----------------------------------------- */
+  /* ----------------------------------------- */
+  /*  Obligation — add button in header         */
+  /* ----------------------------------------- */
+  /* ----------------------------------------- */
+  /*  Obligation — empty state                  */
+  /* ----------------------------------------- */
 }
 .swerpg.sheet.actor .tab.commitments .header {
   display: flex;
@@ -3538,6 +3544,48 @@ input[type='range'] {
   border-radius: 3px;
   background: var(--color-frame-bg);
   font-style: italic;
+}
+.swerpg.sheet.actor .tab.commitments .obligation-add-btn {
+  background: transparent;
+  border: none;
+  color: var(--color-primary);
+  cursor: pointer;
+  font-size: var(--font-size-14);
+  line-height: 1;
+  padding: 0.15rem 0.35rem;
+}
+.swerpg.sheet.actor .tab.commitments .obligation-add-btn:hover {
+  color: var(--color-glow);
+}
+.swerpg.sheet.actor .tab.commitments .obligation-empty-state {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 1rem 0.75rem;
+  color: var(--color-secondary);
+  font-size: var(--font-size-12);
+  text-align: center;
+}
+.swerpg.sheet.actor .tab.commitments .obligation-empty-state__message {
+  margin: 0;
+}
+.swerpg.sheet.actor .tab.commitments .obligation-empty-state__cta {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.35rem 0.75rem;
+  border: 1px solid var(--color-primary);
+  border-radius: 4px;
+  background: transparent;
+  color: var(--color-primary);
+  cursor: pointer;
+  font-size: var(--font-size-12);
+}
+.swerpg.sheet.actor .tab.commitments .obligation-empty-state__cta:hover {
+  background: var(--color-frame-bg-25);
+  color: var(--color-glow);
+  border-color: var(--color-glow);
 }
 .swerpg.sheet.actor .tab.secondary {
   /* ----------------------------------------- */
@@ -4650,6 +4698,30 @@ input[type='range'] {
 }
 .swerpg.action fieldset.hook button {
   flex: 0;
+}
+/* ----------------------------------------- */
+/*  Obligation item sheet                    */
+/* ----------------------------------------- */
+.swerpg.item.obligation .obligation-narrative-hint {
+  margin: 0 0 0.75rem;
+  padding: 0.5rem 0.75rem;
+  border-left: 3px solid var(--color-primary);
+  background: var(--color-frame-bg-25);
+  border-radius: 0 4px 4px 0;
+  font-size: var(--font-size-12);
+  color: var(--color-secondary);
+}
+.swerpg.item.obligation .obligation-extra-section {
+  margin-top: 0.5rem;
+}
+.swerpg.item.obligation .obligation-extra-section__hint {
+  margin: 0.25rem 0 0;
+  padding: 0.3rem 0.5rem;
+  border-radius: 3px;
+  background: var(--color-frame-bg);
+  font-size: var(--font-size-11);
+  color: var(--color-secondary);
+  font-style: italic;
 }
 /** ----------------------------------------- *
  *  Journal Sheet                             *

--- a/templates/sheets/actor/character-commitments.hbs
+++ b/templates/sheets/actor/character-commitments.hbs
@@ -23,7 +23,29 @@
             <div class="column slim">
                 <span class="title">{{localize "ACTOR.LABELS.OBLIGATIONS_COLUMN_ACTIONS"}}</span>
             </div>
+
+            <div class="column slim">
+                <button type="button"
+                        class="button icon fa-solid fa-plus obligation-add-btn"
+                        data-action="obligationCreate"
+                        data-tooltip="{{localize "ACTOR.LABELS.OBLIGATIONS_ADD_TOOLTIP"}}"
+                        aria-label="{{localize "ACTOR.LABELS.OBLIGATIONS_ADD_TOOLTIP"}}">
+                </button>
+            </div>
         </div>
+
+        {{#unless obligations.length}}
+        <div class="obligation-empty-state">
+            <p class="obligation-empty-state__message">{{localize "ACTOR.LABELS.OBLIGATIONS_EMPTY_MESSAGE"}}</p>
+            <button type="button"
+                    class="button obligation-empty-state__cta"
+                    data-action="obligationCreate"
+                    aria-label="{{localize "ACTOR.LABELS.OBLIGATIONS_ADD_TOOLTIP"}}">
+                <i class="fa-solid fa-plus" aria-hidden="true"></i>
+                {{localize "ACTOR.LABELS.OBLIGATIONS_ADD_CTA"}}
+            </button>
+        </div>
+        {{/unless}}
 
         {{#each obligations as |obligation s|}}
             <div class="line-item {{obligation.cssClass}} obligation" data-item-id="{{obligation.id}}">

--- a/templates/sheets/partials/obligation-config.hbs
+++ b/templates/sheets/partials/obligation-config.hbs
@@ -1,8 +1,15 @@
 <section class="tab sheet-body flexcol {{tabs.config.cssClass}}" data-tab="{{tabs.config.id}}" data-group="{{tabs.config.group}}">
 
+  <p class="obligation-narrative-hint">{{localize "OBLIGATION.UI.NARRATIVE_HINT"}}</p>
+
   {{formField @root.fields.value value=source.system.value localize=true rootId=partId}}
 
-  {{formField @root.fields.isExtra value=source.system.isExtra localize=true rootId=partId}}
+  <div class="obligation-extra-section">
+    {{formField @root.fields.isExtra value=source.system.isExtra localize=true rootId=partId}}
+    {{#unless source.system.isExtra}}
+    <p class="obligation-extra-section__hint">{{localize "OBLIGATION.UI.EXTRA_SECONDARY_HINT"}}</p>
+    {{/unless}}
+  </div>
 
   {{#if source.system.isExtra}}
   <fieldset>

--- a/tests/applications/sheets/character-sheet-commitments.test.mjs
+++ b/tests/applications/sheets/character-sheet-commitments.test.mjs
@@ -16,6 +16,14 @@ vi.mock('../../../module/lib/featured-equipment.mjs', () => ({
 }))
 
 /**
+ * Build a minimal mock for the Item document class.
+ * Captures the arguments passed to createDialog.
+ */
+function buildItemClassMock() {
+  return { createDialog: vi.fn().mockResolvedValue(undefined) }
+}
+
+/**
  * Build a minimal obligation item mock.
  * @param {object} [overrides]
  * @returns {object}
@@ -114,5 +122,64 @@ describe('CharacterSheet — toggleObligationExtraState action', () => {
 
       expect(logger.debug).toHaveBeenCalledWith(expect.stringContaining('Medical Debt'))
     })
+  })
+})
+
+describe('CharacterSheet — obligationCreate action', () => {
+  let CharacterSheet
+  let logger
+
+  beforeEach(async () => {
+    setupFoundryMock()
+    CharacterSheet = (await import('../../../module/applications/sheets/character-sheet.mjs')).default
+    logger = (await import('../../../module/utils/logger.mjs')).logger
+  })
+
+  afterEach(() => {
+    vi.resetModules()
+    vi.clearAllMocks()
+    teardownFoundryMock()
+  })
+
+  it('is registered in DEFAULT_OPTIONS actions', () => {
+    expect(typeof CharacterSheet.DEFAULT_OPTIONS.actions.obligationCreate).toBe('function')
+  })
+
+  it('calls createDialog with type obligation, not the generic weapon default', async () => {
+    const itemCls = buildItemClassMock()
+    globalThis.getDocumentClass = vi.fn(() => itemCls)
+
+    const document = { pack: null }
+    const sheet = { document }
+    const event = {}
+
+    await CharacterSheet.DEFAULT_OPTIONS.actions.obligationCreate.call(sheet, event)
+
+    expect(itemCls.createDialog).toHaveBeenCalledWith(expect.objectContaining({ type: 'obligation' }), expect.objectContaining({ parent: document }))
+  })
+
+  it('does not call createDialog with type weapon', async () => {
+    const itemCls = buildItemClassMock()
+    globalThis.getDocumentClass = vi.fn(() => itemCls)
+
+    const sheet = { document: { pack: null } }
+    const event = {}
+
+    await CharacterSheet.DEFAULT_OPTIONS.actions.obligationCreate.call(sheet, event)
+
+    const [defaults] = itemCls.createDialog.mock.calls[0]
+    expect(defaults.type).not.toBe('weapon')
+  })
+
+  it('logs a debug message when triggered', async () => {
+    const itemCls = buildItemClassMock()
+    globalThis.getDocumentClass = vi.fn(() => itemCls)
+
+    const sheet = { document: { pack: null } }
+    const event = {}
+
+    await CharacterSheet.DEFAULT_OPTIONS.actions.obligationCreate.call(sheet, event)
+
+    expect(logger.debug).toHaveBeenCalledWith(expect.stringContaining('obligationCreate'))
   })
 })

--- a/tests/applications/sheets/obligation-sheet.test.mjs
+++ b/tests/applications/sheets/obligation-sheet.test.mjs
@@ -92,3 +92,26 @@ describe('ObligationSheet — campaign evolution schema contract', () => {
     expect(schema.campaignDelta.config.initial).toBe(0)
   })
 })
+
+describe('ObligationSheet — narrative vs extra creation distinction (schema contract)', () => {
+  it('isExtra defaults to false so a new obligation is a standard narrative obligation', async () => {
+    const SwerpgObligation = (await import('../../../module/models/obligation.mjs')).default
+    const schema = SwerpgObligation.defineSchema()
+    // A brand-new obligation should be a narrative obligation by default.
+    // Enabling isExtra is an explicit secondary choice, not the default entry point.
+    expect(schema.isExtra.config.initial).toBe(false)
+  })
+
+  it('schema exposes isExtra field to allow explicit opting-in to the creation bonus', async () => {
+    const SwerpgObligation = (await import('../../../module/models/obligation.mjs')).default
+    const schema = SwerpgObligation.defineSchema()
+    expect(schema).toHaveProperty('isExtra')
+  })
+
+  it('schema exposes extraXp and extraCredits as creation-bonus fields separate from the narrative value', async () => {
+    const SwerpgObligation = (await import('../../../module/models/obligation.mjs')).default
+    const schema = SwerpgObligation.defineSchema()
+    expect(schema).toHaveProperty('extraXp')
+    expect(schema).toHaveProperty('extraCredits')
+  })
+})


### PR DESCRIPTION
## Description

Permet au joueur/MJ d'identifier immédiatement, depuis l'onglet `Commitments`, comment ajouter une Obligation narrative sans passer par un flux générique de création d'item orienté inventaire.

## Changements

```
 ...e-l-ajout-d-obligation-narrative-decouvrable.md |  67 ++++++
 .../ux-review-obligation-purchase-workflow.md      | 259 +++++++++++++++++++++
 lang/en.json                                       |   9 +-
 lang/fr.json                                       |   9 +-
 module/applications/sheets/character-sheet.mjs     |  15 ++
 styles/actor.less                                  |  56 +++++
 styles/item.less                                   |  30 +++
 styles/swerpg.css                                  |  72 ++++++
 templates/sheets/actor/character-commitments.hbs   |  22 ++
 templates/sheets/partials/obligation-config.hbs    |   9 +-
 .../sheets/character-sheet-commitments.test.mjs    |  67 ++++++
 .../applications/sheets/obligation-sheet.test.mjs  |  23 ++
 12 files changed, 633 insertions(+), 5 deletions(-)
```

### Principaux fichiers modifiés

- **`templates/sheets/actor/character-commitments.hbs`** — CTA explicite d'ajout d'Obligation dans l'en-tête du bloc, avec état vide guidant l'utilisateur
- **`module/applications/sheets/character-sheet.mjs`** — Action `addObligation` ciblant directement le type `obligation` (évite le flux générique `weapon`)
- **`templates/sheets/partials/obligation-config.hbs`** — Clarification microcopy : distinction Obligation narrative standard vs bonus de création (`isExtra`)
- **`lang/en.json`, `lang/fr.json`** — Nouvelles clés i18n pour le CTA, l'état vide, et les aides contextuelles
- **`styles/actor.less`, `styles/item.less`** — Styles du CTA et de l'état vide dans le bloc Commitments
- **`tests/applications/sheets/character-sheet-commitments.test.mjs`** — Tests de présence CTA, routage vers `obligation`, état vide
- **`tests/applications/sheets/obligation-sheet.test.mjs`** — Tests du rendu initial avec microcopy clarifiée

## Validation

- [x] Tests unitaires passants
- [x] Documentation de plan dans `documentation/plan/character-sheet/obligation/`

Closes #656