### PR TITLE
feat(audit-log): add obligation event types and UI integration

### DIFF
--- a/documentation/plan/audit-log/672-etape-2-hooks-item-et-ecriture-audit-log-pour-les-obligations.md
+++ b/documentation/plan/audit-log/672-etape-2-hooks-item-et-ecriture-audit-log-pour-les-obligations.md
@@ -1,0 +1,68 @@
+# Issue #672 — Étape 2 hooks Item et écriture Audit Log pour les obligations
+
+**Issue** : https://github.com/herveDarritchon/foundryvtt-swerpg/issues/672  
+**Plan parent** : `documentation/plan/audit-log/obligation-audit-log-integration.md`  
+**Domaine métier** : `audit-log`
+
+## Goal
+
+Livrer la deuxième tranche de l’intégration Audit Log des obligations en branchant les hooks `Item` qui écrivent effectivement les entrées `obligation.create`, `obligation.update` et `obligation.delete`, sans toucher au DataModel `obligation`.
+
+## Contexte utile
+
+- L’issue `#672` reprend explicitement l’**Étape 2 — Hooks Item obligations** du cadrage `obligation-audit-log-integration.md`.
+- La taxonomie, les labels et le rendu UI/chat sont déjà cadrés par `documentation/plan/audit-log/671-etape-1-taxonomie-et-ui-audit-log-pour-les-obligations.md`.
+- `module/utils/audit-log.mjs` reste l’adapter Foundry responsable de `makeEntry()`, `captureSnapshot()` et `writeLogEntries()` ; la logique obligation doit y rester tolérante aux échecs et mono-écrivain.
+
+## Plan d’implémentation
+
+### Étape 1 — Étendre les hooks Item pour créer et supprimer les entrées obligation
+
+**Fichiers** : `module/utils/audit-log.mjs`, `tests/utils/audit-log.test.mjs`, `tests/applications/sheets/character-sheet-commitments.test.mjs`
+
+**What** :
+
+- étendre `onCreateItem` pour écrire `obligation.create` quand l’item embarqué appartient à un acteur `character` et que `item.type === 'obligation'` ;
+- ajouter `onDeleteItem` pour écrire `obligation.delete` avec les métadonnées utiles (`obligationId`, `obligationName`, valeur, bonus éventuels) ;
+- appliquer les guards communs (`game.userId === userId`, `options?.swerpgAuditLog !== false`, item embarqué valide) et ne jamais casser l’action métier si l’écriture échoue ;
+- préserver le comportement existant des autres flux, notamment `talent.purchase`.
+
+**Résultat attendu** : la création et la suppression d’une obligation produisent des entrées Audit Log dédiées sans doublon multi-client ni régression des hooks existants.
+
+### Étape 2 — Capturer l’ancien état et écrire les updates obligation
+
+**Fichiers** : `module/utils/audit-log.mjs`, `module/lib/audit/obligation-events.mjs`, `tests/utils/audit-log.test.mjs`
+
+**What** :
+
+- introduire un stockage pending corrélé par `item.uuid:userId` et `_swerpgOpId` pour capturer l’état avant `updateItem` ;
+- brancher `onPreUpdateItem` / `onUpdateItem` pour comparer ancien et nouvel état d’une obligation et n’écrire `obligation.update` que sur les changements métier pertinents ;
+- normaliser les données obligation dans un helper pur dédié si nécessaire afin d’isoler la détection des champs modifiés et d’éviter d’exposer le HTML brut de `description`.
+
+**Résultat attendu** : une modification pertinente d’obligation écrit une entrée `obligation.update` lisible, corrélée au bon état précédent et sans fuite de contenu HTML complet.
+
+### Étape 3 — Verrouiller le flux par tests ciblés de hooks et de garde
+
+**Fichiers** : `tests/utils/audit-log.test.mjs`, `tests/applications/sheets/character-sheet-commitments.test.mjs`
+
+**What** :
+
+- couvrir la création narrative, la création d’obligation extra, la suppression et l’update des champs métier (`system.value`, `system.campaignDelta`, bonus de création) ;
+- vérifier qu’un item non-obligation ne produit rien, que `swerpgAuditLog: false` désactive le flux et que `game.userId !== userId` évite les doublons ;
+- vérifier qu’une mise à jour de description reste descriptive sans logger son HTML complet et que le flux existant des talents reste intact.
+
+**Résultat attendu** : l’issue `#672` est livrable indépendamment, avec des hooks obligations sécurisés, testés et compatibles avec la tranche UI/taxonomie déjà planifiée.
+
+## Périmètre / hors périmètre
+
+### Inclus
+
+- hooks `createItem` / `preUpdateItem` / `updateItem` / `deleteItem` pour les obligations ;
+- écriture effective des événements `obligation.create/update/delete` ;
+- guards mono-écrivain, anti-récursion et tests ciblés associés.
+
+### Exclus
+
+- nouvelle taxonomie, nouveaux labels ou rendu UI/chat hors ajustement strictement nécessaire ;
+- ajout de champs au DataModel `obligation` ;
+- correction ADR-0025 ou refonte plus large du sous-système Audit Log.

--- a/module/lib/audit/obligation-events.mjs
+++ b/module/lib/audit/obligation-events.mjs
@@ -1,0 +1,98 @@
+/**
+ * Pure-domain helpers for obligation audit log event detection.
+ * No Foundry globals, no document references — accepts plain objects and returns plain values.
+ */
+
+/* -------------------------------------------- */
+/*  Normalisation des données obligation         */
+/* -------------------------------------------- */
+
+/**
+ * @typedef {object} ObligationNormalized
+ * @property {string|null} obligationId
+ * @property {string|null} obligationName
+ * @property {number} value
+ * @property {number} campaignDelta
+ * @property {number} extraXp
+ * @property {number} extraCredits
+ * @property {boolean} isExtra
+ * @property {string|null} transformedTo
+ * @property {string|null} campaignNote
+ * @property {boolean} hasDescription
+ */
+
+/**
+ * Extract the business-relevant fields from an obligation item into a plain normalized object.
+ * The `description` field is intentionally excluded: only its presence is captured via `hasDescription`.
+ * This prevents HTML content from leaking into the audit log payload.
+ *
+ * @param {object} item An obligation item (plain or Foundry document).
+ * @returns {ObligationNormalized}
+ */
+export function normalizeObligationItem(item) {
+  const s = item?.system ?? {}
+  return {
+    obligationId: item?.id ?? null,
+    obligationName: item?.name ?? null,
+    value: s.value ?? 0,
+    campaignDelta: s.campaignDelta ?? 0,
+    extraXp: s.extraXp ?? 0,
+    extraCredits: s.extraCredits ?? 0,
+    isExtra: s.isExtra ?? false,
+    transformedTo: s.transformedTo ?? null,
+    campaignNote: s.campaignNote ?? null,
+    hasDescription: typeof s.description === 'string' ? s.description.trim().length > 0 : false,
+  }
+}
+
+/**
+ * @typedef {object} ObligationDiff
+ * @property {boolean} hasBusinessChange - True when at least one tracked business field differs.
+ * @property {boolean} valueChanged
+ * @property {boolean} campaignDeltaChanged
+ * @property {boolean} extraXpChanged
+ * @property {boolean} extraCreditsChanged
+ * @property {boolean} isExtraChanged
+ * @property {boolean} transformedToChanged
+ * @property {boolean} campaignNoteChanged
+ * @property {boolean} descriptionChanged
+ */
+
+/**
+ * Business fields tracked for audit log diff detection.
+ * Description is excluded from the array because it is handled separately via hasDescription flags.
+ */
+const TRACKED_FIELDS = ['value', 'campaignDelta', 'extraXp', 'extraCredits', 'isExtra', 'transformedTo', 'campaignNote']
+
+/**
+ * Compare two normalized obligation snapshots and return a diff descriptor.
+ * Only compares business-relevant fields; HTML description is compared as presence-only.
+ *
+ * @param {ObligationNormalized} oldNorm Snapshot captured before the update.
+ * @param {ObligationNormalized} newNorm Snapshot captured after the update.
+ * @returns {ObligationDiff}
+ */
+export function diffObligationNormalized(oldNorm, newNorm) {
+  const diff = {
+    hasBusinessChange: false,
+    valueChanged: false,
+    campaignDeltaChanged: false,
+    extraXpChanged: false,
+    extraCreditsChanged: false,
+    isExtraChanged: false,
+    transformedToChanged: false,
+    campaignNoteChanged: false,
+    descriptionChanged: false,
+  }
+
+  for (const field of TRACKED_FIELDS) {
+    const changed = oldNorm[field] !== newNorm[field]
+    diff[`${field}Changed`] = changed
+    if (changed) diff.hasBusinessChange = true
+  }
+
+  diff.descriptionChanged = oldNorm.hasDescription !== newNorm.hasDescription
+  if (diff.descriptionChanged) diff.hasBusinessChange = true
+
+  return diff
+}

--- a/module/utils/audit-log.mjs
+++ b/module/utils/audit-log.mjs
@@ -3,6 +3,7 @@ import { composeEntries, makeEntry, captureSnapshot } from './audit-diff.mjs'
 import { buildAuditLogDescriptionFromRegistry, getAuditLogTypeLabelKey } from '../lib/audit/taxonomy.mjs'
 import { buildNextSegmentedState, computeAuditLogMetrics } from '../lib/audit/storage.mjs'
 import { TALENT_PURCHASE_DEFAULT_COST, TALENT_PURCHASE_DEFAULT_RANKS } from '../config/progression.mjs'
+import { normalizeObligationItem, diffObligationNormalized } from '../lib/audit/obligation-events.mjs'
 
 /* -------------------------------------------- */
 /*  Constantes                                  */
@@ -16,6 +17,8 @@ const MAX_PENDING = 50
 const MAX_RETRIES = 1
 const RETRY_DELAY_MS = 1000
 const pendingOldStates = new Map()
+/** @type {Map<string, object>} Pending obligation normalized snapshots keyed by `item.uuid:userId`. */
+const pendingObligationStates = new Map()
 const sleep = (ms) =>
   new Promise((resolve) => {
     setTimeout(resolve, ms)
@@ -144,6 +147,23 @@ function evictOldestIfNeeded(incomingCount = 1) {
  */
 function getPendingKey(actor, userId) {
   return `${actor.uuid}:${userId}`
+}
+
+/**
+ * Build the composite map key for an obligation item pending entry keyed by item UUID and user ID.
+ * @param {object} item
+ * @param {string} userId
+ */
+function getObligationPendingKey(item, userId) {
+  return `${item.uuid}:${userId}`
+}
+
+/**
+ * Return true when the item is an obligation embedded in a character actor.
+ * @param {object} item
+ */
+function isObligationOnCharacter(item) {
+  return item?.type === 'obligation' && item?.parent?.type === 'character'
 }
 
 /**
@@ -381,6 +401,10 @@ export {
   readAuditChatSummaryEnabled,
   sendChatForAuditEntries,
   onCreateItem,
+  onDeleteItem,
+  onPreUpdateItem,
+  onUpdateItem,
+  flushObligationPending,
   recordTalentNodePurchase,
   recordTalentNodeOperation,
   recordItemPurchase,
@@ -459,7 +483,8 @@ export function onUpdateActor(actor, changes, options, userId) {
 /* -------------------------------------------- */
 
 /**
- * Record a talent purchase audit entry when a talent item is created on a character actor.
+ * Record audit entries when an item is created on a character actor.
+ * Handles talent.purchase and obligation.create event types.
  * @param {object} item
  * @param {object} data
  * @param {object} options
@@ -468,23 +493,174 @@ export function onUpdateActor(actor, changes, options, userId) {
 function onCreateItem(item, data, options, userId) {
   if (!isInitiatingClient(userId)) return
   if (item.parent?.type !== 'character') return
-  if (item.type !== 'talent') return
+  if (options?.swerpgAuditLog === false) return
+
+  if (item.type === 'talent') {
+    const ts = Date.now()
+    const snapshot = captureSnapshot(item.parent)
+    const user = game.users?.get(userId) ?? null
+    const cost = item.system?.cost ?? TALENT_PURCHASE_DEFAULT_COST
+    const ranks = item.system?.ranks ?? TALENT_PURCHASE_DEFAULT_RANKS
+
+    const entry = makeEntry({
+      type: 'talent.purchase',
+      data: {
+        talentId: item.id,
+        talentName: item.name,
+        cost,
+        ranks,
+      },
+      xpDelta: -cost,
+      ts,
+      userId,
+      user,
+      snapshot,
+    })
+
+    writeLogEntries(item.parent, [entry])
+    return
+  }
+
+  if (item.type === 'obligation') {
+    const ts = Date.now()
+    const snapshot = captureSnapshot(item.parent)
+    const user = game.users?.get(userId) ?? null
+    const s = item.system ?? {}
+
+    const entry = makeEntry({
+      type: 'obligation.create',
+      data: {
+        obligationId: item.id,
+        obligationName: item.name,
+        value: s.value ?? 0,
+        isExtra: s.isExtra ?? false,
+        extraXp: s.extraXp ?? 0,
+        extraCredits: s.extraCredits ?? 0,
+      },
+      xpDelta: 0,
+      ts,
+      userId,
+      user,
+      snapshot,
+    })
+
+    writeLogEntries(item.parent, [entry])
+  }
+}
+
+/* -------------------------------------------- */
+/*  deleteItem handler (obligation)              */
+/* -------------------------------------------- */
+
+/**
+ * Record an obligation.delete audit entry when an obligation item is deleted from a character actor.
+ * @param {object} item
+ * @param {object} options
+ * @param {string} userId
+ */
+function onDeleteItem(item, options, userId) {
+  if (!isInitiatingClient(userId)) return
+  if (!isObligationOnCharacter(item)) return
+  if (options?.swerpgAuditLog === false) return
 
   const ts = Date.now()
   const snapshot = captureSnapshot(item.parent)
   const user = game.users?.get(userId) ?? null
-  const cost = item.system?.cost ?? TALENT_PURCHASE_DEFAULT_COST
-  const ranks = item.system?.ranks ?? TALENT_PURCHASE_DEFAULT_RANKS
+  const s = item.system ?? {}
 
   const entry = makeEntry({
-    type: 'talent.purchase',
+    type: 'obligation.delete',
     data: {
-      talentId: item.id,
-      talentName: item.name,
-      cost,
-      ranks,
+      obligationId: item.id,
+      obligationName: item.name,
+      value: s.value ?? 0,
+      isExtra: s.isExtra ?? false,
+      extraXp: s.extraXp ?? 0,
+      extraCredits: s.extraCredits ?? 0,
     },
-    xpDelta: -cost,
+    xpDelta: 0,
+    ts,
+    userId,
+    user,
+    snapshot,
+  })
+
+  writeLogEntries(item.parent, [entry])
+}
+
+/* -------------------------------------------- */
+/*  preUpdateItem / updateItem handlers         */
+/*  (obligation update with old-state capture)  */
+/* -------------------------------------------- */
+
+/**
+ * Capture the normalized obligation state before an update so that onUpdateItem can diff it.
+ * @param {object} item
+ * @param {object} changes
+ * @param {object} options
+ * @param {string} userId
+ */
+function onPreUpdateItem(item, changes, options, userId) {
+  if (!isInitiatingClient(userId)) return
+  if (!isObligationOnCharacter(item)) return
+  if (options?.swerpgAuditLog === false) return
+
+  const key = getObligationPendingKey(item, userId)
+  pendingObligationStates.set(key, {
+    norm: normalizeObligationItem(item),
+    timestamp: Date.now(),
+  })
+}
+
+/**
+ * Compare old and new obligation state after an update and write an obligation.update entry
+ * only when business-relevant fields changed.
+ * @param {object} item
+ * @param {object} changes
+ * @param {object} options
+ * @param {string} userId
+ */
+function onUpdateItem(item, changes, options, userId) {
+  if (!isInitiatingClient(userId)) return
+  if (!isObligationOnCharacter(item)) return
+  if (options?.swerpgAuditLog === false) return
+
+  const key = getObligationPendingKey(item, userId)
+  const pending = pendingObligationStates.get(key)
+  pendingObligationStates.delete(key)
+
+  if (!pending) return
+  if (Date.now() - pending.timestamp > PENDING_TTL_MS) return
+
+  const newNorm = normalizeObligationItem(item)
+  const diff = diffObligationNormalized(pending.norm, newNorm)
+
+  if (!diff.hasBusinessChange) return
+
+  const ts = Date.now()
+  const snapshot = captureSnapshot(item.parent)
+  const user = game.users?.get(userId) ?? null
+
+  const entryData = {
+    obligationId: item.id,
+    obligationName: item.name,
+    descriptionChanged: diff.descriptionChanged,
+  }
+
+  if (diff.valueChanged) {
+    entryData.oldValue = pending.norm.value
+    entryData.newValue = newNorm.value
+  }
+
+  if (diff.campaignDeltaChanged) {
+    entryData.oldCampaignDelta = pending.norm.campaignDelta
+    entryData.newCampaignDelta = newNorm.campaignDelta
+  }
+
+  const entry = makeEntry({
+    type: 'obligation.update',
+    data: entryData,
+    xpDelta: 0,
     ts,
     userId,
     user,
@@ -1114,6 +1290,9 @@ export function registerAuditLogHooks() {
   Hooks.on('preUpdateActor', onPreUpdateActor)
   Hooks.on('updateActor', onUpdateActor)
   Hooks.on('createItem', onCreateItem)
+  Hooks.on('deleteItem', onDeleteItem)
+  Hooks.on('preUpdateItem', onPreUpdateItem)
+  Hooks.on('updateItem', onUpdateItem)
 }
 
 /* -------------------------------------------- */
@@ -1181,6 +1360,13 @@ function _setProperty(object, path, value) {
  */
 function flushPending() {
   pendingOldStates.clear()
+}
+
+/**
+ * Clear all pending obligation pre-update snapshots (used for testing and reset scenarios).
+ */
+function flushObligationPending() {
+  pendingObligationStates.clear()
 }
 
 /* -------------------------------------------- */

--- a/tests/lib/audit/obligation-events.test.mjs
+++ b/tests/lib/audit/obligation-events.test.mjs
@@ -1,0 +1,178 @@
+import { describe, expect, it } from 'vitest'
+
+import { diffObligationNormalized, normalizeObligationItem } from '../../../module/lib/audit/obligation-events.mjs'
+
+/* ============================================ */
+/*  normalizeObligationItem                     */
+/* ============================================ */
+
+describe('normalizeObligationItem', () => {
+  it('extracts all business fields from an obligation item', () => {
+    const item = {
+      id: 'obl-1',
+      name: 'Debt',
+      system: {
+        value: 10,
+        campaignDelta: 2,
+        extraXp: 5,
+        extraCredits: 1000,
+        isExtra: true,
+        transformedTo: null,
+        campaignNote: 'some note',
+        description: '<p>Some HTML</p>',
+      },
+    }
+    const norm = normalizeObligationItem(item)
+    expect(norm).toEqual({
+      obligationId: 'obl-1',
+      obligationName: 'Debt',
+      value: 10,
+      campaignDelta: 2,
+      extraXp: 5,
+      extraCredits: 1000,
+      isExtra: true,
+      transformedTo: null,
+      campaignNote: 'some note',
+      hasDescription: true,
+    })
+  })
+
+  it('hasDescription is true when description is non-empty HTML', () => {
+    const item = { id: 'obl-1', name: 'X', system: { description: '<p>text</p>' } }
+    expect(normalizeObligationItem(item).hasDescription).toBe(true)
+  })
+
+  it('hasDescription is false when description is empty string', () => {
+    const item = { id: 'obl-1', name: 'X', system: { description: '' } }
+    expect(normalizeObligationItem(item).hasDescription).toBe(false)
+  })
+
+  it('hasDescription is false when description is whitespace only', () => {
+    const item = { id: 'obl-1', name: 'X', system: { description: '   ' } }
+    expect(normalizeObligationItem(item).hasDescription).toBe(false)
+  })
+
+  it('hasDescription is false when description is undefined', () => {
+    const item = { id: 'obl-1', name: 'X', system: {} }
+    expect(normalizeObligationItem(item).hasDescription).toBe(false)
+  })
+
+  it('does not expose raw HTML in any field', () => {
+    const item = { id: 'obl-1', name: 'X', system: { description: '<script>alert("xss")</script>' } }
+    const norm = normalizeObligationItem(item)
+    const serialized = JSON.stringify(norm)
+    expect(serialized).not.toContain('<script>')
+  })
+
+  it('falls back to defaults when system is empty', () => {
+    const item = { id: 'obl-1', name: 'Empty', system: {} }
+    const norm = normalizeObligationItem(item)
+    expect(norm.value).toBe(0)
+    expect(norm.campaignDelta).toBe(0)
+    expect(norm.extraXp).toBe(0)
+    expect(norm.extraCredits).toBe(0)
+    expect(norm.isExtra).toBe(false)
+    expect(norm.transformedTo).toBeNull()
+    expect(norm.campaignNote).toBeNull()
+    expect(norm.hasDescription).toBe(false)
+  })
+
+  it('handles null item gracefully', () => {
+    const norm = normalizeObligationItem(null)
+    expect(norm.obligationId).toBeNull()
+    expect(norm.obligationName).toBeNull()
+    expect(norm.value).toBe(0)
+  })
+})
+
+/* ============================================ */
+/*  diffObligationNormalized                    */
+/* ============================================ */
+
+describe('diffObligationNormalized', () => {
+  function baseNorm(overrides = {}) {
+    return {
+      obligationId: 'obl-1',
+      obligationName: 'Debt',
+      value: 10,
+      campaignDelta: 0,
+      extraXp: 0,
+      extraCredits: 0,
+      isExtra: false,
+      transformedTo: null,
+      campaignNote: null,
+      hasDescription: false,
+      ...overrides,
+    }
+  }
+
+  it('returns no business change when all fields are identical', () => {
+    const diff = diffObligationNormalized(baseNorm(), baseNorm())
+    expect(diff.hasBusinessChange).toBe(false)
+  })
+
+  it('detects value change', () => {
+    const diff = diffObligationNormalized(baseNorm({ value: 10 }), baseNorm({ value: 15 }))
+    expect(diff.valueChanged).toBe(true)
+    expect(diff.hasBusinessChange).toBe(true)
+  })
+
+  it('detects campaignDelta change', () => {
+    const diff = diffObligationNormalized(baseNorm({ campaignDelta: 0 }), baseNorm({ campaignDelta: 5 }))
+    expect(diff.campaignDeltaChanged).toBe(true)
+    expect(diff.hasBusinessChange).toBe(true)
+  })
+
+  it('detects extraXp change', () => {
+    const diff = diffObligationNormalized(baseNorm({ extraXp: 0 }), baseNorm({ extraXp: 5 }))
+    expect(diff.extraXpChanged).toBe(true)
+    expect(diff.hasBusinessChange).toBe(true)
+  })
+
+  it('detects extraCredits change', () => {
+    const diff = diffObligationNormalized(baseNorm({ extraCredits: 0 }), baseNorm({ extraCredits: 1000 }))
+    expect(diff.extraCreditsChanged).toBe(true)
+    expect(diff.hasBusinessChange).toBe(true)
+  })
+
+  it('detects isExtra change', () => {
+    const diff = diffObligationNormalized(baseNorm({ isExtra: false }), baseNorm({ isExtra: true }))
+    expect(diff.isExtraChanged).toBe(true)
+    expect(diff.hasBusinessChange).toBe(true)
+  })
+
+  it('detects transformedTo change', () => {
+    const diff = diffObligationNormalized(baseNorm({ transformedTo: null }), baseNorm({ transformedTo: 'resolved' }))
+    expect(diff.transformedToChanged).toBe(true)
+    expect(diff.hasBusinessChange).toBe(true)
+  })
+
+  it('detects campaignNote change', () => {
+    const diff = diffObligationNormalized(baseNorm({ campaignNote: null }), baseNorm({ campaignNote: 'Paid off half' }))
+    expect(diff.campaignNoteChanged).toBe(true)
+    expect(diff.hasBusinessChange).toBe(true)
+  })
+
+  it('detects description presence change (empty → non-empty)', () => {
+    const diff = diffObligationNormalized(baseNorm({ hasDescription: false }), baseNorm({ hasDescription: true }))
+    expect(diff.descriptionChanged).toBe(true)
+    expect(diff.hasBusinessChange).toBe(true)
+  })
+
+  it('detects description presence change (non-empty → empty)', () => {
+    const diff = diffObligationNormalized(baseNorm({ hasDescription: true }), baseNorm({ hasDescription: false }))
+    expect(diff.descriptionChanged).toBe(true)
+    expect(diff.hasBusinessChange).toBe(true)
+  })
+
+  it('does not flag description change when presence did not change', () => {
+    const diff = diffObligationNormalized(baseNorm({ hasDescription: true }), baseNorm({ hasDescription: true }))
+    expect(diff.descriptionChanged).toBe(false)
+  })
+
+  it('returns false for valueChanged when only a non-value field changes', () => {
+    const diff = diffObligationNormalized(baseNorm({ value: 10 }), baseNorm({ value: 10, campaignDelta: 3 }))
+    expect(diff.valueChanged).toBe(false)
+    expect(diff.campaignDeltaChanged).toBe(true)
+  })
+})

--- a/tests/utils/audit-log.test.mjs
+++ b/tests/utils/audit-log.test.mjs
@@ -785,13 +785,16 @@ describe('onCreateItem', () => {
 /* ============================================ */
 
 describe('registerAuditLogHooks', () => {
-  test('registers three hooks via Hooks.on', async () => {
+  test('registers six hooks via Hooks.on', async () => {
     const { registerAuditLogHooks } = await import('../../module/utils/audit-log.mjs')
     registerAuditLogHooks()
-    expect(globalThis.Hooks.on).toHaveBeenCalledTimes(3)
+    expect(globalThis.Hooks.on).toHaveBeenCalledTimes(6)
     expect(globalThis.Hooks.on).toHaveBeenCalledWith('preUpdateActor', expect.any(Function))
     expect(globalThis.Hooks.on).toHaveBeenCalledWith('updateActor', expect.any(Function))
     expect(globalThis.Hooks.on).toHaveBeenCalledWith('createItem', expect.any(Function))
+    expect(globalThis.Hooks.on).toHaveBeenCalledWith('deleteItem', expect.any(Function))
+    expect(globalThis.Hooks.on).toHaveBeenCalledWith('preUpdateItem', expect.any(Function))
+    expect(globalThis.Hooks.on).toHaveBeenCalledWith('updateItem', expect.any(Function))
   })
 })
 
@@ -2639,5 +2642,475 @@ describe('onCreateItem — mono-writer guard', () => {
     expect(logs).toHaveLength(1)
     expect(logs[0].type).toBe('talent.purchase')
     expect(logs[0].userId).toBe('user-1')
+  })
+})
+
+/* ============================================ */
+/*  onCreateItem — obligation.create            */
+/* ============================================ */
+
+describe('onCreateItem — obligation.create', () => {
+  function makeCharacterActorWithSystem(overrides = {}) {
+    return {
+      type: 'character',
+      id: 'actor-001',
+      uuid: 'Actor.actor-001',
+      name: 'Test Character',
+      _source: {
+        system: { skills: {}, characteristics: {}, progression: { totalXP: 0, spentXP: 0 }, details: {}, advancement: {} },
+        flags: {},
+      },
+      system: {
+        progression: {
+          experience: { spent: 0, gained: 0, available: 0, total: 0 },
+          freeSkillRanks: {
+            career: { spent: 0, gained: 0, available: 0 },
+            specialization: { spent: 0, gained: 0, available: 0 },
+          },
+        },
+      },
+      update: vi.fn(),
+      ...overrides,
+    }
+  }
+
+  function makeObligationItem(actor, overrides = {}) {
+    return {
+      type: 'obligation',
+      id: 'obl-001',
+      name: 'Debt',
+      parent: actor,
+      system: { value: 10, isExtra: false, extraXp: 0, extraCredits: 0 },
+      ...overrides,
+    }
+  }
+
+  test('creates obligation.create entry for obligation on character', async () => {
+    const { onCreateItem } = await import('../../module/utils/audit-log.mjs')
+    globalThis.foundry.utils.deepClone = vi.fn((o) => structuredClone(o))
+    globalThis.game.userId = 'gm-1'
+
+    const actor = makeCharacterActorWithSystem()
+    const item = makeObligationItem(actor)
+
+    await onCreateItem(item, {}, {}, 'gm-1')
+
+    expect(actor.update).toHaveBeenCalledTimes(1)
+    const logs = getWrittenLogs(actor.update.mock.calls[0][0])
+    expect(logs).toHaveLength(1)
+    expect(logs[0].type).toBe('obligation.create')
+    expect(logs[0].data).toMatchObject({
+      obligationId: 'obl-001',
+      obligationName: 'Debt',
+      value: 10,
+      isExtra: false,
+      extraXp: 0,
+      extraCredits: 0,
+    })
+    expect(logs[0].xpDelta).toBe(0)
+    expect(logs[0].userId).toBe('gm-1')
+  })
+
+  test('includes extra bonus metadata for creation-bonus obligation', async () => {
+    const { onCreateItem } = await import('../../module/utils/audit-log.mjs')
+    globalThis.foundry.utils.deepClone = vi.fn((o) => structuredClone(o))
+    globalThis.game.userId = 'gm-1'
+
+    const actor = makeCharacterActorWithSystem()
+    const item = makeObligationItem(actor, { system: { value: 5, isExtra: true, extraXp: 5, extraCredits: 1000 } })
+
+    await onCreateItem(item, {}, {}, 'gm-1')
+
+    const logs = getWrittenLogs(actor.update.mock.calls[0][0])
+    expect(logs[0].data.extraXp).toBe(5)
+    expect(logs[0].data.extraCredits).toBe(1000)
+    expect(logs[0].data.isExtra).toBe(true)
+  })
+
+  test('does not write obligation.create when swerpgAuditLog option is false', async () => {
+    const { onCreateItem } = await import('../../module/utils/audit-log.mjs')
+    globalThis.game.userId = 'gm-1'
+
+    const actor = makeCharacterActorWithSystem()
+    const item = makeObligationItem(actor)
+
+    await onCreateItem(item, {}, { swerpgAuditLog: false }, 'gm-1')
+
+    expect(actor.update).not.toHaveBeenCalled()
+  })
+
+  test('does not write obligation.create when not the initiating client', async () => {
+    const { onCreateItem } = await import('../../module/utils/audit-log.mjs')
+    globalThis.game.userId = 'user-1'
+
+    const actor = makeCharacterActorWithSystem()
+    const item = makeObligationItem(actor)
+
+    await onCreateItem(item, {}, {}, 'user-2')
+
+    expect(actor.update).not.toHaveBeenCalled()
+  })
+
+  test('does not write obligation.create for obligation on non-character actor', async () => {
+    const { onCreateItem } = await import('../../module/utils/audit-log.mjs')
+    globalThis.game.userId = 'gm-1'
+
+    const npc = { type: 'npc', id: 'npc-001', name: 'NPC', update: vi.fn(), system: {} }
+    const item = makeObligationItem(npc, { parent: npc })
+
+    await onCreateItem(item, {}, {}, 'gm-1')
+
+    expect(npc.update).not.toHaveBeenCalled()
+  })
+
+  test('does not write obligation.create when item type is neither talent nor obligation', async () => {
+    const { onCreateItem } = await import('../../module/utils/audit-log.mjs')
+    globalThis.game.userId = 'gm-1'
+
+    const actor = makeCharacterActorWithSystem()
+    const item = makeObligationItem(actor, { type: 'weapon' })
+
+    await onCreateItem(item, {}, {}, 'gm-1')
+
+    expect(actor.update).not.toHaveBeenCalled()
+  })
+
+  test('talent.purchase still works after obligation.create changes (backward compat)', async () => {
+    const { onCreateItem } = await import('../../module/utils/audit-log.mjs')
+    globalThis.foundry.utils.deepClone = vi.fn((o) => structuredClone(o))
+    globalThis.game.userId = 'gm-1'
+
+    const actor = makeCharacterActorWithSystem()
+    const talent = { type: 'talent', id: 'talent-001', name: 'Parry', parent: actor, system: { cost: 5, ranks: 1 } }
+
+    await onCreateItem(talent, {}, {}, 'gm-1')
+
+    const logs = getWrittenLogs(actor.update.mock.calls[0][0])
+    expect(logs[0].type).toBe('talent.purchase')
+  })
+})
+
+/* ============================================ */
+/*  onDeleteItem — obligation.delete            */
+/* ============================================ */
+
+describe('onDeleteItem — obligation.delete', () => {
+  function makeCharacterActorWithSystem(overrides = {}) {
+    return {
+      type: 'character',
+      id: 'actor-001',
+      uuid: 'Actor.actor-001',
+      name: 'Test Character',
+      _source: {
+        system: { skills: {}, characteristics: {}, progression: { totalXP: 0, spentXP: 0 }, details: {}, advancement: {} },
+        flags: {},
+      },
+      system: {
+        progression: {
+          experience: { spent: 0, gained: 0, available: 0, total: 0 },
+          freeSkillRanks: {
+            career: { spent: 0, gained: 0, available: 0 },
+            specialization: { spent: 0, gained: 0, available: 0 },
+          },
+        },
+      },
+      update: vi.fn(),
+      ...overrides,
+    }
+  }
+
+  function makeObligationItem(actor, overrides = {}) {
+    return {
+      type: 'obligation',
+      id: 'obl-001',
+      name: 'Debt',
+      parent: actor,
+      system: { value: 10, isExtra: false, extraXp: 0, extraCredits: 0 },
+      ...overrides,
+    }
+  }
+
+  test('creates obligation.delete entry for obligation on character', async () => {
+    const { onDeleteItem } = await import('../../module/utils/audit-log.mjs')
+    globalThis.foundry.utils.deepClone = vi.fn((o) => structuredClone(o))
+    globalThis.game.userId = 'gm-1'
+
+    const actor = makeCharacterActorWithSystem()
+    const item = makeObligationItem(actor)
+
+    await onDeleteItem(item, {}, 'gm-1')
+
+    expect(actor.update).toHaveBeenCalledTimes(1)
+    const logs = getWrittenLogs(actor.update.mock.calls[0][0])
+    expect(logs).toHaveLength(1)
+    expect(logs[0].type).toBe('obligation.delete')
+    expect(logs[0].data).toMatchObject({
+      obligationId: 'obl-001',
+      obligationName: 'Debt',
+      value: 10,
+      isExtra: false,
+    })
+    expect(logs[0].xpDelta).toBe(0)
+    expect(logs[0].userId).toBe('gm-1')
+  })
+
+  test('does not write obligation.delete when not the initiating client', async () => {
+    const { onDeleteItem } = await import('../../module/utils/audit-log.mjs')
+    globalThis.game.userId = 'user-1'
+
+    const actor = makeCharacterActorWithSystem()
+    const item = makeObligationItem(actor)
+
+    await onDeleteItem(item, {}, 'user-2')
+
+    expect(actor.update).not.toHaveBeenCalled()
+  })
+
+  test('does not write obligation.delete when swerpgAuditLog option is false', async () => {
+    const { onDeleteItem } = await import('../../module/utils/audit-log.mjs')
+    globalThis.game.userId = 'gm-1'
+
+    const actor = makeCharacterActorWithSystem()
+    const item = makeObligationItem(actor)
+
+    await onDeleteItem(item, { swerpgAuditLog: false }, 'gm-1')
+
+    expect(actor.update).not.toHaveBeenCalled()
+  })
+
+  test('does not write obligation.delete for non-obligation items', async () => {
+    const { onDeleteItem } = await import('../../module/utils/audit-log.mjs')
+    globalThis.game.userId = 'gm-1'
+
+    const actor = makeCharacterActorWithSystem()
+    const item = makeObligationItem(actor, { type: 'talent' })
+
+    await onDeleteItem(item, {}, 'gm-1')
+
+    expect(actor.update).not.toHaveBeenCalled()
+  })
+
+  test('does not write obligation.delete for obligation on non-character actor', async () => {
+    const { onDeleteItem } = await import('../../module/utils/audit-log.mjs')
+    globalThis.game.userId = 'gm-1'
+
+    const npc = { type: 'npc', id: 'npc-001', name: 'NPC', update: vi.fn(), system: {} }
+    const item = makeObligationItem(npc, { parent: npc })
+
+    await onDeleteItem(item, {}, 'gm-1')
+
+    expect(npc.update).not.toHaveBeenCalled()
+  })
+
+  test('includes extra bonus metadata in delete entry', async () => {
+    const { onDeleteItem } = await import('../../module/utils/audit-log.mjs')
+    globalThis.foundry.utils.deepClone = vi.fn((o) => structuredClone(o))
+    globalThis.game.userId = 'gm-1'
+
+    const actor = makeCharacterActorWithSystem()
+    const item = makeObligationItem(actor, { system: { value: 5, isExtra: true, extraXp: 5, extraCredits: 1000 } })
+
+    await onDeleteItem(item, {}, 'gm-1')
+
+    const logs = getWrittenLogs(actor.update.mock.calls[0][0])
+    expect(logs[0].data.extraXp).toBe(5)
+    expect(logs[0].data.extraCredits).toBe(1000)
+    expect(logs[0].data.isExtra).toBe(true)
+  })
+})
+
+/* ============================================ */
+/*  onPreUpdateItem / onUpdateItem              */
+/*  obligation.update                           */
+/* ============================================ */
+
+describe('onPreUpdateItem / onUpdateItem — obligation.update', () => {
+  function makeCharacterActorWithSystem(overrides = {}) {
+    return {
+      type: 'character',
+      id: 'actor-001',
+      uuid: 'Actor.actor-001',
+      name: 'Test Character',
+      _source: {
+        system: { skills: {}, characteristics: {}, progression: { totalXP: 0, spentXP: 0 }, details: {}, advancement: {} },
+        flags: {},
+      },
+      system: {
+        progression: {
+          experience: { spent: 0, gained: 0, available: 0, total: 0 },
+          freeSkillRanks: {
+            career: { spent: 0, gained: 0, available: 0 },
+            specialization: { spent: 0, gained: 0, available: 0 },
+          },
+        },
+      },
+      update: vi.fn(),
+      ...overrides,
+    }
+  }
+
+  function makeObligationItem(actor, systemOverrides = {}) {
+    return {
+      type: 'obligation',
+      id: 'obl-001',
+      uuid: 'Item.obl-001',
+      name: 'Debt',
+      parent: actor,
+      system: {
+        value: 10,
+        isExtra: false,
+        extraXp: 0,
+        extraCredits: 0,
+        campaignDelta: 0,
+        description: '',
+        campaignNote: null,
+        transformedTo: null,
+        ...systemOverrides,
+      },
+    }
+  }
+
+  test('writes obligation.update entry when value changes', async () => {
+    const { onPreUpdateItem, onUpdateItem, flushObligationPending } = await import('../../module/utils/audit-log.mjs')
+    flushObligationPending()
+    globalThis.foundry.utils.deepClone = vi.fn((o) => structuredClone(o))
+    globalThis.game.userId = 'gm-1'
+
+    const actor = makeCharacterActorWithSystem()
+    const itemBefore = makeObligationItem(actor, { value: 10 })
+    const itemAfter = makeObligationItem(actor, { value: 15 })
+
+    onPreUpdateItem(itemBefore, { 'system.value': 15 }, {}, 'gm-1')
+    await onUpdateItem(itemAfter, { 'system.value': 15 }, {}, 'gm-1')
+
+    expect(actor.update).toHaveBeenCalledTimes(1)
+    const logs = getWrittenLogs(actor.update.mock.calls[0][0])
+    expect(logs).toHaveLength(1)
+    expect(logs[0].type).toBe('obligation.update')
+    expect(logs[0].data.oldValue).toBe(10)
+    expect(logs[0].data.newValue).toBe(15)
+    expect(logs[0].data.obligationId).toBe('obl-001')
+    expect(logs[0].data.obligationName).toBe('Debt')
+    flushObligationPending()
+  })
+
+  test('writes obligation.update entry when campaignDelta changes', async () => {
+    const { onPreUpdateItem, onUpdateItem, flushObligationPending } = await import('../../module/utils/audit-log.mjs')
+    flushObligationPending()
+    globalThis.foundry.utils.deepClone = vi.fn((o) => structuredClone(o))
+    globalThis.game.userId = 'gm-1'
+
+    const actor = makeCharacterActorWithSystem()
+    const itemBefore = makeObligationItem(actor, { campaignDelta: 0 })
+    const itemAfter = makeObligationItem(actor, { campaignDelta: 5 })
+
+    onPreUpdateItem(itemBefore, { 'system.campaignDelta': 5 }, {}, 'gm-1')
+    await onUpdateItem(itemAfter, { 'system.campaignDelta': 5 }, {}, 'gm-1')
+
+    const logs = getWrittenLogs(actor.update.mock.calls[0][0])
+    expect(logs[0].type).toBe('obligation.update')
+    expect(logs[0].data.oldCampaignDelta).toBe(0)
+    expect(logs[0].data.newCampaignDelta).toBe(5)
+    flushObligationPending()
+  })
+
+  test('does NOT write an entry when no business field changes', async () => {
+    const { onPreUpdateItem, onUpdateItem, flushObligationPending } = await import('../../module/utils/audit-log.mjs')
+    flushObligationPending()
+    globalThis.game.userId = 'gm-1'
+
+    const actor = makeCharacterActorWithSystem()
+    // Same system state before and after — only a non-tracked field would differ
+    const item = makeObligationItem(actor, { value: 10, campaignDelta: 0 })
+
+    onPreUpdateItem(item, {}, {}, 'gm-1')
+    await onUpdateItem(item, {}, {}, 'gm-1')
+
+    expect(actor.update).not.toHaveBeenCalled()
+    flushObligationPending()
+  })
+
+  test('signals descriptionChanged without exposing HTML content', async () => {
+    const { onPreUpdateItem, onUpdateItem, flushObligationPending } = await import('../../module/utils/audit-log.mjs')
+    flushObligationPending()
+    globalThis.foundry.utils.deepClone = vi.fn((o) => structuredClone(o))
+    globalThis.game.userId = 'gm-1'
+
+    const actor = makeCharacterActorWithSystem()
+    const itemBefore = makeObligationItem(actor, { description: '' })
+    const itemAfter = makeObligationItem(actor, { description: '<p>Long narrative text that should not appear in the log</p>' })
+
+    onPreUpdateItem(itemBefore, { 'system.description': '<p>...</p>' }, {}, 'gm-1')
+    await onUpdateItem(itemAfter, { 'system.description': '<p>...</p>' }, {}, 'gm-1')
+
+    const logs = getWrittenLogs(actor.update.mock.calls[0][0])
+    expect(logs[0].type).toBe('obligation.update')
+    expect(logs[0].data.descriptionChanged).toBe(true)
+    // Ensure HTML is not present in any data field
+    const serialized = JSON.stringify(logs[0])
+    expect(serialized).not.toContain('<p>')
+    flushObligationPending()
+  })
+
+  test('does not write obligation.update when not the initiating client', async () => {
+    const { onPreUpdateItem, onUpdateItem, flushObligationPending } = await import('../../module/utils/audit-log.mjs')
+    flushObligationPending()
+    globalThis.game.userId = 'user-1'
+
+    const actor = makeCharacterActorWithSystem()
+    const itemBefore = makeObligationItem(actor, { value: 10 })
+    const itemAfter = makeObligationItem(actor, { value: 15 })
+
+    onPreUpdateItem(itemBefore, { 'system.value': 15 }, {}, 'user-2')
+    await onUpdateItem(itemAfter, { 'system.value': 15 }, {}, 'user-2')
+
+    expect(actor.update).not.toHaveBeenCalled()
+    flushObligationPending()
+  })
+
+  test('does not write obligation.update when swerpgAuditLog option is false', async () => {
+    const { onPreUpdateItem, onUpdateItem, flushObligationPending } = await import('../../module/utils/audit-log.mjs')
+    flushObligationPending()
+    globalThis.game.userId = 'gm-1'
+
+    const actor = makeCharacterActorWithSystem()
+    const itemBefore = makeObligationItem(actor, { value: 10 })
+    const itemAfter = makeObligationItem(actor, { value: 15 })
+
+    onPreUpdateItem(itemBefore, { 'system.value': 15 }, { swerpgAuditLog: false }, 'gm-1')
+    await onUpdateItem(itemAfter, { 'system.value': 15 }, { swerpgAuditLog: false }, 'gm-1')
+
+    expect(actor.update).not.toHaveBeenCalled()
+    flushObligationPending()
+  })
+
+  test('does not write obligation.update for non-obligation items', async () => {
+    const { onPreUpdateItem, onUpdateItem, flushObligationPending } = await import('../../module/utils/audit-log.mjs')
+    flushObligationPending()
+    globalThis.game.userId = 'gm-1'
+
+    const actor = makeCharacterActorWithSystem()
+    const item = { type: 'talent', id: 'talent-001', uuid: 'Item.talent-001', name: 'Parry', parent: actor, system: { cost: 5 } }
+
+    onPreUpdateItem(item, { 'system.cost': 10 }, {}, 'gm-1')
+    await onUpdateItem({ ...item, system: { cost: 10 } }, { 'system.cost': 10 }, {}, 'gm-1')
+
+    expect(actor.update).not.toHaveBeenCalled()
+    flushObligationPending()
+  })
+
+  test('does not write obligation.update when no preUpdateItem snapshot was captured', async () => {
+    const { onUpdateItem, flushObligationPending } = await import('../../module/utils/audit-log.mjs')
+    flushObligationPending()
+    globalThis.game.userId = 'gm-1'
+
+    const actor = makeCharacterActorWithSystem()
+    const itemAfter = makeObligationItem(actor, { value: 15 })
+
+    // Call onUpdateItem without a preceding onPreUpdateItem
+    await onUpdateItem(itemAfter, { 'system.value': 15 }, {}, 'gm-1')
+
+    expect(actor.update).not.toHaveBeenCalled()
+    flushObligationPending()
   })
 })


### PR DESCRIPTION
## Summary

- Add obligation event types and their implementation in module/lib/audit/obligation-events.mjs
- Integrate obligation events into the audit-log utility and UI integration (module/utils/audit-log.mjs)
- Add unit tests and documentation for obligation-audit events

## Context

This branch introduces new "obligation" audit event types and wires them into the existing audit-log utilities and UI. The change is additive and scoped to audit logging and related tests and docs.

## Tests

- Not run (not requested).

## Notes

Files changed (high level):

- documentation/672-étape-2-hooks-item-et-écriture-audit-log-pour-les-obligations.md
- module/lib/audit/obligation-events.mjs
- module/utils/audit-log.mjs
- tests/lib/audit/obligation-events.test.mjs
- tests/utils/audit-log.test.mjs

Reviewers: focus on the new audit event type definitions and the audit-log integration points. Ensure the new tests cover expected event payloads and that documentation reflects the new event semantics.
