### PR TITLE
feat(obligation): enhance obligation sheet with expert fallback and warnings

### DIFF
--- a/documentation/plan/character-sheet/obligation/661-transformer-la-sheet-obligation-en-fallback-expert-securise.md
+++ b/documentation/plan/character-sheet/obligation/661-transformer-la-sheet-obligation-en-fallback-expert-securise.md
@@ -1,0 +1,57 @@
+# Character Sheet — Transformer la sheet Obligation en fallback expert sécurisé
+
+**Issue** : [#661 — Transformer la sheet Obligation en fallback expert sécurisé](https://github.com/herveDarritchon/foundryvtt-swerpg/issues/661)
+**Domaine métier** : `character-sheet/obligation`
+
+## Objectif
+
+Faire de la sheet item `obligation` un fallback expert sûr et cohérent avec le parcours guidé des bonus de création : l’édition narrative reste simple, les options officielles sont privilégiées dès qu’une Obligation est marquée `isExtra`, et les combinaisons non officielles deviennent difficiles à produire par erreur tout en restant clairement signalées si elles existent déjà.
+
+## Contexte utile
+
+- L’issue `#658` a déjà déplacé le parcours nominal d’ajout de bonus vers un sélecteur guidé dans `Commitments` ; `#661` finalise le repositionnement de la fiche item comme filet de sécurité expert.
+- `templates/sheets/partials/obligation-config.hbs` expose encore des champs libres `extraXp` / `extraCredits` dès qu’une Obligation est `isExtra`, ce qui laisse trop facilement produire une combinaison hors cadre officiel.
+- `module/applications/sheets/obligation.mjs` est aujourd’hui quasi passif ; c’est le bon point d’entrée pour préparer un contexte de rendu qui distingue cas narratif, bonus officiel reconnu et état legacy/non officiel.
+- L’ADR-0025 impose de ne pas enrichir le DataModel `obligation` : la sécurisation doit rester portée par le runtime, le rendu de sheet et la microcopy.
+
+## Plan d'implémentation
+
+### Étape 1 — Préparer un état de fallback expert dérivé des options officielles
+
+**Fichiers** : `module/lib/obligations/obligation-bonus-calculator.mjs`, `module/applications/sheets/obligation.mjs`, `tests/lib/obligations/obligation-bonus-calculator.test.mjs`, `tests/applications/sheets/obligation-sheet.test.mjs`
+
+**What** :
+
+- exposer, depuis le domaine pur ou un helper dédié déjà canonique, la résolution de la combinaison courante d’une Obligation `isExtra` vers une option officielle reconnue ou un état `legacy/non-officiel` ;
+- préparer dans `ObligationSheet` un contexte séparant explicitement l’édition narrative simple, la configuration bonus officielle, et l’éventuelle alerte expert quand les valeurs existantes sortent du cadre officiel ;
+- verrouiller par tests les trois cas de contrat : Obligation narrative standard, bonus officiel reconnu, combinaison non officielle existante affichée comme anomalie sans toucher au schéma.
+
+**Résultat attendu** : avant même le rendu du template, la sheet sait si elle doit présenter un bonus officiel guidé ou un état expert à risque, sans ajouter de nouveau champ métier.
+
+### Étape 2 — Recomposer la sheet pour privilégier les options officielles et encadrer la saisie libre
+
+**Fichiers** : `templates/sheets/partials/obligation-config.hbs`, `module/applications/sheets/obligation.mjs`, `lang/en.json`, `lang/fr.json`, `tests/applications/sheets/obligation-sheet.test.mjs`
+
+**What** :
+
+- conserver l’édition narrative (`description`, `value`) comme parcours simple et principal pour toute Obligation ;
+- quand `isExtra === true`, remplacer l’exposition frontale des inputs libres par une présentation guidée des options officielles, puis reléguer toute modification manuelle derrière une affordance explicitement experte afin qu’une combinaison non officielle ne soit plus le chemin naturel ;
+- afficher un warning localisé et visible quand l’item courant porte déjà une combinaison non officielle, avec microcopy indiquant que le sélecteur guidé reste le parcours recommandé ;
+- compléter la couverture de tests de rendu/configuration pour vérifier la séparation narrative/bonus, la mise en avant des options officielles, et la signalisation claire des états legacy.
+
+**Résultat attendu** : la fiche item n’encourage plus la saisie arbitraire de `extraXp` / `extraCredits`, tout en restant éditable de façon délibérée par un MJ ou un utilisateur avancé.
+
+## Périmètre / hors périmètre
+
+### Inclus
+
+- fallback expert sécurisé dans la sheet item `obligation`
+- priorité donnée aux options officielles pour les bonus de création
+- signalisation localisée des combinaisons non officielles existantes
+- tests ciblés de contrat de rendu et de configuration de la sheet
+
+### Exclus
+
+- ajout de nouveaux champs au DataModel `obligation` interdit par l’ADR-0025
+- refonte globale du workflow Obligation hors fallback de la fiche item
+- harmonisation transverse complète de toute la microcopy/accessibilité du workflow Obligation au-delà du périmètre de cette sheet

--- a/lang/en.json
+++ b/lang/en.json
@@ -1024,7 +1024,12 @@
       "CREATION_BONUS_DELETE_TITLE": "Remove creation bonus — {name}",
       "CREATION_BONUS_DELETE_CONTENT": "Remove the creation bonus <strong>{name}</strong>? This will also reduce your total obligation and cancel the associated XP or credit bonus.",
       "CREATION_BONUS_DELETE_CONFIRM": "Remove",
-      "CREATION_BONUS_DELETE_CANCEL": "Cancel"
+      "CREATION_BONUS_DELETE_CANCEL": "Cancel",
+      "OFFICIAL_BONUS_LABEL": "Official bonus",
+      "OFFICIAL_BONUS_HINT": "This obligation uses an official creation bonus. To change it, use the guided selector on the Commitments tab.",
+      "LEGACY_WARNING": "Non-official combination detected",
+      "LEGACY_WARNING_HINT": "The XP / credits amounts do not match any official creation option. Use the guided selector on the Commitments tab to replace this with a valid option.",
+      "EXPERT_EDIT_LABEL": "Expert edit (advanced)"
     }
   },
   "RESOURCES": {

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -1127,7 +1127,12 @@
       "CREATION_BONUS_DELETE_TITLE": "Retirer le bonus de création — {name}",
       "CREATION_BONUS_DELETE_CONTENT": "Retirer le bonus de création <strong>{name}</strong> ? Cela réduira également votre Obligation totale et annulera le bonus de XP ou de crédits associé.",
       "CREATION_BONUS_DELETE_CONFIRM": "Retirer",
-      "CREATION_BONUS_DELETE_CANCEL": "Annuler"
+      "CREATION_BONUS_DELETE_CANCEL": "Annuler",
+      "OFFICIAL_BONUS_LABEL": "Bonus officiel",
+      "OFFICIAL_BONUS_HINT": "Cette obligation utilise un bonus de création officiel. Pour le modifier, utilisez le sélecteur guidé dans l'onglet Engagements.",
+      "LEGACY_WARNING": "Combinaison non officielle détectée",
+      "LEGACY_WARNING_HINT": "Les montants de XP / crédits ne correspondent à aucune option de création officielle. Utilisez le sélecteur guidé dans l'onglet Engagements pour remplacer cette option par une valeur valide.",
+      "EXPERT_EDIT_LABEL": "Modification expert (avancé)"
     }
   },
   "RESOURCES": {

--- a/module/applications/sheets/obligation.mjs
+++ b/module/applications/sheets/obligation.mjs
@@ -1,8 +1,14 @@
 import SwerpgBaseItemSheet from './base-item.mjs'
 import { logger } from '../../utils/logger.mjs'
+import ObligationBonusCalculator from '../../lib/obligations/obligation-bonus-calculator.mjs'
 
 /**
  * A SwerpgBaseItemSheet subclass used to configure Items of the "obligation" type.
+ *
+ * The sheet acts as an expert fallback: narrative editing is always simple and primary.
+ * When isExtra is true, the sheet resolves the obligation's bonus state so the template
+ * can prioritise official options and clearly signal legacy (non-official) combinations.
+ *
  * @extends SwerpgBaseItemSheet
  */
 export default class ObligationSheet extends SwerpgBaseItemSheet {
@@ -19,9 +25,7 @@ export default class ObligationSheet extends SwerpgBaseItemSheet {
     item: {
       type: 'obligation',
     },
-    actions: {
-      // Actions spécifiques à ObligationSheet
-    },
+    actions: {},
   }
 
   // Initialize subclass options
@@ -35,10 +39,40 @@ export default class ObligationSheet extends SwerpgBaseItemSheet {
   async _prepareContext(options) {
     const context = await super._prepareContext(options)
 
-    // ✅ Debug conditionnel uniquement si nécessaire
+    context.obligationBonus = this.#prepareObligationBonusContext(context.system)
+
     logger.debug(`[${this.constructor.name}] Context prepared:`, context)
 
     return context
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Prepare the obligation bonus context used by the config template to determine
+   * which rendering mode to apply.
+   *
+   * Returns a plain object with three exclusive boolean flags and the matched
+   * official option when applicable.
+   *
+   * @param {object} system The obligation system data (plain or Foundry model).
+   * @returns {{isNarrative: boolean, isOfficialBonus: boolean, isLegacyBonus: boolean, officialOption: import('../../lib/obligations/obligation-bonus-calculator.mjs').ObligationCreationOption|null}}
+   */
+  #prepareObligationBonusContext(system) {
+    const input = {
+      isExtra: system.isExtra ?? false,
+      extraXp: system.extraXp ?? 0,
+      extraCredits: system.extraCredits ?? 0,
+    }
+
+    const { state, officialOption } = ObligationBonusCalculator.resolveObligationState(input)
+
+    return {
+      isNarrative: state === 'narrative',
+      isOfficialBonus: state === 'official',
+      isLegacyBonus: state === 'legacy',
+      officialOption,
+    }
   }
 
   /* -------------------------------------------- */

--- a/module/lib/obligations/obligation-bonus-calculator.mjs
+++ b/module/lib/obligations/obligation-bonus-calculator.mjs
@@ -30,6 +30,23 @@ import {
  */
 
 /**
+ * @typedef {'narrative'|'official'|'legacy'} ObligationBonusState
+ * Classification of a single obligation item for expert-fallback rendering.
+ *
+ * - `narrative`  — isExtra is false; standard narrative obligation, no bonus.
+ * - `official`   — isExtra is true and the (extraXp, extraCredits) pair matches an official option exactly.
+ * - `legacy`     — isExtra is true but the amounts do not match any official option (non-official combination).
+ */
+
+/**
+ * @typedef {Object} ObligationStateResult
+ * Resolution of a single obligation's bonus state.
+ *
+ * @property {ObligationBonusState}        state          - Classification of the obligation.
+ * @property {ObligationCreationOption|null} officialOption - The matched official option, or null for narrative/legacy.
+ */
+
+/**
  * @typedef {Object} ObligationBonusSelectOption
  * UI-ready annotated bonus option for a guided selector.
  *
@@ -194,6 +211,41 @@ export default class ObligationBonusCalculator {
    */
   static get OFFICIAL_OPTIONS() {
     return OFFICIAL_OPTIONS
+  }
+
+  /* -------------------------------------------- */
+  /*  Expert-fallback state resolution             */
+  /* -------------------------------------------- */
+
+  /**
+   * Resolve the bonus state of a single obligation item.
+   *
+   * This is the canonical classifier used by the item sheet to determine which rendering
+   * mode to apply:
+   * - `narrative`  → isExtra is false; show only description and value.
+   * - `official`   → isExtra is true and amounts match an official option.
+   * - `legacy`     → isExtra is true but amounts are non-official; display an expert warning.
+   *
+   * The function is pure: it accepts a plain obligation object and returns a plain result.
+   * No Foundry APIs are used.
+   *
+   * @param {ObligationBonusInput} obligation Plain obligation data object.
+   * @returns {ObligationStateResult}
+   */
+  static resolveObligationState(obligation) {
+    if (!obligation.isExtra) {
+      return { state: 'narrative', officialOption: null }
+    }
+
+    const xp = obligation.extraXp || 0
+    const credits = obligation.extraCredits || 0
+    const match = OFFICIAL_OPTIONS.find((opt) => opt.xp === xp && opt.credits === credits)
+
+    if (match) {
+      return { state: 'official', officialOption: match }
+    }
+
+    return { state: 'legacy', officialOption: null }
   }
 
   /* -------------------------------------------- */

--- a/templates/sheets/partials/obligation-config.hbs
+++ b/templates/sheets/partials/obligation-config.hbs
@@ -1,5 +1,6 @@
 <section class="tab sheet-body flexcol {{tabs.config.cssClass}}" data-tab="{{tabs.config.id}}" data-group="{{tabs.config.group}}">
 
+  {{!-- Narrative hint — always visible, primary entry point --}}
   <p class="obligation-narrative-hint">{{localize "OBLIGATION.UI.NARRATIVE_HINT"}}</p>
 
   {{formField @root.fields.value value=source.system.value localize=true rootId=partId}}
@@ -12,9 +13,26 @@
   </div>
 
   {{#if source.system.isExtra}}
-  <fieldset>
+  <fieldset class="obligation-extra-bonus">
     <legend>{{localize "OBLIGATION.UI.EXTRA_BONUS_LEGEND"}}</legend>
 
+    {{!-- Official bonus: show what the current bonus is, read-only display --}}
+    {{#if obligationBonus.isOfficialBonus}}
+    <div class="obligation-official-bonus" role="status" aria-label="{{localize "OBLIGATION.UI.OFFICIAL_BONUS_LABEL"}}">
+      <p class="obligation-official-bonus__label">{{localize "OBLIGATION.UI.OFFICIAL_BONUS_LABEL"}}</p>
+      <p class="obligation-official-bonus__hint">{{localize "OBLIGATION.UI.OFFICIAL_BONUS_HINT"}}</p>
+    </div>
+    {{/if}}
+
+    {{!-- Legacy warning: amounts do not match any official option --}}
+    {{#if obligationBonus.isLegacyBonus}}
+    <div class="obligation-legacy-warning" role="alert" aria-label="{{localize "OBLIGATION.UI.LEGACY_WARNING"}}">
+      <p class="obligation-legacy-warning__title">{{localize "OBLIGATION.UI.LEGACY_WARNING"}}</p>
+      <p class="obligation-legacy-warning__hint">{{localize "OBLIGATION.UI.LEGACY_WARNING_HINT"}}</p>
+    </div>
+    {{/if}}
+
+    {{!-- Official options reference list --}}
     <div class="obligation-official-options" aria-label="{{localize "OBLIGATION.UI.OFFICIAL_OPTIONS_LABEL"}}">
       <p class="obligation-official-options__hint">{{localize "OBLIGATION.UI.EXTRA_EXPERT_FALLBACK_HINT"}}</p>
       <ul class="obligation-official-options__list">
@@ -25,8 +43,12 @@
       </ul>
     </div>
 
-    {{formField @root.fields.extraXp value=source.system.extraXp localize=true rootId=partId}}
-    {{formField @root.fields.extraCredits value=source.system.extraCredits localize=true rootId=partId}}
+    {{!-- Expert edit inputs: always present but clearly labelled as advanced --}}
+    <details class="obligation-expert-edit">
+      <summary class="obligation-expert-edit__label">{{localize "OBLIGATION.UI.EXPERT_EDIT_LABEL"}}</summary>
+      {{formField @root.fields.extraXp value=source.system.extraXp localize=true rootId=partId}}
+      {{formField @root.fields.extraCredits value=source.system.extraCredits localize=true rootId=partId}}
+    </details>
   </fieldset>
   {{/if}}
 

--- a/tests/applications/sheets/obligation-sheet.test.mjs
+++ b/tests/applications/sheets/obligation-sheet.test.mjs
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { setupFoundryMock, teardownFoundryMock } from '../../helpers/mock-foundry.mjs'
+import ObligationBonusCalculator from '../../../module/lib/obligations/obligation-bonus-calculator.mjs'
 
 vi.mock('../../../module/utils/logger.mjs', () => ({
   logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
@@ -113,5 +114,70 @@ describe('ObligationSheet — narrative vs extra creation distinction (schema co
     const schema = SwerpgObligation.defineSchema()
     expect(schema).toHaveProperty('extraXp')
     expect(schema).toHaveProperty('extraCredits')
+  })
+})
+
+describe('ObligationSheet — obligationBonus context derivation (pure contract via calculator)', () => {
+  // These tests drive the logic that _prepareObligationBonusContext delegates to
+  // ObligationBonusCalculator.resolveObligationState. They verify the three rendering
+  // branches the template depends on are correctly derived from system data.
+
+  it('narrative obligation: isNarrative=true, isOfficialBonus=false, isLegacyBonus=false', () => {
+    const system = { isExtra: false, extraXp: 0, extraCredits: 0 }
+    const { state, officialOption } = ObligationBonusCalculator.resolveObligationState(system)
+
+    expect(state).toBe('narrative')
+    expect(officialOption).toBeNull()
+    // Derived booleans that ObligationSheet builds from this result:
+    expect(state === 'narrative').toBe(true)
+    expect(state === 'official').toBe(false)
+    expect(state === 'legacy').toBe(false)
+  })
+
+  it('official bonus obligation: isOfficialBonus=true, officialOption is the matched entry', () => {
+    const system = { isExtra: true, extraXp: 5, extraCredits: 0 }
+    const { state, officialOption } = ObligationBonusCalculator.resolveObligationState(system)
+
+    expect(state).toBe('official')
+    expect(officialOption).not.toBeNull()
+    expect(officialOption.key).toBe('xp_5')
+    // Derived booleans:
+    expect(state === 'official').toBe(true)
+    expect(state === 'narrative').toBe(false)
+    expect(state === 'legacy').toBe(false)
+  })
+
+  it('legacy bonus obligation: isLegacyBonus=true, officialOption=null', () => {
+    const system = { isExtra: true, extraXp: 3, extraCredits: 0 }
+    const { state, officialOption } = ObligationBonusCalculator.resolveObligationState(system)
+
+    expect(state).toBe('legacy')
+    expect(officialOption).toBeNull()
+    // Derived booleans:
+    expect(state === 'legacy').toBe(true)
+    expect(state === 'narrative').toBe(false)
+    expect(state === 'official').toBe(false)
+  })
+
+  it('obligationBonus context shape has the three exclusive boolean keys', () => {
+    // Verify that the shape produced matches the template expectations.
+    const cases = [
+      { system: { isExtra: false, extraXp: 0, extraCredits: 0 }, expected: { isNarrative: true, isOfficialBonus: false, isLegacyBonus: false } },
+      { system: { isExtra: true, extraXp: 10, extraCredits: 0 }, expected: { isNarrative: false, isOfficialBonus: true, isLegacyBonus: false } },
+      { system: { isExtra: true, extraXp: 0, extraCredits: 500 }, expected: { isNarrative: false, isOfficialBonus: false, isLegacyBonus: true } },
+    ]
+
+    for (const { system, expected } of cases) {
+      const { state, officialOption } = ObligationBonusCalculator.resolveObligationState(system)
+      const derived = {
+        isNarrative: state === 'narrative',
+        isOfficialBonus: state === 'official',
+        isLegacyBonus: state === 'legacy',
+        officialOption,
+      }
+      expect(derived.isNarrative).toBe(expected.isNarrative)
+      expect(derived.isOfficialBonus).toBe(expected.isOfficialBonus)
+      expect(derived.isLegacyBonus).toBe(expected.isLegacyBonus)
+    }
   })
 })

--- a/tests/lib/obligations/obligation-bonus-calculator.test.mjs
+++ b/tests/lib/obligations/obligation-bonus-calculator.test.mjs
@@ -402,4 +402,92 @@ describe('ObligationBonusCalculator', () => {
       })
     })
   })
+
+  describe('resolveObligationState', () => {
+    describe('narrative obligations (isExtra=false)', () => {
+      test('returns state=narrative and officialOption=null when isExtra is false', () => {
+        const result = ObligationBonusCalculator.resolveObligationState({ isExtra: false, extraXp: 0, extraCredits: 0 })
+        expect(result.state).toBe('narrative')
+        expect(result.officialOption).toBeNull()
+      })
+
+      test('returns state=narrative even when extraXp and extraCredits are non-zero but isExtra is false', () => {
+        const result = ObligationBonusCalculator.resolveObligationState({ isExtra: false, extraXp: 5, extraCredits: 1000 })
+        expect(result.state).toBe('narrative')
+        expect(result.officialOption).toBeNull()
+      })
+
+      test('returns state=narrative when isExtra is missing (falsy)', () => {
+        const result = ObligationBonusCalculator.resolveObligationState({ extraXp: 5, extraCredits: 0 })
+        expect(result.state).toBe('narrative')
+        expect(result.officialOption).toBeNull()
+      })
+    })
+
+    describe('official bonus obligations', () => {
+      test('returns state=official and matching officialOption for xp=5, credits=0', () => {
+        const result = ObligationBonusCalculator.resolveObligationState({ isExtra: true, extraXp: 5, extraCredits: 0 })
+        expect(result.state).toBe('official')
+        expect(result.officialOption).not.toBeNull()
+        expect(result.officialOption.key).toBe('xp_5')
+      })
+
+      test('returns state=official and matching officialOption for xp=10, credits=0', () => {
+        const result = ObligationBonusCalculator.resolveObligationState({ isExtra: true, extraXp: 10, extraCredits: 0 })
+        expect(result.state).toBe('official')
+        expect(result.officialOption.key).toBe('xp_10')
+      })
+
+      test('returns state=official and matching officialOption for xp=0, credits=1000', () => {
+        const result = ObligationBonusCalculator.resolveObligationState({ isExtra: true, extraXp: 0, extraCredits: 1000 })
+        expect(result.state).toBe('official')
+        expect(result.officialOption.key).toBe('credits_1000')
+      })
+
+      test('returns state=official and matching officialOption for xp=0, credits=2500', () => {
+        const result = ObligationBonusCalculator.resolveObligationState({ isExtra: true, extraXp: 0, extraCredits: 2500 })
+        expect(result.state).toBe('official')
+        expect(result.officialOption.key).toBe('credits_2500')
+      })
+
+      test('officialOption includes obligationCost for the matched option', () => {
+        const result = ObligationBonusCalculator.resolveObligationState({ isExtra: true, extraXp: 5, extraCredits: 0 })
+        expect(result.officialOption.obligationCost).toBe(5)
+      })
+    })
+
+    describe('legacy (non-official) bonus obligations', () => {
+      test('returns state=legacy and officialOption=null for non-official xp amount', () => {
+        const result = ObligationBonusCalculator.resolveObligationState({ isExtra: true, extraXp: 7, extraCredits: 0 })
+        expect(result.state).toBe('legacy')
+        expect(result.officialOption).toBeNull()
+      })
+
+      test('returns state=legacy for non-official credits amount', () => {
+        const result = ObligationBonusCalculator.resolveObligationState({ isExtra: true, extraXp: 0, extraCredits: 500 })
+        expect(result.state).toBe('legacy')
+        expect(result.officialOption).toBeNull()
+      })
+
+      test('returns state=legacy for mixed non-official xp+credits combo', () => {
+        const result = ObligationBonusCalculator.resolveObligationState({ isExtra: true, extraXp: 5, extraCredits: 1000 })
+        expect(result.state).toBe('legacy')
+        expect(result.officialOption).toBeNull()
+      })
+
+      test('returns state=legacy when isExtra is true but both values are 0 (ambiguous zero bonus)', () => {
+        const result = ObligationBonusCalculator.resolveObligationState({ isExtra: true, extraXp: 0, extraCredits: 0 })
+        expect(result.state).toBe('legacy')
+        expect(result.officialOption).toBeNull()
+      })
+    })
+
+    describe('result shape', () => {
+      test('result always has state and officialOption keys', () => {
+        const result = ObligationBonusCalculator.resolveObligationState({ isExtra: false, extraXp: 0, extraCredits: 0 })
+        expect(result).toHaveProperty('state')
+        expect(result).toHaveProperty('officialOption')
+      })
+    })
+  })
 })


### PR DESCRIPTION
## Summary

- Transforms the obligation item sheet into a secure expert fallback after the guided bonus selector (#658)
- Adds `ObligationBonusCalculator.resolveObligationState()` to classify obligations as narrative/official/legacy
- Updates the config template to show read-only official bonus info or legacy warning, with expert edit behind `<details>`
- Adds localized strings (en/fr) and sheet unit tests for the three rendering branches

## Context

Closes #661

## Tests

- Not run (not requested).
