### PR TITLE
feat(obligation): prevent duplicates and cap exceedances in bonus selector

### DIFF
--- a/documentation/plan/character-sheet/obligation/659-prevenir-doublons-et-depassements-dans-le-selecteur-de-bonus-obligation.md
+++ b/documentation/plan/character-sheet/obligation/659-prevenir-doublons-et-depassements-dans-le-selecteur-de-bonus-obligation.md
@@ -1,0 +1,55 @@
+# Character Sheet — Prévenir doublons et dépassements dans le sélecteur de bonus Obligation
+
+**Issue** : [#659 — Prévenir doublons et dépassements dans le sélecteur de bonus Obligation](https://github.com/herveDarritchon/foundryvtt-swerpg/issues/659)
+**Domaine métier** : `character-sheet/obligation`
+
+## Objectif
+
+Empêcher le parcours guidé de bonus d’Obligation de proposer ou confirmer une option déjà prise ou hors plafond, tout en conservant les erreurs globales de conformité pour les états legacy, importés ou modifiés hors du flux standard.
+
+## Contexte utile
+
+- `documentation/plan/character-sheet/obligation/658-ajouter-un-selecteur-guide-pour-prendre-un-bonus-officiel-d-obligation.md` pose déjà le sélecteur guidé et l’exposition des options officielles côté UI.
+- L’issue `#659` durcit ce parcours : les erreurs doivent être évitées avant confirmation, pas seulement diagnostiquées après coup.
+- Les critères d’acceptation distinguent bien deux niveaux : prévention locale dans le sélecteur, puis maintien du diagnostic global pour les données non conformes préexistantes.
+
+## Plan d'implémentation
+
+### Étape 1 — Canoniser les états de disponibilité du sélecteur
+
+**Fichiers** : `module/lib/obligations/obligation-bonus-calculator.mjs`, `module/models/character.mjs`, `module/applications/sheets/character-sheet.mjs`, `tests/lib/obligations/obligation-bonus-calculator.test.mjs`, `tests/applications/sheets/character-sheet-commitments.test.mjs`
+
+**What** :
+
+- faire porter par l’état dérivé des bonus une distinction explicite entre `available`, `already-selected` et `over-cap`, avec raison localisable et booléen de confirmation autorisée ;
+- conserver séparément les erreurs globales de conformité pour les combinaisons legacy afin qu’un état invalide existant reste visible sans polluer le chemin nominal ;
+- verrouiller par tests ciblés les cas limites de doublon, de dépassement du plafond restant et de combinaison encore autorisée.
+
+**Résultat attendu** : le runtime fournit au sélecteur un contrat simple et sûr, suffisant pour interdire préventivement les choix invalides sans perdre le diagnostic legacy.
+
+### Étape 2 — Verrouiller l’UX de sélection et de confirmation
+
+**Fichiers** : `module/applications/sheets/character-sheet.mjs`, `templates/sheets/actor/character-commitments.hbs`, `module/applications/sheets/obligation.mjs` ou application/dialog du sélecteur, `lang/en.json`, `lang/fr.json`, `tests/applications/sheets/character-sheet-commitments.test.mjs`, `tests/applications/sheets/obligation-sheet.test.mjs`
+
+**What** :
+
+- afficher chaque option avec son état localisé et accessible, en désactivant explicitement celles déjà prises ou hors plafond avec explication claire ;
+- empêcher la validation d’une option indisponible, y compris si l’utilisateur tente de contourner le disabled via un état UI incohérent ;
+- maintenir l’affichage des erreurs globales de conformité pour les obligations bonus déjà invalides présentes sur l’acteur.
+
+**Résultat attendu** : le joueur ne peut plus créer naturellement un doublon ni dépasser le plafond via le sélecteur, tout en gardant un feedback utile sur les données non conformes héritées.
+
+## Périmètre / hors périmètre
+
+### Inclus
+
+- indisponibilité préventive des options déjà prises
+- indisponibilité préventive des options hors plafond restant
+- raisons d’indisponibilité localisées et accessibles
+- maintien du diagnostic global pour états legacy non conformes
+
+### Exclus
+
+- création initiale du sélecteur guidé déjà cadrée par l’issue `#658`
+- harmonisation globale de toute la microcopy/accessibilité du workflow Obligation au-delà des états du sélecteur
+- évolution des règles métier officielles des bonus d’Obligation

--- a/module/applications/sheets/character-sheet.mjs
+++ b/module/applications/sheets/character-sheet.mjs
@@ -544,6 +544,18 @@ export default class CharacterSheet extends SwerpgBaseActorSheet {
       return
     }
 
+    // Guard: reject a key that does not correspond to an available option, even if the
+    // disabled attribute was bypassed via external DOM manipulation.
+    const selectedOption = options.find((opt) => opt.key === selectedKey)
+    if (!selectedOption || !selectedOption.isAvailable) {
+      logger.warn('[CharacterSheet] creationBonusObligationCreate — selected option is unavailable, aborting', {
+        selectedKey,
+        isAlreadyTaken: selectedOption?.isAlreadyTaken ?? null,
+        isExceedsCap: selectedOption?.isExceedsCap ?? null,
+      })
+      return
+    }
+
     const chosen = ObligationBonusCalculator.OFFICIAL_OPTIONS.find((opt) => opt.key === selectedKey)
     if (!chosen) {
       logger.warn('[CharacterSheet] creationBonusObligationCreate — unknown option key selected', { selectedKey })

--- a/tests/applications/sheets/character-sheet-commitments.test.mjs
+++ b/tests/applications/sheets/character-sheet-commitments.test.mjs
@@ -254,6 +254,149 @@ describe('CharacterSheet — creationBonusObligationCreate action (guided select
   })
 })
 
+/**
+ * Build a promptMock that simulates the user selecting a given bonus key via the ok callback.
+ * The callback receives (event, button, dialog); the implementation reads from button.form.
+ * @param {string} selectedKey
+ * @returns {import('vitest').Mock}
+ */
+function buildPromptMockWithSelection(selectedKey) {
+  return vi.fn().mockImplementation(async (options) => {
+    if (options?.ok?.callback) {
+      const fakeChecked = { value: selectedKey }
+      const fakeForm = { querySelector: vi.fn(() => fakeChecked) }
+      const fakeButton = { form: fakeForm }
+      options.ok.callback({}, fakeButton, null)
+    }
+  })
+}
+
+describe('CharacterSheet — creationBonusObligationCreate availability guard', () => {
+  let CharacterSheet
+  let logger
+
+  beforeEach(async () => {
+    setupFoundryMock()
+    CharacterSheet = (await import('../../../module/applications/sheets/character-sheet.mjs')).default
+    logger = (await import('../../../module/utils/logger.mjs')).logger
+  })
+
+  afterEach(() => {
+    vi.resetModules()
+    vi.clearAllMocks()
+    teardownFoundryMock()
+  })
+
+  it('creates the obligation when the selected key is available', async () => {
+    globalThis.foundry.applications.api.DialogV2.prompt = buildPromptMockWithSelection('xp_5')
+    const cls = { create: vi.fn().mockResolvedValue(undefined) }
+    globalThis.getDocumentClass = vi.fn(() => cls)
+
+    const sheet = {
+      actor: {
+        items: {
+          filter: vi.fn(() => []),
+        },
+        system: { obligationCreationState: { remainingObligationCap: Infinity } },
+      },
+      document: {},
+    }
+
+    await CharacterSheet.DEFAULT_OPTIONS.actions.creationBonusObligationCreate.call(sheet, {})
+
+    expect(cls.create).toHaveBeenCalledOnce()
+    expect(cls.create.mock.calls[0][0].system.extraXp).toBe(5)
+  })
+
+  it('does not create the obligation when the selected key is already taken (bypass attempt)', async () => {
+    // xp_5 is already taken by an existing obligation
+    const existingObligation = buildObligationItem({ id: 'obl-taken', isExtra: true, extraXp: 5, extraCredits: 0, value: 5 })
+
+    globalThis.foundry.applications.api.DialogV2.prompt = buildPromptMockWithSelection('xp_5')
+    const cls = { create: vi.fn().mockResolvedValue(undefined) }
+    globalThis.getDocumentClass = vi.fn(() => cls)
+
+    const sheet = {
+      actor: {
+        items: {
+          filter: vi.fn(() => [existingObligation]),
+        },
+        system: { obligationCreationState: { remainingObligationCap: Infinity } },
+      },
+      document: {},
+    }
+
+    await CharacterSheet.DEFAULT_OPTIONS.actions.creationBonusObligationCreate.call(sheet, {})
+
+    expect(cls.create).not.toHaveBeenCalled()
+    expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('unavailable'), expect.objectContaining({ selectedKey: 'xp_5', isAlreadyTaken: true }))
+  })
+
+  it('does not create the obligation when the selected key exceeds the remaining cap (bypass attempt)', async () => {
+    // remainingObligationCap = 5, so xp_10 (cost=10) exceeds it
+    globalThis.foundry.applications.api.DialogV2.prompt = buildPromptMockWithSelection('xp_10')
+    const cls = { create: vi.fn().mockResolvedValue(undefined) }
+    globalThis.getDocumentClass = vi.fn(() => cls)
+
+    const sheet = {
+      actor: {
+        items: {
+          filter: vi.fn(() => []),
+        },
+        system: { obligationCreationState: { remainingObligationCap: 5 } },
+      },
+      document: {},
+    }
+
+    await CharacterSheet.DEFAULT_OPTIONS.actions.creationBonusObligationCreate.call(sheet, {})
+
+    expect(cls.create).not.toHaveBeenCalled()
+    expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('unavailable'), expect.objectContaining({ selectedKey: 'xp_10', isExceedsCap: true }))
+  })
+
+  it('does not create the obligation when the selected key is entirely unknown', async () => {
+    globalThis.foundry.applications.api.DialogV2.prompt = buildPromptMockWithSelection('unknown_key')
+    const cls = { create: vi.fn().mockResolvedValue(undefined) }
+    globalThis.getDocumentClass = vi.fn(() => cls)
+
+    const sheet = {
+      actor: {
+        items: {
+          filter: vi.fn(() => []),
+        },
+        system: { obligationCreationState: { remainingObligationCap: Infinity } },
+      },
+      document: {},
+    }
+
+    await CharacterSheet.DEFAULT_OPTIONS.actions.creationBonusObligationCreate.call(sheet, {})
+
+    expect(cls.create).not.toHaveBeenCalled()
+    expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('unavailable'), expect.objectContaining({ selectedKey: 'unknown_key' }))
+  })
+
+  it('does not create when cap is 0 (all options exceed cap)', async () => {
+    // All four options have obligationCost >= 5, so with cap=0 none is available
+    globalThis.foundry.applications.api.DialogV2.prompt = buildPromptMockWithSelection('credits_1000')
+    const cls = { create: vi.fn().mockResolvedValue(undefined) }
+    globalThis.getDocumentClass = vi.fn(() => cls)
+
+    const sheet = {
+      actor: {
+        items: {
+          filter: vi.fn(() => []),
+        },
+        system: { obligationCreationState: { remainingObligationCap: 0 } },
+      },
+      document: {},
+    }
+
+    await CharacterSheet.DEFAULT_OPTIONS.actions.creationBonusObligationCreate.call(sheet, {})
+
+    expect(cls.create).not.toHaveBeenCalled()
+  })
+})
+
 describe('CharacterSheet — obligation partitioning (narrativeObligations / creationBonusObligations)', () => {
   /**
    * These tests verify the partitioning logic that splits the obligation list into


### PR DESCRIPTION
## Summary

- Prevent duplicate selections and cap exceedances in the obligation bonus selector.
- Add unit tests covering character sheet commitment behavior.

## Context

This branch implements frontend guards and tests to ensure the obligation bonus selector cannot select options that are already taken or that would exceed the remaining cap. It addresses UX and data-consistency issues discovered during QA.

Closes #659

## Tests

- Unit tests added and included in the commits.

## Notes

- No lint/test/build was executed during PR creation.

