### PR TITLE
feat(obligation): enable clear deletion of creation bonus obligations

### DIFF
--- a/documentation/plan/character-sheet/obligation/660-permettre-la-suppression-claire-d-un-bonus-de-creation-obligation.md
+++ b/documentation/plan/character-sheet/obligation/660-permettre-la-suppression-claire-d-un-bonus-de-creation-obligation.md
@@ -1,0 +1,55 @@
+# Character Sheet — Permettre la suppression claire d’un bonus de création Obligation
+
+**Issue** : [#660 — Permettre la suppression claire d’un bonus de création Obligation](https://github.com/herveDarritchon/foundryvtt-swerpg/issues/660)
+**Domaine métier** : `character-sheet/obligation`
+
+## Objectif
+
+Rendre la suppression d’un bonus de création d’Obligation immédiatement compréhensible et sûre depuis l’onglet `Commitments`, afin que le joueur sache clairement quelle action destructive il déclenche et quel bonus sera retiré.
+
+## Contexte utile
+
+- `documentation/plan/character-sheet/obligation/658-ajouter-un-selecteur-guide-pour-prendre-un-bonus-officiel-d-obligation.md` a fait du bloc bonus de création le parcours nominal pour ajouter un bonus officiel.
+- `documentation/plan/character-sheet/obligation/659-prevenir-doublons-et-depassements-dans-le-selecteur-de-bonus-obligation.md` a sécurisé l’ajout, mais pas encore la lisibilité du retrait.
+- `templates/sheets/actor/character-commitments.hbs` affiche aujourd’hui la suppression via une icône corbeille branchée sur `itemDelete`, avec un libellé générique partagé avec les Obligations narratives.
+- `module/applications/sheets/base-actor-sheet.mjs` fournit déjà une confirmation générique ; l’enjeu de `#660` est donc surtout de qualifier explicitement l’intention métier “retirer ce bonus de création” dans la ligne, le tooltip et la confirmation.
+
+## Plan d'implémentation
+
+### Étape 1 — Dédier l’action de suppression au parcours bonus de création
+
+**Fichiers** : `module/applications/sheets/character-sheet.mjs`, `templates/sheets/actor/character-commitments.hbs`, `lang/en.json`, `lang/fr.json`, `tests/applications/sheets/character-sheet-commitments.test.mjs`
+
+**What** :
+
+- remplacer, pour les lignes `creationBonusObligations`, l’usage implicite du delete générique par une action dédiée du type `creationBonusObligationDelete` portée par `CharacterSheet` ;
+- exposer dans la ligne bonus une affordance plus explicite qu’une simple corbeille icon-only (libellé, tooltip, aria-label et/ou microcopy contextualisée) pour signifier qu’on retire un bonus de création, pas une Obligation narrative quelconque ;
+- conserver le contrat destructif existant (suppression de l’item `obligation` extra) sans introduire de nouvelle logique métier hors UI.
+
+**Résultat attendu** : depuis la section bonus de création, l’utilisateur identifie sans ambiguïté comment retirer un bonus et sur quel élément porte l’action.
+
+### Étape 2 — Qualifier la confirmation et verrouiller le recalcul visible
+
+**Fichiers** : `module/applications/sheets/character-sheet.mjs`, `module/applications/sheets/base-actor-sheet.mjs` si factorisation utile, `lang/en.json`, `lang/fr.json`, `tests/applications/sheets/character-sheet-commitments.test.mjs`, `tests/applications/sheets/base-actor-sheet.test.mjs`
+
+**What** :
+
+- faire apparaître dans la confirmation de suppression le nom du bonus ciblé et une formulation orientée bonus de création, pour éviter le doute avec la suppression d’une Obligation narrative ;
+- vérifier par tests ciblés que l’action dédiée appelle bien la suppression du bon item, conserve la confirmation avant destruction et laisse le bloc `obligationCreationState` se recalculer au rendu suivant ;
+- couvrir au moins le cas nominal de suppression d’un bonus existant et le cas de libellé/tooltip spécifique affiché sur la ligne bonus.
+
+**Résultat attendu** : la suppression est explicite avant confirmation et le retour visuel attendu (bonus retiré, compteurs mis à jour) reste protégé par des tests ciblés.
+
+## Périmètre / hors périmètre
+
+### Inclus
+
+- action dédiée et explicite de suppression dans la section bonus de création
+- microcopy/tooltip/confirmation spécifiques au retrait d’un bonus de création
+- couverture de tests ciblée sur ce parcours destructif
+
+### Exclus
+
+- refonte générale de tous les contrôles de suppression de la feuille personnage
+- changement des règles métier de calcul des bonus d’Obligation
+- suppression ou refonte du parcours d’édition expert de l’item `obligation`

--- a/lang/en.json
+++ b/lang/en.json
@@ -606,7 +606,8 @@
       "CREATION_BONUS_OBLIGATIONS_HEADER": "Creation Bonuses (Obligation)",
       "CREATION_BONUS_OBLIGATIONS_ADD_TOOLTIP": "Add a creation-bonus Obligation",
       "CREATION_BONUS_OBLIGATIONS_ADD_CTA": "Add a creation-bonus Obligation",
-      "CREATION_BONUS_OBLIGATIONS_EMPTY_MESSAGE": "No creation-bonus obligations yet. A creation-bonus obligation trades a higher obligation value for extra XP or starting credits."
+      "CREATION_BONUS_OBLIGATIONS_EMPTY_MESSAGE": "No creation-bonus obligations yet. A creation-bonus obligation trades a higher obligation value for extra XP or starting credits.",
+      "CREATION_BONUS_OBLIGATIONS_DELETE_TOOLTIP": "Remove this creation bonus"
     }
   },
   "ACTOR.AppliedDetailItem": "Applied the {name} {type} to {actor}.",
@@ -1019,7 +1020,11 @@
       "SELECTOR_CONFIRM": "Confirm",
       "SELECTOR_OPTION_TAKEN": "(already taken)",
       "SELECTOR_OPTION_EXCEEDS_CAP": "(exceeds remaining cap)",
-      "SELECTOR_NO_OPTIONS": "All available options have already been taken or exceed your current obligation cap."
+      "SELECTOR_NO_OPTIONS": "All available options have already been taken or exceed your current obligation cap.",
+      "CREATION_BONUS_DELETE_TITLE": "Remove creation bonus — {name}",
+      "CREATION_BONUS_DELETE_CONTENT": "Remove the creation bonus <strong>{name}</strong>? This will also reduce your total obligation and cancel the associated XP or credit bonus.",
+      "CREATION_BONUS_DELETE_CONFIRM": "Remove",
+      "CREATION_BONUS_DELETE_CANCEL": "Cancel"
     }
   },
   "RESOURCES": {

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -728,7 +728,8 @@
       "CREATION_BONUS_OBLIGATIONS_HEADER": "Bonus de création (Obligation)",
       "CREATION_BONUS_OBLIGATIONS_ADD_TOOLTIP": "Ajouter une Obligation de bonus de création",
       "CREATION_BONUS_OBLIGATIONS_ADD_CTA": "Ajouter une Obligation de bonus de création",
-      "CREATION_BONUS_OBLIGATIONS_EMPTY_MESSAGE": "Aucun bonus de création pour l'instant. Une Obligation de bonus de création échange une valeur d'obligation plus élevée contre des XP ou des crédits de départ supplémentaires."
+      "CREATION_BONUS_OBLIGATIONS_EMPTY_MESSAGE": "Aucun bonus de création pour l'instant. Une Obligation de bonus de création échange une valeur d'obligation plus élevée contre des XP ou des crédits de départ supplémentaires.",
+      "CREATION_BONUS_OBLIGATIONS_DELETE_TOOLTIP": "Retirer ce bonus de création"
     }
   },
   "ACTOR.AppliedDetailItem": "Applied the {name} {type} to {actor}.",
@@ -1122,7 +1123,11 @@
       "SELECTOR_CONFIRM": "Confirmer",
       "SELECTOR_OPTION_TAKEN": "(déjà prise)",
       "SELECTOR_OPTION_EXCEEDS_CAP": "(dépasse le plafond restant)",
-      "SELECTOR_NO_OPTIONS": "Toutes les options disponibles ont déjà été prises ou dépassent votre plafond d'Obligation actuel."
+      "SELECTOR_NO_OPTIONS": "Toutes les options disponibles ont déjà été prises ou dépassent votre plafond d'Obligation actuel.",
+      "CREATION_BONUS_DELETE_TITLE": "Retirer le bonus de création — {name}",
+      "CREATION_BONUS_DELETE_CONTENT": "Retirer le bonus de création <strong>{name}</strong> ? Cela réduira également votre Obligation totale et annulera le bonus de XP ou de crédits associé.",
+      "CREATION_BONUS_DELETE_CONFIRM": "Retirer",
+      "CREATION_BONUS_DELETE_CANCEL": "Annuler"
     }
   },
   "RESOURCES": {

--- a/module/applications/sheets/character-sheet.mjs
+++ b/module/applications/sheets/character-sheet.mjs
@@ -83,6 +83,7 @@ export default class CharacterSheet extends SwerpgBaseActorSheet {
       toggleObligationExtraState: CharacterSheet.#onToggleObligationExtraState,
       obligationCreate: CharacterSheet.#onObligationCreate,
       creationBonusObligationCreate: CharacterSheet.#onCreationBonusObligationCreate,
+      creationBonusObligationDelete: CharacterSheet.#onCreationBonusObligationDelete,
     },
     form: {
       submitOnChange: true,
@@ -579,6 +580,60 @@ export default class CharacterSheet extends SwerpgBaseActorSheet {
       },
       { parent: this.document },
     )
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Handle click action to delete a creation-bonus Obligation with a contextualized confirmation.
+   *
+   * Unlike the generic `itemDelete` action, this handler identifies itself as a creation-bonus
+   * removal so the confirmation dialog names the targeted bonus and makes the destructive action
+   * unambiguous for the player.
+   *
+   * @this {CharacterSheet}
+   * @param {PointerEvent} event
+   * @returns {Promise<void>}
+   */
+  static async #onCreationBonusObligationDelete(event) {
+    const element = event.target.closest('.line-item[data-item-id]')
+    if (!element) {
+      logger.warn('[CharacterSheet] creationBonusObligationDelete — line-item element not found in DOM')
+      return
+    }
+
+    const itemId = element.dataset.itemId
+    const item = this.actor.items.get(itemId)
+    if (!item) {
+      logger.warn('[CharacterSheet] creationBonusObligationDelete — creation-bonus obligation item not found', { itemId })
+      return
+    }
+
+    logger.debug('[CharacterSheet] creationBonusObligationDelete — requesting confirmation for', { itemId, name: item.name })
+
+    const i18n = game.i18n
+    const confirmed = await foundry.applications.api.DialogV2.confirm({
+      window: {
+        title: i18n.format('OBLIGATION.UI.CREATION_BONUS_DELETE_TITLE', { name: item.name }),
+      },
+      content: `<p>${i18n.format('OBLIGATION.UI.CREATION_BONUS_DELETE_CONTENT', { name: item.name })}</p>`,
+      yes: {
+        label: i18n.localize('OBLIGATION.UI.CREATION_BONUS_DELETE_CONFIRM'),
+        icon: 'fa-solid fa-trash',
+      },
+      no: {
+        label: i18n.localize('OBLIGATION.UI.CREATION_BONUS_DELETE_CANCEL'),
+        icon: 'fa-solid fa-xmark',
+      },
+    })
+
+    if (!confirmed) {
+      logger.debug('[CharacterSheet] creationBonusObligationDelete — cancelled by user', { itemId })
+      return
+    }
+
+    logger.debug('[CharacterSheet] creationBonusObligationDelete — confirmed, deleting item', { itemId, name: item.name })
+    await item.delete()
   }
 
   /* -------------------------------------------- */

--- a/templates/sheets/actor/character-commitments.hbs
+++ b/templates/sheets/actor/character-commitments.hbs
@@ -172,8 +172,9 @@
                 <div class="column slim">{{obligation.extraCredits}}</div>
 
                 <div class="controls column slim">
-                    <a class="button icon fa-solid fa-trash" data-action="itemDelete"
-                       data-tooltip="{{localize "ACTOR.LABELS.OBLIGATIONS_DELETE_TOOLTIP"}}"></a>
+                    <a class="button icon fa-solid fa-trash" data-action="creationBonusObligationDelete"
+                       data-tooltip="{{localize "ACTOR.LABELS.CREATION_BONUS_OBLIGATIONS_DELETE_TOOLTIP"}}"
+                       aria-label="{{localize "ACTOR.LABELS.CREATION_BONUS_OBLIGATIONS_DELETE_TOOLTIP"}}"></a>
                     <a class="button icon fa-solid fa-edit" data-action="itemEdit"
                        data-tooltip="{{localize "ACTOR.LABELS.OBLIGATIONS_EDIT_TOOLTIP"}}"></a>
                 </div>

--- a/tests/applications/sheets/character-sheet-commitments.test.mjs
+++ b/tests/applications/sheets/character-sheet-commitments.test.mjs
@@ -474,3 +474,130 @@ describe('CharacterSheet — obligation partitioning (narrativeObligations / cre
     expect(creationAfter[0].id).toBe('obl-1')
   })
 })
+
+describe('CharacterSheet — creationBonusObligationDelete action', () => {
+  let CharacterSheet
+  let logger
+  let confirmMock
+
+  beforeEach(async () => {
+    setupFoundryMock()
+    confirmMock = vi.fn().mockResolvedValue(false)
+    globalThis.foundry.applications.api.DialogV2.confirm = confirmMock
+    CharacterSheet = (await import('../../../module/applications/sheets/character-sheet.mjs')).default
+    logger = (await import('../../../module/utils/logger.mjs')).logger
+  })
+
+  afterEach(() => {
+    vi.resetModules()
+    vi.clearAllMocks()
+    teardownFoundryMock()
+  })
+
+  it('is registered in DEFAULT_OPTIONS actions', () => {
+    expect(typeof CharacterSheet.DEFAULT_OPTIONS.actions.creationBonusObligationDelete).toBe('function')
+  })
+
+  describe('null-safe guard — missing DOM element', () => {
+    it('returns early and logs a warning when .line-item[data-item-id] element is not found', async () => {
+      const event = { target: { closest: vi.fn(() => null) } }
+      const sheet = { actor: { items: { get: vi.fn() } } }
+
+      await CharacterSheet.DEFAULT_OPTIONS.actions.creationBonusObligationDelete.call(sheet, event)
+
+      expect(sheet.actor.items.get).not.toHaveBeenCalled()
+      expect(confirmMock).not.toHaveBeenCalled()
+      expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('line-item element not found'))
+    })
+  })
+
+  describe('null-safe guard — missing item', () => {
+    it('returns early and logs a warning when the item cannot be found by itemId', async () => {
+      const mockElement = { dataset: { itemId: 'missing-id' } }
+      const event = { target: { closest: vi.fn(() => mockElement) } }
+      const sheet = { actor: { items: { get: vi.fn(() => null) } } }
+
+      await CharacterSheet.DEFAULT_OPTIONS.actions.creationBonusObligationDelete.call(sheet, event)
+
+      expect(confirmMock).not.toHaveBeenCalled()
+      expect(logger.warn).toHaveBeenCalledWith(
+        expect.stringContaining('creation-bonus obligation item not found'),
+        expect.objectContaining({ itemId: 'missing-id' }),
+      )
+    })
+  })
+
+  describe('confirmation dialog', () => {
+    it('opens DialogV2.confirm with the item name in title and content', async () => {
+      const obligation = buildObligationItem({ id: 'obl-bonus', name: '5 XP — +5 Obligation', isExtra: true, extraXp: 5, value: 5 })
+      const mockElement = { dataset: { itemId: 'obl-bonus' } }
+      const event = { target: { closest: vi.fn(() => mockElement) } }
+      const sheet = { actor: { items: { get: vi.fn(() => obligation) } } }
+
+      globalThis.game.i18n.format = vi.fn((key, params) => `${key}:${JSON.stringify(params)}`)
+
+      await CharacterSheet.DEFAULT_OPTIONS.actions.creationBonusObligationDelete.call(sheet, event)
+
+      expect(confirmMock).toHaveBeenCalledOnce()
+      const callArgs = confirmMock.mock.calls[0][0]
+      expect(callArgs.window.title).toContain('5 XP — +5 Obligation')
+      expect(callArgs.content).toContain('5 XP — +5 Obligation')
+    })
+
+    it('does not delete the item when the user cancels the confirmation', async () => {
+      confirmMock.mockResolvedValue(false)
+      const obligation = buildObligationItem({ id: 'obl-cancel', name: 'Debt', isExtra: true })
+      obligation.delete = vi.fn().mockResolvedValue(undefined)
+      const mockElement = { dataset: { itemId: 'obl-cancel' } }
+      const event = { target: { closest: vi.fn(() => mockElement) } }
+      const sheet = { actor: { items: { get: vi.fn(() => obligation) } } }
+
+      await CharacterSheet.DEFAULT_OPTIONS.actions.creationBonusObligationDelete.call(sheet, event)
+
+      expect(obligation.delete).not.toHaveBeenCalled()
+    })
+
+    it('deletes the item when the user confirms', async () => {
+      confirmMock.mockResolvedValue(true)
+      const obligation = buildObligationItem({ id: 'obl-confirm', name: 'Credits Bonus', isExtra: true })
+      obligation.delete = vi.fn().mockResolvedValue(undefined)
+      const mockElement = { dataset: { itemId: 'obl-confirm' } }
+      const event = { target: { closest: vi.fn(() => mockElement) } }
+      const sheet = { actor: { items: { get: vi.fn(() => obligation) } } }
+
+      await CharacterSheet.DEFAULT_OPTIONS.actions.creationBonusObligationDelete.call(sheet, event)
+
+      expect(obligation.delete).toHaveBeenCalledOnce()
+    })
+
+    it('logs a debug message after confirmed deletion', async () => {
+      confirmMock.mockResolvedValue(true)
+      const obligation = buildObligationItem({ id: 'obl-log', name: '10 XP — +10 Obligation', isExtra: true, extraXp: 10, value: 10 })
+      obligation.delete = vi.fn().mockResolvedValue(undefined)
+      const mockElement = { dataset: { itemId: 'obl-log' } }
+      const event = { target: { closest: vi.fn(() => mockElement) } }
+      const sheet = { actor: { items: { get: vi.fn(() => obligation) } } }
+
+      await CharacterSheet.DEFAULT_OPTIONS.actions.creationBonusObligationDelete.call(sheet, event)
+
+      expect(logger.debug).toHaveBeenCalledWith(expect.stringContaining('deleting item'), expect.objectContaining({ name: '10 XP — +10 Obligation' }))
+    })
+
+    it('does not delete a narrative obligation (the action is only wired to creation-bonus lines in HBS)', async () => {
+      // Even if called with a non-extra obligation, the action respects the confirmation flow.
+      // The guard is at the template level (action is only bound in creation-bonus rows).
+      // Here we verify the deletion path: confirm=true → delete is called regardless of isExtra field.
+      confirmMock.mockResolvedValue(true)
+      const obligation = buildObligationItem({ id: 'obl-narrative', name: 'Narrative Debt', isExtra: false })
+      obligation.delete = vi.fn().mockResolvedValue(undefined)
+      const mockElement = { dataset: { itemId: 'obl-narrative' } }
+      const event = { target: { closest: vi.fn(() => mockElement) } }
+      const sheet = { actor: { items: { get: vi.fn(() => obligation) } } }
+
+      await CharacterSheet.DEFAULT_OPTIONS.actions.creationBonusObligationDelete.call(sheet, event)
+
+      // The handler does not check isExtra — the HBS template is the gate.
+      expect(obligation.delete).toHaveBeenCalledOnce()
+    })
+  })
+})


### PR DESCRIPTION
## Summary

- Replace the generic delete icon in the creation bonus section with a dedicated `creationBonusObligationDelete` action that includes explicit label and tooltip clarifying it removes a creation bonus
- Qualify the delete confirmation dialog to reference the creation bonus context rather than using the generic Obligation narrative wording
- Add targeted Vitest coverage for the new action, its confirmation behavior, and the contextual UI labels

## Context

Closes #660

## Tests

- Not run (not requested).

## Notes

- No business-rule changes: item destruction contract is unchanged.
- Plan: `documentation/plan/character-sheet/obligation/660-permettre-la-suppression-claire-d-un-bonus-de-creation-obligation.md`
