### PR TITLE
feat(obligation): add guided selector for official creation bonus options

### DIFF
--- a/documentation/plan/character-sheet/obligation/658-ajouter-un-selecteur-guide-pour-prendre-un-bonus-officiel-d-obligation.md
+++ b/documentation/plan/character-sheet/obligation/658-ajouter-un-selecteur-guide-pour-prendre-un-bonus-officiel-d-obligation.md
@@ -1,0 +1,68 @@
+# Character Sheet — Ajouter un sélecteur guidé pour prendre un bonus officiel d’Obligation
+
+**Issue** : [#658 — Ajouter un sélecteur guidé pour prendre un bonus officiel d’Obligation](https://github.com/herveDarritchon/foundryvtt-swerpg/issues/658)
+**Domaine métier** : `character-sheet/obligation`
+
+## Objectif
+
+Permettre au joueur de prendre un bonus officiel d’Obligation depuis l’onglet `Commitments` via un parcours guidé, contraint et immédiatement compréhensible, sans devoir éditer manuellement `extraXp` / `extraCredits` dans une fiche item séparée.
+
+## Contexte utile
+
+- `documentation/plan/character-sheet/obligation/646-appliquer-les-regles-officielles-de-bonus-de-creation-lies-aux-obligations.md` a déjà cadré les options officielles et le diagnostic canonique de conformité.
+- `documentation/plan/character-sheet/obligation/657-separer-obligations-narratives-et-bonus-de-creation-dans-la-feuille.md` a déjà séparé visuellement les Obligations narratives et les bonus de création dans l’onglet `Commitments`.
+- `templates/sheets/partials/obligation-config.hbs` affiche encore des champs libres `extraXp` / `extraCredits`, accompagnés d’une simple liste statique des options officielles.
+- `module/models/character.mjs` dérive déjà `obligationCreationState` avec les options reconnues, le plafond restant et les erreurs, ce qui fournit le socle métier nécessaire pour désactiver les choix impossibles au lieu de les signaler après coup.
+- La revue UX `documentation/review/character/obligations/ux-review-obligation-purchase-workflow.md` recommande explicitement un sélecteur guidé avec options désactivées quand elles sont déjà prises ou hors plafond.
+
+## Plan d'implémentation
+
+### Étape 1 — Exposer des options officielles prêtes à consommer côté UI
+
+**Fichiers** : `module/lib/obligations/obligation-bonus-calculator.mjs`, `module/models/character.mjs`, `module/applications/sheets/character-sheet.mjs`, `tests/lib/obligations/obligation-bonus-calculator.test.mjs`, `tests/applications/sheets/character-sheet-commitments.test.mjs`
+
+**What** :
+
+- partir de la source canonique des bonus officiels pour produire une liste d’options UI homogène (`id`, bonus XP/crédits, coût en Obligation, libellé, état de disponibilité) au lieu de laisser les templates reconstituer les règles ;
+- enrichir le contexte de feuille avec les métadonnées nécessaires au sélecteur guidé : option déjà prise, option bloquée par le plafond restant, raison de désactivation, prévisualisation d’impact sur le total d’Obligation ;
+- verrouiller par tests les cas clés de disponibilité : option libre, doublon interdit, option au-delà du plafond, combinaison valide restant sélectionnable.
+
+**Résultat attendu** : la UI dispose d’un catalogue d’options officielles déjà annoté par le runtime, sans recalcul métier ad hoc dans les templates.
+
+### Étape 2 — Remplacer l’ajout générique de bonus par un parcours guidé depuis `Commitments`
+
+**Fichiers** : `module/applications/sheets/character-sheet.mjs`, `templates/sheets/actor/character-commitments.hbs`, `module/applications/sheets/obligation.mjs` ou nouvelle application/dialog dédiée, `tests/applications/sheets/character-sheet-commitments.test.mjs`, `tests/applications/sheets/obligation-sheet.test.mjs`
+
+**What** :
+
+- brancher l’action `creationBonusObligationCreate` sur un sélecteur guidé qui ne propose que les bonus officiels, au lieu d’ouvrir directement une Obligation extra vierge ;
+- afficher pour chaque option son gain, son coût en Obligation et son impact sur le total/plafond, avec désactivation explicite des choix déjà consommés ou impossibles ;
+- à la confirmation, créer ou préremplir l’Obligation bonus avec les valeurs officielles exactes (`isExtra`, `value`, `extraXp`, `extraCredits`) pour éviter toute saisie libre sur le chemin nominal.
+
+**Résultat attendu** : prendre un bonus officiel devient une action unique, guidée et sûre depuis la fiche personnage.
+
+### Étape 3 — Repositionner la fiche d’Obligation en fallback expert et finaliser la couverture UX
+
+**Fichiers** : `templates/sheets/partials/obligation-config.hbs`, `lang/en.json`, `lang/fr.json`, `tests/applications/sheets/obligation-sheet.test.mjs`, `tests/applications/sheets/character-sheet-commitments.test.mjs`
+
+**What** :
+
+- faire évoluer la fiche item `obligation` pour qu’un bonus de création édité manuellement renvoie vers les options officielles guidées ou, à minima, n’encourage plus la saisie arbitraire de montants ;
+- ajouter les libellés, aides et raisons d’indisponibilité EN/FR nécessaires au sélecteur et à son fallback d’édition ;
+- compléter les tests ciblés sur le rendu du sélecteur, les états disabled, le payload créé/prérempli et la lisibilité du fallback expert.
+
+**Résultat attendu** : le flux guidé devient le parcours standard, tandis que la fiche item reste cohérente et ne réintroduit pas silencieusement des combinaisons invalides.
+
+## Périmètre / hors périmètre
+
+### Inclus
+
+- sélecteur guidé pour choisir un bonus officiel d’Obligation depuis l’onglet `Commitments`
+- désactivation préventive des options déjà prises ou hors plafond
+- harmonisation du fallback d’édition et des libellés i18n autour du nouveau parcours
+
+### Exclus
+
+- redéfinition des règles officielles des bonus d’Obligation déjà cadrées par l’issue `#646`
+- refonte générale du domaine Obligation hors achat de bonus de création
+- automatisation d’autres parcours de création de personnage non liés aux Obligations

--- a/lang/en.json
+++ b/lang/en.json
@@ -1011,7 +1011,15 @@
       "CAMPAIGN_TRANSFORMED_LABEL": "Transformed into:",
       "CAMPAIGN_NO_EVOLUTION": "No campaign evolution recorded yet.",
       "NARRATIVE_HINT": "A narrative Obligation represents a debt, secret, or bond that drives the story. Fill in the name and base value to get started.",
-      "EXTRA_SECONDARY_HINT": "The Extra Obligation option grants additional XP or credits at character creation. Enable it only if you took on a higher obligation than the base value during character creation."
+      "EXTRA_SECONDARY_HINT": "The Extra Obligation option grants additional XP or credits at character creation. Enable it only if you took on a higher obligation than the base value during character creation.",
+      "EXTRA_EXPERT_FALLBACK_HINT": "Expert mode — edit directly. Prefer the guided selector on the Commitments tab to avoid invalid combinations.",
+      "SELECTOR_TITLE": "Choose a Creation Bonus",
+      "SELECTOR_HINT": "Each option may be chosen at most once. Options already taken or exceeding your remaining obligation cap are disabled.",
+      "SELECTOR_LEGEND": "Official options (FFG / Edge Studio)",
+      "SELECTOR_CONFIRM": "Confirm",
+      "SELECTOR_OPTION_TAKEN": "(already taken)",
+      "SELECTOR_OPTION_EXCEEDS_CAP": "(exceeds remaining cap)",
+      "SELECTOR_NO_OPTIONS": "All available options have already been taken or exceed your current obligation cap."
     }
   },
   "RESOURCES": {

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -1114,7 +1114,15 @@
       "CAMPAIGN_TRANSFORMED_LABEL": "Transformée en :",
       "CAMPAIGN_NO_EVOLUTION": "Aucune évolution de campagne enregistrée pour l'instant.",
       "NARRATIVE_HINT": "Une Obligation narrative représente une dette, un secret ou un lien qui fait avancer l'histoire. Renseignez le nom et la valeur de base pour commencer.",
-      "EXTRA_SECONDARY_HINT": "L'option Obligation Extra accorde des XP ou des crédits supplémentaires à la création du personnage. Activez-la uniquement si vous avez accepté une obligation plus élevée que la valeur de base lors de la création."
+      "EXTRA_SECONDARY_HINT": "L'option Obligation Extra accorde des XP ou des crédits supplémentaires à la création du personnage. Activez-la uniquement si vous avez accepté une obligation plus élevée que la valeur de base lors de la création.",
+      "EXTRA_EXPERT_FALLBACK_HINT": "Mode expert — modification directe. Préférez le sélecteur guidé dans l'onglet Engagements pour éviter les combinaisons invalides.",
+      "SELECTOR_TITLE": "Choisir un bonus de création",
+      "SELECTOR_HINT": "Chaque option ne peut être choisie qu'une seule fois. Les options déjà prises ou dépassant votre plafond d'Obligation restant sont désactivées.",
+      "SELECTOR_LEGEND": "Options officielles (FFG / Edge Studio)",
+      "SELECTOR_CONFIRM": "Confirmer",
+      "SELECTOR_OPTION_TAKEN": "(déjà prise)",
+      "SELECTOR_OPTION_EXCEEDS_CAP": "(dépasse le plafond restant)",
+      "SELECTOR_NO_OPTIONS": "Toutes les options disponibles ont déjà été prises ou dépassent votre plafond d'Obligation actuel."
     }
   },
   "RESOURCES": {

--- a/module/applications/sheets/character-sheet.mjs
+++ b/module/applications/sheets/character-sheet.mjs
@@ -12,6 +12,7 @@ import { getPositiveDicePoolPreview } from '../../utils/skill-costs.mjs'
 import SkillCostCalculator from '../../lib/skills/skill-cost-calculator.mjs'
 import { evaluateSpecializationPurchase } from '../../lib/specializations/specialization-purchase-flow.mjs'
 import { computeEffectiveValue } from '../../lib/obligations/obligation-evolution.mjs'
+import ObligationBonusCalculator from '../../lib/obligations/obligation-bonus-calculator.mjs'
 
 /**
  * @typedef {Object} DefenseDisplayData
@@ -446,17 +447,126 @@ export default class CharacterSheet extends SwerpgBaseActorSheet {
   /* -------------------------------------------- */
 
   /**
-   * Handle click action to create a new creation-bonus Obligation (isExtra = true) directly on the actor.
-   * Creates the obligation pre-configured as a creation bonus so the user lands directly on the
-   * creation-bonus flow without having to toggle isExtra manually.
+   * Build the i18n label for a guided bonus selector option.
+   * @param {import('../../lib/obligations/obligation-bonus-calculator.mjs').ObligationBonusSelectOption} opt
+   * @returns {string}
+   */
+  static #getOptionLabel(opt) {
+    const i18n = game.i18n
+    if (opt.key === 'xp_5') return i18n.localize('OBLIGATION.UI.OFFICIAL_OPTION_XP_5')
+    if (opt.key === 'xp_10') return i18n.localize('OBLIGATION.UI.OFFICIAL_OPTION_XP_10')
+    if (opt.key === 'credits_1000') return i18n.localize('OBLIGATION.UI.OFFICIAL_OPTION_CREDITS_1000')
+    if (opt.key === 'credits_2500') return i18n.localize('OBLIGATION.UI.OFFICIAL_OPTION_CREDITS_2500')
+    return opt.key
+  }
+
+  /**
+   * Handle click action to select an official creation-bonus Obligation from a guided selector.
+   *
+   * Opens a DialogV2 prompt listing the four official FFG/Edge bonus options with each option
+   * disabled when already taken or when selecting it would exceed the remaining obligation cap.
+   * On confirmation, creates an Obligation item pre-filled with the official values
+   * (isExtra=true, value, extraXp, extraCredits) so no free-text editing is needed on the nominal path.
+   *
    * @this {CharacterSheet}
    * @param {PointerEvent} event
    * @returns {Promise<void>}
    */
   static async #onCreationBonusObligationCreate(event) {
-    logger.debug('[CharacterSheet] creationBonusObligationCreate — opening creation-bonus obligation dialog')
+    logger.debug('[CharacterSheet] creationBonusObligationCreate — opening guided bonus selector')
+
+    const obligationData = this.actor.items
+      .filter((item) => item.type === 'obligation')
+      .map((item) => ({
+        isExtra: item.system.isExtra,
+        extraXp: item.system.extraXp || 0,
+        extraCredits: item.system.extraCredits || 0,
+        value: item.system.value || 0,
+      }))
+
+    const remainingCap = this.actor.system.obligationCreationState?.remainingObligationCap ?? Infinity
+    const options = ObligationBonusCalculator.buildObligationBonusOptions(obligationData, remainingCap)
+
+    const i18n = game.i18n
+    const anyAvailable = options.some((opt) => opt.isAvailable)
+
+    const optionRows = options
+      .map((opt) => {
+        const label = CharacterSheet.#getOptionLabel(opt)
+        const disabled = !opt.isAvailable
+
+        let reasonHtml = ''
+        if (opt.isAlreadyTaken) {
+          reasonHtml = `<span class="obligation-selector__reason">${i18n.localize('OBLIGATION.UI.SELECTOR_OPTION_TAKEN')}</span>`
+        } else if (opt.isExceedsCap) {
+          reasonHtml = `<span class="obligation-selector__reason">${i18n.localize('OBLIGATION.UI.SELECTOR_OPTION_EXCEEDS_CAP')}</span>`
+        }
+
+        return `<label class="obligation-selector__option${disabled ? ' obligation-selector__option--disabled' : ''}">
+  <input type="radio" name="bonusKey" value="${opt.key}"${disabled ? ' disabled' : ''}/>
+  <span class="obligation-selector__label">${label}</span>
+  ${reasonHtml}
+</label>`
+      })
+      .join('\n')
+
+    const noOptionsHtml = anyAvailable ? '' : `<p class="obligation-selector__no-options">${i18n.localize('OBLIGATION.UI.SELECTOR_NO_OPTIONS')}</p>`
+
+    const content = `<form class="obligation-selector">
+  <p class="obligation-selector__hint">${i18n.localize('OBLIGATION.UI.SELECTOR_HINT')}</p>
+  <fieldset class="obligation-selector__list">
+    <legend>${i18n.localize('OBLIGATION.UI.SELECTOR_LEGEND')}</legend>
+    ${optionRows}
+    ${noOptionsHtml}
+  </fieldset>
+</form>`
+
+    let selectedKey = null
+
+    await foundry.applications.api.DialogV2.prompt({
+      window: { title: i18n.localize('OBLIGATION.UI.SELECTOR_TITLE') },
+      content,
+      ok: {
+        label: i18n.localize('OBLIGATION.UI.SELECTOR_CONFIRM'),
+        icon: 'fa-solid fa-check',
+        callback: (event, button, dialog) => {
+          const form = button.form ?? dialog.querySelector('form')
+          if (!form) return
+          const checked = form.querySelector('input[name="bonusKey"]:checked')
+          if (checked) selectedKey = checked.value
+        },
+      },
+      rejectClose: false,
+    })
+
+    if (!selectedKey) {
+      logger.debug('[CharacterSheet] creationBonusObligationCreate — no option selected, aborting')
+      return
+    }
+
+    const chosen = ObligationBonusCalculator.OFFICIAL_OPTIONS.find((opt) => opt.key === selectedKey)
+    if (!chosen) {
+      logger.warn('[CharacterSheet] creationBonusObligationCreate — unknown option key selected', { selectedKey })
+      return
+    }
+
+    logger.debug('[CharacterSheet] creationBonusObligationCreate — creating obligation for option', { selectedKey, chosen })
+
     const cls = getDocumentClass('Item')
-    await cls.createDialog({ type: 'obligation', 'system.isExtra': true }, { parent: this.document, pack: this.document.pack })
+    const name = CharacterSheet.#getOptionLabel({ key: selectedKey })
+    await cls.create(
+      {
+        name,
+        type: 'obligation',
+        system: {
+          isExtra: true,
+          value: chosen.obligationCost,
+          extraXp: chosen.xp,
+          extraCredits: chosen.credits,
+        },
+      },
+      { parent: this.document },
+    )
   }
 
   /* -------------------------------------------- */

--- a/module/lib/obligations/obligation-bonus-calculator.mjs
+++ b/module/lib/obligations/obligation-bonus-calculator.mjs
@@ -30,6 +30,20 @@ import {
  */
 
 /**
+ * @typedef {Object} ObligationBonusSelectOption
+ * UI-ready annotated bonus option for a guided selector.
+ *
+ * @property {'xp_5'|'xp_10'|'credits_1000'|'credits_2500'} key      - Canonical key for the option.
+ * @property {number}  xp                 - XP bonus granted by this option (0 if none).
+ * @property {number}  credits            - Credits bonus granted by this option (0 if none).
+ * @property {number}  obligationCost     - Extra Obligation points consumed.
+ * @property {boolean} isAlreadyTaken     - True when the character has already selected this option.
+ * @property {boolean} isExceedsCap       - True when selecting this option would exceed the remaining cap.
+ * @property {boolean} isAvailable        - True when the option can be chosen right now.
+ * @property {string|null} unavailableReason - Human-readable reason why the option is unavailable, or null.
+ */
+
+/**
  * @typedef {Object} ObligationCreationSummary
  * Canonical result of analysing the extra-obligation bonus selections for a character.
  *
@@ -180,5 +194,61 @@ export default class ObligationBonusCalculator {
    */
   static get OFFICIAL_OPTIONS() {
     return OFFICIAL_OPTIONS
+  }
+
+  /* -------------------------------------------- */
+  /*  Guided selector helpers                      */
+  /* -------------------------------------------- */
+
+  /**
+   * Build a UI-ready annotated list of official bonus options for a guided selector.
+   *
+   * Each option is annotated with:
+   * - `isAlreadyTaken`  — the character already has this option selected;
+   * - `isExceedsCap`    — selecting it would exceed the remaining obligation cap;
+   * - `isAvailable`     — the option can be chosen (not taken and within cap);
+   * - `unavailableReason` — a short English reason key when unavailable, or `null`.
+   *
+   * The method is pure: callers must map their Foundry Items to `ObligationBonusInput[]`
+   * before calling, and must pass the creation state summary separately so no Foundry
+   * dependency leaks into this layer.
+   *
+   * @param {ObligationBonusInput[]} obligations        All obligation items for the character.
+   * @param {number}                 remainingObligationCap Remaining obligation cap after existing selections.
+   * @returns {ObligationBonusSelectOption[]}
+   */
+  static buildObligationBonusOptions(obligations, remainingObligationCap) {
+    const extraObligations = obligations.filter((o) => o.isExtra === true)
+
+    const takenKeys = new Set()
+    for (const obl of extraObligations) {
+      const xp = obl.extraXp || 0
+      const credits = obl.extraCredits || 0
+      const match = OFFICIAL_OPTIONS.find((opt) => opt.xp === xp && opt.credits === credits)
+      if (match) takenKeys.add(match.key)
+    }
+
+    const cap = Number.isFinite(remainingObligationCap) ? remainingObligationCap : Infinity
+
+    return OFFICIAL_OPTIONS.map((opt) => {
+      const isAlreadyTaken = takenKeys.has(opt.key)
+      const isExceedsCap = !isAlreadyTaken && opt.obligationCost > cap
+      const isAvailable = !isAlreadyTaken && !isExceedsCap
+
+      let unavailableReason = null
+      if (isAlreadyTaken) unavailableReason = 'already-taken'
+      else if (isExceedsCap) unavailableReason = 'exceeds-cap'
+
+      return {
+        key: opt.key,
+        xp: opt.xp,
+        credits: opt.credits,
+        obligationCost: opt.obligationCost,
+        isAlreadyTaken,
+        isExceedsCap,
+        isAvailable,
+        unavailableReason,
+      }
+    })
   }
 }

--- a/templates/sheets/partials/obligation-config.hbs
+++ b/templates/sheets/partials/obligation-config.hbs
@@ -16,12 +16,12 @@
     <legend>{{localize "OBLIGATION.UI.EXTRA_BONUS_LEGEND"}}</legend>
 
     <div class="obligation-official-options" aria-label="{{localize "OBLIGATION.UI.OFFICIAL_OPTIONS_LABEL"}}">
-      <p class="obligation-official-options__hint">{{localize "OBLIGATION.UI.OFFICIAL_OPTIONS_HINT"}}</p>
+      <p class="obligation-official-options__hint">{{localize "OBLIGATION.UI.EXTRA_EXPERT_FALLBACK_HINT"}}</p>
       <ul class="obligation-official-options__list">
-        <li>+{{localize "OBLIGATION.UI.OFFICIAL_OPTION_XP_5"}}</li>
-        <li>+{{localize "OBLIGATION.UI.OFFICIAL_OPTION_XP_10"}}</li>
-        <li>+{{localize "OBLIGATION.UI.OFFICIAL_OPTION_CREDITS_1000"}}</li>
-        <li>+{{localize "OBLIGATION.UI.OFFICIAL_OPTION_CREDITS_2500"}}</li>
+        <li>{{localize "OBLIGATION.UI.OFFICIAL_OPTION_XP_5"}}</li>
+        <li>{{localize "OBLIGATION.UI.OFFICIAL_OPTION_XP_10"}}</li>
+        <li>{{localize "OBLIGATION.UI.OFFICIAL_OPTION_CREDITS_1000"}}</li>
+        <li>{{localize "OBLIGATION.UI.OFFICIAL_OPTION_CREDITS_2500"}}</li>
       </ul>
     </div>
 

--- a/tests/applications/sheets/character-sheet-commitments.test.mjs
+++ b/tests/applications/sheets/character-sheet-commitments.test.mjs
@@ -184,12 +184,16 @@ describe('CharacterSheet — obligationCreate action', () => {
   })
 })
 
-describe('CharacterSheet — creationBonusObligationCreate action', () => {
+describe('CharacterSheet — creationBonusObligationCreate action (guided selector)', () => {
   let CharacterSheet
   let logger
+  let promptMock
 
   beforeEach(async () => {
     setupFoundryMock()
+    // Patch DialogV2.prompt on the foundry mock installed by setupFoundryMock
+    promptMock = vi.fn().mockResolvedValue(null)
+    globalThis.foundry.applications.api.DialogV2.prompt = promptMock
     CharacterSheet = (await import('../../../module/applications/sheets/character-sheet.mjs')).default
     logger = (await import('../../../module/utils/logger.mjs')).logger
   })
@@ -204,40 +208,47 @@ describe('CharacterSheet — creationBonusObligationCreate action', () => {
     expect(typeof CharacterSheet.DEFAULT_OPTIONS.actions.creationBonusObligationCreate).toBe('function')
   })
 
-  it('calls createDialog with type obligation', async () => {
-    const itemCls = buildItemClassMock()
-    globalThis.getDocumentClass = vi.fn(() => itemCls)
+  it('opens the DialogV2.prompt guided selector when triggered', async () => {
+    const sheet = {
+      actor: {
+        items: { filter: vi.fn(() => []) },
+        system: { obligationCreationState: { remainingObligationCap: Infinity } },
+      },
+      document: {},
+    }
 
-    const document = { pack: null }
-    const sheet = { document }
-    const event = {}
+    await CharacterSheet.DEFAULT_OPTIONS.actions.creationBonusObligationCreate.call(sheet, {})
 
-    await CharacterSheet.DEFAULT_OPTIONS.actions.creationBonusObligationCreate.call(sheet, event)
-
-    expect(itemCls.createDialog).toHaveBeenCalledWith(expect.objectContaining({ type: 'obligation' }), expect.objectContaining({ parent: document }))
+    expect(promptMock).toHaveBeenCalled()
   })
 
-  it('passes system.isExtra = true to createDialog so the item starts as a creation-bonus obligation', async () => {
-    const itemCls = buildItemClassMock()
-    globalThis.getDocumentClass = vi.fn(() => itemCls)
+  it('does not call Item.create when DialogV2 resolves without selection', async () => {
+    const cls = { create: vi.fn().mockResolvedValue(undefined) }
+    globalThis.getDocumentClass = vi.fn(() => cls)
 
-    const sheet = { document: { pack: null } }
-    const event = {}
+    const sheet = {
+      actor: {
+        items: { filter: vi.fn(() => []) },
+        system: { obligationCreationState: { remainingObligationCap: Infinity } },
+      },
+      document: {},
+    }
 
-    await CharacterSheet.DEFAULT_OPTIONS.actions.creationBonusObligationCreate.call(sheet, event)
+    await CharacterSheet.DEFAULT_OPTIONS.actions.creationBonusObligationCreate.call(sheet, {})
 
-    const [defaults] = itemCls.createDialog.mock.calls[0]
-    expect(defaults['system.isExtra']).toBe(true)
+    expect(cls.create).not.toHaveBeenCalled()
   })
 
   it('logs a debug message when triggered', async () => {
-    const itemCls = buildItemClassMock()
-    globalThis.getDocumentClass = vi.fn(() => itemCls)
+    const sheet = {
+      actor: {
+        items: { filter: vi.fn(() => []) },
+        system: { obligationCreationState: { remainingObligationCap: Infinity } },
+      },
+      document: {},
+    }
 
-    const sheet = { document: { pack: null } }
-    const event = {}
-
-    await CharacterSheet.DEFAULT_OPTIONS.actions.creationBonusObligationCreate.call(sheet, event)
+    await CharacterSheet.DEFAULT_OPTIONS.actions.creationBonusObligationCreate.call(sheet, {})
 
     expect(logger.debug).toHaveBeenCalledWith(expect.stringContaining('creationBonusObligationCreate'))
   })

--- a/tests/lib/obligations/obligation-bonus-calculator.test.mjs
+++ b/tests/lib/obligations/obligation-bonus-calculator.test.mjs
@@ -271,4 +271,135 @@ describe('ObligationBonusCalculator', () => {
       })
     })
   })
+
+  describe('buildObligationBonusOptions', () => {
+    describe('with no obligations', () => {
+      test('returns 4 options all available when no obligations exist', () => {
+        const result = ObligationBonusCalculator.buildObligationBonusOptions([], Infinity)
+        expect(result).toHaveLength(4)
+        expect(result.every((opt) => opt.isAvailable)).toBe(true)
+      })
+
+      test('all options have unavailableReason null when all available', () => {
+        const result = ObligationBonusCalculator.buildObligationBonusOptions([], Infinity)
+        expect(result.every((opt) => opt.unavailableReason === null)).toBe(true)
+      })
+
+      test('all options have isAlreadyTaken=false when no obligations exist', () => {
+        const result = ObligationBonusCalculator.buildObligationBonusOptions([], Infinity)
+        expect(result.every((opt) => opt.isAlreadyTaken === false)).toBe(true)
+      })
+
+      test('all options have isExceedsCap=false when remainingCap is Infinity', () => {
+        const result = ObligationBonusCalculator.buildObligationBonusOptions([], Infinity)
+        expect(result.every((opt) => opt.isExceedsCap === false)).toBe(true)
+      })
+    })
+
+    describe('with an already-taken option', () => {
+      test('marks xp_5 as already taken when it is in obligations', () => {
+        const obligations = [{ isExtra: true, extraXp: 5, extraCredits: 0, value: 5 }]
+        const result = ObligationBonusCalculator.buildObligationBonusOptions(obligations, Infinity)
+        const xp5 = result.find((opt) => opt.key === 'xp_5')
+        expect(xp5.isAlreadyTaken).toBe(true)
+        expect(xp5.isAvailable).toBe(false)
+        expect(xp5.unavailableReason).toBe('already-taken')
+      })
+
+      test('marks credits_1000 as already taken and other options still available', () => {
+        const obligations = [{ isExtra: true, extraXp: 0, extraCredits: 1000, value: 5 }]
+        const result = ObligationBonusCalculator.buildObligationBonusOptions(obligations, Infinity)
+        const credits1000 = result.find((opt) => opt.key === 'credits_1000')
+        expect(credits1000.isAlreadyTaken).toBe(true)
+        const others = result.filter((opt) => opt.key !== 'credits_1000')
+        expect(others.every((opt) => opt.isAvailable)).toBe(true)
+      })
+
+      test('marks two taken options as unavailable and two others as available', () => {
+        const obligations = [
+          { isExtra: true, extraXp: 5, extraCredits: 0, value: 5 },
+          { isExtra: true, extraXp: 0, extraCredits: 1000, value: 5 },
+        ]
+        const result = ObligationBonusCalculator.buildObligationBonusOptions(obligations, Infinity)
+        const taken = result.filter((opt) => opt.isAlreadyTaken)
+        const available = result.filter((opt) => opt.isAvailable)
+        expect(taken).toHaveLength(2)
+        expect(available).toHaveLength(2)
+      })
+    })
+
+    describe('with remaining cap constraints', () => {
+      test('marks options exceeding remainingCap as isExceedsCap=true', () => {
+        // remainingCap = 5 so only options with obligationCost <= 5 are within cap
+        const result = ObligationBonusCalculator.buildObligationBonusOptions([], 5)
+        const exceedsCap = result.filter((opt) => opt.isExceedsCap)
+        // xp_10 (cost=10) and credits_2500 (cost=10) exceed cap=5
+        expect(exceedsCap.every((opt) => opt.obligationCost > 5)).toBe(true)
+        expect(exceedsCap.every((opt) => opt.unavailableReason === 'exceeds-cap')).toBe(true)
+      })
+
+      test('marks options within cap as available', () => {
+        const result = ObligationBonusCalculator.buildObligationBonusOptions([], 5)
+        const available = result.filter((opt) => opt.isAvailable)
+        // xp_5 (cost=5) and credits_1000 (cost=5) are within cap
+        expect(available.every((opt) => opt.obligationCost <= 5)).toBe(true)
+      })
+
+      test('returns all options as isExceedsCap when remainingCap is 0', () => {
+        const result = ObligationBonusCalculator.buildObligationBonusOptions([], 0)
+        expect(result.every((opt) => opt.isExceedsCap)).toBe(true)
+        expect(result.every((opt) => !opt.isAvailable)).toBe(true)
+      })
+
+      test('does not mark taken options as isExceedsCap even when cost would exceed cap', () => {
+        // xp_5 is taken; remainingCap=0 — taken takes priority over cap check
+        const obligations = [{ isExtra: true, extraXp: 5, extraCredits: 0, value: 5 }]
+        const result = ObligationBonusCalculator.buildObligationBonusOptions(obligations, 0)
+        const xp5 = result.find((opt) => opt.key === 'xp_5')
+        expect(xp5.isAlreadyTaken).toBe(true)
+        expect(xp5.isExceedsCap).toBe(false)
+        expect(xp5.unavailableReason).toBe('already-taken')
+      })
+    })
+
+    describe('option shape', () => {
+      test('each option has key, xp, credits, obligationCost fields', () => {
+        const result = ObligationBonusCalculator.buildObligationBonusOptions([], Infinity)
+        for (const opt of result) {
+          expect(opt).toHaveProperty('key')
+          expect(opt).toHaveProperty('xp')
+          expect(opt).toHaveProperty('credits')
+          expect(opt).toHaveProperty('obligationCost')
+        }
+      })
+
+      test('each option has availability annotation fields', () => {
+        const result = ObligationBonusCalculator.buildObligationBonusOptions([], Infinity)
+        for (const opt of result) {
+          expect(opt).toHaveProperty('isAlreadyTaken')
+          expect(opt).toHaveProperty('isExceedsCap')
+          expect(opt).toHaveProperty('isAvailable')
+          expect(opt).toHaveProperty('unavailableReason')
+        }
+      })
+
+      test('returns options in the same order as OFFICIAL_OPTIONS', () => {
+        const result = ObligationBonusCalculator.buildObligationBonusOptions([], Infinity)
+        const resultKeys = result.map((opt) => opt.key)
+        const officialKeys = ObligationBonusCalculator.OFFICIAL_OPTIONS.map((opt) => opt.key)
+        expect(resultKeys).toEqual(officialKeys)
+      })
+    })
+
+    describe('non-extra obligations are ignored', () => {
+      test('non-extra obligations do not affect availability', () => {
+        const obligations = [
+          { isExtra: false, extraXp: 5, extraCredits: 0, value: 10 },
+          { isExtra: false, extraXp: 0, extraCredits: 1000, value: 10 },
+        ]
+        const result = ObligationBonusCalculator.buildObligationBonusOptions(obligations, Infinity)
+        expect(result.every((opt) => opt.isAvailable)).toBe(true)
+      })
+    })
+  })
 })


### PR DESCRIPTION
## Summary

- Add a guided selector to the Character Sheet obligation configuration to choose official creation bonus options.
- Implement business logic in module/lib/obligations/obligation-bonus-calculator.mjs, update sheet template and character-sheet integration, and add tests.

## Context

Files changed in this branch relative to develop:

- documentation/plan/character-sheet/obligation/658-ajouter-un-selecteur-guide-pour-prendre-un-bonus-officiel-d-obligation.md
- lang/en.json
- lang/fr.json
- module/applications/sheets/character-sheet.mjs
- module/lib/obligations/obligation-bonus-calculator.mjs
- templates/sheets/partials/obligation-config.hbs
- tests/applications/sheets/character-sheet-commitments.test.mjs
- tests/lib/obligations/obligation-bonus-calculator.test.mjs

## Tests

- Not run (not requested).

## Notes

- Branch is published and tracks origin/658-ajouter-un-sélecteur-guidé-pour-prendre-un-bonus-officiel-dobligation.
- No lint/test/build was executed as part of this PR creation.
